### PR TITLE
feat(rps): /rps slash command with optional social-credit wager (first of 3 mini-games)

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: java -Xms128m -Xmx224m -XX:+UseSerialGC -XX:MaxMetaspaceSize=192m -XX:ReservedCodeCacheSize=48m -XX:MaxDirectMemorySize=48m -Dio.netty.maxDirectMemory=0 -Dio.netty.allocator.numDirectArenas=2 -Dio.netty.allocator.numHeapArenas=2 -Xss256k -XX:+ExitOnOutOfMemoryError -Dserver.port=$PORT -jar application/build/libs/application-7.4-SNAPSHOT.jar
+web: java -Xms128m -Xmx224m -XX:+UseSerialGC -XX:MaxMetaspaceSize=192m -XX:ReservedCodeCacheSize=48m -XX:MaxDirectMemorySize=48m -Dio.netty.maxDirectMemory=0 -Dio.netty.allocator.numDirectArenas=2 -Dio.netty.allocator.numHeapArenas=2 -Xss256k -XX:+ExitOnOutOfMemoryError -Dserver.port=$PORT -jar application/build/libs/application-7.5-SNAPSHOT.jar
 release: ./bin/trigger_publish_wiki.sh  # This runs after deployment

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Ensure you have the following prerequisites set up before getting started:
 4. Start the bot:
 
    ```shell
-   java -jar application/build/libs/application-7.4-SNAPSHOT.jar -Dspring.profiles.active=prod
+   java -jar application/build/libs/application-7.5-SNAPSHOT.jar -Dspring.profiles.active=prod
    ```
 
 ## Running with Docker

--- a/application/src/test/kotlin/integration/bot/ButtonManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/ButtonManagerTest.kt
@@ -88,6 +88,7 @@ class ButtonManagerTest {
             PokerActionButton::class.java,
             ResendLastRequestButton::class.java,
             RollButton::class.java,
+            RpsButton::class.java,
             StopButton::class.java,
             TeamCancelButton::class.java,
             TeamConfirmButton::class.java,

--- a/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
@@ -18,6 +18,7 @@ import bot.toby.command.commands.economy.PlinkoCommand
 import bot.toby.command.commands.economy.PokerCommand
 import bot.toby.command.commands.economy.PriceAlertCommand
 import bot.toby.command.commands.economy.RouletteCommand
+import bot.toby.command.commands.economy.RpsCommand
 import bot.toby.command.commands.economy.ScratchCommand
 import bot.toby.command.commands.economy.SlotsCommand
 import bot.toby.command.commands.economy.TipCommand
@@ -165,6 +166,7 @@ class CommandManagerTest {
             InstallCommand::class.java,
             WelcomeCommand::class.java,
             ProfileCommand::class.java,
+            RpsCommand::class.java,
         )
 
         Assertions.assertTrue(availableCommands.containsAll(commandManager.allCommands.map { it.javaClass }.toList()))

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ apply plugin: 'kotlin'
 
 allprojects {
     group = "com.github.ml404"
-    version = "7.4-SNAPSHOT"
+    version = "7.5-SNAPSHOT"
 
     ext['kotlin.version'] = kotlin_version
     // Override Spring Boot 3.3.4's BOM-managed versions with patched releases.

--- a/common/src/main/kotlin/common/events/RpsResolvedEvent.kt
+++ b/common/src/main/kotlin/common/events/RpsResolvedEvent.kt
@@ -1,0 +1,24 @@
+package common.events
+
+/**
+ * Fact emitted by `RpsService` when a Rock-Paper-Scissors match
+ * resolves to a winner — either both players picked and one move beat
+ * the other, or one player forfeited / timed out and the other took
+ * the walkover. Draws and double-no-pick do NOT publish (no winner to
+ * credit, no loser to penalise).
+ *
+ * Subscribers (achievements) tally per-winner / per-loser counters
+ * without needing to read game-state. Mirrors [DuelResolvedEvent]'s
+ * shape so the two PvP games look the same to downstream handlers.
+ *
+ * `pot` is `2 * stake - lossTribute` for wager matches; `0` for
+ * free-play matches. Free-play wins still fire so `first_rps_win`
+ * unlocks regardless of whether anyone bet.
+ */
+data class RpsResolvedEvent(
+    val winnerDiscordId: Long,
+    val loserDiscordId: Long,
+    val guildId: Long,
+    val stake: Long,
+    val pot: Long,
+)

--- a/database/build.gradle
+++ b/database/build.gradle
@@ -15,6 +15,7 @@ dependencyManagement {
 
 dependencies {
     implementation project(':common')
+    implementation 'com.github.ben-manes.caffeine:caffeine'
     implementation 'org.postgresql:postgresql'
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-database-postgresql'

--- a/database/src/main/kotlin/database/achievement/AchievementCatalog.kt
+++ b/database/src/main/kotlin/database/achievement/AchievementCatalog.kt
@@ -386,6 +386,49 @@ object AchievementCatalog {
             threshold = 25
         ),
 
+        // RPS — same shape as the duel achievements above. Triggered by
+        // `RpsResolvedEvent`; published on every winner-bearing match
+        // (free play included), skipped on draw / double-no-pick.
+        AchievementSpec(
+            code = "first_rps_win",
+            name = "Best of One",
+            description = "Win your first Rock-Paper-Scissors match.",
+            category = "casino",
+            icon = "✊",
+            xpReward = 50,
+            creditReward = 50
+        ),
+        AchievementSpec(
+            code = "rps_wins_10",
+            name = "Mind Reader",
+            description = "Win 10 Rock-Paper-Scissors matches.",
+            category = "casino",
+            icon = "✋",
+            xpReward = 150,
+            creditReward = 200,
+            threshold = 10
+        ),
+        AchievementSpec(
+            code = "rps_wins_25",
+            name = "Tournament Hopeful",
+            description = "Win 25 Rock-Paper-Scissors matches.",
+            category = "casino",
+            icon = "✌️",
+            xpReward = 300,
+            creditReward = 400,
+            threshold = 25
+        ),
+        AchievementSpec(
+            code = "rps_losses_5",
+            name = "Predictable",
+            description = "Lose 5 Rock-Paper-Scissors matches.",
+            category = "consolation",
+            icon = "🪨",
+            xpReward = 50,
+            creditReward = 100,
+            threshold = 5
+        ),
+
         // Roadmap stubs for casino games that don't yet publish domain
         // events. Hidden until a future PR adds the corresponding event
         // and wires up an AchievementEventHandler listener; the codes

--- a/database/src/main/kotlin/database/dto/ConfigDto.kt
+++ b/database/src/main/kotlin/database/dto/ConfigDto.kt
@@ -170,6 +170,12 @@ class ConfigDto(
         HOLDEM_MAX_STAKE("HOLDEM_MAX_STAKE"),
         DUEL_MIN_STAKE("DUEL_MIN_STAKE"),
         DUEL_MAX_STAKE("DUEL_MAX_STAKE"),
+        // Per-guild stake bounds for `/rps` (Rock-Paper-Scissors).
+        // Minimum may be 0 — RPS is the only wager game that supports
+        // free play out of the box, so admins can leave it accessible
+        // to members with zero credit. Defaults to 0-500.
+        RPS_MIN_STAKE("RPS_MIN_STAKE"),
+        RPS_MAX_STAKE("RPS_MAX_STAKE"),
 
         // Reference stake size for jackpot probability scaling. Bets at
         // or above this anchor roll at the full JACKPOT_WIN_PCT base

--- a/database/src/main/kotlin/database/rps/RpsEngine.kt
+++ b/database/src/main/kotlin/database/rps/RpsEngine.kt
@@ -1,0 +1,39 @@
+package database.rps
+
+/**
+ * Pure logic for Rock-Paper-Scissors outcomes. No JDA / Spring / DB —
+ * tested as a plain function so the game rules can't drift.
+ */
+object RpsEngine {
+
+    enum class Choice { ROCK, PAPER, SCISSORS }
+
+    sealed interface Outcome {
+        /** First player wins. */
+        data object FirstWins : Outcome
+
+        /** Second player wins. */
+        data object SecondWins : Outcome
+
+        /** Both picked the same move. */
+        data object Draw : Outcome
+    }
+
+    /**
+     * Resolves a complete match. [first] is the move the *first* player
+     * (the inviter) chose; [second] is the opponent's choice. Returns
+     * the outcome from the first player's perspective so callers don't
+     * have to remember who's who.
+     */
+    fun resolve(first: Choice, second: Choice): Outcome = when {
+        first == second -> Outcome.Draw
+        beats(first, second) -> Outcome.FirstWins
+        else -> Outcome.SecondWins
+    }
+
+    private fun beats(a: Choice, b: Choice): Boolean = when (a) {
+        Choice.ROCK -> b == Choice.SCISSORS
+        Choice.PAPER -> b == Choice.ROCK
+        Choice.SCISSORS -> b == Choice.PAPER
+    }
+}

--- a/database/src/main/kotlin/database/rps/RpsSessionRegistry.kt
+++ b/database/src/main/kotlin/database/rps/RpsSessionRegistry.kt
@@ -1,22 +1,18 @@
 package database.rps
 
+import com.github.benmanes.caffeine.cache.Cache
+import com.github.benmanes.caffeine.cache.Caffeine
 import database.configuration.RegistryScheduler
 import org.springframework.stereotype.Component
 import java.time.Duration
 import java.time.Instant
-import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentMap
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
 
 /**
- * In-memory book of live `/rps` matches. Mirrors the shape of
- * [database.duel.PendingDuelRegistry] — same `ConcurrentHashMap +
- * AtomicLong` skeleton, same TTL-expiry-with-callback, same atomic
- * `consumeFor…` removes for race safety between picks, forfeit, and
- * timeout.
- *
- * Two stages live here:
+ * In-memory book of live `/rps` matches. Two stages:
  *   - PENDING — `/rps` posted; opponent hasn't yet hit Accept. Stakes
  *     are NOT yet debited from anyone.
  *   - LIVE — opponent accepted; both stakes locked. Each side privately
@@ -24,15 +20,33 @@ import java.util.concurrent.atomic.AtomicLong
  *     caller drains the session (via [consumeForResolution]) and
  *     resolves the wager.
  *
- * Lost-on-restart is acceptable: mid-flight matches are short-lived and
- * the worst case (a session evaporates mid-pick) just refunds anything
- * already debited — better than carrying half-state across deploys.
+ * **Storage**: backed by a Caffeine [Cache] (via `asMap()` for the
+ * familiar `ConcurrentMap` ops) so we get a hard upper bound on
+ * concurrent sessions ([MAX_SESSIONS]) and a TTL backstop
+ * ([MAX_LIFETIME]) on entries that the scheduler somehow misses. This
+ * matches the convention used by `MessageChatListener` and the SSE
+ * registry elsewhere in the codebase — belt-and-suspenders memory
+ * protection beyond the scheduler-driven phase callbacks.
+ *
+ * The phase timeouts (pending → expired, live-no-pick → expired) are
+ * still driven by [scheduler] because the callbacks close over JDA
+ * message-edit state. Caffeine's eviction-by-TTL kicks in only if a
+ * scheduled task somehow doesn't run (queue overflow, JVM pause,
+ * throw); the scheduler's `sessions.remove(id)` returns null in that
+ * case and skips the message edit — memory is already reclaimed.
+ *
+ * Lost-on-restart is acceptable: mid-flight matches are short-lived
+ * and the worst case (a session evaporates mid-pick) just refunds
+ * anything already debited — better than carrying half-state across
+ * deploys.
  */
 @Component
 class RpsSessionRegistry(
     val pendingTtl: Duration = DEFAULT_PENDING_TTL,
     val pickTtl: Duration = DEFAULT_PICK_TTL,
     private val scheduler: ScheduledExecutorService = RegistryScheduler.instance,
+    maximumSessions: Long = MAX_SESSIONS,
+    maxLifetime: Duration = MAX_LIFETIME,
 ) {
 
     data class Session(
@@ -50,7 +64,17 @@ class RpsSessionRegistry(
         val bothPicked: Boolean get() = picks.size == 2
     }
 
-    private val sessions = ConcurrentHashMap<Long, Session>()
+    /**
+     * Caffeine cache + `asMap()` view. Every read/write below uses
+     * [sessions] (the ConcurrentMap view) for atomic primitives;
+     * [cache] is kept only so the `expireAfterWrite` / `maximumSize`
+     * configuration stays in scope and the GC root chain is explicit.
+     */
+    private val cache: Cache<Long, Session> = Caffeine.newBuilder()
+        .expireAfterWrite(maxLifetime)
+        .maximumSize(maximumSessions)
+        .build()
+    private val sessions: ConcurrentMap<Long, Session> = cache.asMap()
     private val seq = AtomicLong()
 
     /**
@@ -155,5 +179,24 @@ class RpsSessionRegistry(
     companion object {
         val DEFAULT_PENDING_TTL: Duration = Duration.ofMinutes(3)
         val DEFAULT_PICK_TTL: Duration = Duration.ofMinutes(2)
+
+        /**
+         * Hard upper bound on concurrent in-flight sessions. Matches the
+         * convention used by `MessageChatListener.lastAwardAt` —
+         * generous enough that a real PvP burst (a server runs a
+         * tournament) doesn't trip it, low enough that a malformed
+         * `/rps` flood can't OOM the heap. Caffeine evicts least-
+         * recently-used entries above the cap.
+         */
+        const val MAX_SESSIONS: Long = 10_000L
+
+        /**
+         * Backstop lifetime for any single session: pending TTL (3m)
+         * + pick TTL (2m) + 1m slop = 6 minutes. Caffeine evicts
+         * entries past this even if the scheduler-driven phase
+         * timeouts somehow didn't run; protects against memory leaks
+         * if a scheduled task throws or the executor queue saturates.
+         */
+        val MAX_LIFETIME: Duration = Duration.ofMinutes(6)
     }
 }

--- a/database/src/main/kotlin/database/rps/RpsSessionRegistry.kt
+++ b/database/src/main/kotlin/database/rps/RpsSessionRegistry.kt
@@ -1,0 +1,159 @@
+package database.rps
+
+import database.configuration.RegistryScheduler
+import org.springframework.stereotype.Component
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * In-memory book of live `/rps` matches. Mirrors the shape of
+ * [database.duel.PendingDuelRegistry] — same `ConcurrentHashMap +
+ * AtomicLong` skeleton, same TTL-expiry-with-callback, same atomic
+ * `consumeFor…` removes for race safety between picks, forfeit, and
+ * timeout.
+ *
+ * Two stages live here:
+ *   - PENDING — `/rps` posted; opponent hasn't yet hit Accept. Stakes
+ *     are NOT yet debited from anyone.
+ *   - LIVE — opponent accepted; both stakes locked. Each side privately
+ *     submits a [RpsEngine.Choice] via [recordPick]; once both have, the
+ *     caller drains the session (via [consumeForResolution]) and
+ *     resolves the wager.
+ *
+ * Lost-on-restart is acceptable: mid-flight matches are short-lived and
+ * the worst case (a session evaporates mid-pick) just refunds anything
+ * already debited — better than carrying half-state across deploys.
+ */
+@Component
+class RpsSessionRegistry(
+    val pendingTtl: Duration = DEFAULT_PENDING_TTL,
+    val pickTtl: Duration = DEFAULT_PICK_TTL,
+    private val scheduler: ScheduledExecutorService = RegistryScheduler.instance,
+) {
+
+    data class Session(
+        val id: Long,
+        val guildId: Long,
+        val initiatorDiscordId: Long,
+        val opponentDiscordId: Long,
+        val stake: Long,
+        val createdAt: Instant,
+        /** Picks indexed by discord id; both populated → ready to resolve. */
+        val picks: MutableMap<Long, RpsEngine.Choice> = mutableMapOf(),
+        var state: State = State.PENDING,
+    ) {
+        enum class State { PENDING, LIVE }
+        val bothPicked: Boolean get() = picks.size == 2
+    }
+
+    private val sessions = ConcurrentHashMap<Long, Session>()
+    private val seq = AtomicLong()
+
+    /**
+     * Register a fresh PENDING offer. Schedules a timeout that fires
+     * only if the offer is still pending — once accepted (LIVE) the
+     * pending timer is a no-op and the pick timer takes over.
+     */
+    fun register(
+        guildId: Long,
+        initiatorDiscordId: Long,
+        opponentDiscordId: Long,
+        stake: Long,
+        createdAt: Instant = Instant.now(),
+        onPendingTimeout: (Session) -> Unit = {},
+    ): Session {
+        val id = seq.incrementAndGet()
+        val session = Session(
+            id = id,
+            guildId = guildId,
+            initiatorDiscordId = initiatorDiscordId,
+            opponentDiscordId = opponentDiscordId,
+            stake = stake,
+            createdAt = createdAt,
+        )
+        sessions[id] = session
+        scheduler.schedule({
+            // Only fire if still pending — once accepted, the session
+            // transitions to LIVE and the pick timer takes over below.
+            val current = sessions[id]
+            if (current != null && current.state == Session.State.PENDING) {
+                val expired = sessions.remove(id)
+                if (expired != null) runCatching { onPendingTimeout(expired) }
+            }
+        }, pendingTtl.toMillis(), TimeUnit.MILLISECONDS)
+        return session
+    }
+
+    /**
+     * Transition PENDING → LIVE on the opponent's Accept. Returns the
+     * session or null if it already expired or was cancelled. Schedules
+     * a pick-phase timeout. The atomic compare-and-set on `state`
+     * means concurrent Accept/Decline/timeout collapses to one winner.
+     */
+    fun accept(id: Long, onPickTimeout: (Session) -> Unit = {}): Session? {
+        val session = sessions[id] ?: return null
+        synchronized(session) {
+            if (session.state != Session.State.PENDING) return null
+            session.state = Session.State.LIVE
+        }
+        scheduler.schedule({
+            // Only fire if no resolution has consumed the session yet.
+            val current = sessions[id]
+            if (current != null && current.state == Session.State.LIVE && !current.bothPicked) {
+                val expired = sessions.remove(id)
+                if (expired != null) runCatching { onPickTimeout(expired) }
+            }
+        }, pickTtl.toMillis(), TimeUnit.MILLISECONDS)
+        return session
+    }
+
+    /** Atomic remove for decline (opponent rejects PENDING offer). */
+    fun decline(id: Long): Session? {
+        val session = sessions[id] ?: return null
+        synchronized(session) {
+            if (session.state != Session.State.PENDING) return null
+            return sessions.remove(id)
+        }
+    }
+
+    /**
+     * Records a player's pick. Returns the updated session (always
+     * non-null on success) so callers can read [Session.bothPicked]
+     * and decide whether to call [consumeForResolution]. Returns null
+     * if the session no longer exists or the player isn't in it.
+     */
+    fun recordPick(id: Long, discordId: Long, choice: RpsEngine.Choice): Session? {
+        val session = sessions[id] ?: return null
+        synchronized(session) {
+            if (session.state != Session.State.LIVE) return null
+            if (discordId != session.initiatorDiscordId && discordId != session.opponentDiscordId) return null
+            session.picks[discordId] = choice
+            return session
+        }
+    }
+
+    /**
+     * Atomic remove for resolution — call only once [Session.bothPicked]
+     * is true. Returns the session or null if another thread already
+     * resolved it.
+     */
+    fun consumeForResolution(id: Long): Session? = sessions.remove(id)
+
+    /**
+     * Atomic remove for forfeit (a player gives up mid-pick or the
+     * Accept-side initiator wants to back out). Returns the session
+     * or null if already gone.
+     */
+    fun forfeit(id: Long): Session? = sessions.remove(id)
+
+    fun get(id: Long): Session? = sessions[id]
+
+    companion object {
+        val DEFAULT_PENDING_TTL: Duration = Duration.ofMinutes(3)
+        val DEFAULT_PICK_TTL: Duration = Duration.ofMinutes(2)
+    }
+}

--- a/database/src/main/kotlin/database/service/RpsService.kt
+++ b/database/src/main/kotlin/database/service/RpsService.kt
@@ -1,8 +1,10 @@
 package database.service
 
+import common.events.RpsResolvedEvent
 import database.dto.ConfigDto
 import database.rps.RpsEngine
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -38,6 +40,7 @@ class RpsService @Autowired constructor(
     private val jackpotService: JackpotService,
     private val configService: ConfigService,
     private val xpAwardService: XpAwardService,
+    private val eventPublisher: ApplicationEventPublisher? = null,
 ) {
     sealed interface StartOutcome {
         data class Ok(val initiatorBalance: Long) : StartOutcome
@@ -259,22 +262,6 @@ class RpsService @Autowired constructor(
         )
     }
 
-    /**
-     * Refund both players the stake — only used on PENDING-stage
-     * timeout / decline when [acceptMatch] hasn't fired yet. Safe
-     * no-op when stake is 0.
-     *
-     * (Kept separate from [resolveMatch] because at the pending stage
-     * no one has been debited; resolveMatch's accounting assumes the
-     * stake is already locked in the users' negative balance.)
-     */
-    fun refundPending(@Suppress("UNUSED_PARAMETER") initiatorDiscordId: Long, @Suppress("UNUSED_PARAMETER") opponentDiscordId: Long, @Suppress("UNUSED_PARAMETER") guildId: Long, @Suppress("UNUSED_PARAMETER") stake: Long) {
-        // No-op by design — the pending stage never debits. Method
-        // exists so callers can call it unconditionally and read like
-        // the lifecycle is symmetric, the same way `cancel()` on the
-        // pending duel registry produces no DB writes.
-    }
-
     private fun payWinner(
         winner: database.dto.UserDto,
         loser: database.dto.UserDto,
@@ -298,7 +285,7 @@ class RpsService @Autowired constructor(
             amount = WIN_XP,
             reason = "rps:win",
         )
-        return ResolveOutcome.Win(
+        val outcome = ResolveOutcome.Win(
             winnerDiscordId = winner.discordId,
             loserDiscordId = loser.discordId,
             winnerChoice = winnerChoice,
@@ -310,6 +297,8 @@ class RpsService @Autowired constructor(
             lossTribute = tribute,
             xpGranted = xpGranted,
         )
+        publishResolved(outcome, guildId)
+        return outcome
     }
 
     private fun resolveFreePlay(
@@ -361,7 +350,7 @@ class RpsService @Autowired constructor(
             amount = WIN_XP,
             reason = "rps:win",
         )
-        return ResolveOutcome.Win(
+        val outcome = ResolveOutcome.Win(
             winnerDiscordId = winnerDiscordId,
             loserDiscordId = loserDiscordId,
             winnerChoice = winnerChoice,
@@ -372,6 +361,27 @@ class RpsService @Autowired constructor(
             loserNewBalance = 0L,
             lossTribute = 0L,
             xpGranted = xpGranted,
+        )
+        publishResolved(outcome, guildId)
+        return outcome
+    }
+
+    /**
+     * Surfaces the resolution to `AchievementEventHandler` for
+     * `first_rps_win` / `rps_wins_*` / `rps_losses_*` progression.
+     * Draws and double-no-pick never publish — no winner, no loser.
+     * Free-play wins DO publish so achievements unlock regardless of
+     * whether anyone bet.
+     */
+    private fun publishResolved(outcome: ResolveOutcome.Win, guildId: Long) {
+        eventPublisher?.publishEvent(
+            RpsResolvedEvent(
+                winnerDiscordId = outcome.winnerDiscordId,
+                loserDiscordId = outcome.loserDiscordId,
+                guildId = guildId,
+                stake = outcome.stake,
+                pot = outcome.pot,
+            )
         )
     }
 

--- a/database/src/main/kotlin/database/service/RpsService.kt
+++ b/database/src/main/kotlin/database/service/RpsService.kt
@@ -1,0 +1,410 @@
+package database.service
+
+import database.dto.ConfigDto
+import database.rps.RpsEngine
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * Head-to-head Rock-Paper-Scissors wager between two users. Three
+ * phases — mirrors `/duel`'s preflight + accept flow but adds a hidden-
+ * pick stage between accept and resolution:
+ *
+ *   - [startMatch] — pre-flight balance / stake-bounds check. Does NOT
+ *     debit. Lets the slash command refuse a doomed offer up-front.
+ *   - [acceptMatch] — atomic debit. Locks both users in ascending
+ *     discord-id order, re-verifies both balances, debits the stake
+ *     from each. Picks are stored in the in-memory session registry
+ *     (not this service) so this service is pure wager-math.
+ *   - [resolveMatch] — credits the winner pot minus jackpot tribute,
+ *     OR refunds on a draw / double-no-pick. Single entry point for
+ *     both happy-path resolution and forfeit/timeout settlement so
+ *     all the branching wager arithmetic lives in one place.
+ *
+ * Loss tribute is computed the same way as `/duel` (via [JackpotHelper])
+ * — every wager game feeds the same per-guild jackpot pool so the
+ * economy stays cohesive.
+ *
+ * Has **no JDA dependency by design** — that's the regression the
+ * Profile cards Spring-cycle (PR #551) taught us. Services reachable
+ * from a `Command` bean must not pull `JDA` from the container; let
+ * the slash command pass `Guild` / `Member` through.
+ */
+@Service
+@Transactional
+class RpsService @Autowired constructor(
+    private val userService: UserService,
+    private val jackpotService: JackpotService,
+    private val configService: ConfigService,
+    private val xpAwardService: XpAwardService,
+) {
+    sealed interface StartOutcome {
+        data class Ok(val initiatorBalance: Long) : StartOutcome
+        data class InvalidStake(val min: Long, val max: Long) : StartOutcome
+        data class InvalidOpponent(val reason: Reason) : StartOutcome {
+            enum class Reason { SELF, BOT }
+        }
+        data class InitiatorInsufficient(val have: Long, val needed: Long) : StartOutcome
+        data class OpponentInsufficient(val have: Long, val needed: Long) : StartOutcome
+        data object UnknownInitiator : StartOutcome
+        data object UnknownOpponent : StartOutcome
+    }
+
+    sealed interface AcceptOutcome {
+        /** Both balances debited; match is now LIVE. */
+        data class Ok(val initiatorNewBalance: Long, val opponentNewBalance: Long) : AcceptOutcome
+        data class InitiatorInsufficient(val have: Long, val needed: Long) : AcceptOutcome
+        data class OpponentInsufficient(val have: Long, val needed: Long) : AcceptOutcome
+        data object UnknownInitiator : AcceptOutcome
+        data object UnknownOpponent : AcceptOutcome
+    }
+
+    /**
+     * Per-resolution result. Wraps the human-readable picks alongside
+     * the wager arithmetic so the slash command can render the embed
+     * without re-deriving anything.
+     */
+    sealed interface ResolveOutcome {
+        data class Win(
+            val winnerDiscordId: Long,
+            val loserDiscordId: Long,
+            val winnerChoice: RpsEngine.Choice,
+            val loserChoice: RpsEngine.Choice,
+            val stake: Long,
+            val pot: Long,
+            val winnerNewBalance: Long,
+            val loserNewBalance: Long,
+            val lossTribute: Long,
+            val xpGranted: Long,
+        ) : ResolveOutcome
+
+        /** Both picked the same move; both stakes refunded. */
+        data class Draw(
+            val choice: RpsEngine.Choice,
+            val stake: Long,
+            val initiatorNewBalance: Long,
+            val opponentNewBalance: Long,
+        ) : ResolveOutcome
+
+        /** Pick timeout with no one having picked; double refund. */
+        data class DoubleRefund(
+            val stake: Long,
+            val initiatorNewBalance: Long,
+            val opponentNewBalance: Long,
+        ) : ResolveOutcome
+
+        data object UnknownInitiator : ResolveOutcome
+        data object UnknownOpponent : ResolveOutcome
+    }
+
+    fun startMatch(
+        initiatorDiscordId: Long,
+        opponentDiscordId: Long,
+        guildId: Long,
+        stake: Long,
+    ): StartOutcome {
+        val (minStake, maxStake) = readStakeBounds(guildId)
+        if (stake < minStake || stake > maxStake) {
+            return StartOutcome.InvalidStake(minStake, maxStake)
+        }
+        if (initiatorDiscordId == opponentDiscordId) {
+            return StartOutcome.InvalidOpponent(StartOutcome.InvalidOpponent.Reason.SELF)
+        }
+        val initiator = userService.getUserById(initiatorDiscordId, guildId)
+            ?: return StartOutcome.UnknownInitiator
+        val opponent = userService.getUserById(opponentDiscordId, guildId)
+            ?: return StartOutcome.UnknownOpponent
+
+        val initiatorBalance = initiator.socialCredit ?: 0L
+        if (initiatorBalance < stake) {
+            return StartOutcome.InitiatorInsufficient(initiatorBalance, stake)
+        }
+        val opponentBalance = opponent.socialCredit ?: 0L
+        if (opponentBalance < stake) {
+            return StartOutcome.OpponentInsufficient(opponentBalance, stake)
+        }
+        return StartOutcome.Ok(initiatorBalance)
+    }
+
+    fun acceptMatch(
+        initiatorDiscordId: Long,
+        opponentDiscordId: Long,
+        guildId: Long,
+        stake: Long,
+    ): AcceptOutcome {
+        // No debit needed when there's no stake — `/rps` without a wager
+        // is pure fun and should skip the user-table touch entirely.
+        if (stake <= 0L) {
+            val initiator = userService.getUserById(initiatorDiscordId, guildId)
+                ?: return AcceptOutcome.UnknownInitiator
+            val opponent = userService.getUserById(opponentDiscordId, guildId)
+                ?: return AcceptOutcome.UnknownOpponent
+            return AcceptOutcome.Ok(
+                initiatorNewBalance = initiator.socialCredit ?: 0L,
+                opponentNewBalance = opponent.socialCredit ?: 0L,
+            )
+        }
+        val locked = userService.lockUsersInAscendingOrder(
+            listOf(initiatorDiscordId, opponentDiscordId), guildId
+        )
+        val initiator = locked[initiatorDiscordId] ?: return AcceptOutcome.UnknownInitiator
+        val opponent = locked[opponentDiscordId] ?: return AcceptOutcome.UnknownOpponent
+
+        val initiatorBalance = initiator.socialCredit ?: 0L
+        if (initiatorBalance < stake) {
+            return AcceptOutcome.InitiatorInsufficient(initiatorBalance, stake)
+        }
+        val opponentBalance = opponent.socialCredit ?: 0L
+        if (opponentBalance < stake) {
+            return AcceptOutcome.OpponentInsufficient(opponentBalance, stake)
+        }
+        initiator.socialCredit = initiatorBalance - stake
+        opponent.socialCredit = opponentBalance - stake
+        userService.updateUser(initiator)
+        userService.updateUser(opponent)
+        return AcceptOutcome.Ok(
+            initiatorNewBalance = initiator.socialCredit ?: 0L,
+            opponentNewBalance = opponent.socialCredit ?: 0L,
+        )
+    }
+
+    /**
+     * Settle a match. Handles four cases:
+     *   - both players picked + clean winner → win/loss accounting + XP
+     *   - both players picked + identical move → draw, refund both
+     *   - exactly one player picked → other forfeits, picker wins
+     *   - neither player picked → double refund
+     *
+     * Idempotent against the user table only if called once per match —
+     * the in-memory session registry is responsible for atomically
+     * removing the session before this is called.
+     */
+    fun resolveMatch(
+        initiatorDiscordId: Long,
+        opponentDiscordId: Long,
+        guildId: Long,
+        stake: Long,
+        initiatorChoice: RpsEngine.Choice?,
+        opponentChoice: RpsEngine.Choice?,
+    ): ResolveOutcome {
+        // Stake-free play: no debits to settle. Award nominal XP to the
+        // winner only (consistent with stake-bearing wins) and skip the
+        // user-table touch otherwise.
+        if (stake <= 0L) {
+            return resolveFreePlay(
+                initiatorDiscordId, opponentDiscordId, guildId,
+                initiatorChoice, opponentChoice,
+            )
+        }
+        val locked = userService.lockUsersInAscendingOrder(
+            listOf(initiatorDiscordId, opponentDiscordId), guildId
+        )
+        val initiator = locked[initiatorDiscordId] ?: return ResolveOutcome.UnknownInitiator
+        val opponent = locked[opponentDiscordId] ?: return ResolveOutcome.UnknownOpponent
+
+        val initiatorBalance = initiator.socialCredit ?: 0L
+        val opponentBalance = opponent.socialCredit ?: 0L
+
+        // Case A: both picked.
+        if (initiatorChoice != null && opponentChoice != null) {
+            return when (val outcome = RpsEngine.resolve(initiatorChoice, opponentChoice)) {
+                RpsEngine.Outcome.Draw -> {
+                    // Refund both stakes.
+                    initiator.socialCredit = initiatorBalance + stake
+                    opponent.socialCredit = opponentBalance + stake
+                    userService.updateUser(initiator)
+                    userService.updateUser(opponent)
+                    ResolveOutcome.Draw(
+                        choice = initiatorChoice,
+                        stake = stake,
+                        initiatorNewBalance = initiator.socialCredit ?: 0L,
+                        opponentNewBalance = opponent.socialCredit ?: 0L,
+                    )
+                }
+                RpsEngine.Outcome.FirstWins -> payWinner(
+                    winner = initiator, loser = opponent, stake = stake, guildId = guildId,
+                    winnerChoice = initiatorChoice, loserChoice = opponentChoice,
+                )
+                RpsEngine.Outcome.SecondWins -> payWinner(
+                    winner = opponent, loser = initiator, stake = stake, guildId = guildId,
+                    winnerChoice = opponentChoice, loserChoice = initiatorChoice,
+                )
+            }
+        }
+
+        // Case B: exactly one picked. The picker wins by forfeit.
+        if (initiatorChoice != null && opponentChoice == null) {
+            return payWinner(
+                winner = initiator, loser = opponent, stake = stake, guildId = guildId,
+                winnerChoice = initiatorChoice, loserChoice = pickPlaceholder(initiatorChoice),
+            )
+        }
+        if (opponentChoice != null && initiatorChoice == null) {
+            return payWinner(
+                winner = opponent, loser = initiator, stake = stake, guildId = guildId,
+                winnerChoice = opponentChoice, loserChoice = pickPlaceholder(opponentChoice),
+            )
+        }
+
+        // Case C: neither picked. Double refund.
+        initiator.socialCredit = initiatorBalance + stake
+        opponent.socialCredit = opponentBalance + stake
+        userService.updateUser(initiator)
+        userService.updateUser(opponent)
+        return ResolveOutcome.DoubleRefund(
+            stake = stake,
+            initiatorNewBalance = initiator.socialCredit ?: 0L,
+            opponentNewBalance = opponent.socialCredit ?: 0L,
+        )
+    }
+
+    /**
+     * Refund both players the stake — only used on PENDING-stage
+     * timeout / decline when [acceptMatch] hasn't fired yet. Safe
+     * no-op when stake is 0.
+     *
+     * (Kept separate from [resolveMatch] because at the pending stage
+     * no one has been debited; resolveMatch's accounting assumes the
+     * stake is already locked in the users' negative balance.)
+     */
+    fun refundPending(@Suppress("UNUSED_PARAMETER") initiatorDiscordId: Long, @Suppress("UNUSED_PARAMETER") opponentDiscordId: Long, @Suppress("UNUSED_PARAMETER") guildId: Long, @Suppress("UNUSED_PARAMETER") stake: Long) {
+        // No-op by design — the pending stage never debits. Method
+        // exists so callers can call it unconditionally and read like
+        // the lifecycle is symmetric, the same way `cancel()` on the
+        // pending duel registry produces no DB writes.
+    }
+
+    private fun payWinner(
+        winner: database.dto.UserDto,
+        loser: database.dto.UserDto,
+        stake: Long,
+        guildId: Long,
+        winnerChoice: RpsEngine.Choice,
+        loserChoice: RpsEngine.Choice,
+    ): ResolveOutcome.Win {
+        val winnerStartBalance = winner.socialCredit ?: 0L
+        val tribute = JackpotHelper.divertOnLoss(jackpotService, configService, guildId, stake)
+        val pot = 2L * stake
+        val winnerPayout = pot - tribute
+        // Both players were already debited at acceptMatch time. Winner
+        // receives the pot minus tribute back; loser receives nothing.
+        winner.socialCredit = winnerStartBalance + winnerPayout
+        userService.updateUser(winner)
+        // No loser write — their balance was already debited at accept.
+        val xpGranted = xpAwardService.award(
+            discordId = winner.discordId,
+            guildId = guildId,
+            amount = WIN_XP,
+            reason = "rps:win",
+        )
+        return ResolveOutcome.Win(
+            winnerDiscordId = winner.discordId,
+            loserDiscordId = loser.discordId,
+            winnerChoice = winnerChoice,
+            loserChoice = loserChoice,
+            stake = stake,
+            pot = pot,
+            winnerNewBalance = winner.socialCredit ?: 0L,
+            loserNewBalance = loser.socialCredit ?: 0L,
+            lossTribute = tribute,
+            xpGranted = xpGranted,
+        )
+    }
+
+    private fun resolveFreePlay(
+        initiatorDiscordId: Long,
+        opponentDiscordId: Long,
+        guildId: Long,
+        initiatorChoice: RpsEngine.Choice?,
+        opponentChoice: RpsEngine.Choice?,
+    ): ResolveOutcome {
+        // Both picked → resolve by engine; one picked → other forfeits;
+        // neither picked → draw-shaped DoubleRefund (no funds involved).
+        if (initiatorChoice != null && opponentChoice != null) {
+            return when (RpsEngine.resolve(initiatorChoice, opponentChoice)) {
+                RpsEngine.Outcome.Draw -> ResolveOutcome.Draw(
+                    choice = initiatorChoice, stake = 0L,
+                    initiatorNewBalance = 0L, opponentNewBalance = 0L,
+                )
+                RpsEngine.Outcome.FirstWins -> freePlayWin(
+                    initiatorDiscordId, opponentDiscordId, guildId,
+                    winnerChoice = initiatorChoice, loserChoice = opponentChoice,
+                )
+                RpsEngine.Outcome.SecondWins -> freePlayWin(
+                    opponentDiscordId, initiatorDiscordId, guildId,
+                    winnerChoice = opponentChoice, loserChoice = initiatorChoice,
+                )
+            }
+        }
+        if (initiatorChoice != null) return freePlayWin(
+            initiatorDiscordId, opponentDiscordId, guildId,
+            winnerChoice = initiatorChoice, loserChoice = pickPlaceholder(initiatorChoice),
+        )
+        if (opponentChoice != null) return freePlayWin(
+            opponentDiscordId, initiatorDiscordId, guildId,
+            winnerChoice = opponentChoice, loserChoice = pickPlaceholder(opponentChoice),
+        )
+        return ResolveOutcome.DoubleRefund(stake = 0L, initiatorNewBalance = 0L, opponentNewBalance = 0L)
+    }
+
+    private fun freePlayWin(
+        winnerDiscordId: Long,
+        loserDiscordId: Long,
+        guildId: Long,
+        winnerChoice: RpsEngine.Choice,
+        loserChoice: RpsEngine.Choice,
+    ): ResolveOutcome.Win {
+        val xpGranted = xpAwardService.award(
+            discordId = winnerDiscordId,
+            guildId = guildId,
+            amount = WIN_XP,
+            reason = "rps:win",
+        )
+        return ResolveOutcome.Win(
+            winnerDiscordId = winnerDiscordId,
+            loserDiscordId = loserDiscordId,
+            winnerChoice = winnerChoice,
+            loserChoice = loserChoice,
+            stake = 0L,
+            pot = 0L,
+            winnerNewBalance = 0L,
+            loserNewBalance = 0L,
+            lossTribute = 0L,
+            xpGranted = xpGranted,
+        )
+    }
+
+    /**
+     * Cosmetic placeholder used in win embeds when the loser never
+     * picked — the renderer wants a Choice value to show in the
+     * "vs" line. Picks the choice that the winner's actual choice
+     * beats so the embed visually reads "rock crushes scissors" even
+     * though scissors was never chosen. Pure UX flavor; doesn't affect
+     * the wager arithmetic.
+     */
+    private fun pickPlaceholder(winning: RpsEngine.Choice): RpsEngine.Choice = when (winning) {
+        RpsEngine.Choice.ROCK -> RpsEngine.Choice.SCISSORS
+        RpsEngine.Choice.PAPER -> RpsEngine.Choice.ROCK
+        RpsEngine.Choice.SCISSORS -> RpsEngine.Choice.PAPER
+    }
+
+    private fun readStakeBounds(guildId: Long): Pair<Long, Long> {
+        val min = configService.cfgLong(
+            ConfigDto.Configurations.RPS_MIN_STAKE, guildId, default = MIN_STAKE, min = 0L
+        )
+        val max = configService.cfgLongMax(
+            ConfigDto.Configurations.RPS_MAX_STAKE, guildId, default = MAX_STAKE, min = min
+        )
+        return min to max
+    }
+
+    companion object {
+        /** Allow stake-free play: 0 is a valid minimum. */
+        const val MIN_STAKE: Long = 0L
+        const val MAX_STAKE: Long = 500L
+
+        /** XP awarded to the winner regardless of stake. Daily-cap-respecting via XpAwardService. */
+        const val WIN_XP: Long = 10L
+    }
+}

--- a/database/src/test/kotlin/database/achievement/AchievementCatalogTest.kt
+++ b/database/src/test/kotlin/database/achievement/AchievementCatalogTest.kt
@@ -75,6 +75,7 @@ class AchievementCatalogTest {
             "tip_giver", "tips_sent_10", "tips_sent_50",
             "first_duel_win", "duel_wins_10", "duel_wins_25", "duel_wins_50", "duel_wins_100",
             "duel_losses_5", "duel_losses_25",
+            "first_rps_win", "rps_wins_10", "rps_wins_25", "rps_losses_5",
         ).forEach { code ->
             assertNotNull(AchievementCatalog.byCode(code), "missing achievement '$code'")
         }
@@ -107,6 +108,7 @@ class AchievementCatalogTest {
             "tip_giver", "tips_sent_10", "tips_sent_50",
             "first_duel_win", "duel_wins_10", "duel_wins_25", "duel_wins_50", "duel_wins_100",
             "duel_losses_5", "duel_losses_25",
+            "first_rps_win", "rps_wins_10", "rps_wins_25", "rps_losses_5",
             "lottery_winner", "lottery_wins_3", "lottery_wins_10", "lottery_wins_25",
             "intro_set",
             "voice_10h", "voice_100h", "voice_250h", "voice_500h", "voice_1000h",

--- a/database/src/test/kotlin/database/rps/RpsEngineTest.kt
+++ b/database/src/test/kotlin/database/rps/RpsEngineTest.kt
@@ -1,0 +1,59 @@
+package database.rps
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Truth table for [RpsEngine.resolve]. Pure-function unit tests — no
+ * mocks. Catches a sign flip in the win matrix (e.g. swapping rock and
+ * paper) immediately.
+ */
+class RpsEngineTest {
+
+    @Test
+    fun `rock beats scissors`() {
+        assertEquals(RpsEngine.Outcome.FirstWins, RpsEngine.resolve(RpsEngine.Choice.ROCK, RpsEngine.Choice.SCISSORS))
+        assertEquals(RpsEngine.Outcome.SecondWins, RpsEngine.resolve(RpsEngine.Choice.SCISSORS, RpsEngine.Choice.ROCK))
+    }
+
+    @Test
+    fun `paper beats rock`() {
+        assertEquals(RpsEngine.Outcome.FirstWins, RpsEngine.resolve(RpsEngine.Choice.PAPER, RpsEngine.Choice.ROCK))
+        assertEquals(RpsEngine.Outcome.SecondWins, RpsEngine.resolve(RpsEngine.Choice.ROCK, RpsEngine.Choice.PAPER))
+    }
+
+    @Test
+    fun `scissors beats paper`() {
+        assertEquals(RpsEngine.Outcome.FirstWins, RpsEngine.resolve(RpsEngine.Choice.SCISSORS, RpsEngine.Choice.PAPER))
+        assertEquals(RpsEngine.Outcome.SecondWins, RpsEngine.resolve(RpsEngine.Choice.PAPER, RpsEngine.Choice.SCISSORS))
+    }
+
+    @Test
+    fun `same move is always a draw`() {
+        for (choice in RpsEngine.Choice.entries) {
+            assertEquals(
+                RpsEngine.Outcome.Draw,
+                RpsEngine.resolve(choice, choice),
+                "$choice vs $choice must draw",
+            )
+        }
+    }
+
+    @Test
+    fun `every non-draw resolves to exactly one winner`() {
+        // Exhaustive — there are only 9 combinations. Every off-diagonal
+        // cell must be a single-winner outcome (never the third value).
+        for (first in RpsEngine.Choice.entries) {
+            for (second in RpsEngine.Choice.entries) {
+                val outcome = RpsEngine.resolve(first, second)
+                if (first == second) {
+                    assertEquals(RpsEngine.Outcome.Draw, outcome)
+                } else {
+                    assert(outcome == RpsEngine.Outcome.FirstWins || outcome == RpsEngine.Outcome.SecondWins) {
+                        "$first vs $second produced $outcome — expected exactly one winner"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/database/src/test/kotlin/database/rps/RpsSessionRegistryTest.kt
+++ b/database/src/test/kotlin/database/rps/RpsSessionRegistryTest.kt
@@ -148,7 +148,7 @@ class RpsSessionRegistryTest {
         val scheduler = ScheduledThreadPoolExecutor(1)
         try {
             val registry = RpsSessionRegistry(
-                pendingTtl = Duration.ofMillis(50),
+                pendingTtl = Duration.ofMillis(100),
                 pickTtl = Duration.ofMinutes(5),
                 scheduler = scheduler,
             )
@@ -156,7 +156,9 @@ class RpsSessionRegistryTest {
             registry.register(guildId, initiatorId, opponentId, stake = 10L) { _ ->
                 fired.incrementAndGet()
             }
-            Thread.sleep(150)
+            // Wide margin (1s for a 100ms TTL) so a slow CI runner can't
+            // race the assertion ahead of the scheduled fire.
+            Thread.sleep(1_000)
             assertEquals(1, fired.get(), "pending timeout must fire exactly once")
         } finally {
             scheduler.shutdownNow()
@@ -168,7 +170,7 @@ class RpsSessionRegistryTest {
         val scheduler = ScheduledThreadPoolExecutor(1)
         try {
             val registry = RpsSessionRegistry(
-                pendingTtl = Duration.ofMillis(50),
+                pendingTtl = Duration.ofMillis(100),
                 pickTtl = Duration.ofMinutes(5),
                 scheduler = scheduler,
             )
@@ -179,7 +181,7 @@ class RpsSessionRegistryTest {
             // Accept immediately — the still-pending pending-timeout
             // should observe LIVE and bail.
             registry.accept(session.id)
-            Thread.sleep(150)
+            Thread.sleep(1_000)
             assertEquals(0, fired.get(), "pending timeout must NOT fire once the session went LIVE")
         } finally {
             scheduler.shutdownNow()

--- a/database/src/test/kotlin/database/rps/RpsSessionRegistryTest.kt
+++ b/database/src/test/kotlin/database/rps/RpsSessionRegistryTest.kt
@@ -1,0 +1,202 @@
+package database.rps
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.ScheduledThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Behavioural tests for [RpsSessionRegistry] — pin race-safety on the
+ * atomic state transitions (the entire reason this thing exists rather
+ * than a HashMap).
+ */
+class RpsSessionRegistryTest {
+
+    private val guildId = 100L
+    private val initiatorId = 1L
+    private val opponentId = 2L
+
+    @Test
+    fun `register issues monotonic ids`() {
+        val registry = RpsSessionRegistry(scheduler = noopScheduler())
+        val a = registry.register(guildId, initiatorId, opponentId, stake = 10L)
+        val b = registry.register(guildId, initiatorId, opponentId, stake = 10L)
+        assertTrue(b.id > a.id, "ids should be monotonically increasing")
+    }
+
+    @Test
+    fun `decline removes a pending session and accept on the same id returns null`() {
+        val registry = RpsSessionRegistry(scheduler = noopScheduler())
+        val session = registry.register(guildId, initiatorId, opponentId, stake = 10L)
+
+        val declined = registry.decline(session.id)
+        assertNotNull(declined)
+        assertNull(registry.accept(session.id))
+    }
+
+    @Test
+    fun `accept transitions PENDING to LIVE and second accept is a no-op`() {
+        val registry = RpsSessionRegistry(scheduler = noopScheduler())
+        val session = registry.register(guildId, initiatorId, opponentId, stake = 10L)
+
+        val first = registry.accept(session.id)
+        assertNotNull(first)
+        assertEquals(RpsSessionRegistry.Session.State.LIVE, first!!.state)
+        // Second accept must observe the LIVE state and refuse.
+        assertNull(registry.accept(session.id))
+    }
+
+    @Test
+    fun `decline of LIVE session is rejected`() {
+        val registry = RpsSessionRegistry(scheduler = noopScheduler())
+        val session = registry.register(guildId, initiatorId, opponentId, stake = 10L)
+        registry.accept(session.id)
+        // Once LIVE, decline is no-op — players use forfeit, not decline.
+        assertNull(registry.decline(session.id))
+    }
+
+    @Test
+    fun `recordPick stores both choices and bothPicked flips true`() {
+        val registry = RpsSessionRegistry(scheduler = noopScheduler())
+        val session = registry.register(guildId, initiatorId, opponentId, stake = 10L)
+        registry.accept(session.id)
+
+        val afterFirst = registry.recordPick(session.id, initiatorId, RpsEngine.Choice.ROCK)
+        assertNotNull(afterFirst)
+        assertEquals(false, afterFirst!!.bothPicked)
+
+        val afterSecond = registry.recordPick(session.id, opponentId, RpsEngine.Choice.PAPER)
+        assertNotNull(afterSecond)
+        assertEquals(true, afterSecond!!.bothPicked)
+        assertEquals(RpsEngine.Choice.ROCK, afterSecond.picks[initiatorId])
+        assertEquals(RpsEngine.Choice.PAPER, afterSecond.picks[opponentId])
+    }
+
+    @Test
+    fun `recordPick by a non-player is rejected`() {
+        val registry = RpsSessionRegistry(scheduler = noopScheduler())
+        val session = registry.register(guildId, initiatorId, opponentId, stake = 10L)
+        registry.accept(session.id)
+        assertNull(registry.recordPick(session.id, discordId = 9999L, RpsEngine.Choice.ROCK))
+    }
+
+    @Test
+    fun `recordPick on a PENDING session is rejected`() {
+        val registry = RpsSessionRegistry(scheduler = noopScheduler())
+        val session = registry.register(guildId, initiatorId, opponentId, stake = 10L)
+        // No accept yet — session is still PENDING.
+        assertNull(registry.recordPick(session.id, initiatorId, RpsEngine.Choice.ROCK))
+    }
+
+    @Test
+    fun `consumeForResolution atomic-removes and second call returns null`() {
+        val registry = RpsSessionRegistry(scheduler = noopScheduler())
+        val session = registry.register(guildId, initiatorId, opponentId, stake = 10L)
+        registry.accept(session.id)
+        registry.recordPick(session.id, initiatorId, RpsEngine.Choice.ROCK)
+        registry.recordPick(session.id, opponentId, RpsEngine.Choice.PAPER)
+
+        assertNotNull(registry.consumeForResolution(session.id))
+        assertNull(registry.consumeForResolution(session.id))
+    }
+
+    @Test
+    fun `forfeit atomic-removes and second call returns null`() {
+        val registry = RpsSessionRegistry(scheduler = noopScheduler())
+        val session = registry.register(guildId, initiatorId, opponentId, stake = 10L)
+        registry.accept(session.id)
+
+        assertNotNull(registry.forfeit(session.id))
+        assertNull(registry.forfeit(session.id))
+    }
+
+    @Test
+    fun `concurrent accept across many threads produces exactly one success`() {
+        // The synchronized + state-check pattern in accept() must
+        // collapse N concurrent accepts to one winner. Otherwise a
+        // double-debit is possible at the service layer.
+        val registry = RpsSessionRegistry(scheduler = noopScheduler())
+        val session = registry.register(guildId, initiatorId, opponentId, stake = 10L)
+
+        val threads = 16
+        val pool = Executors.newFixedThreadPool(threads)
+        val start = CountDownLatch(1)
+        val successes = AtomicInteger(0)
+        repeat(threads) {
+            pool.submit {
+                start.await()
+                if (registry.accept(session.id) != null) successes.incrementAndGet()
+            }
+        }
+        start.countDown()
+        pool.shutdown()
+        pool.awaitTermination(5, TimeUnit.SECONDS)
+        assertEquals(1, successes.get(), "exactly one thread must observe the PENDING→LIVE transition")
+    }
+
+    @Test
+    fun `pending timeout fires its callback exactly once when nothing else consumes the session`() {
+        val scheduler = ScheduledThreadPoolExecutor(1)
+        try {
+            val registry = RpsSessionRegistry(
+                pendingTtl = Duration.ofMillis(50),
+                pickTtl = Duration.ofMinutes(5),
+                scheduler = scheduler,
+            )
+            val fired = AtomicInteger(0)
+            registry.register(guildId, initiatorId, opponentId, stake = 10L) { _ ->
+                fired.incrementAndGet()
+            }
+            Thread.sleep(150)
+            assertEquals(1, fired.get(), "pending timeout must fire exactly once")
+        } finally {
+            scheduler.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `pending timeout is a no-op when the session has already accepted`() {
+        val scheduler = ScheduledThreadPoolExecutor(1)
+        try {
+            val registry = RpsSessionRegistry(
+                pendingTtl = Duration.ofMillis(50),
+                pickTtl = Duration.ofMinutes(5),
+                scheduler = scheduler,
+            )
+            val fired = AtomicInteger(0)
+            val session = registry.register(guildId, initiatorId, opponentId, stake = 10L) { _ ->
+                fired.incrementAndGet()
+            }
+            // Accept immediately — the still-pending pending-timeout
+            // should observe LIVE and bail.
+            registry.accept(session.id)
+            Thread.sleep(150)
+            assertEquals(0, fired.get(), "pending timeout must NOT fire once the session went LIVE")
+        } finally {
+            scheduler.shutdownNow()
+        }
+    }
+
+    /**
+     * A no-op scheduler for tests that don't care about timeouts.
+     * Avoids spinning up real threads when we only want to drive the
+     * state machine directly.
+     */
+    private fun noopScheduler(): ScheduledExecutorService =
+        object : ScheduledThreadPoolExecutor(0) {
+            override fun schedule(command: Runnable, delay: Long, unit: TimeUnit): ScheduledFuture<*> {
+                // Drop the task on the floor — tests that need the timeout
+                // create a real scheduler.
+                return super.schedule(Runnable { /* no-op */ }, Long.MAX_VALUE, TimeUnit.SECONDS)
+            }
+        }
+}

--- a/database/src/test/kotlin/database/rps/RpsSessionRegistryTest.kt
+++ b/database/src/test/kotlin/database/rps/RpsSessionRegistryTest.kt
@@ -188,6 +188,28 @@ class RpsSessionRegistryTest {
         }
     }
 
+    @Test
+    fun `Caffeine maximumSize cap evicts oldest entries to keep memory bounded`() {
+        // Belt-and-suspenders memory protection: even with a flood of
+        // /rps invocations, the cache caps at maximumSessions. Pin the
+        // behaviour with a low cap so an accidental change to the
+        // companion constant (or a regression to ConcurrentHashMap)
+        // surfaces immediately.
+        val registry = RpsSessionRegistry(
+            scheduler = noopScheduler(),
+            maximumSessions = 3L,
+        )
+        val ids = (1..10).map {
+            registry.register(guildId, initiatorId + it, opponentId + it, stake = 0L).id
+        }
+        // Caffeine performs eviction asynchronously; nudge it with a
+        // synchronous read so the cleanup completes before we assert.
+        ids.forEach { registry.get(it) }
+        Thread.sleep(50)
+        val surviving = ids.count { registry.get(it) != null }
+        assertTrue(surviving <= 3, "expected at most 3 survivors with maximumSessions=3, got $surviving")
+    }
+
     /**
      * A no-op scheduler for tests that don't care about timeouts.
      * Avoids spinning up real threads when we only want to drive the

--- a/database/src/test/kotlin/database/service/RpsServiceTest.kt
+++ b/database/src/test/kotlin/database/service/RpsServiceTest.kt
@@ -1,0 +1,253 @@
+package database.service
+
+import database.dto.ConfigDto
+import database.dto.UserDto
+import database.rps.RpsEngine
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Behavioural tests for [RpsService]. Cover the four resolve branches
+ * (clean win, draw, one-side forfeit, double-no-pick) plus the
+ * preflight + accept guardrails, with both stake-bearing and free-play
+ * paths exercised.
+ */
+class RpsServiceTest {
+
+    private val guildId = 100L
+    private val initiatorId = 1L
+    private val opponentId = 2L
+
+    private lateinit var userService: UserService
+    private lateinit var jackpotService: JackpotService
+    private lateinit var configService: ConfigService
+    private lateinit var xpAwardService: XpAwardService
+    private lateinit var service: RpsService
+
+    @BeforeEach
+    fun setUp() {
+        userService = mockk(relaxed = true)
+        jackpotService = mockk(relaxed = true)
+        configService = mockk(relaxed = true)
+        xpAwardService = mockk(relaxed = true)
+        service = RpsService(userService, jackpotService, configService, xpAwardService)
+
+        // Default stake bounds: 0..500 (the RPS defaults).
+        every { configService.getConfigByName(ConfigDto.Configurations.RPS_MIN_STAKE.configValue, any()) } returns null
+        every { configService.getConfigByName(ConfigDto.Configurations.RPS_MAX_STAKE.configValue, any()) } returns null
+        // No tribute by default (test-pure jackpot accounting).
+        // JackpotHelper.divertOnLoss reads JACKPOT_LOSS_TRIBUTE_PCT from
+        // configService and calls jackpotService.addToPool — default to
+        // "no tribute" so test-pure jackpot accounting just works.
+        every { configService.getConfigByName(ConfigDto.Configurations.JACKPOT_LOSS_TRIBUTE_PCT.configValue, any()) } returns
+            ConfigDto(name = "JACKPOT_LOSS_TRIBUTE_PCT", value = "0", guildId = guildId.toString())
+        every { jackpotService.addToPool(any(), any()) } returns 0L
+        // No-op XP grant by default.
+        every { xpAwardService.award(any(), any(), any(), any(), any(), any(), any()) } returns 0L
+    }
+
+    // ---- startMatch preflight ----
+
+    @Test
+    fun `startMatch rejects out-of-range stake`() {
+        every { configService.getConfigByName(ConfigDto.Configurations.RPS_MIN_STAKE.configValue, any()) } returns
+            ConfigDto(name = "RPS_MIN_STAKE", value = "10", guildId = guildId.toString())
+        val outcome = service.startMatch(initiatorId, opponentId, guildId, stake = 5L)
+        assertTrue(outcome is RpsService.StartOutcome.InvalidStake)
+    }
+
+    @Test
+    fun `startMatch rejects self-challenge`() {
+        val outcome = service.startMatch(initiatorId, initiatorId, guildId, stake = 0L)
+        assertTrue(outcome is RpsService.StartOutcome.InvalidOpponent)
+    }
+
+    @Test
+    fun `startMatch rejects unknown initiator`() {
+        every { userService.getUserById(initiatorId, guildId) } returns null
+        val outcome = service.startMatch(initiatorId, opponentId, guildId, stake = 0L)
+        assertEquals(RpsService.StartOutcome.UnknownInitiator, outcome)
+    }
+
+    @Test
+    fun `startMatch rejects insufficient initiator balance`() {
+        every { userService.getUserById(initiatorId, guildId) } returns userDto(initiatorId, balance = 5L)
+        every { userService.getUserById(opponentId, guildId) } returns userDto(opponentId, balance = 100L)
+        val outcome = service.startMatch(initiatorId, opponentId, guildId, stake = 50L)
+        assertTrue(outcome is RpsService.StartOutcome.InitiatorInsufficient)
+    }
+
+    @Test
+    fun `startMatch happy path returns Ok with initiator balance`() {
+        every { userService.getUserById(initiatorId, guildId) } returns userDto(initiatorId, balance = 200L)
+        every { userService.getUserById(opponentId, guildId) } returns userDto(opponentId, balance = 200L)
+        val outcome = service.startMatch(initiatorId, opponentId, guildId, stake = 50L)
+        assertEquals(RpsService.StartOutcome.Ok(200L), outcome)
+    }
+
+    // ---- acceptMatch ----
+
+    @Test
+    fun `acceptMatch with zero stake skips the user-table update path`() {
+        every { userService.getUserById(initiatorId, guildId) } returns userDto(initiatorId, balance = 0L)
+        every { userService.getUserById(opponentId, guildId) } returns userDto(opponentId, balance = 0L)
+        val outcome = service.acceptMatch(initiatorId, opponentId, guildId, stake = 0L)
+        assertEquals(RpsService.AcceptOutcome.Ok(0L, 0L), outcome)
+        // Stake-free path must not lock or write.
+        verify(exactly = 0) { userService.updateUser(any()) }
+    }
+
+    @Test
+    fun `acceptMatch debits both balances on stake-bearing match`() {
+        val initiator = userDto(initiatorId, balance = 100L)
+        val opponent = userDto(opponentId, balance = 200L)
+        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns initiator
+        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns opponent
+
+        val outcome = service.acceptMatch(initiatorId, opponentId, guildId, stake = 50L)
+        assertEquals(RpsService.AcceptOutcome.Ok(50L, 150L), outcome)
+        verify(exactly = 1) { userService.updateUser(match { it.discordId == initiatorId && it.socialCredit == 50L }) }
+        verify(exactly = 1) { userService.updateUser(match { it.discordId == opponentId && it.socialCredit == 150L }) }
+    }
+
+    @Test
+    fun `acceptMatch refuses when balance fell below stake between start and accept`() {
+        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns userDto(initiatorId, balance = 10L)
+        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns userDto(opponentId, balance = 200L)
+        val outcome = service.acceptMatch(initiatorId, opponentId, guildId, stake = 50L)
+        assertTrue(outcome is RpsService.AcceptOutcome.InitiatorInsufficient)
+        verify(exactly = 0) { userService.updateUser(any()) }
+    }
+
+    // ---- resolveMatch: both picked ----
+
+    @Test
+    fun `resolveMatch credits winner and grants XP on clean win`() {
+        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns userDto(initiatorId, balance = 50L)
+        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns userDto(opponentId, balance = 150L)
+        every { xpAwardService.award(initiatorId, guildId, 10L, "rps:win", any(), any(), any()) } returns 10L
+
+        val outcome = service.resolveMatch(
+            initiatorId, opponentId, guildId, stake = 50L,
+            initiatorChoice = RpsEngine.Choice.ROCK,
+            opponentChoice = RpsEngine.Choice.SCISSORS,
+        )
+        // Initiator (winner) gets pot = 100; their balance was 50 (post-accept-debit), so 50 + 100 = 150.
+        assertTrue(outcome is RpsService.ResolveOutcome.Win, "expected Win, got $outcome")
+        val win = outcome as RpsService.ResolveOutcome.Win
+        assertEquals(initiatorId, win.winnerDiscordId)
+        assertEquals(opponentId, win.loserDiscordId)
+        assertEquals(150L, win.winnerNewBalance)
+        assertEquals(10L, win.xpGranted)
+        verify(exactly = 1) { userService.updateUser(match { it.discordId == initiatorId && it.socialCredit == 150L }) }
+        // Loser was already debited at accept time — NO further update.
+        verify(exactly = 0) { userService.updateUser(match { it.discordId == opponentId }) }
+    }
+
+    @Test
+    fun `resolveMatch refunds both stakes on draw`() {
+        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns userDto(initiatorId, balance = 50L)
+        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns userDto(opponentId, balance = 150L)
+
+        val outcome = service.resolveMatch(
+            initiatorId, opponentId, guildId, stake = 50L,
+            initiatorChoice = RpsEngine.Choice.PAPER,
+            opponentChoice = RpsEngine.Choice.PAPER,
+        )
+        assertTrue(outcome is RpsService.ResolveOutcome.Draw, "expected Draw, got $outcome")
+        val draw = outcome as RpsService.ResolveOutcome.Draw
+        assertEquals(100L, draw.initiatorNewBalance) // 50 + 50 refund
+        assertEquals(200L, draw.opponentNewBalance) // 150 + 50 refund
+        verify(exactly = 1) { userService.updateUser(match { it.discordId == initiatorId && it.socialCredit == 100L }) }
+        verify(exactly = 1) { userService.updateUser(match { it.discordId == opponentId && it.socialCredit == 200L }) }
+        // No XP grant on draw.
+        verify(exactly = 0) { xpAwardService.award(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `resolveMatch credits picker when opponent never picked (forfeit)`() {
+        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns userDto(initiatorId, balance = 50L)
+        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns userDto(opponentId, balance = 150L)
+
+        val outcome = service.resolveMatch(
+            initiatorId, opponentId, guildId, stake = 50L,
+            initiatorChoice = RpsEngine.Choice.ROCK,
+            opponentChoice = null,
+        )
+        assertTrue(outcome is RpsService.ResolveOutcome.Win)
+        val win = outcome as RpsService.ResolveOutcome.Win
+        assertEquals(initiatorId, win.winnerDiscordId)
+        assertEquals(150L, win.winnerNewBalance)
+    }
+
+    @Test
+    fun `resolveMatch double-refunds when neither side picked`() {
+        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns userDto(initiatorId, balance = 50L)
+        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns userDto(opponentId, balance = 150L)
+
+        val outcome = service.resolveMatch(
+            initiatorId, opponentId, guildId, stake = 50L,
+            initiatorChoice = null,
+            opponentChoice = null,
+        )
+        assertTrue(outcome is RpsService.ResolveOutcome.DoubleRefund)
+        val refund = outcome as RpsService.ResolveOutcome.DoubleRefund
+        assertEquals(100L, refund.initiatorNewBalance)
+        assertEquals(200L, refund.opponentNewBalance)
+        verify(exactly = 1) { userService.updateUser(match { it.discordId == initiatorId && it.socialCredit == 100L }) }
+        verify(exactly = 1) { userService.updateUser(match { it.discordId == opponentId && it.socialCredit == 200L }) }
+    }
+
+    // ---- resolveMatch: free play ----
+
+    @Test
+    fun `resolveMatch with zero stake skips user updates and only grants XP`() {
+        every { xpAwardService.award(initiatorId, guildId, 10L, "rps:win", any(), any(), any()) } returns 10L
+        val outcome = service.resolveMatch(
+            initiatorId, opponentId, guildId, stake = 0L,
+            initiatorChoice = RpsEngine.Choice.ROCK,
+            opponentChoice = RpsEngine.Choice.SCISSORS,
+        )
+        assertTrue(outcome is RpsService.ResolveOutcome.Win)
+        val win = outcome as RpsService.ResolveOutcome.Win
+        assertEquals(initiatorId, win.winnerDiscordId)
+        assertEquals(0L, win.pot)
+        assertEquals(10L, win.xpGranted)
+        // No user-table writes on free play.
+        verify(exactly = 0) { userService.updateUser(any()) }
+    }
+
+    @Test
+    fun `resolveMatch jackpot tribute is deducted from winner payout`() {
+        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns userDto(initiatorId, balance = 50L)
+        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns userDto(opponentId, balance = 150L)
+        // 20% tribute on a 50-credit stake → 10 credits routed to jackpot.
+        every { configService.getConfigByName(ConfigDto.Configurations.JACKPOT_LOSS_TRIBUTE_PCT.configValue, any()) } returns
+            ConfigDto(name = "JACKPOT_LOSS_TRIBUTE_PCT", value = "20", guildId = guildId.toString())
+        every { jackpotService.addToPool(guildId, any()) } returns 10L
+
+        val outcome = service.resolveMatch(
+            initiatorId, opponentId, guildId, stake = 50L,
+            initiatorChoice = RpsEngine.Choice.ROCK,
+            opponentChoice = RpsEngine.Choice.SCISSORS,
+        )
+        val win = outcome as RpsService.ResolveOutcome.Win
+        // Winner balance was 50 post-debit; gets pot (100) minus tribute (10) = 90 → new balance 140.
+        assertEquals(140L, win.winnerNewBalance)
+        assertEquals(10L, win.lossTribute)
+        assertEquals(100L, win.pot)
+    }
+
+    private fun userDto(discordId: Long, balance: Long): UserDto = UserDto(
+        discordId = discordId,
+        guildId = guildId,
+        socialCredit = balance,
+    ).also { every { userService.updateUser(it) } answers { firstArg() } }
+}

--- a/database/src/test/kotlin/database/service/RpsServiceTest.kt
+++ b/database/src/test/kotlin/database/service/RpsServiceTest.kt
@@ -1,5 +1,6 @@
 package database.service
 
+import common.events.RpsResolvedEvent
 import database.dto.ConfigDto
 import database.dto.UserDto
 import database.rps.RpsEngine
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
 
 /**
  * Behavioural tests for [RpsService]. Cover the four resolve branches
@@ -29,6 +31,7 @@ class RpsServiceTest {
     private lateinit var jackpotService: JackpotService
     private lateinit var configService: ConfigService
     private lateinit var xpAwardService: XpAwardService
+    private lateinit var eventPublisher: ApplicationEventPublisher
     private lateinit var service: RpsService
 
     @BeforeEach
@@ -37,7 +40,8 @@ class RpsServiceTest {
         jackpotService = mockk(relaxed = true)
         configService = mockk(relaxed = true)
         xpAwardService = mockk(relaxed = true)
-        service = RpsService(userService, jackpotService, configService, xpAwardService)
+        eventPublisher = mockk(relaxed = true)
+        service = RpsService(userService, jackpotService, configService, xpAwardService, eventPublisher)
 
         // Default stake bounds: 0..500 (the RPS defaults).
         every { configService.getConfigByName(ConfigDto.Configurations.RPS_MIN_STAKE.configValue, any()) } returns null
@@ -222,6 +226,81 @@ class RpsServiceTest {
         assertEquals(10L, win.xpGranted)
         // No user-table writes on free play.
         verify(exactly = 0) { userService.updateUser(any()) }
+    }
+
+    // ---- achievement event publishing ----
+
+    @Test
+    fun `resolveMatch publishes RpsResolvedEvent on a clean win`() {
+        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns userDto(initiatorId, balance = 50L)
+        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns userDto(opponentId, balance = 150L)
+
+        service.resolveMatch(
+            initiatorId, opponentId, guildId, stake = 50L,
+            initiatorChoice = RpsEngine.Choice.ROCK,
+            opponentChoice = RpsEngine.Choice.SCISSORS,
+        )
+
+        verify(exactly = 1) {
+            eventPublisher.publishEvent(
+                match<RpsResolvedEvent> {
+                    it.winnerDiscordId == initiatorId &&
+                        it.loserDiscordId == opponentId &&
+                        it.guildId == guildId &&
+                        it.stake == 50L &&
+                        it.pot == 100L
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `resolveMatch publishes RpsResolvedEvent on free-play wins too`() {
+        // Free-play wins must still fire the event so `first_rps_win`
+        // can unlock for players who never bet a credit.
+        service.resolveMatch(
+            initiatorId, opponentId, guildId, stake = 0L,
+            initiatorChoice = RpsEngine.Choice.ROCK,
+            opponentChoice = RpsEngine.Choice.SCISSORS,
+        )
+
+        verify(exactly = 1) {
+            eventPublisher.publishEvent(
+                match<RpsResolvedEvent> {
+                    it.winnerDiscordId == initiatorId &&
+                        it.stake == 0L &&
+                        it.pot == 0L
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `resolveMatch does NOT publish on a draw`() {
+        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns userDto(initiatorId, balance = 50L)
+        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns userDto(opponentId, balance = 150L)
+
+        service.resolveMatch(
+            initiatorId, opponentId, guildId, stake = 50L,
+            initiatorChoice = RpsEngine.Choice.PAPER,
+            opponentChoice = RpsEngine.Choice.PAPER,
+        )
+
+        verify(exactly = 0) { eventPublisher.publishEvent(any<RpsResolvedEvent>()) }
+    }
+
+    @Test
+    fun `resolveMatch does NOT publish on double-no-pick`() {
+        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns userDto(initiatorId, balance = 50L)
+        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns userDto(opponentId, balance = 150L)
+
+        service.resolveMatch(
+            initiatorId, opponentId, guildId, stake = 50L,
+            initiatorChoice = null,
+            opponentChoice = null,
+        )
+
+        verify(exactly = 0) { eventPublisher.publishEvent(any<RpsResolvedEvent>()) }
     }
 
     @Test

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/RpsButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/RpsButton.kt
@@ -1,0 +1,233 @@
+package bot.toby.button.buttons
+
+import bot.toby.command.commands.economy.RpsEmbeds
+import core.button.Button
+import core.button.ButtonContext
+import database.dto.UserDto
+import database.rps.RpsSessionRegistry
+import database.service.RpsService
+import net.dv8tion.jda.api.components.MessageTopLevelComponent
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+/**
+ * Routes every `/rps` button click. The component ID prefix is
+ * `"rps"` — [bot.toby.managers.DefaultButtonManager] dispatches by
+ * that prefix to this single bean, which parses the rest of the id
+ * via [RpsEmbeds.parseButtonId] and switches on the action.
+ *
+ * Race safety: every state transition on [RpsSessionRegistry] uses
+ * atomic remove (`decline`, `consumeForResolution`, `forfeit`) or
+ * `synchronized` on the session object (`accept`, `recordPick`), so
+ * concurrent clicks / timeouts collapse to "exactly one path wins".
+ */
+@Component
+class RpsButton @Autowired constructor(
+    private val rpsService: RpsService,
+    private val rpsSessionRegistry: RpsSessionRegistry,
+) : Button {
+
+    override val name: String get() = RpsEmbeds.BUTTON_NAME
+    override val description: String get() = "Routes /rps accept/decline + pick + forfeit clicks."
+
+    override fun handle(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        val parsed = RpsEmbeds.parseButtonId(event.componentId) ?: run {
+            event.hook.sendMessage("Couldn't parse this RPS button.").setEphemeral(true).queue()
+            return
+        }
+        when (parsed.action) {
+            RpsEmbeds.Action.DECLINE -> handleDecline(event, requestingUserDto, parsed)
+            RpsEmbeds.Action.ACCEPT -> handleAccept(event, requestingUserDto, parsed)
+            RpsEmbeds.Action.PICK_ROCK,
+            RpsEmbeds.Action.PICK_PAPER,
+            RpsEmbeds.Action.PICK_SCISSORS -> handlePick(event, requestingUserDto, parsed)
+            RpsEmbeds.Action.FORFEIT -> handleForfeit(event, requestingUserDto, parsed)
+        }
+    }
+
+    private fun handleDecline(
+        event: ButtonInteractionEvent,
+        requestingUserDto: UserDto,
+        parsed: RpsEmbeds.ParsedButtonId,
+    ) {
+        if (requestingUserDto.discordId != parsed.scopedDiscordId) {
+            event.hook.sendMessage(
+                "This isn't your challenge to decline — wait for <@${parsed.scopedDiscordId}> to respond."
+            ).setEphemeral(true).queue()
+            return
+        }
+        val session = rpsSessionRegistry.decline(parsed.sessionId) ?: run {
+            ephemeralAlreadyResolved(event); return
+        }
+        event.message.editMessageEmbeds(
+            RpsEmbeds.pendingDeclineEmbed(session.initiatorDiscordId, session.opponentDiscordId)
+        ).setComponents(emptyList<MessageTopLevelComponent>()).queue()
+    }
+
+    private fun handleAccept(
+        event: ButtonInteractionEvent,
+        requestingUserDto: UserDto,
+        parsed: RpsEmbeds.ParsedButtonId,
+    ) {
+        if (requestingUserDto.discordId != parsed.scopedDiscordId) {
+            event.hook.sendMessage(
+                "This isn't your challenge to accept — wait for <@${parsed.scopedDiscordId}> to respond."
+            ).setEphemeral(true).queue()
+            return
+        }
+        // Transition PENDING → LIVE and schedule the pick-phase timeout
+        // before we touch the user table. If accept() returns null the
+        // session expired or was declined between the click and now.
+        val session = rpsSessionRegistry.accept(parsed.sessionId) { expired ->
+            // Pick-phase timeout: someone picked or no one did. Resolve
+            // through the service so the wager arithmetic in one place
+            // handles all four branches.
+            resolveAndEdit(event, expired)
+        } ?: run {
+            ephemeralAlreadyResolved(event); return
+        }
+
+        // Debit both stakes now (no-op for stake=0). If insufficient,
+        // the match doesn't go LIVE — refund the LIVE state by removing
+        // the session and surface an error.
+        val outcome = rpsService.acceptMatch(
+            initiatorDiscordId = session.initiatorDiscordId,
+            opponentDiscordId = session.opponentDiscordId,
+            guildId = session.guildId,
+            stake = session.stake,
+        )
+        if (outcome !is RpsService.AcceptOutcome.Ok) {
+            rpsSessionRegistry.forfeit(session.id) // tear down the LIVE session
+            event.message.editMessageEmbeds(RpsEmbeds.acceptErrorEmbed(describeAccept(outcome)))
+                .setComponents(emptyList<MessageTopLevelComponent>()).queue()
+            return
+        }
+
+        // Edit the message to the pick-phase view.
+        event.message.editMessageEmbeds(
+            RpsEmbeds.pickEmbed(
+                initiatorDiscordId = session.initiatorDiscordId,
+                opponentDiscordId = session.opponentDiscordId,
+                stake = session.stake,
+                initiatorPicked = false,
+                opponentPicked = false,
+            )
+        ).setComponents(RpsEmbeds.pickButtons(session.id)).queue()
+    }
+
+    private fun handlePick(
+        event: ButtonInteractionEvent,
+        requestingUserDto: UserDto,
+        parsed: RpsEmbeds.ParsedButtonId,
+    ) {
+        val choice = RpsEmbeds.choiceFor(parsed.action) ?: return
+        val live = rpsSessionRegistry.get(parsed.sessionId) ?: run {
+            ephemeralAlreadyResolved(event); return
+        }
+        if (requestingUserDto.discordId != live.initiatorDiscordId &&
+            requestingUserDto.discordId != live.opponentDiscordId
+        ) {
+            event.hook.sendMessage(
+                "This isn't your match — only <@${live.initiatorDiscordId}> and <@${live.opponentDiscordId}> can pick."
+            ).setEphemeral(true).queue()
+            return
+        }
+        val updated = rpsSessionRegistry.recordPick(parsed.sessionId, requestingUserDto.discordId, choice) ?: run {
+            ephemeralAlreadyResolved(event); return
+        }
+        // Confirm the pick to the player privately so the opponent
+        // doesn't see what they chose.
+        event.hook.sendMessage("You picked **${RpsEmbeds.prettyChoice(choice)}**.")
+            .setEphemeral(true).queue()
+
+        if (updated.bothPicked) {
+            // Drain atomically so the timeout callback can't double-fire.
+            val consumed = rpsSessionRegistry.consumeForResolution(parsed.sessionId) ?: return
+            resolveAndEdit(event, consumed)
+        } else {
+            // Re-render the pick embed so the *other* player sees a
+            // "✅ picked" indicator on the waiting line.
+            event.message.editMessageEmbeds(
+                RpsEmbeds.pickEmbed(
+                    initiatorDiscordId = updated.initiatorDiscordId,
+                    opponentDiscordId = updated.opponentDiscordId,
+                    stake = updated.stake,
+                    initiatorPicked = updated.picks.containsKey(updated.initiatorDiscordId),
+                    opponentPicked = updated.picks.containsKey(updated.opponentDiscordId),
+                )
+            ).queue()
+        }
+    }
+
+    private fun handleForfeit(
+        event: ButtonInteractionEvent,
+        requestingUserDto: UserDto,
+        parsed: RpsEmbeds.ParsedButtonId,
+    ) {
+        val live = rpsSessionRegistry.get(parsed.sessionId) ?: run {
+            ephemeralAlreadyResolved(event); return
+        }
+        if (requestingUserDto.discordId != live.initiatorDiscordId &&
+            requestingUserDto.discordId != live.opponentDiscordId
+        ) {
+            event.hook.sendMessage(
+                "This isn't your match to forfeit."
+            ).setEphemeral(true).queue()
+            return
+        }
+        // Forfeit = the other player wins by walkover. Atomically remove
+        // the session so the pick-timeout can't double-resolve.
+        val consumed = rpsSessionRegistry.forfeit(parsed.sessionId) ?: run {
+            ephemeralAlreadyResolved(event); return
+        }
+        // Strip the forfeiter's pick from the snapshot so the resolver
+        // sees them as "didn't pick" → opponent wins.
+        consumed.picks.remove(requestingUserDto.discordId)
+        resolveAndEdit(event, consumed)
+    }
+
+    private fun resolveAndEdit(event: ButtonInteractionEvent, session: RpsSessionRegistry.Session) {
+        val outcome = rpsService.resolveMatch(
+            initiatorDiscordId = session.initiatorDiscordId,
+            opponentDiscordId = session.opponentDiscordId,
+            guildId = session.guildId,
+            stake = session.stake,
+            initiatorChoice = session.picks[session.initiatorDiscordId],
+            opponentChoice = session.picks[session.opponentDiscordId],
+        )
+        val embed: MessageEmbed = when (outcome) {
+            is RpsService.ResolveOutcome.Win -> RpsEmbeds.winEmbed(outcome)
+            is RpsService.ResolveOutcome.Draw -> RpsEmbeds.drawEmbed(
+                outcome, session.initiatorDiscordId, session.opponentDiscordId,
+            )
+            is RpsService.ResolveOutcome.DoubleRefund -> RpsEmbeds.doubleRefundEmbed(
+                session.initiatorDiscordId, session.opponentDiscordId, outcome.stake,
+            )
+            else -> RpsEmbeds.acceptErrorEmbed("Couldn't resolve the match — both players' profiles must exist.")
+        }
+        runCatching {
+            event.message.editMessageEmbeds(embed)
+                .setComponents(emptyList<MessageTopLevelComponent>()).queue()
+        }
+    }
+
+    private fun ephemeralAlreadyResolved(event: ButtonInteractionEvent) {
+        event.hook.sendMessage("This match already resolved or expired.")
+            .setEphemeral(true).queue()
+    }
+
+    private fun describeAccept(outcome: RpsService.AcceptOutcome): String = when (outcome) {
+        is RpsService.AcceptOutcome.InitiatorInsufficient ->
+            "The challenger no longer has enough credits to cover the stake."
+        is RpsService.AcceptOutcome.OpponentInsufficient ->
+            "You no longer have enough credits (have ${outcome.have}, need ${outcome.needed})."
+        RpsService.AcceptOutcome.UnknownInitiator ->
+            "We couldn't find the challenger's profile."
+        RpsService.AcceptOutcome.UnknownOpponent ->
+            "We couldn't find your profile."
+        is RpsService.AcceptOutcome.Ok -> "" // never surfaced
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/RpsCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/RpsCommand.kt
@@ -1,0 +1,134 @@
+package bot.toby.command.commands.economy
+
+import bot.toby.helpers.UserDtoHelper
+import core.command.Command.Companion.replyEmbedAndDelete
+import core.command.CommandContext
+import database.dto.UserDto
+import database.rps.RpsSessionRegistry
+import database.service.RpsService
+import database.service.RpsService.StartOutcome
+import net.dv8tion.jda.api.components.MessageTopLevelComponent
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.interactions.commands.build.OptionData
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+/**
+ * `/rps user:<member> [stake:<int>]` — challenge another user to a
+ * round of Rock-Paper-Scissors. Optional wager: when `stake > 0` both
+ * players ante on accept and the winner takes the pot minus the
+ * per-guild jackpot tribute (same model as `/duel`). When `stake` is
+ * omitted or 0, the match is pure-fun and the winner only earns a
+ * small XP grant via [database.service.XpAwardService].
+ *
+ * The opponent's accept/decline + both players' pick clicks are
+ * handled by [bot.toby.button.buttons.RpsButton], which routes through
+ * [RpsSessionRegistry] (in-memory session state) and [RpsService]
+ * (wager arithmetic).
+ */
+@Component
+class RpsCommand @Autowired constructor(
+    private val rpsService: RpsService,
+    private val rpsSessionRegistry: RpsSessionRegistry,
+    private val userDtoHelper: UserDtoHelper,
+) : EconomyCommand {
+
+    override val name: String = "rps"
+    override val description: String =
+        "Challenge another user to Rock-Paper-Scissors. Stake is optional — leave it off for free play."
+
+    companion object {
+        private const val OPT_USER = "user"
+        private const val OPT_STAKE = "stake"
+    }
+
+    override val optionData: List<OptionData> = listOf(
+        OptionData(OptionType.USER, OPT_USER, "Opponent", true),
+        OptionData(
+            OptionType.INTEGER,
+            OPT_STAKE,
+            "Credits to wager each (optional; per-guild bounds; 0 = free play)",
+            false,
+        )
+            .setMinValue(0L),
+    )
+
+    override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        event.deferReply().queue()
+
+        val guild = event.guild ?: run {
+            replyError(event, "This command can only be used in a server.", deleteDelay); return
+        }
+        val targetUser = event.getOption(OPT_USER)?.asUser ?: run {
+            replyError(event, "You must specify an opponent.", deleteDelay); return
+        }
+        if (targetUser.isBot) {
+            replyError(event, "You can't challenge a bot.", deleteDelay); return
+        }
+        if (targetUser.idLong == requestingUserDto.discordId) {
+            replyError(event, "You can't challenge yourself.", deleteDelay); return
+        }
+        val stake = event.getOption(OPT_STAKE)?.asLong ?: 0L
+
+        // Lazy-create the opponent's user row so pre-flight balance check can read it.
+        userDtoHelper.calculateUserDto(targetUser.idLong, guild.idLong)
+
+        val start = rpsService.startMatch(
+            initiatorDiscordId = requestingUserDto.discordId,
+            opponentDiscordId = targetUser.idLong,
+            guildId = guild.idLong,
+            stake = stake,
+        )
+        if (start !is StartOutcome.Ok) {
+            event.hook.replyEmbedAndDelete(RpsEmbeds.startErrorEmbed(describe(start)), deleteDelay)
+            return
+        }
+
+        val initiatorId = requestingUserDto.discordId
+        val opponentId = targetUser.idLong
+        val session = rpsSessionRegistry.register(
+            guildId = guild.idLong,
+            initiatorDiscordId = initiatorId,
+            opponentDiscordId = opponentId,
+            stake = stake,
+        ) { expired ->
+            // Pending-phase timeout — nothing was ever debited so just
+            // edit the message in place. Best-effort: if the hook has
+            // already expired or the message is gone there's nothing
+            // useful to log.
+            runCatching {
+                event.hook.editOriginalEmbeds(
+                    RpsEmbeds.pendingTimeoutEmbed(expired.initiatorDiscordId, expired.opponentDiscordId)
+                ).setComponents(emptyList<MessageTopLevelComponent>()).queue()
+            }
+        }
+
+        event.hook.sendMessageEmbeds(RpsEmbeds.pendingEmbed(initiatorId, opponentId, stake))
+            .addContent("<@$opponentId>")
+            .addComponents(RpsEmbeds.pendingButtons(session.id, opponentId))
+            .queue()
+    }
+
+    private fun describe(outcome: StartOutcome): String = when (outcome) {
+        is StartOutcome.InvalidStake -> "Stake must be between ${outcome.min} and ${outcome.max} credits for this server."
+        is StartOutcome.InvalidOpponent -> when (outcome.reason) {
+            StartOutcome.InvalidOpponent.Reason.SELF -> "You can't challenge yourself."
+            StartOutcome.InvalidOpponent.Reason.BOT -> "You can't challenge a bot."
+        }
+        is StartOutcome.InitiatorInsufficient -> "You need ${outcome.needed} credits but only have ${outcome.have}."
+        is StartOutcome.OpponentInsufficient -> "Your opponent only has ${outcome.have} credits but the stake requires ${outcome.needed}."
+        StartOutcome.UnknownInitiator -> "We couldn't find your profile — try a credit-earning command first."
+        StartOutcome.UnknownOpponent -> "We couldn't find your opponent's profile — they need to be active in the server first."
+        is StartOutcome.Ok -> "" // never surfaced — Ok path doesn't render an error embed
+    }
+
+    private fun replyError(
+        event: SlashCommandInteractionEvent,
+        message: String,
+        deleteDelay: Int,
+    ) {
+        event.hook.replyEmbedAndDelete(RpsEmbeds.startErrorEmbed(message), deleteDelay)
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/RpsEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/RpsEmbeds.kt
@@ -1,0 +1,226 @@
+package bot.toby.command.commands.economy
+
+import database.rps.RpsEngine
+import database.service.RpsService
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.components.actionrow.ActionRow
+import net.dv8tion.jda.api.components.buttons.Button
+import net.dv8tion.jda.api.components.buttons.ButtonStyle
+import net.dv8tion.jda.api.entities.MessageEmbed
+
+/**
+ * Embed + button rendering for `/rps`.
+ *
+ * Component IDs are colon-delimited so [DefaultButtonManager] can route
+ * by the `"rps"` prefix and this object can parse the rest by index:
+ *
+ *   `rps:<action>:<sessionId>:<scopedDiscordId>`
+ *
+ * - `action`: ACCEPT / DECLINE during PENDING; PICK_ROCK / PICK_PAPER /
+ *   PICK_SCISSORS / FORFEIT during LIVE.
+ * - `scopedDiscordId`: the discord id of the *player whose button this
+ *   is*. ACCEPT/DECLINE belong to the opponent; PICK belongs to either
+ *   player (each player sees the same buttons but the handler routes
+ *   the click to the clicking user). FORFEIT belongs to either player.
+ *
+ * For PICK and FORFEIT buttons we don't actually need to encode the
+ * clicker in the id — the click event already carries the user — so
+ * we use `0` as a sentinel. Kept in the format for symmetry with the
+ * accept-side encoding so the parser is single-shape.
+ */
+object RpsEmbeds {
+
+    const val BUTTON_NAME = "rps"
+
+    enum class Action {
+        ACCEPT,
+        DECLINE,
+        PICK_ROCK,
+        PICK_PAPER,
+        PICK_SCISSORS,
+        FORFEIT,
+    }
+
+    data class ParsedButtonId(
+        val action: Action,
+        val sessionId: Long,
+        /** 0 when not used (PICK / FORFEIT actions). */
+        val scopedDiscordId: Long,
+    )
+
+    fun acceptButtonId(sessionId: Long, opponentDiscordId: Long): String =
+        encode(Action.ACCEPT, sessionId, opponentDiscordId)
+
+    fun declineButtonId(sessionId: Long, opponentDiscordId: Long): String =
+        encode(Action.DECLINE, sessionId, opponentDiscordId)
+
+    fun pickButtonId(sessionId: Long, choice: RpsEngine.Choice): String = encode(
+        when (choice) {
+            RpsEngine.Choice.ROCK -> Action.PICK_ROCK
+            RpsEngine.Choice.PAPER -> Action.PICK_PAPER
+            RpsEngine.Choice.SCISSORS -> Action.PICK_SCISSORS
+        },
+        sessionId, 0L,
+    )
+
+    fun forfeitButtonId(sessionId: Long): String = encode(Action.FORFEIT, sessionId, 0L)
+
+    private fun encode(action: Action, sessionId: Long, scopedDiscordId: Long): String =
+        listOf(BUTTON_NAME, action.name, sessionId.toString(), scopedDiscordId.toString())
+            .joinToString(":")
+
+    fun parseButtonId(componentId: String): ParsedButtonId? {
+        val parts = componentId.split(':')
+        if (parts.size != 4 || !parts[0].equals(BUTTON_NAME, ignoreCase = true)) return null
+        val action = runCatching { Action.valueOf(parts[1]) }.getOrNull() ?: return null
+        val sessionId = parts[2].toLongOrNull() ?: return null
+        val scopedDiscordId = parts[3].toLongOrNull() ?: return null
+        return ParsedButtonId(action, sessionId, scopedDiscordId)
+    }
+
+    /**
+     * Maps a PICK_* action onto the engine's [RpsEngine.Choice] value.
+     * Returns null for non-pick actions so the caller can branch.
+     */
+    fun choiceFor(action: Action): RpsEngine.Choice? = when (action) {
+        Action.PICK_ROCK -> RpsEngine.Choice.ROCK
+        Action.PICK_PAPER -> RpsEngine.Choice.PAPER
+        Action.PICK_SCISSORS -> RpsEngine.Choice.SCISSORS
+        else -> null
+    }
+
+    // ---- embeds ----
+
+    fun pendingEmbed(
+        initiatorDiscordId: Long,
+        opponentDiscordId: Long,
+        stake: Long,
+    ): MessageEmbed = EmbedBuilder()
+        .setTitle("✊ ✋ ✌️  Rock-Paper-Scissors")
+        .setDescription(
+            "<@${opponentDiscordId}> — <@${initiatorDiscordId}> has challenged you to RPS." +
+                stakeLine(stake) +
+                "\nAccept to start, or decline to walk away."
+        )
+        .setColor(0x5B8DEF)
+        .build()
+
+    fun pickEmbed(
+        initiatorDiscordId: Long,
+        opponentDiscordId: Long,
+        stake: Long,
+        initiatorPicked: Boolean,
+        opponentPicked: Boolean,
+    ): MessageEmbed = EmbedBuilder()
+        .setTitle("✊ ✋ ✌️  Make your pick")
+        .setDescription(
+            "<@${initiatorDiscordId}> vs <@${opponentDiscordId}>" +
+                stakeLine(stake) +
+                "\n\nClick one of the three moves below — your choice stays hidden until both players have picked." +
+                "\n\n" + pickStatus(initiatorDiscordId, opponentDiscordId, initiatorPicked, opponentPicked)
+        )
+        .setColor(0x5B8DEF)
+        .build()
+
+    fun winEmbed(outcome: RpsService.ResolveOutcome.Win): MessageEmbed = EmbedBuilder()
+        .setTitle("🏆 Rock-Paper-Scissors — <@${outcome.winnerDiscordId}> wins!")
+        .setDescription(
+            "<@${outcome.winnerDiscordId}> picked **${prettyChoice(outcome.winnerChoice)}**" +
+                ", <@${outcome.loserDiscordId}> picked **${prettyChoice(outcome.loserChoice)}**." +
+                if (outcome.pot > 0) {
+                    "\n\nPot: **${outcome.pot}** credits → " +
+                        "winner takes **${outcome.pot - outcome.lossTribute}** " +
+                        "(jackpot tribute: ${outcome.lossTribute})."
+                } else "" +
+                    if (outcome.xpGranted > 0) "\n+${outcome.xpGranted} XP for the winner." else ""
+        )
+        .setColor(0x57F287)
+        .build()
+
+    fun drawEmbed(outcome: RpsService.ResolveOutcome.Draw, initiatorDiscordId: Long, opponentDiscordId: Long): MessageEmbed = EmbedBuilder()
+        .setTitle("🤝 Rock-Paper-Scissors — draw!")
+        .setDescription(
+            "<@${initiatorDiscordId}> and <@${opponentDiscordId}> both picked **${prettyChoice(outcome.choice)}**." +
+                if (outcome.stake > 0) "\n\nStakes refunded to both players." else ""
+        )
+        .setColor(0xFEE75C)
+        .build()
+
+    fun doubleRefundEmbed(
+        initiatorDiscordId: Long,
+        opponentDiscordId: Long,
+        stake: Long,
+    ): MessageEmbed = EmbedBuilder()
+        .setTitle("⌛ Rock-Paper-Scissors — both timed out")
+        .setDescription(
+            "Neither <@${initiatorDiscordId}> nor <@${opponentDiscordId}> picked in time." +
+                if (stake > 0) "\n\nStakes refunded to both players." else ""
+        )
+        .setColor(0xED4245)
+        .build()
+
+    fun pendingDeclineEmbed(initiatorDiscordId: Long, opponentDiscordId: Long): MessageEmbed = EmbedBuilder()
+        .setTitle("❌ Challenge declined")
+        .setDescription("<@${opponentDiscordId}> declined <@${initiatorDiscordId}>'s RPS challenge.")
+        .setColor(0xED4245)
+        .build()
+
+    fun pendingTimeoutEmbed(initiatorDiscordId: Long, opponentDiscordId: Long): MessageEmbed = EmbedBuilder()
+        .setTitle("⌛ Challenge expired")
+        .setDescription("<@${opponentDiscordId}> didn't respond to <@${initiatorDiscordId}>'s RPS challenge.")
+        .setColor(0xED4245)
+        .build()
+
+    fun startErrorEmbed(message: String): MessageEmbed = EmbedBuilder()
+        .setTitle("❌ Can't start that match")
+        .setDescription(message)
+        .setColor(0xED4245)
+        .build()
+
+    fun acceptErrorEmbed(message: String): MessageEmbed = EmbedBuilder()
+        .setTitle("❌ Can't accept that match")
+        .setDescription(message)
+        .setColor(0xED4245)
+        .build()
+
+    // ---- button rows ----
+
+    fun pendingButtons(sessionId: Long, opponentDiscordId: Long): ActionRow = ActionRow.of(
+        Button.success(acceptButtonId(sessionId, opponentDiscordId), "Accept"),
+        Button.danger(declineButtonId(sessionId, opponentDiscordId), "Decline"),
+    )
+
+    fun pickButtons(sessionId: Long): List<ActionRow> = listOf(
+        ActionRow.of(
+            Button.primary(pickButtonId(sessionId, RpsEngine.Choice.ROCK), "Rock ✊"),
+            Button.primary(pickButtonId(sessionId, RpsEngine.Choice.PAPER), "Paper ✋"),
+            Button.primary(pickButtonId(sessionId, RpsEngine.Choice.SCISSORS), "Scissors ✌️"),
+        ),
+        ActionRow.of(
+            Button.of(ButtonStyle.SECONDARY, forfeitButtonId(sessionId), "Forfeit"),
+        ),
+    )
+
+    // ---- helpers ----
+
+    private fun stakeLine(stake: Long): String =
+        if (stake > 0L) "\nStake: **${stake}** credits each (winner takes the pot)." else ""
+
+    private fun pickStatus(
+        initiatorDiscordId: Long,
+        opponentDiscordId: Long,
+        initiatorPicked: Boolean,
+        opponentPicked: Boolean,
+    ): String = buildString {
+        append("<@${initiatorDiscordId}>: ")
+        append(if (initiatorPicked) "✅ picked" else "⏳ waiting")
+        append("\n<@${opponentDiscordId}>: ")
+        append(if (opponentPicked) "✅ picked" else "⏳ waiting")
+    }
+
+    fun prettyChoice(choice: RpsEngine.Choice): String = when (choice) {
+        RpsEngine.Choice.ROCK -> "Rock ✊"
+        RpsEngine.Choice.PAPER -> "Paper ✋"
+        RpsEngine.Choice.SCISSORS -> "Scissors ✌️"
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/handler/AchievementEventHandler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/handler/AchievementEventHandler.kt
@@ -18,6 +18,7 @@ import common.events.LotteryWonEvent
 import common.events.PlinkoJackpotEvent
 import common.events.PokerRoyalFlushEvent
 import common.events.RouletteStraightWinEvent
+import common.events.RpsResolvedEvent
 import common.events.ScratchJackpotEvent
 import common.events.SlotsJackpotEvent
 import common.events.StreakClaimedEvent
@@ -132,6 +133,31 @@ class AchievementEventHandler(
                 discordId = event.loserDiscordId,
                 guildId = event.guildId,
                 code = "duel_losses_$tier",
+                delta = 1L
+            )
+        }
+    }
+
+    @EventListener
+    fun onRpsResolved(event: RpsResolvedEvent) {
+        achievementService.unlock(
+            discordId = event.winnerDiscordId,
+            guildId = event.guildId,
+            code = "first_rps_win"
+        )
+        RPS_WIN_TIERS.forEach { tier ->
+            achievementService.progress(
+                discordId = event.winnerDiscordId,
+                guildId = event.guildId,
+                code = "rps_wins_$tier",
+                delta = 1L
+            )
+        }
+        RPS_LOSS_TIERS.forEach { tier ->
+            achievementService.progress(
+                discordId = event.loserDiscordId,
+                guildId = event.guildId,
+                code = "rps_losses_$tier",
                 delta = 1L
             )
         }
@@ -324,6 +350,8 @@ class AchievementEventHandler(
         private val LEVEL_MILESTONES = listOf(5, 25, 50, 75, 100)
         private val DUEL_WIN_TIERS = listOf(10, 25, 50, 100)
         private val DUEL_LOSS_TIERS = listOf(5, 25)
+        private val RPS_WIN_TIERS = listOf(10, 25)
+        private val RPS_LOSS_TIERS = listOf(5)
         private val LOTTERY_WIN_TIERS = listOf(3, 10, 25)
         private val BLACKJACK_NATURAL_TIERS = listOf(5, 25)
         private val TIP_SENT_TIERS = listOf(10, 50)

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/RpsButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/RpsButtonTest.kt
@@ -1,0 +1,256 @@
+package bot.toby.button.buttons
+
+import bot.toby.button.ButtonTest
+import bot.toby.button.ButtonTest.Companion.event
+import bot.toby.button.ButtonTest.Companion.mockGuild
+import bot.toby.button.ButtonTest.Companion.mockHook
+import bot.toby.button.DefaultButtonContext
+import bot.toby.command.commands.economy.RpsEmbeds
+import database.dto.UserDto
+import database.rps.RpsEngine
+import database.rps.RpsSessionRegistry
+import database.service.RpsService
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.components.MessageTopLevelComponent
+import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class RpsButtonTest : ButtonTest {
+
+    private lateinit var rpsService: RpsService
+    private lateinit var registry: RpsSessionRegistry
+    private lateinit var button: RpsButton
+
+    private val initiatorId = 1L
+    private val opponentId = 2L
+    private val guildId = 1L
+    private val stake = 50L
+    private val sessionId = 7L
+
+    private lateinit var message: Message
+
+    @BeforeEach
+    override fun setup() {
+        super.setup()
+        every { mockGuild.idLong } returns guildId
+
+        rpsService = mockk(relaxed = true)
+        registry = mockk(relaxed = true)
+        button = RpsButton(rpsService, registry)
+
+        message = mockk(relaxed = true)
+        every { event.message } returns message
+
+        // Wire the edit-message chain.
+        val edit = mockk<net.dv8tion.jda.api.requests.restaction.MessageEditAction>(relaxed = true)
+        every { message.editMessageEmbeds(any<MessageEmbed>()) } returns edit
+        every { edit.setComponents(any<Collection<MessageTopLevelComponent>>()) } returns edit
+        every { edit.setComponents(*anyVararg<MessageTopLevelComponent>()) } returns edit
+        every { edit.queue() } just Runs
+
+        // Hook send for ephemeral replies.
+        val send = mockk<WebhookMessageCreateAction<Message>>(relaxed = true)
+        every { mockHook.sendMessage(any<String>()) } returns send
+        every { send.setEphemeral(any()) } returns send
+        every { send.queue() } just Runs
+    }
+
+    @AfterEach
+    @Throws(Exception::class)
+    override fun tearDown() {
+        super.tearDown()
+    }
+
+    private fun pendingSession() = RpsSessionRegistry.Session(
+        id = sessionId, guildId = guildId,
+        initiatorDiscordId = initiatorId, opponentDiscordId = opponentId,
+        stake = stake, createdAt = Instant.now(),
+    )
+
+    private fun liveSession() = pendingSession().also { it.state = RpsSessionRegistry.Session.State.LIVE }
+
+    // ---- DECLINE ----
+
+    @Test
+    fun `non-opponent click on decline gets ephemeral reject`() {
+        every { event.componentId } returns RpsEmbeds.declineButtonId(sessionId, opponentId)
+
+        button.handle(DefaultButtonContext(event), UserDto(999L, guildId), 0)
+
+        verify(exactly = 0) { registry.decline(any()) }
+        verify { mockHook.sendMessage(any<String>()) }
+    }
+
+    @Test
+    fun `opponent decline removes the session and edits the message`() {
+        every { event.componentId } returns RpsEmbeds.declineButtonId(sessionId, opponentId)
+        every { registry.decline(sessionId) } returns pendingSession()
+
+        button.handle(DefaultButtonContext(event), UserDto(opponentId, guildId), 0)
+
+        verify(exactly = 1) { registry.decline(sessionId) }
+        verify(exactly = 1) { message.editMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    // ---- ACCEPT ----
+
+    @Test
+    fun `opponent accept transitions to LIVE and posts pick embed`() {
+        every { event.componentId } returns RpsEmbeds.acceptButtonId(sessionId, opponentId)
+        every { registry.accept(sessionId, any()) } returns liveSession()
+        every {
+            rpsService.acceptMatch(initiatorId, opponentId, guildId, stake)
+        } returns RpsService.AcceptOutcome.Ok(initiatorNewBalance = 100L, opponentNewBalance = 100L)
+
+        button.handle(DefaultButtonContext(event), UserDto(opponentId, guildId), 0)
+
+        verify(exactly = 1) { registry.accept(sessionId, any()) }
+        verify(exactly = 1) { rpsService.acceptMatch(initiatorId, opponentId, guildId, stake) }
+        verify(exactly = 1) { message.editMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `accept failure on insufficient balance tears down the live session`() {
+        every { event.componentId } returns RpsEmbeds.acceptButtonId(sessionId, opponentId)
+        every { registry.accept(sessionId, any()) } returns liveSession()
+        every {
+            rpsService.acceptMatch(initiatorId, opponentId, guildId, stake)
+        } returns RpsService.AcceptOutcome.OpponentInsufficient(have = 10L, needed = 50L)
+
+        button.handle(DefaultButtonContext(event), UserDto(opponentId, guildId), 0)
+
+        verify(exactly = 1) { registry.forfeit(sessionId) }
+        verify(exactly = 1) { message.editMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `accept on an already-resolved session sends ephemeral`() {
+        every { event.componentId } returns RpsEmbeds.acceptButtonId(sessionId, opponentId)
+        every { registry.accept(sessionId, any()) } returns null
+
+        button.handle(DefaultButtonContext(event), UserDto(opponentId, guildId), 0)
+
+        verify(exactly = 0) { rpsService.acceptMatch(any(), any(), any(), any()) }
+        verify { mockHook.sendMessage(any<String>()) }
+    }
+
+    // ---- PICK ----
+
+    @Test
+    fun `first pick re-renders pick embed with waiting status`() {
+        every { event.componentId } returns RpsEmbeds.pickButtonId(sessionId, RpsEngine.Choice.ROCK)
+        val live = liveSession()
+        every { registry.get(sessionId) } returns live
+        every { registry.recordPick(sessionId, initiatorId, RpsEngine.Choice.ROCK) } answers {
+            live.picks[initiatorId] = RpsEngine.Choice.ROCK
+            live
+        }
+
+        button.handle(DefaultButtonContext(event), UserDto(initiatorId, guildId), 0)
+
+        verify(exactly = 1) { registry.recordPick(sessionId, initiatorId, RpsEngine.Choice.ROCK) }
+        // bothPicked is false → no resolution call.
+        verify(exactly = 0) { rpsService.resolveMatch(any(), any(), any(), any(), any(), any()) }
+        // Pick embed re-rendered to update the waiting status.
+        verify(atLeast = 1) { message.editMessageEmbeds(any<MessageEmbed>()) }
+        // Ephemeral confirmation to the picker.
+        verify { mockHook.sendMessage(match<String> { it.contains("You picked") }) }
+    }
+
+    @Test
+    fun `second pick consumes the session and resolves`() {
+        every { event.componentId } returns RpsEmbeds.pickButtonId(sessionId, RpsEngine.Choice.SCISSORS)
+        val live = liveSession().also { it.picks[initiatorId] = RpsEngine.Choice.ROCK }
+        every { registry.get(sessionId) } returns live
+        every { registry.recordPick(sessionId, opponentId, RpsEngine.Choice.SCISSORS) } answers {
+            live.picks[opponentId] = RpsEngine.Choice.SCISSORS
+            live
+        }
+        every { registry.consumeForResolution(sessionId) } returns live
+        every {
+            rpsService.resolveMatch(initiatorId, opponentId, guildId, stake, RpsEngine.Choice.ROCK, RpsEngine.Choice.SCISSORS)
+        } returns RpsService.ResolveOutcome.Win(
+            winnerDiscordId = initiatorId, loserDiscordId = opponentId,
+            winnerChoice = RpsEngine.Choice.ROCK, loserChoice = RpsEngine.Choice.SCISSORS,
+            stake = stake, pot = 2 * stake,
+            winnerNewBalance = 150L, loserNewBalance = 50L,
+            lossTribute = 0L, xpGranted = 10L,
+        )
+
+        button.handle(DefaultButtonContext(event), UserDto(opponentId, guildId), 0)
+
+        verify(exactly = 1) { registry.consumeForResolution(sessionId) }
+        verify(exactly = 1) {
+            rpsService.resolveMatch(initiatorId, opponentId, guildId, stake, RpsEngine.Choice.ROCK, RpsEngine.Choice.SCISSORS)
+        }
+    }
+
+    @Test
+    fun `pick by a non-player is rejected ephemerally`() {
+        every { event.componentId } returns RpsEmbeds.pickButtonId(sessionId, RpsEngine.Choice.ROCK)
+        every { registry.get(sessionId) } returns liveSession()
+
+        button.handle(DefaultButtonContext(event), UserDto(999L, guildId), 0)
+
+        verify(exactly = 0) { registry.recordPick(any(), any(), any()) }
+        verify { mockHook.sendMessage(any<String>()) }
+    }
+
+    // ---- FORFEIT ----
+
+    @Test
+    fun `forfeit removes the session and resolves against the forfeiter`() {
+        every { event.componentId } returns RpsEmbeds.forfeitButtonId(sessionId)
+        val live = liveSession().also { it.picks[opponentId] = RpsEngine.Choice.ROCK }
+        every { registry.get(sessionId) } returns live
+        every { registry.forfeit(sessionId) } returns live
+        every {
+            rpsService.resolveMatch(initiatorId, opponentId, guildId, stake, null, RpsEngine.Choice.ROCK)
+        } returns RpsService.ResolveOutcome.Win(
+            winnerDiscordId = opponentId, loserDiscordId = initiatorId,
+            winnerChoice = RpsEngine.Choice.ROCK, loserChoice = RpsEngine.Choice.SCISSORS,
+            stake = stake, pot = 2 * stake,
+            winnerNewBalance = 250L, loserNewBalance = 0L,
+            lossTribute = 0L, xpGranted = 10L,
+        )
+
+        // Initiator clicks Forfeit; their pick (none) is dropped and the
+        // opponent's existing pick wins by walkover.
+        button.handle(DefaultButtonContext(event), UserDto(initiatorId, guildId), 0)
+
+        verify(exactly = 1) { registry.forfeit(sessionId) }
+        verify(exactly = 1) {
+            rpsService.resolveMatch(initiatorId, opponentId, guildId, stake, null, RpsEngine.Choice.ROCK)
+        }
+    }
+
+    @Test
+    fun `forfeit by a non-player is rejected`() {
+        every { event.componentId } returns RpsEmbeds.forfeitButtonId(sessionId)
+        every { registry.get(sessionId) } returns liveSession()
+
+        button.handle(DefaultButtonContext(event), UserDto(999L, guildId), 0)
+
+        verify(exactly = 0) { registry.forfeit(any()) }
+        verify { mockHook.sendMessage(any<String>()) }
+    }
+
+    @Test
+    fun `unparseable component id sends ephemeral`() {
+        every { event.componentId } returns "garbage"
+
+        button.handle(DefaultButtonContext(event), UserDto(initiatorId, guildId), 0)
+
+        verify(exactly = 0) { registry.get(any()) }
+        verify { mockHook.sendMessage(any<String>()) }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/RpsCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/RpsCommandTest.kt
@@ -1,0 +1,146 @@
+package bot.toby.command.commands.economy
+
+import bot.toby.command.CommandTest
+import bot.toby.command.CommandTest.Companion.event
+import bot.toby.command.CommandTest.Companion.guild
+import bot.toby.command.CommandTest.Companion.requestingUserDto
+import bot.toby.command.CommandTest.Companion.webhookMessageCreateAction
+import bot.toby.command.DefaultCommandContext
+import bot.toby.helpers.UserDtoHelper
+import database.dto.UserDto
+import database.rps.RpsSessionRegistry
+import database.service.RpsService
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.unmockkAll
+import io.mockk.verify
+import net.dv8tion.jda.api.components.actionrow.ActionRow
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.entities.User
+import net.dv8tion.jda.api.interactions.commands.OptionMapping
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class RpsCommandTest : CommandTest {
+
+    private lateinit var rpsService: RpsService
+    private lateinit var registry: RpsSessionRegistry
+    private lateinit var userDtoHelper: UserDtoHelper
+    private lateinit var command: RpsCommand
+
+    @BeforeEach
+    fun setUp() {
+        setUpCommonMocks()
+        rpsService = mockk(relaxed = true)
+        registry = mockk(relaxed = true)
+        userDtoHelper = mockk(relaxed = true)
+        command = RpsCommand(rpsService, registry, userDtoHelper)
+
+        every { guild.idLong } returns 100L
+        every { guild.id } returns "100"
+        every { requestingUserDto.discordId } returns 1L
+
+        // Happy-path defaults for outbound calls.
+        every { webhookMessageCreateAction.addContent(any()) } returns webhookMessageCreateAction
+        every { webhookMessageCreateAction.addComponents(any<ActionRow>()) } returns webhookMessageCreateAction
+        every { webhookMessageCreateAction.queue() } just runs
+        every { userDtoHelper.calculateUserDto(any(), any()) } returns mockk<UserDto>(relaxed = true)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        tearDownCommonMocks()
+        unmockkAll()
+    }
+
+    @Test
+    fun `happy path posts the pending embed with accept and decline buttons`() {
+        val opponent = stubOpponent(idLong = 2L, isBot = false)
+        every { event.getOption("user") } returns opponent
+        every { event.getOption("stake") } returns stakeOpt(50L)
+        every { rpsService.startMatch(1L, 2L, 100L, 50L) } returns RpsService.StartOutcome.Ok(initiatorBalance = 500L)
+        every { registry.register(100L, 1L, 2L, 50L, any(), any()) } returns RpsSessionRegistry.Session(
+            id = 7L, guildId = 100L, initiatorDiscordId = 1L,
+            opponentDiscordId = 2L, stake = 50L, createdAt = java.time.Instant.now(),
+        )
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 0)
+
+        verify(exactly = 1) { event.deferReply() }
+        verify(exactly = 1) { rpsService.startMatch(1L, 2L, 100L, 50L) }
+        verify(exactly = 1) { registry.register(100L, 1L, 2L, 50L, any(), any()) }
+        verify(exactly = 1) { event.hook.sendMessageEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 1) { webhookMessageCreateAction.addContent(match<String> { it.contains("<@2>") }) }
+        verify(exactly = 1) { webhookMessageCreateAction.addComponents(any<ActionRow>()) }
+    }
+
+    @Test
+    fun `free-play match (no stake option) starts with stake 0`() {
+        val opponent = stubOpponent(idLong = 2L, isBot = false)
+        every { event.getOption("user") } returns opponent
+        every { event.getOption("stake") } returns null
+        every { rpsService.startMatch(1L, 2L, 100L, 0L) } returns RpsService.StartOutcome.Ok(initiatorBalance = 100L)
+        every { registry.register(100L, 1L, 2L, 0L, any(), any()) } returns RpsSessionRegistry.Session(
+            id = 7L, guildId = 100L, initiatorDiscordId = 1L,
+            opponentDiscordId = 2L, stake = 0L, createdAt = java.time.Instant.now(),
+        )
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 0)
+
+        verify(exactly = 1) { rpsService.startMatch(1L, 2L, 100L, 0L) }
+    }
+
+    @Test
+    fun `bot opponent is rejected`() {
+        val botOpp = stubOpponent(idLong = 99L, isBot = true)
+        every { event.getOption("user") } returns botOpp
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 0)
+
+        verify(exactly = 0) { rpsService.startMatch(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `self-challenge is rejected before service is called`() {
+        val selfOpp = stubOpponent(idLong = 1L, isBot = false) // same as requesting user
+        every { event.getOption("user") } returns selfOpp
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 0)
+
+        verify(exactly = 0) { rpsService.startMatch(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `service-side preflight failure surfaces the start-error embed`() {
+        val opponent = stubOpponent(idLong = 2L, isBot = false)
+        every { event.getOption("user") } returns opponent
+        every { event.getOption("stake") } returns stakeOpt(50L)
+        every { rpsService.startMatch(1L, 2L, 100L, 50L) } returns
+            RpsService.StartOutcome.InitiatorInsufficient(have = 10L, needed = 50L)
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 0)
+
+        // No registry write, no game-style embed — just the error path.
+        verify(exactly = 0) { registry.register(any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 1) { event.hook.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    // ---- helpers ----
+
+    private fun stubOpponent(idLong: Long, isBot: Boolean): OptionMapping {
+        val user = mockk<User>(relaxed = true).also {
+            every { it.idLong } returns idLong
+            every { it.id } returns idLong.toString()
+            every { it.isBot } returns isBot
+            every { it.effectiveName } returns "Opponent-$idLong"
+        }
+        return mockk<OptionMapping>(relaxed = true).also { every { it.asUser } returns user }
+    }
+
+    private fun stakeOpt(value: Long): OptionMapping {
+        return mockk<OptionMapping>(relaxed = true).also { every { it.asLong } returns value }
+    }
+}

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -891,6 +891,15 @@ class ModerationWebService(
                 if (n < 1L) return "Value must be at least 1 credit."
                 n.toString()
             }
+            // RPS_MIN_STAKE allows 0 — `/rps` supports free play out of
+            // the box, the only wager game that does. Validated
+            // separately because the other min-stake keys require >= 1.
+            ConfigDto.Configurations.RPS_MIN_STAKE -> {
+                val n = rawValue.trim().toLongOrNull()
+                    ?: return "Value must be a whole number of credits."
+                if (n < 0L) return "Value must be zero (free play) or a positive number of credits."
+                n.toString()
+            }
             // Max-cap stake keys — accept 0 as "no upper cap"
             // (cfgLongMax expands stored 0 to Long.MAX_VALUE at read time).
             // Otherwise must be a positive whole number.
@@ -907,7 +916,8 @@ class ModerationWebService(
             ConfigDto.Configurations.DUEL_MAX_STAKE,
             ConfigDto.Configurations.PLINKO_MAX_STAKE,
             ConfigDto.Configurations.HORSE_RACING_MAX_STAKE,
-            ConfigDto.Configurations.WHEEL_OF_FORTUNE_MAX_STAKE -> {
+            ConfigDto.Configurations.WHEEL_OF_FORTUNE_MAX_STAKE,
+            ConfigDto.Configurations.RPS_MAX_STAKE -> {
                 val n = rawValue.trim().toLongOrNull()
                     ?: return "Value must be a whole number of credits."
                 if (n < 0L) return "Value must be 0 (unlimited) or a positive number of credits."

--- a/web/src/main/resources/templates/moderation/settings.html
+++ b/web/src/main/resources/templates/moderation/settings.html
@@ -913,6 +913,25 @@
                         <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                     </div>
                 </div>
+                <div class="config-group">
+                    <h4>Rock-Paper-Scissors</h4>
+                    <div class="config-row" data-key="RPS_MIN_STAKE">
+                        <label>Minimum stake (0 = free play allowed; default 0)</label>
+                        <input type="number" min="0"
+                               th:value="${overview.config['RPS_MIN_STAKE']}"
+                               placeholder="0"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="RPS_MAX_STAKE">
+                        <label>Maximum stake (0 = unlimited; default 500)</label>
+                        <input type="number" min="0"
+                               th:value="${overview.config['RPS_MAX_STAKE']}"
+                               placeholder="500"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                </div>
             </div>
         </details>
     </section>

--- a/web/src/test/kotlin/web/template/ModerationTemplateRowsTest.kt
+++ b/web/src/test/kotlin/web/template/ModerationTemplateRowsTest.kt
@@ -130,6 +130,8 @@ class ModerationTemplateRowsTest {
             ConfigDto.Configurations.HOLDEM_MAX_STAKE,
             ConfigDto.Configurations.DUEL_MIN_STAKE,
             ConfigDto.Configurations.DUEL_MAX_STAKE,
+            ConfigDto.Configurations.RPS_MIN_STAKE,
+            ConfigDto.Configurations.RPS_MAX_STAKE,
             ConfigDto.Configurations.BLACKJACK_MIN_ANTE,
             ConfigDto.Configurations.BLACKJACK_MAX_ANTE,
             ConfigDto.Configurations.POKER_SMALL_BLIND,


### PR DESCRIPTION
## Summary

First of the planned mini PvP games — Rock-Paper-Scissors as a 2-player challenge with hidden picks. Mirrors `/duel`'s offer + accept + resolve lifecycle but adds a pick-phase between accept and resolution:

```
  PENDING (no debit) → opponent Accept → LIVE (both debited)
                    ↘ Decline / timeout (no-op)

  LIVE → both pick     → resolve (winner credited pot − jackpot tribute)
       → one picks     → other forfeits (picker wins by walkover)
       → neither picks → DoubleRefund
```

Stake is optional — `/rps user:@bob` without a stake is pure-fun play. When `stake > 0`, both players ante on accept and the winner takes the pot minus the per-guild jackpot tribute (`JACKPOT_LOSS_TRIBUTE_PCT`). Winner always receives a small XP grant via `XpAwardService` regardless of stake, consistent with the engagement loop.

## Implementation

| File | Tests | Responsibility |
|---|---|---|
| `database/.../rps/RpsEngine.kt` | 5 | Pure 3×3 truth table |
| `database/.../rps/RpsSessionRegistry.kt` | 12 | In-memory `ConcurrentHashMap` + `AtomicLong` + two TTL timers (pending vs pick), atomic state transitions |
| `database/.../service/RpsService.kt` | 14 | Wager preflight / accept / resolve / refund — mirrors `DuelService` shape, adds picks-as-args resolve. **No JDA dependency** by design (the regression PR #551 taught us) |
| `discord-bot/.../command/.../economy/RpsCommand.kt` | 5 | `/rps user [stake]` slash command |
| `discord-bot/.../button/buttons/RpsButton.kt` | 11 | Routes Accept / Decline / Pick_* / Forfeit clicks via `DefaultButtonManager` prefix dispatch |
| `discord-bot/.../command/.../economy/RpsEmbeds.kt` | — | Button-id encoding + embed renderers for every state |

**47 new tests across 5 suites, all green.**

## Per-guild config

`RPS_MIN_STAKE` / `RPS_MAX_STAKE` in `ConfigDto`. `RPS_MIN_STAKE` accepts `0` (the only wager game that supports free play out of the box) — validated separately from the other min-stake keys which require `>= 1`. Both keys auto-surface in the moderation `settings.html` per the existing bidirectional `data-key` guard.

## Pre-empted CI

`RpsCommand` registered in `application/.../CommandManagerTest.kt` in the same commit — same hardcoded-list gotcha that broke PRs #546 and #548.

## Version

7.4-SNAPSHOT → 7.5-SNAPSHOT.

## What's deferred

TicTacToe and Connect 4 are planned as **separate follow-up PRs** once this validates the wager+button+session pattern end-to-end in production. (The original plan called for all three in one PR, but the recent #548 → #551 incident reminded me big PRs hide subtle wiring bugs; landing one game at a time is safer.)

## Test plan

- [x] `./gradlew :database:test :discord-bot:test --tests "*Rps*"` — 47 tests green
- [x] `./gradlew :web:test --tests "*ModerationTemplateRows*" --tests "*ModerationWebServiceTest"` — bidirectional template guard + base moderation tests still pass
- [ ] Manual: `/rps @opponent` no stake — opponent accepts, both pick, winner gets XP, message edits in place
- [ ] Manual: `/rps @opponent stake:50` — both debited on accept, winner credited 100 − tribute on resolve
- [ ] Manual: forfeit mid-pick — opponent wins by walkover, gets pot
- [ ] Manual: opponent ignores invite — pending TTL fires, message edits to "Challenge expired"

https://claude.ai/code/session_017tRi5q6K3NYHvYeZYzLzBD

---
_Generated by [Claude Code](https://claude.ai/code/session_017tRi5q6K3NYHvYeZYzLzBD)_