### PR TITLE
refactor(duel): back PendingDuelRegistry + RecentDuelResolutions with Caffeine

### DIFF
--- a/database/src/main/kotlin/database/duel/PendingDuelRegistry.kt
+++ b/database/src/main/kotlin/database/duel/PendingDuelRegistry.kt
@@ -1,10 +1,12 @@
 package database.duel
 
+import com.github.benmanes.caffeine.cache.Cache
+import com.github.benmanes.caffeine.cache.Caffeine
 import database.configuration.RegistryScheduler
 import org.springframework.stereotype.Component
 import java.time.Duration
 import java.time.Instant
-import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentMap
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
@@ -18,11 +20,24 @@ import java.util.concurrent.atomic.AtomicLong
  *
  * Mid-flight offers are lost on bot restart. Acceptable since the TTL
  * is short and offers don't move credits until accepted.
+ *
+ * **Storage**: backed by a Caffeine [Cache] via `asMap()` so we get a
+ * hard upper bound on concurrent offers ([MAX_OFFERS]) and a TTL
+ * backstop ([MAX_LIFETIME]) for entries the scheduler somehow misses.
+ * Matches the convention used by `MessageChatListener.lastAwardAt` and
+ * the SSE registry — belt-and-suspenders memory protection beyond the
+ * scheduler-driven [onTimeout] callbacks. The scheduler remains the
+ * primary mechanism because the callback closes over JDA message-edit
+ * state Caffeine's removalListener can't reach; the cache TTL is the
+ * leak guard if a scheduled task throws or the executor queue
+ * saturates.
  */
 @Component
 class PendingDuelRegistry(
     val ttl: Duration = DEFAULT_TTL,
-    private val scheduler: ScheduledExecutorService = RegistryScheduler.instance
+    private val scheduler: ScheduledExecutorService = RegistryScheduler.instance,
+    maximumOffers: Long = MAX_OFFERS,
+    maxLifetime: Duration = MAX_LIFETIME,
 ) {
     data class PendingDuel(
         val id: Long,
@@ -33,7 +48,17 @@ class PendingDuelRegistry(
         val createdAt: Instant
     )
 
-    private val offers = ConcurrentHashMap<Long, PendingDuel>()
+    /**
+     * Caffeine cache + `asMap()` view. Every read/write below uses
+     * [offers] (the ConcurrentMap view) for atomic primitives; [cache]
+     * is kept only so the `expireAfterWrite` / `maximumSize`
+     * configuration stays in scope.
+     */
+    private val cache: Cache<Long, PendingDuel> = Caffeine.newBuilder()
+        .expireAfterWrite(maxLifetime)
+        .maximumSize(maximumOffers)
+        .build()
+    private val offers: ConcurrentMap<Long, PendingDuel> = cache.asMap()
     private val seq = AtomicLong()
 
     /**
@@ -88,6 +113,22 @@ class PendingDuelRegistry(
 
     companion object {
         val DEFAULT_TTL: Duration = Duration.ofMinutes(3)
+
+        /**
+         * Hard upper bound on concurrent in-flight offers. Generous
+         * enough that a server-wide tournament doesn't trip it, low
+         * enough that a malformed `/duel` flood can't OOM the heap.
+         * Caffeine evicts least-recently-used entries above the cap.
+         */
+        const val MAX_OFFERS: Long = 10_000L
+
+        /**
+         * Backstop lifetime for any single offer: default pending TTL
+         * (3m) + 1m slop = 4 minutes. Caffeine evicts past this even
+         * if the scheduler-driven timeout somehow didn't run; protects
+         * memory if a scheduled task throws or the executor saturates.
+         */
+        val MAX_LIFETIME: Duration = Duration.ofMinutes(4)
 
         /** "3m" / "90s" / "1h 5m" — short-form TTL display for embed copy and web UI. */
         fun formatTtl(ttl: Duration): String {

--- a/database/src/main/kotlin/database/duel/RecentDuelResolutions.kt
+++ b/database/src/main/kotlin/database/duel/RecentDuelResolutions.kt
@@ -1,10 +1,12 @@
 package database.duel
 
+import com.github.benmanes.caffeine.cache.Cache
+import com.github.benmanes.caffeine.cache.Caffeine
 import database.configuration.RegistryScheduler
 import org.springframework.stereotype.Component
 import java.time.Duration
 import java.time.Instant
-import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentMap
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
@@ -25,11 +27,19 @@ import java.util.concurrent.atomic.AtomicLong
  * In-memory only — like [PendingDuelRegistry]. A bot restart between
  * resolve and poll just means the animation doesn't play; balances
  * are already authoritative in the DB.
+ *
+ * **Storage**: backed by a Caffeine [Cache] via `asMap()`. Bounds
+ * concurrent retained resolutions at [MAX_ENTRIES] and adds a TTL
+ * backstop ([MAX_LIFETIME]) for entries that the scheduler-driven
+ * eviction somehow misses. Same belt-and-suspenders pattern as
+ * `RpsSessionRegistry` and `PendingDuelRegistry`.
  */
 @Component
 class RecentDuelResolutions(
     val ttl: Duration = DEFAULT_TTL,
     private val scheduler: ScheduledExecutorService = RegistryScheduler.instance,
+    maximumEntries: Long = MAX_ENTRIES,
+    maxLifetime: Duration = MAX_LIFETIME,
 ) {
     data class Resolution(
         val guildId: Long,
@@ -43,7 +53,11 @@ class RecentDuelResolutions(
         val resolvedAt: Instant,
     )
 
-    private val entries = ConcurrentHashMap<Long, Resolution>()
+    private val cache: Cache<Long, Resolution> = Caffeine.newBuilder()
+        .expireAfterWrite(maxLifetime)
+        .maximumSize(maximumEntries)
+        .build()
+    private val entries: ConcurrentMap<Long, Resolution> = cache.asMap()
     private val seq = AtomicLong()
 
     /** Store a resolution and schedule its eviction at `now + ttl`. */
@@ -72,5 +86,20 @@ class RecentDuelResolutions(
 
     companion object {
         val DEFAULT_TTL: Duration = Duration.ofSeconds(30)
+
+        /**
+         * Hard upper bound on concurrent retained resolutions. A 30s
+         * TTL × any plausible duel-resolution rate fits well under this
+         * — the cap is purely a malformed-flood guard, not a normal-
+         * traffic limit.
+         */
+        const val MAX_ENTRIES: Long = 10_000L
+
+        /**
+         * Backstop lifetime: default TTL (30s) + 30s slop = 1 minute.
+         * Caffeine evicts past this even if the scheduler's
+         * `entries.remove(id)` didn't fire.
+         */
+        val MAX_LIFETIME: Duration = Duration.ofMinutes(1)
     }
 }

--- a/database/src/test/kotlin/database/duel/PendingDuelRegistryTest.kt
+++ b/database/src/test/kotlin/database/duel/PendingDuelRegistryTest.kt
@@ -111,4 +111,26 @@ class PendingDuelRegistryTest {
         assertEquals("1m 30s", PendingDuelRegistry.formatTtl(Duration.ofSeconds(90)))
         assertEquals("1h 5m", PendingDuelRegistry.formatTtl(Duration.ofMinutes(65)))
     }
+
+    @Test
+    fun `Caffeine maximumSize cap evicts oldest entries to keep memory bounded`() {
+        // Belt-and-suspenders memory protection: even with a flood of
+        // /duel invocations the registry caps at maximumOffers. Pin
+        // the behaviour with a low cap so an accidental regression
+        // back to ConcurrentHashMap surfaces immediately.
+        val registry = PendingDuelRegistry(
+            ttl = Duration.ofSeconds(60),
+            scheduler = scheduler,
+            maximumOffers = 3L,
+        )
+        val ids = (1..10).map {
+            registry.register(guildId = 1L, initiatorDiscordId = 10L + it, opponentDiscordId = 20L + it, stake = 50L).id
+        }
+        // Caffeine performs eviction asynchronously; nudge it with a
+        // synchronous read so cleanup completes before we assert.
+        ids.forEach { registry.get(it) }
+        Thread.sleep(50)
+        val surviving = ids.count { registry.get(it) != null }
+        assertTrue(surviving <= 3, "expected at most 3 survivors with maximumOffers=3, got $surviving")
+    }
 }

--- a/database/src/test/kotlin/database/duel/RecentDuelResolutionsTest.kt
+++ b/database/src/test/kotlin/database/duel/RecentDuelResolutionsTest.kt
@@ -151,4 +151,24 @@ class RecentDuelResolutionsTest {
         capturedTasks[0].run()
         assertTrue(cache.consumeForInitiator(initiator, guildId).isEmpty())
     }
+
+    @Test
+    fun `Caffeine maximumSize cap evicts oldest entries to keep memory bounded`() {
+        // Belt-and-suspenders memory protection: even if a malformed
+        // surge of resolutions never gets consumed, the cache caps
+        // total retained entries. Pin the behaviour with a low cap so
+        // an accidental regression to ConcurrentHashMap surfaces.
+        val cache = RecentDuelResolutions(
+            ttl = Duration.ofSeconds(60),
+            scheduler = scheduler,
+            maximumEntries = 3L,
+        )
+        repeat(10) { cache.record(sample()) }
+        // Caffeine performs eviction asynchronously; force a read
+        // through to flush pending eviction work.
+        cache.consumeForInitiator(initiator + 9999L, guildId)
+        Thread.sleep(50)
+        val surviving = cache.consumeForInitiator(initiator, guildId)
+        assertTrue(surviving.size <= 3, "expected at most 3 survivors with maximumEntries=3, got ${surviving.size}")
+    }
 }


### PR DESCRIPTION
## Summary

Brings the two duel-area in-memory registries onto the same belt-and-suspenders memory protection that `RpsSessionRegistry` got in #553's review pass. Both `PendingDuelRegistry` and `RecentDuelResolutions` used raw `ConcurrentHashMap + ScheduledExecutorService` — fine on the happy path but no upper bound on heap and no backstop if a scheduled task throws or the executor queue saturates.

## Changes

Same minimal-impact migration as the RPS one:

- Storage swaps from `ConcurrentHashMap` to `Caffeine.asMap()` — same `ConcurrentMap` API, every existing atomic op (`remove`, `get`, `values`) keeps working.
- **`maximumSize = 10_000`** caps both registries against a malformed `/duel`-flood OOM. Matches the convention used by `MessageChatListener.lastAwardAt` and `KeyedSseRegistry`.
- **`expireAfterWrite` backstop** per registry:
  - `PendingDuelRegistry`: 4 minutes (pending TTL 3m + 1m slop)
  - `RecentDuelResolutions`: 1 minute (TTL 30s + 30s slop)
- The scheduler-driven callbacks stay the primary mechanism (they close over JDA message-edit state Caffeine's `removalListener` can't reach). The cache TTL is the leak guard only.

`caffeine` is already on `database/build.gradle` — #553 added it. No new dependencies.

## Tests

- Each registry's existing 8 tests still pass against Caffeine-backed storage (no behaviour change at the API surface).
- One new test per class (`Caffeine maximumSize cap evicts oldest entries to keep memory bounded`) pins the cap behaviour at `maximumOffers=3` / `maximumEntries=3` so a silent revert to `ConcurrentHashMap` or a typo zeroing the cap fails CI. Matches the regression test pattern added to `RpsSessionRegistryTest`.

`./gradlew :database:test --tests "*Duel*"` — 9 + 9 + every dependent suite green.

## Test plan
- [x] Existing `PendingDuelRegistryTest` (9 tests, +1 new)
- [x] Existing `RecentDuelResolutionsTest` (9 tests, +1 new)
- [x] Dependent `DuelService` / `DuelButton` / `DuelCommand` tests still pass
- [ ] Production verification — invite the bot, run `/duel @opponent 50`, opponent accepts, balance settles. Same flow as today; this PR is purely a storage swap.

https://claude.ai/code/session_017tRi5q6K3NYHvYeZYzLzBD

---
_Generated by [Claude Code](https://claude.ai/code/session_017tRi5q6K3NYHvYeZYzLzBD)_