### PR TITLE
feat(tictactoe): /tictactoe slash command with optional social-credit wager

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: java -Xms128m -Xmx224m -XX:+UseSerialGC -XX:MaxMetaspaceSize=192m -XX:ReservedCodeCacheSize=48m -XX:MaxDirectMemorySize=48m -Dio.netty.maxDirectMemory=0 -Dio.netty.allocator.numDirectArenas=2 -Dio.netty.allocator.numHeapArenas=2 -Xss256k -XX:+ExitOnOutOfMemoryError -Dserver.port=$PORT -jar application/build/libs/application-7.5-SNAPSHOT.jar
+web: java -Xms128m -Xmx224m -XX:+UseSerialGC -XX:MaxMetaspaceSize=192m -XX:ReservedCodeCacheSize=48m -XX:MaxDirectMemorySize=48m -Dio.netty.maxDirectMemory=0 -Dio.netty.allocator.numDirectArenas=2 -Dio.netty.allocator.numHeapArenas=2 -Xss256k -XX:+ExitOnOutOfMemoryError -Dserver.port=$PORT -jar application/build/libs/application-7.6-SNAPSHOT.jar
 release: ./bin/trigger_publish_wiki.sh  # This runs after deployment

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Ensure you have the following prerequisites set up before getting started:
 4. Start the bot:
 
    ```shell
-   java -jar application/build/libs/application-7.5-SNAPSHOT.jar -Dspring.profiles.active=prod
+   java -jar application/build/libs/application-7.6-SNAPSHOT.jar -Dspring.profiles.active=prod
    ```
 
 ## Running with Docker

--- a/application/src/test/kotlin/integration/bot/ButtonManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/ButtonManagerTest.kt
@@ -93,6 +93,7 @@ class ButtonManagerTest {
             TeamCancelButton::class.java,
             TeamConfirmButton::class.java,
             TeamRerollButton::class.java,
+            TicTacToeButton::class.java,
             InstallExpressButton::class.java,
             InstallCustomButton::class.java,
             InstallSkipButton::class.java,

--- a/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
@@ -21,6 +21,7 @@ import bot.toby.command.commands.economy.RouletteCommand
 import bot.toby.command.commands.economy.RpsCommand
 import bot.toby.command.commands.economy.ScratchCommand
 import bot.toby.command.commands.economy.SlotsCommand
+import bot.toby.command.commands.economy.TicTacToeCommand
 import bot.toby.command.commands.economy.TipCommand
 import bot.toby.command.commands.economy.TitleCommand
 import bot.toby.command.commands.economy.TobyCoinCommand
@@ -167,6 +168,7 @@ class CommandManagerTest {
             WelcomeCommand::class.java,
             ProfileCommand::class.java,
             RpsCommand::class.java,
+            TicTacToeCommand::class.java,
         )
 
         Assertions.assertTrue(availableCommands.containsAll(commandManager.allCommands.map { it.javaClass }.toList()))

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ apply plugin: 'kotlin'
 
 allprojects {
     group = "com.github.ml404"
-    version = "7.5-SNAPSHOT"
+    version = "7.6-SNAPSHOT"
 
     ext['kotlin.version'] = kotlin_version
     // Override Spring Boot 3.3.4's BOM-managed versions with patched releases.

--- a/common/src/main/kotlin/common/events/TicTacToeResolvedEvent.kt
+++ b/common/src/main/kotlin/common/events/TicTacToeResolvedEvent.kt
@@ -1,0 +1,22 @@
+package common.events
+
+/**
+ * Fact emitted by `TicTacToeService` when a Tic-Tac-Toe match resolves
+ * to a winner — either someone lined up three in a row or one player
+ * forfeited / timed out and the other took the walkover. Draws do NOT
+ * publish (no winner to credit, no loser to penalise).
+ *
+ * Mirrors [RpsResolvedEvent]'s shape so the PvP mini-games look the
+ * same to downstream handlers (achievements).
+ *
+ * `pot` is `2 * stake - lossTribute` for wager matches; `0` for
+ * free-play matches. Free-play wins still fire so `first_tictactoe_win`
+ * unlocks regardless of whether anyone bet.
+ */
+data class TicTacToeResolvedEvent(
+    val winnerDiscordId: Long,
+    val loserDiscordId: Long,
+    val guildId: Long,
+    val stake: Long,
+    val pot: Long,
+)

--- a/common/src/main/kotlin/common/tictactoe/TicTacToeEngine.kt
+++ b/common/src/main/kotlin/common/tictactoe/TicTacToeEngine.kt
@@ -1,0 +1,101 @@
+package common.tictactoe
+
+/**
+ * Pure logic for 3×3 Tic-Tac-Toe outcomes. No JDA / Spring / DB —
+ * tested as plain functions so the game rules can't drift.
+ *
+ * Cells are indexed 0..8 row-major:
+ * ```
+ *   0 | 1 | 2
+ *  ---+---+---
+ *   3 | 4 | 5
+ *  ---+---+---
+ *   6 | 7 | 8
+ * ```
+ *
+ * Marks (`X` / `O`) are abstract — the calling service maps each
+ * Discord id onto a Mark so the engine never has to know about Discord.
+ */
+object TicTacToeEngine {
+
+    enum class Mark { X, O }
+
+    /**
+     * Immutable 9-cell board. `cells[i]` is the mark at cell `i`, or
+     * `null` if empty. Use [empty] to build a fresh game; never
+     * construct from arbitrary input the engine didn't produce.
+     */
+    data class Board(val cells: List<Mark?> = List(CELL_COUNT) { null }) {
+        init { require(cells.size == CELL_COUNT) { "Board must have exactly $CELL_COUNT cells" } }
+        val isFull: Boolean get() = cells.all { it != null }
+        operator fun get(cell: Int): Mark? = cells[cell]
+    }
+
+    /** Outcome of a single [applyMove] call. */
+    sealed interface MoveResult {
+        /** `cell` was outside the valid 0..8 range. */
+        data object IllegalCell : MoveResult
+
+        /** `cell` was already occupied. */
+        data object Occupied : MoveResult
+
+        /** Move accepted, game continues — next player to act. */
+        data class Continued(val board: Board) : MoveResult
+
+        /**
+         * Move accepted and completed a three-in-a-row. [winningLine] is
+         * the three cell indices that line up so the renderer can
+         * highlight them.
+         */
+        data class Win(val board: Board, val winner: Mark, val winningLine: List<Int>) : MoveResult
+
+        /** Move accepted, board is full, no winner. */
+        data class Draw(val board: Board) : MoveResult
+    }
+
+    /** A fresh empty board. */
+    fun empty(): Board = Board()
+
+    /**
+     * Place [mark] at [cell] on [board]. Returns one of:
+     *   - [MoveResult.IllegalCell] / [MoveResult.Occupied] when the move
+     *     is rejected — board is unchanged
+     *   - [MoveResult.Continued] when the move lands and the game
+     *     continues
+     *   - [MoveResult.Win] when the move completes a three-in-a-row
+     *   - [MoveResult.Draw] when the move fills the last empty cell
+     *     without lining up
+     *
+     * The engine does NOT track whose turn it is — the caller is
+     * responsible for alternating marks. This keeps the engine
+     * stateless and trivially testable.
+     */
+    fun applyMove(board: Board, cell: Int, mark: Mark): MoveResult {
+        if (cell !in 0 until CELL_COUNT) return MoveResult.IllegalCell
+        if (board[cell] != null) return MoveResult.Occupied
+        val next = Board(board.cells.toMutableList().also { it[cell] = mark })
+        winningLineFor(next, mark)?.let { return MoveResult.Win(next, mark, it) }
+        return if (next.isFull) MoveResult.Draw(next) else MoveResult.Continued(next)
+    }
+
+    /**
+     * Returns the three-in-a-row line for [mark] if there is one, else
+     * `null`. Public for tests / renderers that want to find a winning
+     * line without applying a move.
+     */
+    fun winningLineFor(board: Board, mark: Mark): List<Int>? {
+        for (line in LINES) {
+            if (board[line[0]] == mark && board[line[1]] == mark && board[line[2]] == mark) return line
+        }
+        return null
+    }
+
+    const val CELL_COUNT: Int = 9
+
+    /** The 8 winning lines: 3 rows, 3 columns, 2 diagonals. */
+    val LINES: List<List<Int>> = listOf(
+        listOf(0, 1, 2), listOf(3, 4, 5), listOf(6, 7, 8),
+        listOf(0, 3, 6), listOf(1, 4, 7), listOf(2, 5, 8),
+        listOf(0, 4, 8), listOf(2, 4, 6),
+    )
+}

--- a/common/src/test/kotlin/common/tictactoe/TicTacToeEngineTest.kt
+++ b/common/src/test/kotlin/common/tictactoe/TicTacToeEngineTest.kt
@@ -1,0 +1,154 @@
+package common.tictactoe
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Truth table for [TicTacToeEngine]. Pure-function unit tests — no
+ * mocks. Pins the 8 winning lines, draw detection, illegal moves, and
+ * the "engine is stateless about turn order" property.
+ */
+class TicTacToeEngineTest {
+
+    private val X = TicTacToeEngine.Mark.X
+    private val O = TicTacToeEngine.Mark.O
+
+    @Test
+    fun `empty board has no marks and is not full`() {
+        val b = TicTacToeEngine.empty()
+        assertTrue(b.cells.all { it == null })
+        assertEquals(false, b.isFull)
+    }
+
+    @Test
+    fun `applyMove rejects out-of-range cells`() {
+        val b = TicTacToeEngine.empty()
+        assertEquals(TicTacToeEngine.MoveResult.IllegalCell, TicTacToeEngine.applyMove(b, -1, X))
+        assertEquals(TicTacToeEngine.MoveResult.IllegalCell, TicTacToeEngine.applyMove(b, 9, X))
+        assertEquals(TicTacToeEngine.MoveResult.IllegalCell, TicTacToeEngine.applyMove(b, 100, X))
+    }
+
+    @Test
+    fun `applyMove rejects occupied cells regardless of mark`() {
+        val first = (TicTacToeEngine.applyMove(TicTacToeEngine.empty(), 4, X)
+            as TicTacToeEngine.MoveResult.Continued).board
+        assertEquals(TicTacToeEngine.MoveResult.Occupied, TicTacToeEngine.applyMove(first, 4, X))
+        assertEquals(TicTacToeEngine.MoveResult.Occupied, TicTacToeEngine.applyMove(first, 4, O))
+    }
+
+    @Test
+    fun `single move continues with the mark placed`() {
+        val r = TicTacToeEngine.applyMove(TicTacToeEngine.empty(), 0, X)
+        val cont = r as TicTacToeEngine.MoveResult.Continued
+        assertEquals(X, cont.board[0])
+        assertEquals(null, cont.board[1])
+    }
+
+    @Test
+    fun `top row wins for X`() {
+        val b = TicTacToeEngine.applyMove(TicTacToeEngine.empty(), 0, X)
+            .let { (it as TicTacToeEngine.MoveResult.Continued).board }
+        val b2 = TicTacToeEngine.applyMove(b, 1, X)
+            .let { (it as TicTacToeEngine.MoveResult.Continued).board }
+        val r = TicTacToeEngine.applyMove(b2, 2, X)
+        val win = r as TicTacToeEngine.MoveResult.Win
+        assertEquals(X, win.winner)
+        assertEquals(listOf(0, 1, 2), win.winningLine)
+    }
+
+    @Test
+    fun `every winning line is detected for both marks`() {
+        // 8 lines × 2 marks = 16 cases. Build a board where exactly the
+        // given line is filled with the given mark and confirm engine
+        // detects it.
+        for (line in TicTacToeEngine.LINES) {
+            for (mark in TicTacToeEngine.Mark.entries) {
+                val cells = MutableList<TicTacToeEngine.Mark?>(9) { null }
+                cells[line[0]] = mark
+                cells[line[1]] = mark
+                val board = TicTacToeEngine.Board(cells)
+                val r = TicTacToeEngine.applyMove(board, line[2], mark)
+                val win = r as TicTacToeEngine.MoveResult.Win
+                assertEquals(mark, win.winner, "expected $mark to win on line $line")
+                assertEquals(line, win.winningLine, "expected winning line $line")
+            }
+        }
+    }
+
+    @Test
+    fun `draw fires when board fills with no line`() {
+        // Sequence yields a full board with no 3-in-a-row:
+        //   X O X
+        //   X O O
+        //   O X X
+        val moves = listOf(
+            0 to X, 1 to O, 2 to X,
+            3 to X, 4 to O, 5 to O,
+            7 to X, 8 to X, /* last move below */
+        )
+        var board = TicTacToeEngine.empty()
+        for ((cell, mark) in moves) {
+            val r = TicTacToeEngine.applyMove(board, cell, mark)
+            board = (r as TicTacToeEngine.MoveResult.Continued).board
+        }
+        // Final cell — must not complete a line (the only remaining
+        // cell is 6 and the only line through 6 that's filled with O is
+        // 6,4,2 which would need O at 6, but we play O at 6 so check
+        // separately).
+        val final = TicTacToeEngine.applyMove(board, 6, O)
+        // Cell 6 with O completes diagonal 6,4,2? cells 4=O, 2=X — no.
+        // It completes column 6,3,0? 3=X, 0=X — no.
+        // It completes row 6,7,8? 7=X, 8=X — no.
+        // So it's a draw.
+        assertTrue(final is TicTacToeEngine.MoveResult.Draw, "expected Draw, got $final")
+    }
+
+    @Test
+    fun `engine doesn't enforce turn order — caller is responsible`() {
+        // Two X moves in a row are accepted; the engine is intentionally
+        // stateless about whose turn it is.
+        val first = TicTacToeEngine.applyMove(TicTacToeEngine.empty(), 0, X)
+            .let { (it as TicTacToeEngine.MoveResult.Continued).board }
+        val second = TicTacToeEngine.applyMove(first, 1, X)
+        assertTrue(second is TicTacToeEngine.MoveResult.Continued)
+    }
+
+    @Test
+    fun `winningLineFor returns null on empty board`() {
+        assertNull(TicTacToeEngine.winningLineFor(TicTacToeEngine.empty(), X))
+        assertNull(TicTacToeEngine.winningLineFor(TicTacToeEngine.empty(), O))
+    }
+
+    @Test
+    fun `winningLineFor finds a completed line without applying a move`() {
+        val cells = MutableList<TicTacToeEngine.Mark?>(9) { null }
+        cells[0] = X; cells[4] = X; cells[8] = X
+        val board = TicTacToeEngine.Board(cells)
+        assertEquals(listOf(0, 4, 8), TicTacToeEngine.winningLineFor(board, X))
+        assertNull(TicTacToeEngine.winningLineFor(board, O))
+    }
+
+    @Test
+    fun `Board constructor rejects wrong-size lists`() {
+        try {
+            TicTacToeEngine.Board(List(8) { null })
+            assert(false) { "expected IllegalArgumentException" }
+        } catch (_: IllegalArgumentException) { /* expected */ }
+    }
+
+    @Test
+    fun `Win result carries the moved board state`() {
+        // Confirm the Win.board reflects the placed mark, not the
+        // pre-move board. Otherwise the renderer would highlight a
+        // board that doesn't have the winning move on it.
+        val cells = MutableList<TicTacToeEngine.Mark?>(9) { null }
+        cells[0] = X; cells[1] = X
+        val board = TicTacToeEngine.Board(cells)
+        val win = TicTacToeEngine.applyMove(board, 2, X) as TicTacToeEngine.MoveResult.Win
+        assertEquals(X, win.board[2])
+        assertNotNull(win.board[0])
+    }
+}

--- a/database/src/main/kotlin/database/achievement/AchievementCatalog.kt
+++ b/database/src/main/kotlin/database/achievement/AchievementCatalog.kt
@@ -429,6 +429,49 @@ object AchievementCatalog {
             threshold = 5
         ),
 
+        // Tic-Tac-Toe — same shape as the RPS achievements above.
+        // Triggered by `TicTacToeResolvedEvent`; published on every
+        // winner-bearing match (free play included), skipped on draw.
+        AchievementSpec(
+            code = "first_tictactoe_win",
+            name = "Three in a Row",
+            description = "Win your first Tic-Tac-Toe match.",
+            category = "casino",
+            icon = "❌",
+            xpReward = 50,
+            creditReward = 50
+        ),
+        AchievementSpec(
+            code = "tictactoe_wins_10",
+            name = "Grid Tactician",
+            description = "Win 10 Tic-Tac-Toe matches.",
+            category = "casino",
+            icon = "⭕",
+            xpReward = 150,
+            creditReward = 200,
+            threshold = 10
+        ),
+        AchievementSpec(
+            code = "tictactoe_wins_25",
+            name = "Center Square",
+            description = "Win 25 Tic-Tac-Toe matches.",
+            category = "casino",
+            icon = "🟦",
+            xpReward = 300,
+            creditReward = 400,
+            threshold = 25
+        ),
+        AchievementSpec(
+            code = "tictactoe_losses_5",
+            name = "Cornered",
+            description = "Lose 5 Tic-Tac-Toe matches.",
+            category = "consolation",
+            icon = "🟥",
+            xpReward = 50,
+            creditReward = 100,
+            threshold = 5
+        ),
+
         // Roadmap stubs for casino games that don't yet publish domain
         // events. Hidden until a future PR adds the corresponding event
         // and wires up an AchievementEventHandler listener; the codes

--- a/database/src/main/kotlin/database/dto/ConfigDto.kt
+++ b/database/src/main/kotlin/database/dto/ConfigDto.kt
@@ -176,6 +176,11 @@ class ConfigDto(
         // to members with zero credit. Defaults to 0-500.
         RPS_MIN_STAKE("RPS_MIN_STAKE"),
         RPS_MAX_STAKE("RPS_MAX_STAKE"),
+        // Per-guild stake bounds for `/tictactoe`. Same shape as RPS —
+        // 0 minimum is allowed (free-play matches still grant XP).
+        // Defaults to 0-500.
+        TICTACTOE_MIN_STAKE("TICTACTOE_MIN_STAKE"),
+        TICTACTOE_MAX_STAKE("TICTACTOE_MAX_STAKE"),
 
         // Reference stake size for jackpot probability scaling. Bets at
         // or above this anchor roll at the full JACKPOT_WIN_PCT base

--- a/database/src/main/kotlin/database/service/PvpWagerService.kt
+++ b/database/src/main/kotlin/database/service/PvpWagerService.kt
@@ -1,0 +1,260 @@
+package database.service
+
+import database.dto.ConfigDto
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * Shared wager primitives for head-to-head PvP mini-games (currently
+ * `/rps` and `/tictactoe`; future `/connect4`). Holds the bits that
+ * are byte-identical between the per-game services:
+ *
+ *  - [preflightStart] — stake-bounds + self-challenge + balance checks
+ *  - [debitBoth] — ascending-id lock + atomic stake debit on accept
+ *  - [payWinner] — winner pay-out (pot − jackpot tribute) + XP grant.
+ *    Handles both stake-bearing matches (locks, computes, updates
+ *    balances) and free play (XP only).
+ *  - [refundBoth] — symmetric stake refund (used on draws / double-
+ *    no-pick). Free-play short-circuits with zeros.
+ *  - [readStakeBounds] — per-guild config-driven min/max lookup
+ *
+ * Per-game services keep their own `ResolveOutcome` shape (RPS has
+ * hidden-picks + draw branches; TTT has board-driven win + draw +
+ * forfeit branches) but delegate the wager arithmetic here so a fix
+ * to e.g. the tribute deduction or the lock-order race lands in one
+ * place. Has **no JDA dependency by design** — same Spring-cycle
+ * lesson the per-game services follow (PR #551).
+ */
+@Service
+@Transactional
+class PvpWagerService @Autowired constructor(
+    private val userService: UserService,
+    private val jackpotService: JackpotService,
+    private val configService: ConfigService,
+    private val xpAwardService: XpAwardService,
+) {
+
+    /** Result of [preflightStart] — what the slash command sees before posting the offer. */
+    sealed interface StartOutcome {
+        data class Ok(val initiatorBalance: Long) : StartOutcome
+        data class InvalidStake(val min: Long, val max: Long) : StartOutcome
+        data class InvalidOpponent(val reason: Reason) : StartOutcome {
+            enum class Reason { SELF, BOT }
+        }
+        data class InitiatorInsufficient(val have: Long, val needed: Long) : StartOutcome
+        data class OpponentInsufficient(val have: Long, val needed: Long) : StartOutcome
+        data object UnknownInitiator : StartOutcome
+        data object UnknownOpponent : StartOutcome
+    }
+
+    /** Result of [debitBoth] — what the accept-button click sees. */
+    sealed interface AcceptOutcome {
+        /** Both balances debited; match is now LIVE. */
+        data class Ok(val initiatorNewBalance: Long, val opponentNewBalance: Long) : AcceptOutcome
+        data class InitiatorInsufficient(val have: Long, val needed: Long) : AcceptOutcome
+        data class OpponentInsufficient(val have: Long, val needed: Long) : AcceptOutcome
+        data object UnknownInitiator : AcceptOutcome
+        data object UnknownOpponent : AcceptOutcome
+    }
+
+    /** Numbers from [payWinner]; the per-game service wraps them into its own Win variant. */
+    data class PayResult(
+        val winnerNewBalance: Long,
+        val loserNewBalance: Long,
+        val pot: Long,
+        val lossTribute: Long,
+        val xpGranted: Long,
+    )
+
+    /** Numbers from [refundBoth]; the per-game service wraps them into its own Draw variant. */
+    data class RefundResult(
+        val initiatorNewBalance: Long,
+        val opponentNewBalance: Long,
+    )
+
+    /**
+     * Pre-flight check the slash command runs before posting the
+     * challenge. Does NOT debit anyone. The opponent-is-a-bot rejection
+     * stays in the command (it has the JDA `User` and can read `isBot`
+     * cheaply); this method only handles the self-challenge variant of
+     * [StartOutcome.InvalidOpponent].
+     */
+    fun preflightStart(
+        initiatorDiscordId: Long,
+        opponentDiscordId: Long,
+        guildId: Long,
+        stake: Long,
+        minStake: Long,
+        maxStake: Long,
+    ): StartOutcome {
+        if (stake < minStake || stake > maxStake) {
+            return StartOutcome.InvalidStake(minStake, maxStake)
+        }
+        if (initiatorDiscordId == opponentDiscordId) {
+            return StartOutcome.InvalidOpponent(StartOutcome.InvalidOpponent.Reason.SELF)
+        }
+        val initiator = userService.getUserById(initiatorDiscordId, guildId)
+            ?: return StartOutcome.UnknownInitiator
+        val opponent = userService.getUserById(opponentDiscordId, guildId)
+            ?: return StartOutcome.UnknownOpponent
+        val initiatorBalance = initiator.socialCredit ?: 0L
+        if (initiatorBalance < stake) {
+            return StartOutcome.InitiatorInsufficient(initiatorBalance, stake)
+        }
+        val opponentBalance = opponent.socialCredit ?: 0L
+        if (opponentBalance < stake) {
+            return StartOutcome.OpponentInsufficient(opponentBalance, stake)
+        }
+        return StartOutcome.Ok(initiatorBalance)
+    }
+
+    /**
+     * Debit `stake` from both players atomically (ascending-id lock so
+     * concurrent matches involving the same user pair can't deadlock).
+     * `stake == 0L` short-circuits past the lock and the user-table
+     * write entirely — free-play accepts are pure ceremony.
+     */
+    fun debitBoth(
+        initiatorDiscordId: Long,
+        opponentDiscordId: Long,
+        guildId: Long,
+        stake: Long,
+    ): AcceptOutcome {
+        if (stake <= 0L) {
+            val initiator = userService.getUserById(initiatorDiscordId, guildId)
+                ?: return AcceptOutcome.UnknownInitiator
+            val opponent = userService.getUserById(opponentDiscordId, guildId)
+                ?: return AcceptOutcome.UnknownOpponent
+            return AcceptOutcome.Ok(
+                initiatorNewBalance = initiator.socialCredit ?: 0L,
+                opponentNewBalance = opponent.socialCredit ?: 0L,
+            )
+        }
+        val locked = userService.lockUsersInAscendingOrder(
+            listOf(initiatorDiscordId, opponentDiscordId), guildId
+        )
+        val initiator = locked[initiatorDiscordId] ?: return AcceptOutcome.UnknownInitiator
+        val opponent = locked[opponentDiscordId] ?: return AcceptOutcome.UnknownOpponent
+
+        val initiatorBalance = initiator.socialCredit ?: 0L
+        if (initiatorBalance < stake) {
+            return AcceptOutcome.InitiatorInsufficient(initiatorBalance, stake)
+        }
+        val opponentBalance = opponent.socialCredit ?: 0L
+        if (opponentBalance < stake) {
+            return AcceptOutcome.OpponentInsufficient(opponentBalance, stake)
+        }
+        initiator.socialCredit = initiatorBalance - stake
+        opponent.socialCredit = opponentBalance - stake
+        userService.updateUser(initiator)
+        userService.updateUser(opponent)
+        return AcceptOutcome.Ok(
+            initiatorNewBalance = initiator.socialCredit ?: 0L,
+            opponentNewBalance = opponent.socialCredit ?: 0L,
+        )
+    }
+
+    /**
+     * Pay the winner the pot minus jackpot tribute and grant them XP.
+     * Both players' stakes were debited at accept time so only the
+     * winner's row needs writing. Re-acquires the lock under the
+     * existing transaction (Postgres permits same-tx re-lock).
+     *
+     * `stake == 0L` is the free-play path: only the XP grant happens
+     * and the wager numbers return as zeros. Callers don't branch.
+     *
+     * Returns `null` on the unreachable defensive case where one of
+     * the players' rows is missing — the per-game service translates
+     * that into its own `Unknown*` outcome.
+     *
+     * `xpReason` is the daily-cap-respecting tag passed to
+     * [XpAwardService.award] (e.g. `"rps:win"`, `"tictactoe:win"`).
+     */
+    fun payWinner(
+        winnerDiscordId: Long,
+        loserDiscordId: Long,
+        stake: Long,
+        guildId: Long,
+        xpReason: String,
+        xpAmount: Long = DEFAULT_WIN_XP,
+    ): PayResult? {
+        if (stake <= 0L) {
+            val xp = xpAwardService.award(
+                discordId = winnerDiscordId, guildId = guildId,
+                amount = xpAmount, reason = xpReason,
+            )
+            return PayResult(
+                winnerNewBalance = 0L, loserNewBalance = 0L,
+                pot = 0L, lossTribute = 0L, xpGranted = xp,
+            )
+        }
+        val locked = userService.lockUsersInAscendingOrder(
+            listOf(winnerDiscordId, loserDiscordId), guildId
+        )
+        val winner = locked[winnerDiscordId] ?: return null
+        val loser = locked[loserDiscordId] ?: return null
+
+        val winnerStartBalance = winner.socialCredit ?: 0L
+        val tribute = JackpotHelper.divertOnLoss(jackpotService, configService, guildId, stake)
+        val pot = 2L * stake
+        winner.socialCredit = winnerStartBalance + (pot - tribute)
+        userService.updateUser(winner)
+        val xp = xpAwardService.award(
+            discordId = winnerDiscordId, guildId = guildId,
+            amount = xpAmount, reason = xpReason,
+        )
+        return PayResult(
+            winnerNewBalance = winner.socialCredit ?: 0L,
+            loserNewBalance = loser.socialCredit ?: 0L,
+            pot = pot,
+            lossTribute = tribute,
+            xpGranted = xp,
+        )
+    }
+
+    /**
+     * Refund `stake` to both players atomically (ascending-id lock).
+     * Used on draws / double-no-pick. `stake <= 0L` returns the
+     * free-play zeros and writes nothing.
+     */
+    fun refundBoth(
+        initiatorDiscordId: Long,
+        opponentDiscordId: Long,
+        stake: Long,
+        guildId: Long,
+    ): RefundResult {
+        if (stake <= 0L) return RefundResult(0L, 0L)
+        val locked = userService.lockUsersInAscendingOrder(
+            listOf(initiatorDiscordId, opponentDiscordId), guildId
+        )
+        val initiator = locked[initiatorDiscordId] ?: return RefundResult(0L, 0L)
+        val opponent = locked[opponentDiscordId] ?: return RefundResult(0L, 0L)
+        initiator.socialCredit = (initiator.socialCredit ?: 0L) + stake
+        opponent.socialCredit = (opponent.socialCredit ?: 0L) + stake
+        userService.updateUser(initiator)
+        userService.updateUser(opponent)
+        return RefundResult(
+            initiatorNewBalance = initiator.socialCredit ?: 0L,
+            opponentNewBalance = opponent.socialCredit ?: 0L,
+        )
+    }
+
+    /** Per-guild stake bounds for a wager game, with sane defaults. */
+    fun readStakeBounds(
+        guildId: Long,
+        minKey: ConfigDto.Configurations,
+        maxKey: ConfigDto.Configurations,
+        defaultMin: Long,
+        defaultMax: Long,
+    ): Pair<Long, Long> {
+        val min = configService.cfgLong(minKey, guildId, default = defaultMin, min = 0L)
+        val max = configService.cfgLongMax(maxKey, guildId, default = defaultMax, min = min)
+        return min to max
+    }
+
+    companion object {
+        /** Default XP grant for a wager-game win. Per-game services can override via [payWinner]. */
+        const val DEFAULT_WIN_XP: Long = 10L
+    }
+}

--- a/database/src/main/kotlin/database/service/RpsService.kt
+++ b/database/src/main/kotlin/database/service/RpsService.kt
@@ -1,67 +1,40 @@
 package database.service
 
 import common.events.RpsResolvedEvent
-import database.dto.ConfigDto
 import common.rps.RpsEngine
+import database.dto.ConfigDto
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 /**
- * Head-to-head Rock-Paper-Scissors wager between two users. Three
- * phases — mirrors `/duel`'s preflight + accept flow but adds a hidden-
- * pick stage between accept and resolution:
+ * Head-to-head Rock-Paper-Scissors wager between two users. RPS-specific
+ * resolve branches live here; the shared wager primitives (start
+ * preflight, accept debit, winner pay, draw refund) delegate to
+ * [PvpWagerService] so the same arithmetic powers `/rps`, `/tictactoe`
+ * (and the planned `/connect4`).
  *
- *   - [startMatch] — pre-flight balance / stake-bounds check. Does NOT
- *     debit. Lets the slash command refuse a doomed offer up-front.
- *   - [acceptMatch] — atomic debit. Locks both users in ascending
- *     discord-id order, re-verifies both balances, debits the stake
- *     from each. Picks are stored in the in-memory session registry
- *     (not this service) so this service is pure wager-math.
- *   - [resolveMatch] — credits the winner pot minus jackpot tribute,
- *     OR refunds on a draw / double-no-pick. Single entry point for
- *     both happy-path resolution and forfeit/timeout settlement so
- *     all the branching wager arithmetic lives in one place.
+ *   - [startMatch] / [acceptMatch] are thin pass-throughs to the
+ *     shared service; the only RPS-specific bit is the per-guild
+ *     config-key wiring.
+ *   - [resolveMatch] handles the four RPS-flavoured branches: both
+ *     picked + clean winner, both picked + identical-move draw,
+ *     exactly one picked (forfeit), and neither picked (double
+ *     refund).
  *
- * Loss tribute is computed the same way as `/duel` (via [JackpotHelper])
- * — every wager game feeds the same per-guild jackpot pool so the
- * economy stays cohesive.
+ * Publishes [RpsResolvedEvent] on every winner-bearing match — free
+ * play included — so achievements unlock regardless of whether anyone
+ * bet. Draws and double-no-pick never publish.
  *
- * Has **no JDA dependency by design** — that's the regression the
- * Profile cards Spring-cycle (PR #551) taught us. Services reachable
- * from a `Command` bean must not pull `JDA` from the container; let
- * the slash command pass `Guild` / `Member` through.
+ * Has **no JDA dependency by design** (PR #551 lesson).
  */
 @Service
 @Transactional
 class RpsService @Autowired constructor(
-    private val userService: UserService,
-    private val jackpotService: JackpotService,
-    private val configService: ConfigService,
-    private val xpAwardService: XpAwardService,
+    private val pvpWagerService: PvpWagerService,
     private val eventPublisher: ApplicationEventPublisher? = null,
 ) {
-    sealed interface StartOutcome {
-        data class Ok(val initiatorBalance: Long) : StartOutcome
-        data class InvalidStake(val min: Long, val max: Long) : StartOutcome
-        data class InvalidOpponent(val reason: Reason) : StartOutcome {
-            enum class Reason { SELF, BOT }
-        }
-        data class InitiatorInsufficient(val have: Long, val needed: Long) : StartOutcome
-        data class OpponentInsufficient(val have: Long, val needed: Long) : StartOutcome
-        data object UnknownInitiator : StartOutcome
-        data object UnknownOpponent : StartOutcome
-    }
-
-    sealed interface AcceptOutcome {
-        /** Both balances debited; match is now LIVE. */
-        data class Ok(val initiatorNewBalance: Long, val opponentNewBalance: Long) : AcceptOutcome
-        data class InitiatorInsufficient(val have: Long, val needed: Long) : AcceptOutcome
-        data class OpponentInsufficient(val have: Long, val needed: Long) : AcceptOutcome
-        data object UnknownInitiator : AcceptOutcome
-        data object UnknownOpponent : AcceptOutcome
-    }
 
     /**
      * Per-resolution result. Wraps the human-readable picks alongside
@@ -97,8 +70,8 @@ class RpsService @Autowired constructor(
             val opponentNewBalance: Long,
         ) : ResolveOutcome
 
-        data object UnknownInitiator : ResolveOutcome
-        data object UnknownOpponent : ResolveOutcome
+        /** Unreachable defensive case — one of the player rows vanished mid-resolve. */
+        data object Unknown : ResolveOutcome
     }
 
     fun startMatch(
@@ -106,28 +79,19 @@ class RpsService @Autowired constructor(
         opponentDiscordId: Long,
         guildId: Long,
         stake: Long,
-    ): StartOutcome {
-        val (minStake, maxStake) = readStakeBounds(guildId)
-        if (stake < minStake || stake > maxStake) {
-            return StartOutcome.InvalidStake(minStake, maxStake)
-        }
-        if (initiatorDiscordId == opponentDiscordId) {
-            return StartOutcome.InvalidOpponent(StartOutcome.InvalidOpponent.Reason.SELF)
-        }
-        val initiator = userService.getUserById(initiatorDiscordId, guildId)
-            ?: return StartOutcome.UnknownInitiator
-        val opponent = userService.getUserById(opponentDiscordId, guildId)
-            ?: return StartOutcome.UnknownOpponent
-
-        val initiatorBalance = initiator.socialCredit ?: 0L
-        if (initiatorBalance < stake) {
-            return StartOutcome.InitiatorInsufficient(initiatorBalance, stake)
-        }
-        val opponentBalance = opponent.socialCredit ?: 0L
-        if (opponentBalance < stake) {
-            return StartOutcome.OpponentInsufficient(opponentBalance, stake)
-        }
-        return StartOutcome.Ok(initiatorBalance)
+    ): PvpWagerService.StartOutcome {
+        val (min, max) = pvpWagerService.readStakeBounds(
+            guildId, ConfigDto.Configurations.RPS_MIN_STAKE, ConfigDto.Configurations.RPS_MAX_STAKE,
+            defaultMin = MIN_STAKE, defaultMax = MAX_STAKE,
+        )
+        return pvpWagerService.preflightStart(
+            initiatorDiscordId = initiatorDiscordId,
+            opponentDiscordId = opponentDiscordId,
+            guildId = guildId,
+            stake = stake,
+            minStake = min,
+            maxStake = max,
+        )
     }
 
     fun acceptMatch(
@@ -135,42 +99,8 @@ class RpsService @Autowired constructor(
         opponentDiscordId: Long,
         guildId: Long,
         stake: Long,
-    ): AcceptOutcome {
-        // No debit needed when there's no stake — `/rps` without a wager
-        // is pure fun and should skip the user-table touch entirely.
-        if (stake <= 0L) {
-            val initiator = userService.getUserById(initiatorDiscordId, guildId)
-                ?: return AcceptOutcome.UnknownInitiator
-            val opponent = userService.getUserById(opponentDiscordId, guildId)
-                ?: return AcceptOutcome.UnknownOpponent
-            return AcceptOutcome.Ok(
-                initiatorNewBalance = initiator.socialCredit ?: 0L,
-                opponentNewBalance = opponent.socialCredit ?: 0L,
-            )
-        }
-        val locked = userService.lockUsersInAscendingOrder(
-            listOf(initiatorDiscordId, opponentDiscordId), guildId
-        )
-        val initiator = locked[initiatorDiscordId] ?: return AcceptOutcome.UnknownInitiator
-        val opponent = locked[opponentDiscordId] ?: return AcceptOutcome.UnknownOpponent
-
-        val initiatorBalance = initiator.socialCredit ?: 0L
-        if (initiatorBalance < stake) {
-            return AcceptOutcome.InitiatorInsufficient(initiatorBalance, stake)
-        }
-        val opponentBalance = opponent.socialCredit ?: 0L
-        if (opponentBalance < stake) {
-            return AcceptOutcome.OpponentInsufficient(opponentBalance, stake)
-        }
-        initiator.socialCredit = initiatorBalance - stake
-        opponent.socialCredit = opponentBalance - stake
-        userService.updateUser(initiator)
-        userService.updateUser(opponent)
-        return AcceptOutcome.Ok(
-            initiatorNewBalance = initiator.socialCredit ?: 0L,
-            opponentNewBalance = opponent.socialCredit ?: 0L,
-        )
-    }
+    ): PvpWagerService.AcceptOutcome =
+        pvpWagerService.debitBoth(initiatorDiscordId, opponentDiscordId, guildId, stake)
 
     /**
      * Settle a match. Handles four cases:
@@ -191,179 +121,99 @@ class RpsService @Autowired constructor(
         initiatorChoice: RpsEngine.Choice?,
         opponentChoice: RpsEngine.Choice?,
     ): ResolveOutcome {
-        // Stake-free play: no debits to settle. Award nominal XP to the
-        // winner only (consistent with stake-bearing wins) and skip the
-        // user-table touch otherwise.
-        if (stake <= 0L) {
-            return resolveFreePlay(
-                initiatorDiscordId, opponentDiscordId, guildId,
-                initiatorChoice, opponentChoice,
-            )
-        }
-        val locked = userService.lockUsersInAscendingOrder(
-            listOf(initiatorDiscordId, opponentDiscordId), guildId
-        )
-        val initiator = locked[initiatorDiscordId] ?: return ResolveOutcome.UnknownInitiator
-        val opponent = locked[opponentDiscordId] ?: return ResolveOutcome.UnknownOpponent
-
-        val initiatorBalance = initiator.socialCredit ?: 0L
-        val opponentBalance = opponent.socialCredit ?: 0L
-
         // Case A: both picked.
         if (initiatorChoice != null && opponentChoice != null) {
-            return when (val outcome = RpsEngine.resolve(initiatorChoice, opponentChoice)) {
-                RpsEngine.Outcome.Draw -> {
-                    // Refund both stakes.
-                    initiator.socialCredit = initiatorBalance + stake
-                    opponent.socialCredit = opponentBalance + stake
-                    userService.updateUser(initiator)
-                    userService.updateUser(opponent)
-                    ResolveOutcome.Draw(
-                        choice = initiatorChoice,
-                        stake = stake,
-                        initiatorNewBalance = initiator.socialCredit ?: 0L,
-                        opponentNewBalance = opponent.socialCredit ?: 0L,
-                    )
-                }
-                RpsEngine.Outcome.FirstWins -> payWinner(
-                    winner = initiator, loser = opponent, stake = stake, guildId = guildId,
+            return when (RpsEngine.resolve(initiatorChoice, opponentChoice)) {
+                RpsEngine.Outcome.Draw -> resolveDraw(
+                    initiatorDiscordId, opponentDiscordId, guildId, stake, initiatorChoice,
+                )
+                RpsEngine.Outcome.FirstWins -> resolveWin(
+                    winnerDiscordId = initiatorDiscordId, loserDiscordId = opponentDiscordId,
+                    guildId = guildId, stake = stake,
                     winnerChoice = initiatorChoice, loserChoice = opponentChoice,
                 )
-                RpsEngine.Outcome.SecondWins -> payWinner(
-                    winner = opponent, loser = initiator, stake = stake, guildId = guildId,
+                RpsEngine.Outcome.SecondWins -> resolveWin(
+                    winnerDiscordId = opponentDiscordId, loserDiscordId = initiatorDiscordId,
+                    guildId = guildId, stake = stake,
                     winnerChoice = opponentChoice, loserChoice = initiatorChoice,
                 )
             }
         }
-
-        // Case B: exactly one picked. The picker wins by forfeit.
-        if (initiatorChoice != null && opponentChoice == null) {
-            return payWinner(
-                winner = initiator, loser = opponent, stake = stake, guildId = guildId,
+        // Case B: exactly one picked → forfeit win for the picker.
+        if (initiatorChoice != null) {
+            return resolveWin(
+                winnerDiscordId = initiatorDiscordId, loserDiscordId = opponentDiscordId,
+                guildId = guildId, stake = stake,
                 winnerChoice = initiatorChoice, loserChoice = pickPlaceholder(initiatorChoice),
             )
         }
-        if (opponentChoice != null && initiatorChoice == null) {
-            return payWinner(
-                winner = opponent, loser = initiator, stake = stake, guildId = guildId,
+        if (opponentChoice != null) {
+            return resolveWin(
+                winnerDiscordId = opponentDiscordId, loserDiscordId = initiatorDiscordId,
+                guildId = guildId, stake = stake,
                 winnerChoice = opponentChoice, loserChoice = pickPlaceholder(opponentChoice),
             )
         }
-
-        // Case C: neither picked. Double refund.
-        initiator.socialCredit = initiatorBalance + stake
-        opponent.socialCredit = opponentBalance + stake
-        userService.updateUser(initiator)
-        userService.updateUser(opponent)
-        return ResolveOutcome.DoubleRefund(
-            stake = stake,
-            initiatorNewBalance = initiator.socialCredit ?: 0L,
-            opponentNewBalance = opponent.socialCredit ?: 0L,
-        )
+        // Case C: neither picked → double refund.
+        return resolveDoubleRefund(initiatorDiscordId, opponentDiscordId, guildId, stake)
     }
 
-    private fun payWinner(
-        winner: database.dto.UserDto,
-        loser: database.dto.UserDto,
-        stake: Long,
-        guildId: Long,
-        winnerChoice: RpsEngine.Choice,
-        loserChoice: RpsEngine.Choice,
-    ): ResolveOutcome.Win {
-        val winnerStartBalance = winner.socialCredit ?: 0L
-        val tribute = JackpotHelper.divertOnLoss(jackpotService, configService, guildId, stake)
-        val pot = 2L * stake
-        val winnerPayout = pot - tribute
-        // Both players were already debited at acceptMatch time. Winner
-        // receives the pot minus tribute back; loser receives nothing.
-        winner.socialCredit = winnerStartBalance + winnerPayout
-        userService.updateUser(winner)
-        // No loser write — their balance was already debited at accept.
-        val xpGranted = xpAwardService.award(
-            discordId = winner.discordId,
-            guildId = guildId,
-            amount = WIN_XP,
-            reason = "rps:win",
-        )
-        val outcome = ResolveOutcome.Win(
-            winnerDiscordId = winner.discordId,
-            loserDiscordId = loser.discordId,
-            winnerChoice = winnerChoice,
-            loserChoice = loserChoice,
-            stake = stake,
-            pot = pot,
-            winnerNewBalance = winner.socialCredit ?: 0L,
-            loserNewBalance = loser.socialCredit ?: 0L,
-            lossTribute = tribute,
-            xpGranted = xpGranted,
-        )
-        publishResolved(outcome, guildId)
-        return outcome
-    }
-
-    private fun resolveFreePlay(
-        initiatorDiscordId: Long,
-        opponentDiscordId: Long,
-        guildId: Long,
-        initiatorChoice: RpsEngine.Choice?,
-        opponentChoice: RpsEngine.Choice?,
-    ): ResolveOutcome {
-        // Both picked → resolve by engine; one picked → other forfeits;
-        // neither picked → draw-shaped DoubleRefund (no funds involved).
-        if (initiatorChoice != null && opponentChoice != null) {
-            return when (RpsEngine.resolve(initiatorChoice, opponentChoice)) {
-                RpsEngine.Outcome.Draw -> ResolveOutcome.Draw(
-                    choice = initiatorChoice, stake = 0L,
-                    initiatorNewBalance = 0L, opponentNewBalance = 0L,
-                )
-                RpsEngine.Outcome.FirstWins -> freePlayWin(
-                    initiatorDiscordId, opponentDiscordId, guildId,
-                    winnerChoice = initiatorChoice, loserChoice = opponentChoice,
-                )
-                RpsEngine.Outcome.SecondWins -> freePlayWin(
-                    opponentDiscordId, initiatorDiscordId, guildId,
-                    winnerChoice = opponentChoice, loserChoice = initiatorChoice,
-                )
-            }
-        }
-        if (initiatorChoice != null) return freePlayWin(
-            initiatorDiscordId, opponentDiscordId, guildId,
-            winnerChoice = initiatorChoice, loserChoice = pickPlaceholder(initiatorChoice),
-        )
-        if (opponentChoice != null) return freePlayWin(
-            opponentDiscordId, initiatorDiscordId, guildId,
-            winnerChoice = opponentChoice, loserChoice = pickPlaceholder(opponentChoice),
-        )
-        return ResolveOutcome.DoubleRefund(stake = 0L, initiatorNewBalance = 0L, opponentNewBalance = 0L)
-    }
-
-    private fun freePlayWin(
+    private fun resolveWin(
         winnerDiscordId: Long,
         loserDiscordId: Long,
         guildId: Long,
+        stake: Long,
         winnerChoice: RpsEngine.Choice,
         loserChoice: RpsEngine.Choice,
-    ): ResolveOutcome.Win {
-        val xpGranted = xpAwardService.award(
-            discordId = winnerDiscordId,
-            guildId = guildId,
-            amount = WIN_XP,
-            reason = "rps:win",
-        )
+    ): ResolveOutcome {
+        val pay = pvpWagerService.payWinner(
+            winnerDiscordId = winnerDiscordId, loserDiscordId = loserDiscordId,
+            stake = stake, guildId = guildId, xpReason = WIN_XP_REASON, xpAmount = WIN_XP,
+        ) ?: return ResolveOutcome.Unknown
         val outcome = ResolveOutcome.Win(
             winnerDiscordId = winnerDiscordId,
             loserDiscordId = loserDiscordId,
             winnerChoice = winnerChoice,
             loserChoice = loserChoice,
-            stake = 0L,
-            pot = 0L,
-            winnerNewBalance = 0L,
-            loserNewBalance = 0L,
-            lossTribute = 0L,
-            xpGranted = xpGranted,
+            stake = stake,
+            pot = pay.pot,
+            winnerNewBalance = pay.winnerNewBalance,
+            loserNewBalance = pay.loserNewBalance,
+            lossTribute = pay.lossTribute,
+            xpGranted = pay.xpGranted,
         )
         publishResolved(outcome, guildId)
         return outcome
+    }
+
+    private fun resolveDraw(
+        initiatorDiscordId: Long,
+        opponentDiscordId: Long,
+        guildId: Long,
+        stake: Long,
+        choice: RpsEngine.Choice,
+    ): ResolveOutcome.Draw {
+        val refund = pvpWagerService.refundBoth(initiatorDiscordId, opponentDiscordId, stake, guildId)
+        return ResolveOutcome.Draw(
+            choice = choice,
+            stake = stake,
+            initiatorNewBalance = refund.initiatorNewBalance,
+            opponentNewBalance = refund.opponentNewBalance,
+        )
+    }
+
+    private fun resolveDoubleRefund(
+        initiatorDiscordId: Long,
+        opponentDiscordId: Long,
+        guildId: Long,
+        stake: Long,
+    ): ResolveOutcome.DoubleRefund {
+        val refund = pvpWagerService.refundBoth(initiatorDiscordId, opponentDiscordId, stake, guildId)
+        return ResolveOutcome.DoubleRefund(
+            stake = stake,
+            initiatorNewBalance = refund.initiatorNewBalance,
+            opponentNewBalance = refund.opponentNewBalance,
+        )
     }
 
     /**
@@ -399,22 +249,13 @@ class RpsService @Autowired constructor(
         RpsEngine.Choice.SCISSORS -> RpsEngine.Choice.PAPER
     }
 
-    private fun readStakeBounds(guildId: Long): Pair<Long, Long> {
-        val min = configService.cfgLong(
-            ConfigDto.Configurations.RPS_MIN_STAKE, guildId, default = MIN_STAKE, min = 0L
-        )
-        val max = configService.cfgLongMax(
-            ConfigDto.Configurations.RPS_MAX_STAKE, guildId, default = MAX_STAKE, min = min
-        )
-        return min to max
-    }
-
     companion object {
         /** Allow stake-free play: 0 is a valid minimum. */
         const val MIN_STAKE: Long = 0L
         const val MAX_STAKE: Long = 500L
 
-        /** XP awarded to the winner regardless of stake. Daily-cap-respecting via XpAwardService. */
+        /** XP awarded to the winner regardless of stake. */
         const val WIN_XP: Long = 10L
+        private const val WIN_XP_REASON = "rps:win"
     }
 }

--- a/database/src/main/kotlin/database/service/TicTacToeService.kt
+++ b/database/src/main/kotlin/database/service/TicTacToeService.kt
@@ -2,67 +2,36 @@ package database.service
 
 import common.events.TicTacToeResolvedEvent
 import database.dto.ConfigDto
-import database.dto.UserDto
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 /**
- * Head-to-head Tic-Tac-Toe wager between two users. Three phases —
- * mirrors `/rps`'s shape but without the hidden-pick stage, since
- * TTT moves are open. Moves themselves are tracked in
- * [database.tictactoe.TicTacToeSessionRegistry]; this service stays
- * pure wager-math.
+ * Head-to-head Tic-Tac-Toe wager between two users. TTT-specific
+ * resolve branches live here; the shared wager primitives (start
+ * preflight, accept debit, winner pay, draw refund) delegate to
+ * [PvpWagerService] so the same arithmetic powers `/rps`, `/tictactoe`
+ * (and the planned `/connect4`).
  *
- *   - [startMatch] — pre-flight balance / stake-bounds check. Does NOT
- *     debit. Lets the slash command refuse a doomed offer up-front.
- *   - [acceptMatch] — atomic debit. Locks both users in ascending
- *     discord-id order, re-verifies both balances, debits the stake
- *     from each. The board state is held in the in-memory session
- *     registry (not this service).
- *   - [resolveMatch] — credits the winner pot minus jackpot tribute on
- *     a win, OR refunds both stakes on a draw. Single entry point for
- *     both happy-path resolution and forfeit/timeout settlement so
- *     the branching wager arithmetic lives in one place.
+ *   - [startMatch] / [acceptMatch] are thin pass-throughs to the
+ *     shared service.
+ *   - [resolveMatch] collapses the three terminal cases (3-in-a-row,
+ *     forfeit walkover, timeout walkover) into a single `winner /
+ *     no-winner` decision the caller hands in.
  *
- * Loss tribute is computed the same way as `/duel` / `/rps` (via
- * [JackpotHelper]) — every wager game feeds the same per-guild
- * jackpot pool so the economy stays cohesive.
+ * Publishes [TicTacToeResolvedEvent] on every winner-bearing match —
+ * free play included — so achievements unlock regardless of whether
+ * anyone bet. Draws never publish.
  *
- * Has **no JDA dependency by design** — that's the regression the
- * Profile cards Spring-cycle (PR #551) taught us. Services reachable
- * from a `Command` bean must not pull `JDA` from the container.
+ * Has **no JDA dependency by design** (PR #551 lesson).
  */
 @Service
 @Transactional
 class TicTacToeService @Autowired constructor(
-    private val userService: UserService,
-    private val jackpotService: JackpotService,
-    private val configService: ConfigService,
-    private val xpAwardService: XpAwardService,
+    private val pvpWagerService: PvpWagerService,
     private val eventPublisher: ApplicationEventPublisher? = null,
 ) {
-
-    sealed interface StartOutcome {
-        data class Ok(val initiatorBalance: Long) : StartOutcome
-        data class InvalidStake(val min: Long, val max: Long) : StartOutcome
-        data class InvalidOpponent(val reason: Reason) : StartOutcome {
-            enum class Reason { SELF, BOT }
-        }
-        data class InitiatorInsufficient(val have: Long, val needed: Long) : StartOutcome
-        data class OpponentInsufficient(val have: Long, val needed: Long) : StartOutcome
-        data object UnknownInitiator : StartOutcome
-        data object UnknownOpponent : StartOutcome
-    }
-
-    sealed interface AcceptOutcome {
-        data class Ok(val initiatorNewBalance: Long, val opponentNewBalance: Long) : AcceptOutcome
-        data class InitiatorInsufficient(val have: Long, val needed: Long) : AcceptOutcome
-        data class OpponentInsufficient(val have: Long, val needed: Long) : AcceptOutcome
-        data object UnknownInitiator : AcceptOutcome
-        data object UnknownOpponent : AcceptOutcome
-    }
 
     sealed interface ResolveOutcome {
         data class Win(
@@ -83,8 +52,8 @@ class TicTacToeService @Autowired constructor(
             val opponentNewBalance: Long,
         ) : ResolveOutcome
 
-        data object UnknownInitiator : ResolveOutcome
-        data object UnknownOpponent : ResolveOutcome
+        /** Unreachable defensive case — one of the player rows vanished mid-resolve. */
+        data object Unknown : ResolveOutcome
     }
 
     fun startMatch(
@@ -92,28 +61,19 @@ class TicTacToeService @Autowired constructor(
         opponentDiscordId: Long,
         guildId: Long,
         stake: Long,
-    ): StartOutcome {
-        val (minStake, maxStake) = readStakeBounds(guildId)
-        if (stake < minStake || stake > maxStake) {
-            return StartOutcome.InvalidStake(minStake, maxStake)
-        }
-        if (initiatorDiscordId == opponentDiscordId) {
-            return StartOutcome.InvalidOpponent(StartOutcome.InvalidOpponent.Reason.SELF)
-        }
-        val initiator = userService.getUserById(initiatorDiscordId, guildId)
-            ?: return StartOutcome.UnknownInitiator
-        val opponent = userService.getUserById(opponentDiscordId, guildId)
-            ?: return StartOutcome.UnknownOpponent
-
-        val initiatorBalance = initiator.socialCredit ?: 0L
-        if (initiatorBalance < stake) {
-            return StartOutcome.InitiatorInsufficient(initiatorBalance, stake)
-        }
-        val opponentBalance = opponent.socialCredit ?: 0L
-        if (opponentBalance < stake) {
-            return StartOutcome.OpponentInsufficient(opponentBalance, stake)
-        }
-        return StartOutcome.Ok(initiatorBalance)
+    ): PvpWagerService.StartOutcome {
+        val (min, max) = pvpWagerService.readStakeBounds(
+            guildId, ConfigDto.Configurations.TICTACTOE_MIN_STAKE, ConfigDto.Configurations.TICTACTOE_MAX_STAKE,
+            defaultMin = MIN_STAKE, defaultMax = MAX_STAKE,
+        )
+        return pvpWagerService.preflightStart(
+            initiatorDiscordId = initiatorDiscordId,
+            opponentDiscordId = opponentDiscordId,
+            guildId = guildId,
+            stake = stake,
+            minStake = min,
+            maxStake = max,
+        )
     }
 
     fun acceptMatch(
@@ -121,46 +81,12 @@ class TicTacToeService @Autowired constructor(
         opponentDiscordId: Long,
         guildId: Long,
         stake: Long,
-    ): AcceptOutcome {
-        // Free-play short-circuit: no debits needed.
-        if (stake <= 0L) {
-            val initiator = userService.getUserById(initiatorDiscordId, guildId)
-                ?: return AcceptOutcome.UnknownInitiator
-            val opponent = userService.getUserById(opponentDiscordId, guildId)
-                ?: return AcceptOutcome.UnknownOpponent
-            return AcceptOutcome.Ok(
-                initiatorNewBalance = initiator.socialCredit ?: 0L,
-                opponentNewBalance = opponent.socialCredit ?: 0L,
-            )
-        }
-        val locked = userService.lockUsersInAscendingOrder(
-            listOf(initiatorDiscordId, opponentDiscordId), guildId
-        )
-        val initiator = locked[initiatorDiscordId] ?: return AcceptOutcome.UnknownInitiator
-        val opponent = locked[opponentDiscordId] ?: return AcceptOutcome.UnknownOpponent
-
-        val initiatorBalance = initiator.socialCredit ?: 0L
-        if (initiatorBalance < stake) {
-            return AcceptOutcome.InitiatorInsufficient(initiatorBalance, stake)
-        }
-        val opponentBalance = opponent.socialCredit ?: 0L
-        if (opponentBalance < stake) {
-            return AcceptOutcome.OpponentInsufficient(opponentBalance, stake)
-        }
-        initiator.socialCredit = initiatorBalance - stake
-        opponent.socialCredit = opponentBalance - stake
-        userService.updateUser(initiator)
-        userService.updateUser(opponent)
-        return AcceptOutcome.Ok(
-            initiatorNewBalance = initiator.socialCredit ?: 0L,
-            opponentNewBalance = opponent.socialCredit ?: 0L,
-        )
-    }
+    ): PvpWagerService.AcceptOutcome =
+        pvpWagerService.debitBoth(initiatorDiscordId, opponentDiscordId, guildId, stake)
 
     /**
-     * Settle a match. The caller passes [winnerDiscordId] / [loserDiscordId]
-     * as the verdict — `null` winner means draw (board full, no line) and
-     * both stakes refund. Passing a non-null [winnerDiscordId] covers
+     * Settle a match. [winnerDiscordId] = `null` means draw (board
+     * full, no line) and both stakes refund. A non-null winner covers
      * three real cases that all collapse to the same wager arithmetic:
      *   1. winner completed a 3-in-a-row
      *   2. loser forfeited mid-game
@@ -177,112 +103,37 @@ class TicTacToeService @Autowired constructor(
         stake: Long,
         winnerDiscordId: Long?,
     ): ResolveOutcome {
-        // Stake-free play: no debits to settle.
-        if (stake <= 0L) {
-            return resolveFreePlay(initiatorDiscordId, opponentDiscordId, guildId, winnerDiscordId)
-        }
-        val locked = userService.lockUsersInAscendingOrder(
-            listOf(initiatorDiscordId, opponentDiscordId), guildId
-        )
-        val initiator = locked[initiatorDiscordId] ?: return ResolveOutcome.UnknownInitiator
-        val opponent = locked[opponentDiscordId] ?: return ResolveOutcome.UnknownOpponent
-
-        val initiatorBalance = initiator.socialCredit ?: 0L
-        val opponentBalance = opponent.socialCredit ?: 0L
-
         if (winnerDiscordId == null) {
-            // Draw — refund both stakes.
-            initiator.socialCredit = initiatorBalance + stake
-            opponent.socialCredit = opponentBalance + stake
-            userService.updateUser(initiator)
-            userService.updateUser(opponent)
+            val refund = pvpWagerService.refundBoth(initiatorDiscordId, opponentDiscordId, stake, guildId)
             return ResolveOutcome.Draw(
                 stake = stake,
-                initiatorNewBalance = initiator.socialCredit ?: 0L,
-                opponentNewBalance = opponent.socialCredit ?: 0L,
+                initiatorNewBalance = refund.initiatorNewBalance,
+                opponentNewBalance = refund.opponentNewBalance,
             )
-        }
-        val (winner, loser) = when (winnerDiscordId) {
-            initiatorDiscordId -> initiator to opponent
-            opponentDiscordId -> opponent to initiator
-            else -> return ResolveOutcome.UnknownInitiator // unknown winner — shouldn't happen
-        }
-        return payWinner(winner = winner, loser = loser, stake = stake, guildId = guildId)
-    }
-
-    private fun payWinner(
-        winner: UserDto,
-        loser: UserDto,
-        stake: Long,
-        guildId: Long,
-    ): ResolveOutcome.Win {
-        val winnerStartBalance = winner.socialCredit ?: 0L
-        val tribute = JackpotHelper.divertOnLoss(jackpotService, configService, guildId, stake)
-        val pot = 2L * stake
-        val winnerPayout = pot - tribute
-        winner.socialCredit = winnerStartBalance + winnerPayout
-        userService.updateUser(winner)
-        val xpGranted = xpAwardService.award(
-            discordId = winner.discordId,
-            guildId = guildId,
-            amount = WIN_XP,
-            reason = "tictactoe:win",
-        )
-        val outcome = ResolveOutcome.Win(
-            winnerDiscordId = winner.discordId,
-            loserDiscordId = loser.discordId,
-            stake = stake,
-            pot = pot,
-            winnerNewBalance = winner.socialCredit ?: 0L,
-            loserNewBalance = loser.socialCredit ?: 0L,
-            lossTribute = tribute,
-            xpGranted = xpGranted,
-        )
-        publishResolved(outcome, guildId)
-        return outcome
-    }
-
-    private fun resolveFreePlay(
-        initiatorDiscordId: Long,
-        opponentDiscordId: Long,
-        guildId: Long,
-        winnerDiscordId: Long?,
-    ): ResolveOutcome {
-        if (winnerDiscordId == null) {
-            return ResolveOutcome.Draw(stake = 0L, initiatorNewBalance = 0L, opponentNewBalance = 0L)
         }
         val loserDiscordId = when (winnerDiscordId) {
             initiatorDiscordId -> opponentDiscordId
             opponentDiscordId -> initiatorDiscordId
-            else -> return ResolveOutcome.UnknownInitiator
+            else -> return ResolveOutcome.Unknown // caller passed an id that's not in this match
         }
-        val xpGranted = xpAwardService.award(
-            discordId = winnerDiscordId,
-            guildId = guildId,
-            amount = WIN_XP,
-            reason = "tictactoe:win",
-        )
+        val pay = pvpWagerService.payWinner(
+            winnerDiscordId = winnerDiscordId, loserDiscordId = loserDiscordId,
+            stake = stake, guildId = guildId, xpReason = WIN_XP_REASON, xpAmount = WIN_XP,
+        ) ?: return ResolveOutcome.Unknown
         val outcome = ResolveOutcome.Win(
             winnerDiscordId = winnerDiscordId,
             loserDiscordId = loserDiscordId,
-            stake = 0L,
-            pot = 0L,
-            winnerNewBalance = 0L,
-            loserNewBalance = 0L,
-            lossTribute = 0L,
-            xpGranted = xpGranted,
+            stake = stake,
+            pot = pay.pot,
+            winnerNewBalance = pay.winnerNewBalance,
+            loserNewBalance = pay.loserNewBalance,
+            lossTribute = pay.lossTribute,
+            xpGranted = pay.xpGranted,
         )
         publishResolved(outcome, guildId)
         return outcome
     }
 
-    /**
-     * Surfaces the resolution to `AchievementEventHandler` for
-     * `first_tictactoe_win` / `tictactoe_wins_*` / `tictactoe_losses_*`
-     * progression. Draws never publish — no winner, no loser. Free-play
-     * wins DO publish so achievements unlock regardless of whether
-     * anyone bet.
-     */
     private fun publishResolved(outcome: ResolveOutcome.Win, guildId: Long) {
         eventPublisher?.publishEvent(
             TicTacToeResolvedEvent(
@@ -295,22 +146,13 @@ class TicTacToeService @Autowired constructor(
         )
     }
 
-    private fun readStakeBounds(guildId: Long): Pair<Long, Long> {
-        val min = configService.cfgLong(
-            ConfigDto.Configurations.TICTACTOE_MIN_STAKE, guildId, default = MIN_STAKE, min = 0L
-        )
-        val max = configService.cfgLongMax(
-            ConfigDto.Configurations.TICTACTOE_MAX_STAKE, guildId, default = MAX_STAKE, min = min
-        )
-        return min to max
-    }
-
     companion object {
         /** Allow stake-free play: 0 is a valid minimum. */
         const val MIN_STAKE: Long = 0L
         const val MAX_STAKE: Long = 500L
 
-        /** XP awarded to the winner regardless of stake. Daily-cap-respecting via XpAwardService. */
+        /** XP awarded to the winner regardless of stake. */
         const val WIN_XP: Long = 10L
+        private const val WIN_XP_REASON = "tictactoe:win"
     }
 }

--- a/database/src/main/kotlin/database/service/TicTacToeService.kt
+++ b/database/src/main/kotlin/database/service/TicTacToeService.kt
@@ -1,0 +1,316 @@
+package database.service
+
+import common.events.TicTacToeResolvedEvent
+import database.dto.ConfigDto
+import database.dto.UserDto
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * Head-to-head Tic-Tac-Toe wager between two users. Three phases —
+ * mirrors `/rps`'s shape but without the hidden-pick stage, since
+ * TTT moves are open. Moves themselves are tracked in
+ * [database.tictactoe.TicTacToeSessionRegistry]; this service stays
+ * pure wager-math.
+ *
+ *   - [startMatch] — pre-flight balance / stake-bounds check. Does NOT
+ *     debit. Lets the slash command refuse a doomed offer up-front.
+ *   - [acceptMatch] — atomic debit. Locks both users in ascending
+ *     discord-id order, re-verifies both balances, debits the stake
+ *     from each. The board state is held in the in-memory session
+ *     registry (not this service).
+ *   - [resolveMatch] — credits the winner pot minus jackpot tribute on
+ *     a win, OR refunds both stakes on a draw. Single entry point for
+ *     both happy-path resolution and forfeit/timeout settlement so
+ *     the branching wager arithmetic lives in one place.
+ *
+ * Loss tribute is computed the same way as `/duel` / `/rps` (via
+ * [JackpotHelper]) — every wager game feeds the same per-guild
+ * jackpot pool so the economy stays cohesive.
+ *
+ * Has **no JDA dependency by design** — that's the regression the
+ * Profile cards Spring-cycle (PR #551) taught us. Services reachable
+ * from a `Command` bean must not pull `JDA` from the container.
+ */
+@Service
+@Transactional
+class TicTacToeService @Autowired constructor(
+    private val userService: UserService,
+    private val jackpotService: JackpotService,
+    private val configService: ConfigService,
+    private val xpAwardService: XpAwardService,
+    private val eventPublisher: ApplicationEventPublisher? = null,
+) {
+
+    sealed interface StartOutcome {
+        data class Ok(val initiatorBalance: Long) : StartOutcome
+        data class InvalidStake(val min: Long, val max: Long) : StartOutcome
+        data class InvalidOpponent(val reason: Reason) : StartOutcome {
+            enum class Reason { SELF, BOT }
+        }
+        data class InitiatorInsufficient(val have: Long, val needed: Long) : StartOutcome
+        data class OpponentInsufficient(val have: Long, val needed: Long) : StartOutcome
+        data object UnknownInitiator : StartOutcome
+        data object UnknownOpponent : StartOutcome
+    }
+
+    sealed interface AcceptOutcome {
+        data class Ok(val initiatorNewBalance: Long, val opponentNewBalance: Long) : AcceptOutcome
+        data class InitiatorInsufficient(val have: Long, val needed: Long) : AcceptOutcome
+        data class OpponentInsufficient(val have: Long, val needed: Long) : AcceptOutcome
+        data object UnknownInitiator : AcceptOutcome
+        data object UnknownOpponent : AcceptOutcome
+    }
+
+    sealed interface ResolveOutcome {
+        data class Win(
+            val winnerDiscordId: Long,
+            val loserDiscordId: Long,
+            val stake: Long,
+            val pot: Long,
+            val winnerNewBalance: Long,
+            val loserNewBalance: Long,
+            val lossTribute: Long,
+            val xpGranted: Long,
+        ) : ResolveOutcome
+
+        /** Board full with no winner; both stakes refunded. */
+        data class Draw(
+            val stake: Long,
+            val initiatorNewBalance: Long,
+            val opponentNewBalance: Long,
+        ) : ResolveOutcome
+
+        data object UnknownInitiator : ResolveOutcome
+        data object UnknownOpponent : ResolveOutcome
+    }
+
+    fun startMatch(
+        initiatorDiscordId: Long,
+        opponentDiscordId: Long,
+        guildId: Long,
+        stake: Long,
+    ): StartOutcome {
+        val (minStake, maxStake) = readStakeBounds(guildId)
+        if (stake < minStake || stake > maxStake) {
+            return StartOutcome.InvalidStake(minStake, maxStake)
+        }
+        if (initiatorDiscordId == opponentDiscordId) {
+            return StartOutcome.InvalidOpponent(StartOutcome.InvalidOpponent.Reason.SELF)
+        }
+        val initiator = userService.getUserById(initiatorDiscordId, guildId)
+            ?: return StartOutcome.UnknownInitiator
+        val opponent = userService.getUserById(opponentDiscordId, guildId)
+            ?: return StartOutcome.UnknownOpponent
+
+        val initiatorBalance = initiator.socialCredit ?: 0L
+        if (initiatorBalance < stake) {
+            return StartOutcome.InitiatorInsufficient(initiatorBalance, stake)
+        }
+        val opponentBalance = opponent.socialCredit ?: 0L
+        if (opponentBalance < stake) {
+            return StartOutcome.OpponentInsufficient(opponentBalance, stake)
+        }
+        return StartOutcome.Ok(initiatorBalance)
+    }
+
+    fun acceptMatch(
+        initiatorDiscordId: Long,
+        opponentDiscordId: Long,
+        guildId: Long,
+        stake: Long,
+    ): AcceptOutcome {
+        // Free-play short-circuit: no debits needed.
+        if (stake <= 0L) {
+            val initiator = userService.getUserById(initiatorDiscordId, guildId)
+                ?: return AcceptOutcome.UnknownInitiator
+            val opponent = userService.getUserById(opponentDiscordId, guildId)
+                ?: return AcceptOutcome.UnknownOpponent
+            return AcceptOutcome.Ok(
+                initiatorNewBalance = initiator.socialCredit ?: 0L,
+                opponentNewBalance = opponent.socialCredit ?: 0L,
+            )
+        }
+        val locked = userService.lockUsersInAscendingOrder(
+            listOf(initiatorDiscordId, opponentDiscordId), guildId
+        )
+        val initiator = locked[initiatorDiscordId] ?: return AcceptOutcome.UnknownInitiator
+        val opponent = locked[opponentDiscordId] ?: return AcceptOutcome.UnknownOpponent
+
+        val initiatorBalance = initiator.socialCredit ?: 0L
+        if (initiatorBalance < stake) {
+            return AcceptOutcome.InitiatorInsufficient(initiatorBalance, stake)
+        }
+        val opponentBalance = opponent.socialCredit ?: 0L
+        if (opponentBalance < stake) {
+            return AcceptOutcome.OpponentInsufficient(opponentBalance, stake)
+        }
+        initiator.socialCredit = initiatorBalance - stake
+        opponent.socialCredit = opponentBalance - stake
+        userService.updateUser(initiator)
+        userService.updateUser(opponent)
+        return AcceptOutcome.Ok(
+            initiatorNewBalance = initiator.socialCredit ?: 0L,
+            opponentNewBalance = opponent.socialCredit ?: 0L,
+        )
+    }
+
+    /**
+     * Settle a match. The caller passes [winnerDiscordId] / [loserDiscordId]
+     * as the verdict — `null` winner means draw (board full, no line) and
+     * both stakes refund. Passing a non-null [winnerDiscordId] covers
+     * three real cases that all collapse to the same wager arithmetic:
+     *   1. winner completed a 3-in-a-row
+     *   2. loser forfeited mid-game
+     *   3. loser timed out on a move
+     *
+     * Idempotent against the user table only if called once per match —
+     * the in-memory session registry is responsible for atomically
+     * removing the session via `consumeForResolution` before this fires.
+     */
+    fun resolveMatch(
+        initiatorDiscordId: Long,
+        opponentDiscordId: Long,
+        guildId: Long,
+        stake: Long,
+        winnerDiscordId: Long?,
+    ): ResolveOutcome {
+        // Stake-free play: no debits to settle.
+        if (stake <= 0L) {
+            return resolveFreePlay(initiatorDiscordId, opponentDiscordId, guildId, winnerDiscordId)
+        }
+        val locked = userService.lockUsersInAscendingOrder(
+            listOf(initiatorDiscordId, opponentDiscordId), guildId
+        )
+        val initiator = locked[initiatorDiscordId] ?: return ResolveOutcome.UnknownInitiator
+        val opponent = locked[opponentDiscordId] ?: return ResolveOutcome.UnknownOpponent
+
+        val initiatorBalance = initiator.socialCredit ?: 0L
+        val opponentBalance = opponent.socialCredit ?: 0L
+
+        if (winnerDiscordId == null) {
+            // Draw — refund both stakes.
+            initiator.socialCredit = initiatorBalance + stake
+            opponent.socialCredit = opponentBalance + stake
+            userService.updateUser(initiator)
+            userService.updateUser(opponent)
+            return ResolveOutcome.Draw(
+                stake = stake,
+                initiatorNewBalance = initiator.socialCredit ?: 0L,
+                opponentNewBalance = opponent.socialCredit ?: 0L,
+            )
+        }
+        val (winner, loser) = when (winnerDiscordId) {
+            initiatorDiscordId -> initiator to opponent
+            opponentDiscordId -> opponent to initiator
+            else -> return ResolveOutcome.UnknownInitiator // unknown winner — shouldn't happen
+        }
+        return payWinner(winner = winner, loser = loser, stake = stake, guildId = guildId)
+    }
+
+    private fun payWinner(
+        winner: UserDto,
+        loser: UserDto,
+        stake: Long,
+        guildId: Long,
+    ): ResolveOutcome.Win {
+        val winnerStartBalance = winner.socialCredit ?: 0L
+        val tribute = JackpotHelper.divertOnLoss(jackpotService, configService, guildId, stake)
+        val pot = 2L * stake
+        val winnerPayout = pot - tribute
+        winner.socialCredit = winnerStartBalance + winnerPayout
+        userService.updateUser(winner)
+        val xpGranted = xpAwardService.award(
+            discordId = winner.discordId,
+            guildId = guildId,
+            amount = WIN_XP,
+            reason = "tictactoe:win",
+        )
+        val outcome = ResolveOutcome.Win(
+            winnerDiscordId = winner.discordId,
+            loserDiscordId = loser.discordId,
+            stake = stake,
+            pot = pot,
+            winnerNewBalance = winner.socialCredit ?: 0L,
+            loserNewBalance = loser.socialCredit ?: 0L,
+            lossTribute = tribute,
+            xpGranted = xpGranted,
+        )
+        publishResolved(outcome, guildId)
+        return outcome
+    }
+
+    private fun resolveFreePlay(
+        initiatorDiscordId: Long,
+        opponentDiscordId: Long,
+        guildId: Long,
+        winnerDiscordId: Long?,
+    ): ResolveOutcome {
+        if (winnerDiscordId == null) {
+            return ResolveOutcome.Draw(stake = 0L, initiatorNewBalance = 0L, opponentNewBalance = 0L)
+        }
+        val loserDiscordId = when (winnerDiscordId) {
+            initiatorDiscordId -> opponentDiscordId
+            opponentDiscordId -> initiatorDiscordId
+            else -> return ResolveOutcome.UnknownInitiator
+        }
+        val xpGranted = xpAwardService.award(
+            discordId = winnerDiscordId,
+            guildId = guildId,
+            amount = WIN_XP,
+            reason = "tictactoe:win",
+        )
+        val outcome = ResolveOutcome.Win(
+            winnerDiscordId = winnerDiscordId,
+            loserDiscordId = loserDiscordId,
+            stake = 0L,
+            pot = 0L,
+            winnerNewBalance = 0L,
+            loserNewBalance = 0L,
+            lossTribute = 0L,
+            xpGranted = xpGranted,
+        )
+        publishResolved(outcome, guildId)
+        return outcome
+    }
+
+    /**
+     * Surfaces the resolution to `AchievementEventHandler` for
+     * `first_tictactoe_win` / `tictactoe_wins_*` / `tictactoe_losses_*`
+     * progression. Draws never publish — no winner, no loser. Free-play
+     * wins DO publish so achievements unlock regardless of whether
+     * anyone bet.
+     */
+    private fun publishResolved(outcome: ResolveOutcome.Win, guildId: Long) {
+        eventPublisher?.publishEvent(
+            TicTacToeResolvedEvent(
+                winnerDiscordId = outcome.winnerDiscordId,
+                loserDiscordId = outcome.loserDiscordId,
+                guildId = guildId,
+                stake = outcome.stake,
+                pot = outcome.pot,
+            )
+        )
+    }
+
+    private fun readStakeBounds(guildId: Long): Pair<Long, Long> {
+        val min = configService.cfgLong(
+            ConfigDto.Configurations.TICTACTOE_MIN_STAKE, guildId, default = MIN_STAKE, min = 0L
+        )
+        val max = configService.cfgLongMax(
+            ConfigDto.Configurations.TICTACTOE_MAX_STAKE, guildId, default = MAX_STAKE, min = min
+        )
+        return min to max
+    }
+
+    companion object {
+        /** Allow stake-free play: 0 is a valid minimum. */
+        const val MIN_STAKE: Long = 0L
+        const val MAX_STAKE: Long = 500L
+
+        /** XP awarded to the winner regardless of stake. Daily-cap-respecting via XpAwardService. */
+        const val WIN_XP: Long = 10L
+    }
+}

--- a/database/src/main/kotlin/database/tictactoe/TicTacToeSessionRegistry.kt
+++ b/database/src/main/kotlin/database/tictactoe/TicTacToeSessionRegistry.kt
@@ -1,0 +1,274 @@
+package database.tictactoe
+
+import com.github.benmanes.caffeine.cache.Cache
+import com.github.benmanes.caffeine.cache.Caffeine
+import common.tictactoe.TicTacToeEngine
+import database.configuration.RegistryScheduler
+import org.springframework.stereotype.Component
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.ConcurrentMap
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * In-memory book of live `/tictactoe` matches. Two stages:
+ *   - PENDING — `/tictactoe` posted; opponent hasn't yet hit Accept.
+ *     Stakes are NOT yet debited from anyone.
+ *   - LIVE — opponent accepted; both stakes locked. Players alternate
+ *     placing marks on the board via [applyMove]; the initiator (X)
+ *     moves first by convention. When a move completes a line or fills
+ *     the board, the caller drains the session (via
+ *     [consumeForResolution]) and the service resolves the wager.
+ *
+ * **Storage**: backed by a Caffeine [Cache] (via `asMap()` for the
+ * familiar `ConcurrentMap` ops) so we get a hard upper bound on
+ * concurrent sessions ([MAX_SESSIONS]) and a TTL backstop
+ * ([MAX_LIFETIME]) on entries that the scheduler somehow misses.
+ * Matches the convention used by [database.rps.RpsSessionRegistry] —
+ * belt-and-suspenders memory protection beyond the scheduler-driven
+ * phase callbacks.
+ *
+ * **Shot clock**: re-armed after every successful move via
+ * [applyMove]'s internal `armMoveClock`. If the current actor doesn't
+ * place a mark within [moveTtl], the registry fires
+ * `onMoveTimeout(session)` — the caller (button) treats the timeout
+ * as a forfeit by the current actor. Pending-phase timeouts work
+ * identically to RPS.
+ */
+@Component
+class TicTacToeSessionRegistry(
+    val pendingTtl: Duration = DEFAULT_PENDING_TTL,
+    val moveTtl: Duration = DEFAULT_MOVE_TTL,
+    private val scheduler: ScheduledExecutorService = RegistryScheduler.instance,
+    maximumSessions: Long = MAX_SESSIONS,
+    maxLifetime: Duration = MAX_LIFETIME,
+) {
+
+    data class Session(
+        val id: Long,
+        val guildId: Long,
+        val initiatorDiscordId: Long,
+        val opponentDiscordId: Long,
+        val stake: Long,
+        val createdAt: Instant,
+        var board: TicTacToeEngine.Board = TicTacToeEngine.empty(),
+        /** Whose turn it is; only meaningful in LIVE. Initiator starts as X. */
+        var currentTurn: TicTacToeEngine.Mark = TicTacToeEngine.Mark.X,
+        /** Move number, starts at 0; used to key shot-clock stale-fire detection. */
+        var moveNumber: Int = 0,
+        var state: State = State.PENDING,
+        /** Set on terminal — winning line for embed highlighting, null on draw. */
+        var winningLine: List<Int>? = null,
+        /** Set on terminal — Mark of the winner, null on draw / no-resolution. */
+        var winner: TicTacToeEngine.Mark? = null,
+    ) {
+        enum class State { PENDING, LIVE }
+
+        /** Discord id of the player whose turn it currently is. */
+        fun currentActorDiscordId(): Long = when (currentTurn) {
+            TicTacToeEngine.Mark.X -> initiatorDiscordId
+            TicTacToeEngine.Mark.O -> opponentDiscordId
+        }
+
+        /** Mark assigned to [discordId]; null if [discordId] isn't in this match. */
+        fun markFor(discordId: Long): TicTacToeEngine.Mark? = when (discordId) {
+            initiatorDiscordId -> TicTacToeEngine.Mark.X
+            opponentDiscordId -> TicTacToeEngine.Mark.O
+            else -> null
+        }
+    }
+
+    private val cache: Cache<Long, Session> = Caffeine.newBuilder()
+        .expireAfterWrite(maxLifetime)
+        .maximumSize(maximumSessions)
+        .build()
+    private val sessions: ConcurrentMap<Long, Session> = cache.asMap()
+    private val seq = AtomicLong()
+
+    /** Per-session pending move-clock task. Keyed by sessionId. */
+    private val moveClocks: ConcurrentMap<Long, ScheduledFuture<*>> = java.util.concurrent.ConcurrentHashMap()
+
+    /**
+     * Register a fresh PENDING offer. Schedules a timeout that fires
+     * only if the offer is still pending — once accepted (LIVE) the
+     * pending timer is a no-op and the per-move timer takes over.
+     */
+    fun register(
+        guildId: Long,
+        initiatorDiscordId: Long,
+        opponentDiscordId: Long,
+        stake: Long,
+        createdAt: Instant = Instant.now(),
+        onPendingTimeout: (Session) -> Unit = {},
+    ): Session {
+        val id = seq.incrementAndGet()
+        val session = Session(
+            id = id,
+            guildId = guildId,
+            initiatorDiscordId = initiatorDiscordId,
+            opponentDiscordId = opponentDiscordId,
+            stake = stake,
+            createdAt = createdAt,
+        )
+        sessions[id] = session
+        scheduler.schedule({
+            val current = sessions[id]
+            if (current != null && current.state == Session.State.PENDING) {
+                val expired = sessions.remove(id)
+                if (expired != null) runCatching { onPendingTimeout(expired) }
+            }
+        }, pendingTtl.toMillis(), TimeUnit.MILLISECONDS)
+        return session
+    }
+
+    /**
+     * Transition PENDING → LIVE on the opponent's Accept. Returns the
+     * session or null if it already expired or was cancelled. Arms the
+     * first per-move timeout; the caller passes [onMoveTimeout] for
+     * the auto-forfeit path.
+     */
+    fun accept(id: Long, onMoveTimeout: (Session) -> Unit = {}): Session? {
+        val session = sessions[id] ?: return null
+        synchronized(session) {
+            if (session.state != Session.State.PENDING) return null
+            session.state = Session.State.LIVE
+        }
+        armMoveClock(session, onMoveTimeout)
+        return session
+    }
+
+    /** Atomic remove for decline (opponent rejects PENDING offer). */
+    fun decline(id: Long): Session? {
+        val session = sessions[id] ?: return null
+        synchronized(session) {
+            if (session.state != Session.State.PENDING) return null
+            return sessions.remove(id)
+        }
+    }
+
+    /**
+     * Apply a move to the session. Validates that the caller is the
+     * current actor and the session is LIVE; delegates the board math
+     * to [TicTacToeEngine.applyMove]. On a terminal result (Win / Draw)
+     * the session is left in place — the caller is expected to call
+     * [consumeForResolution] to atomically drain it.
+     *
+     * Re-arms the per-move shot clock on a Continued result so the
+     * other player now has [moveTtl] to respond.
+     *
+     * Returns:
+     *  - the engine's [TicTacToeEngine.MoveResult] when the call lands
+     *    (note: Continued / Win / Draw are all "landed")
+     *  - `null` when the session no longer exists, the caller isn't a
+     *    participant, the session isn't LIVE, or it isn't the caller's
+     *    turn — i.e. anything the button shouldn't treat as a move
+     */
+    fun applyMove(
+        id: Long,
+        discordId: Long,
+        cell: Int,
+        onMoveTimeout: (Session) -> Unit = {},
+    ): TicTacToeEngine.MoveResult? {
+        val session = sessions[id] ?: return null
+        return synchronized(session) {
+            if (session.state != Session.State.LIVE) return@synchronized null
+            val mark = session.markFor(discordId) ?: return@synchronized null
+            if (mark != session.currentTurn) return@synchronized null
+            val result = TicTacToeEngine.applyMove(session.board, cell, mark)
+            when (result) {
+                is TicTacToeEngine.MoveResult.Continued -> {
+                    session.board = result.board
+                    session.currentTurn = other(mark)
+                    session.moveNumber += 1
+                    armMoveClock(session, onMoveTimeout)
+                }
+                is TicTacToeEngine.MoveResult.Win -> {
+                    session.board = result.board
+                    session.winningLine = result.winningLine
+                    session.winner = result.winner
+                    session.moveNumber += 1
+                    cancelMoveClock(session.id)
+                }
+                is TicTacToeEngine.MoveResult.Draw -> {
+                    session.board = result.board
+                    session.moveNumber += 1
+                    cancelMoveClock(session.id)
+                }
+                TicTacToeEngine.MoveResult.IllegalCell,
+                TicTacToeEngine.MoveResult.Occupied -> { /* board unchanged */ }
+            }
+            result
+        }
+    }
+
+    /**
+     * Atomic remove for resolution — call once a Win / Draw landed or
+     * a forfeit / timeout is being settled. Cancels any pending move
+     * clock so it can't double-fire after the session is drained.
+     */
+    fun consumeForResolution(id: Long): Session? {
+        val removed = sessions.remove(id) ?: return null
+        cancelMoveClock(id)
+        return removed
+    }
+
+    /**
+     * Atomic remove for forfeit (a player gives up mid-game). Returns
+     * the session or null if already gone. Cancels the move clock.
+     */
+    fun forfeit(id: Long): Session? = consumeForResolution(id)
+
+    fun get(id: Long): Session? = sessions[id]
+
+    private fun armMoveClock(session: Session, onMoveTimeout: (Session) -> Unit) {
+        cancelMoveClock(session.id)
+        val expectedMove = session.moveNumber
+        val future = scheduler.schedule({
+            val current = sessions[session.id] ?: return@schedule
+            synchronized(current) {
+                // Stale fire: someone already moved on (move counter
+                // advanced) or the session left LIVE — drop it.
+                if (current.state != Session.State.LIVE) return@synchronized
+                if (current.moveNumber != expectedMove) return@synchronized
+                val expired = sessions.remove(session.id)
+                if (expired != null) runCatching { onMoveTimeout(expired) }
+            }
+        }, moveTtl.toMillis(), TimeUnit.MILLISECONDS)
+        moveClocks[session.id] = future
+    }
+
+    private fun cancelMoveClock(id: Long) {
+        val task = moveClocks.remove(id) ?: return
+        task.cancel(false)
+    }
+
+    private fun other(mark: TicTacToeEngine.Mark): TicTacToeEngine.Mark = when (mark) {
+        TicTacToeEngine.Mark.X -> TicTacToeEngine.Mark.O
+        TicTacToeEngine.Mark.O -> TicTacToeEngine.Mark.X
+    }
+
+    companion object {
+        val DEFAULT_PENDING_TTL: Duration = Duration.ofMinutes(3)
+        val DEFAULT_MOVE_TTL: Duration = Duration.ofMinutes(1)
+
+        /**
+         * Hard upper bound on concurrent in-flight sessions. Same
+         * order of magnitude as [database.rps.RpsSessionRegistry] —
+         * generous enough that a real PvP burst doesn't trip it, low
+         * enough that a malformed `/tictactoe` flood can't OOM the
+         * heap. Caffeine evicts LRU above the cap.
+         */
+        const val MAX_SESSIONS: Long = 10_000L
+
+        /**
+         * Backstop lifetime per session: pending TTL (3m) + up to 9
+         * moves × move TTL (1m each) + slop = 12 minutes. Caffeine
+         * evicts entries past this even if a scheduled task somehow
+         * didn't run.
+         */
+        val MAX_LIFETIME: Duration = Duration.ofMinutes(12)
+    }
+}

--- a/database/src/test/kotlin/database/achievement/AchievementCatalogTest.kt
+++ b/database/src/test/kotlin/database/achievement/AchievementCatalogTest.kt
@@ -76,6 +76,7 @@ class AchievementCatalogTest {
             "first_duel_win", "duel_wins_10", "duel_wins_25", "duel_wins_50", "duel_wins_100",
             "duel_losses_5", "duel_losses_25",
             "first_rps_win", "rps_wins_10", "rps_wins_25", "rps_losses_5",
+            "first_tictactoe_win", "tictactoe_wins_10", "tictactoe_wins_25", "tictactoe_losses_5",
         ).forEach { code ->
             assertNotNull(AchievementCatalog.byCode(code), "missing achievement '$code'")
         }
@@ -109,6 +110,7 @@ class AchievementCatalogTest {
             "first_duel_win", "duel_wins_10", "duel_wins_25", "duel_wins_50", "duel_wins_100",
             "duel_losses_5", "duel_losses_25",
             "first_rps_win", "rps_wins_10", "rps_wins_25", "rps_losses_5",
+            "first_tictactoe_win", "tictactoe_wins_10", "tictactoe_wins_25", "tictactoe_losses_5",
             "lottery_winner", "lottery_wins_3", "lottery_wins_10", "lottery_wins_25",
             "intro_set",
             "voice_10h", "voice_100h", "voice_250h", "voice_500h", "voice_1000h",

--- a/database/src/test/kotlin/database/service/PvpWagerServiceTest.kt
+++ b/database/src/test/kotlin/database/service/PvpWagerServiceTest.kt
@@ -1,0 +1,274 @@
+package database.service
+
+import database.dto.ConfigDto
+import database.dto.UserDto
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Behavioural tests for [PvpWagerService] — the wager primitives shared
+ * across `/rps`, `/tictactoe`, and (future) `/connect4`. Per-game
+ * services delegate here; the resolve-branching tests live in
+ * RpsServiceTest / TicTacToeServiceTest with PvpWagerService mocked.
+ */
+class PvpWagerServiceTest {
+
+    private val guildId = 100L
+    private val initiatorId = 1L
+    private val opponentId = 2L
+
+    private lateinit var userService: UserService
+    private lateinit var jackpotService: JackpotService
+    private lateinit var configService: ConfigService
+    private lateinit var xpAwardService: XpAwardService
+    private lateinit var service: PvpWagerService
+
+    @BeforeEach
+    fun setUp() {
+        userService = mockk(relaxed = true)
+        jackpotService = mockk(relaxed = true)
+        configService = mockk(relaxed = true)
+        xpAwardService = mockk(relaxed = true)
+        service = PvpWagerService(userService, jackpotService, configService, xpAwardService)
+
+        // No tribute by default; per-test override raises it.
+        every { configService.getConfigByName(ConfigDto.Configurations.JACKPOT_LOSS_TRIBUTE_PCT.configValue, any()) } returns
+            ConfigDto(name = "JACKPOT_LOSS_TRIBUTE_PCT", value = "0", guildId = guildId.toString())
+        every { jackpotService.addToPool(any(), any()) } returns 0L
+        every { xpAwardService.award(any(), any(), any(), any(), any(), any(), any()) } returns 0L
+    }
+
+    // ---- preflightStart ----
+
+    @Test
+    fun `preflightStart rejects stake below min`() {
+        val outcome = service.preflightStart(initiatorId, opponentId, guildId, stake = 5L, minStake = 10L, maxStake = 100L)
+        assertTrue(outcome is PvpWagerService.StartOutcome.InvalidStake)
+    }
+
+    @Test
+    fun `preflightStart rejects stake above max`() {
+        val outcome = service.preflightStart(initiatorId, opponentId, guildId, stake = 500L, minStake = 0L, maxStake = 100L)
+        assertTrue(outcome is PvpWagerService.StartOutcome.InvalidStake)
+    }
+
+    @Test
+    fun `preflightStart rejects self-challenge`() {
+        val outcome = service.preflightStart(initiatorId, initiatorId, guildId, stake = 0L, minStake = 0L, maxStake = 500L)
+        assertTrue(outcome is PvpWagerService.StartOutcome.InvalidOpponent)
+        assertEquals(
+            PvpWagerService.StartOutcome.InvalidOpponent.Reason.SELF,
+            (outcome as PvpWagerService.StartOutcome.InvalidOpponent).reason,
+        )
+    }
+
+    @Test
+    fun `preflightStart rejects unknown initiator`() {
+        every { userService.getUserById(initiatorId, guildId) } returns null
+        val outcome = service.preflightStart(initiatorId, opponentId, guildId, stake = 0L, minStake = 0L, maxStake = 500L)
+        assertEquals(PvpWagerService.StartOutcome.UnknownInitiator, outcome)
+    }
+
+    @Test
+    fun `preflightStart rejects unknown opponent`() {
+        every { userService.getUserById(initiatorId, guildId) } returns userDto(initiatorId, balance = 100L)
+        every { userService.getUserById(opponentId, guildId) } returns null
+        val outcome = service.preflightStart(initiatorId, opponentId, guildId, stake = 50L, minStake = 0L, maxStake = 500L)
+        assertEquals(PvpWagerService.StartOutcome.UnknownOpponent, outcome)
+    }
+
+    @Test
+    fun `preflightStart rejects insufficient initiator balance`() {
+        every { userService.getUserById(initiatorId, guildId) } returns userDto(initiatorId, balance = 5L)
+        every { userService.getUserById(opponentId, guildId) } returns userDto(opponentId, balance = 100L)
+        val outcome = service.preflightStart(initiatorId, opponentId, guildId, stake = 50L, minStake = 0L, maxStake = 500L)
+        assertTrue(outcome is PvpWagerService.StartOutcome.InitiatorInsufficient)
+    }
+
+    @Test
+    fun `preflightStart rejects insufficient opponent balance`() {
+        every { userService.getUserById(initiatorId, guildId) } returns userDto(initiatorId, balance = 100L)
+        every { userService.getUserById(opponentId, guildId) } returns userDto(opponentId, balance = 5L)
+        val outcome = service.preflightStart(initiatorId, opponentId, guildId, stake = 50L, minStake = 0L, maxStake = 500L)
+        assertTrue(outcome is PvpWagerService.StartOutcome.OpponentInsufficient)
+    }
+
+    @Test
+    fun `preflightStart happy path returns Ok with initiator balance`() {
+        every { userService.getUserById(initiatorId, guildId) } returns userDto(initiatorId, balance = 200L)
+        every { userService.getUserById(opponentId, guildId) } returns userDto(opponentId, balance = 200L)
+        val outcome = service.preflightStart(initiatorId, opponentId, guildId, stake = 50L, minStake = 0L, maxStake = 500L)
+        assertEquals(PvpWagerService.StartOutcome.Ok(200L), outcome)
+    }
+
+    // ---- debitBoth ----
+
+    @Test
+    fun `debitBoth with zero stake skips the user-table update path`() {
+        every { userService.getUserById(initiatorId, guildId) } returns userDto(initiatorId, balance = 0L)
+        every { userService.getUserById(opponentId, guildId) } returns userDto(opponentId, balance = 0L)
+        val outcome = service.debitBoth(initiatorId, opponentId, guildId, stake = 0L)
+        assertEquals(PvpWagerService.AcceptOutcome.Ok(0L, 0L), outcome)
+        verify(exactly = 0) { userService.updateUser(any()) }
+    }
+
+    @Test
+    fun `debitBoth debits both balances on stake-bearing match`() {
+        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns userDto(initiatorId, balance = 100L)
+        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns userDto(opponentId, balance = 200L)
+
+        val outcome = service.debitBoth(initiatorId, opponentId, guildId, stake = 50L)
+        assertEquals(PvpWagerService.AcceptOutcome.Ok(50L, 150L), outcome)
+        verify(exactly = 1) { userService.updateUser(match { it.discordId == initiatorId && it.socialCredit == 50L }) }
+        verify(exactly = 1) { userService.updateUser(match { it.discordId == opponentId && it.socialCredit == 150L }) }
+    }
+
+    @Test
+    fun `debitBoth refuses when balance fell below stake between start and accept`() {
+        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns userDto(initiatorId, balance = 10L)
+        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns userDto(opponentId, balance = 200L)
+        val outcome = service.debitBoth(initiatorId, opponentId, guildId, stake = 50L)
+        assertTrue(outcome is PvpWagerService.AcceptOutcome.InitiatorInsufficient)
+        verify(exactly = 0) { userService.updateUser(any()) }
+    }
+
+    @Test
+    fun `debitBoth surfaces UnknownInitiator when the row is missing under lock`() {
+        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns null
+        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns userDto(opponentId, balance = 100L)
+        val outcome = service.debitBoth(initiatorId, opponentId, guildId, stake = 50L)
+        assertEquals(PvpWagerService.AcceptOutcome.UnknownInitiator, outcome)
+    }
+
+    // ---- payWinner ----
+
+    @Test
+    fun `payWinner credits the winner the pot minus tribute and grants XP`() {
+        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns userDto(initiatorId, balance = 50L)
+        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns userDto(opponentId, balance = 150L)
+        every { xpAwardService.award(initiatorId, guildId, 10L, "rps:win", any(), any(), any()) } returns 10L
+
+        val result = service.payWinner(
+            winnerDiscordId = initiatorId, loserDiscordId = opponentId,
+            stake = 50L, guildId = guildId, xpReason = "rps:win", xpAmount = 10L,
+        )
+        assertNotNull(result)
+        assertEquals(150L, result!!.winnerNewBalance) // 50 (post-debit) + 100 (pot)
+        assertEquals(150L, result.loserNewBalance) // loser balance unchanged from post-debit
+        assertEquals(100L, result.pot)
+        assertEquals(0L, result.lossTribute)
+        assertEquals(10L, result.xpGranted)
+        verify(exactly = 1) { userService.updateUser(match { it.discordId == initiatorId && it.socialCredit == 150L }) }
+        // Loser was already debited at accept time — no further update.
+        verify(exactly = 0) { userService.updateUser(match { it.discordId == opponentId }) }
+    }
+
+    @Test
+    fun `payWinner deducts jackpot tribute from the winner payout`() {
+        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns userDto(initiatorId, balance = 50L)
+        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns userDto(opponentId, balance = 150L)
+        every { configService.getConfigByName(ConfigDto.Configurations.JACKPOT_LOSS_TRIBUTE_PCT.configValue, any()) } returns
+            ConfigDto(name = "JACKPOT_LOSS_TRIBUTE_PCT", value = "20", guildId = guildId.toString())
+        every { jackpotService.addToPool(guildId, any()) } returns 10L
+
+        val result = service.payWinner(
+            winnerDiscordId = initiatorId, loserDiscordId = opponentId,
+            stake = 50L, guildId = guildId, xpReason = "rps:win", xpAmount = 10L,
+        )
+        assertNotNull(result)
+        assertEquals(140L, result!!.winnerNewBalance) // 50 + (100 pot - 10 tribute) = 140
+        assertEquals(10L, result.lossTribute)
+        assertEquals(100L, result.pot)
+    }
+
+    @Test
+    fun `payWinner with zero stake only grants XP and returns zero wager numbers`() {
+        every { xpAwardService.award(initiatorId, guildId, 10L, "rps:win", any(), any(), any()) } returns 10L
+        val result = service.payWinner(
+            winnerDiscordId = initiatorId, loserDiscordId = opponentId,
+            stake = 0L, guildId = guildId, xpReason = "rps:win", xpAmount = 10L,
+        )
+        assertNotNull(result)
+        assertEquals(0L, result!!.pot)
+        assertEquals(10L, result.xpGranted)
+        verify(exactly = 0) { userService.updateUser(any()) }
+        // No lock-and-fetch on the free-play path. lockUsersInAscendingOrder is a
+        // top-level extension; verify the underlying getUserByIdForUpdate it calls.
+        verify(exactly = 0) { userService.getUserByIdForUpdate(any(), any()) }
+    }
+
+    @Test
+    fun `payWinner returns null when the winner row is missing under lock`() {
+        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns null
+        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns userDto(opponentId, balance = 150L)
+        val result = service.payWinner(
+            winnerDiscordId = initiatorId, loserDiscordId = opponentId,
+            stake = 50L, guildId = guildId, xpReason = "rps:win", xpAmount = 10L,
+        )
+        assertNull(result)
+        verify(exactly = 0) { userService.updateUser(any()) }
+    }
+
+    // ---- refundBoth ----
+
+    @Test
+    fun `refundBoth credits both players the stake back`() {
+        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns userDto(initiatorId, balance = 50L)
+        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns userDto(opponentId, balance = 150L)
+
+        val result = service.refundBoth(initiatorId, opponentId, stake = 50L, guildId = guildId)
+        assertEquals(100L, result.initiatorNewBalance) // 50 + 50
+        assertEquals(200L, result.opponentNewBalance) // 150 + 50
+        verify(exactly = 1) { userService.updateUser(match { it.discordId == initiatorId && it.socialCredit == 100L }) }
+        verify(exactly = 1) { userService.updateUser(match { it.discordId == opponentId && it.socialCredit == 200L }) }
+    }
+
+    @Test
+    fun `refundBoth with zero stake is a no-op`() {
+        val result = service.refundBoth(initiatorId, opponentId, stake = 0L, guildId = guildId)
+        assertEquals(0L, result.initiatorNewBalance)
+        assertEquals(0L, result.opponentNewBalance)
+        verify(exactly = 0) { userService.updateUser(any()) }
+        verify(exactly = 0) { userService.getUserByIdForUpdate(any(), any()) }
+    }
+
+    // ---- readStakeBounds ----
+
+    @Test
+    fun `readStakeBounds returns defaults when no config is set`() {
+        every { configService.getConfigByName(any(), any()) } returns null
+        val (min, max) = service.readStakeBounds(
+            guildId, ConfigDto.Configurations.RPS_MIN_STAKE, ConfigDto.Configurations.RPS_MAX_STAKE,
+            defaultMin = 0L, defaultMax = 500L,
+        )
+        assertEquals(0L, min)
+        assertEquals(500L, max)
+    }
+
+    @Test
+    fun `readStakeBounds reads min and max from the config service`() {
+        every { configService.getConfigByName(ConfigDto.Configurations.RPS_MIN_STAKE.configValue, any()) } returns
+            ConfigDto(name = "RPS_MIN_STAKE", value = "10", guildId = guildId.toString())
+        every { configService.getConfigByName(ConfigDto.Configurations.RPS_MAX_STAKE.configValue, any()) } returns
+            ConfigDto(name = "RPS_MAX_STAKE", value = "200", guildId = guildId.toString())
+        val (min, max) = service.readStakeBounds(
+            guildId, ConfigDto.Configurations.RPS_MIN_STAKE, ConfigDto.Configurations.RPS_MAX_STAKE,
+            defaultMin = 0L, defaultMax = 500L,
+        )
+        assertEquals(10L, min)
+        assertEquals(200L, max)
+    }
+
+    private fun userDto(discordId: Long, balance: Long): UserDto = UserDto(
+        discordId = discordId,
+        guildId = guildId,
+        socialCredit = balance,
+    ).also { every { userService.updateUser(it) } answers { firstArg() } }
+}

--- a/database/src/test/kotlin/database/service/RpsServiceTest.kt
+++ b/database/src/test/kotlin/database/service/RpsServiceTest.kt
@@ -1,12 +1,8 @@
 package database.service
 
 import common.events.RpsResolvedEvent
-import database.dto.ConfigDto
-import database.dto.UserDto
 import common.rps.RpsEngine
-import io.mockk.Runs
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -16,10 +12,14 @@ import org.junit.jupiter.api.Test
 import org.springframework.context.ApplicationEventPublisher
 
 /**
- * Behavioural tests for [RpsService]. Cover the four resolve branches
- * (clean win, draw, one-side forfeit, double-no-pick) plus the
- * preflight + accept guardrails, with both stake-bearing and free-play
- * paths exercised.
+ * Behavioural tests for the RPS-specific branching in [RpsService].
+ * The wager primitives ([PvpWagerService.preflightStart] /
+ * [PvpWagerService.debitBoth] / [PvpWagerService.payWinner] /
+ * [PvpWagerService.refundBoth]) live in PvpWagerService and are
+ * covered by [PvpWagerServiceTest]; this suite mocks them and
+ * verifies that the four resolve cases (both-picked-clean,
+ * both-picked-draw, one-picked-forfeit, neither-picked) route to the
+ * right primitive and the right ResolveOutcome + event.
  */
 class RpsServiceTest {
 
@@ -27,213 +27,165 @@ class RpsServiceTest {
     private val initiatorId = 1L
     private val opponentId = 2L
 
-    private lateinit var userService: UserService
-    private lateinit var jackpotService: JackpotService
-    private lateinit var configService: ConfigService
-    private lateinit var xpAwardService: XpAwardService
+    private lateinit var pvpWagerService: PvpWagerService
     private lateinit var eventPublisher: ApplicationEventPublisher
     private lateinit var service: RpsService
 
     @BeforeEach
     fun setUp() {
-        userService = mockk(relaxed = true)
-        jackpotService = mockk(relaxed = true)
-        configService = mockk(relaxed = true)
-        xpAwardService = mockk(relaxed = true)
+        pvpWagerService = mockk(relaxed = true)
         eventPublisher = mockk(relaxed = true)
-        service = RpsService(userService, jackpotService, configService, xpAwardService, eventPublisher)
-
-        // Default stake bounds: 0..500 (the RPS defaults).
-        every { configService.getConfigByName(ConfigDto.Configurations.RPS_MIN_STAKE.configValue, any()) } returns null
-        every { configService.getConfigByName(ConfigDto.Configurations.RPS_MAX_STAKE.configValue, any()) } returns null
-        // No tribute by default (test-pure jackpot accounting).
-        // JackpotHelper.divertOnLoss reads JACKPOT_LOSS_TRIBUTE_PCT from
-        // configService and calls jackpotService.addToPool — default to
-        // "no tribute" so test-pure jackpot accounting just works.
-        every { configService.getConfigByName(ConfigDto.Configurations.JACKPOT_LOSS_TRIBUTE_PCT.configValue, any()) } returns
-            ConfigDto(name = "JACKPOT_LOSS_TRIBUTE_PCT", value = "0", guildId = guildId.toString())
-        every { jackpotService.addToPool(any(), any()) } returns 0L
-        // No-op XP grant by default.
-        every { xpAwardService.award(any(), any(), any(), any(), any(), any(), any()) } returns 0L
+        service = RpsService(pvpWagerService, eventPublisher)
     }
 
-    // ---- startMatch preflight ----
+    // ---- startMatch / acceptMatch are thin pass-throughs ----
 
     @Test
-    fun `startMatch rejects out-of-range stake`() {
-        every { configService.getConfigByName(ConfigDto.Configurations.RPS_MIN_STAKE.configValue, any()) } returns
-            ConfigDto(name = "RPS_MIN_STAKE", value = "10", guildId = guildId.toString())
-        val outcome = service.startMatch(initiatorId, opponentId, guildId, stake = 5L)
-        assertTrue(outcome is RpsService.StartOutcome.InvalidStake)
+    fun `startMatch returns whatever preflightStart returns`() {
+        val expected = PvpWagerService.StartOutcome.Ok(200L)
+        every { pvpWagerService.readStakeBounds(any(), any(), any(), any(), any()) } returns (0L to 500L)
+        every { pvpWagerService.preflightStart(initiatorId, opponentId, guildId, 50L, 0L, 500L) } returns expected
+
+        val outcome = service.startMatch(initiatorId, opponentId, guildId, 50L)
+        assertEquals(expected, outcome)
     }
 
     @Test
-    fun `startMatch rejects self-challenge`() {
-        val outcome = service.startMatch(initiatorId, initiatorId, guildId, stake = 0L)
-        assertTrue(outcome is RpsService.StartOutcome.InvalidOpponent)
+    fun `acceptMatch returns whatever debitBoth returns`() {
+        val expected = PvpWagerService.AcceptOutcome.Ok(50L, 150L)
+        every { pvpWagerService.debitBoth(initiatorId, opponentId, guildId, 50L) } returns expected
+
+        val outcome = service.acceptMatch(initiatorId, opponentId, guildId, 50L)
+        assertEquals(expected, outcome)
     }
 
-    @Test
-    fun `startMatch rejects unknown initiator`() {
-        every { userService.getUserById(initiatorId, guildId) } returns null
-        val outcome = service.startMatch(initiatorId, opponentId, guildId, stake = 0L)
-        assertEquals(RpsService.StartOutcome.UnknownInitiator, outcome)
-    }
+    // ---- resolveMatch: clean win ----
 
     @Test
-    fun `startMatch rejects insufficient initiator balance`() {
-        every { userService.getUserById(initiatorId, guildId) } returns userDto(initiatorId, balance = 5L)
-        every { userService.getUserById(opponentId, guildId) } returns userDto(opponentId, balance = 100L)
-        val outcome = service.startMatch(initiatorId, opponentId, guildId, stake = 50L)
-        assertTrue(outcome is RpsService.StartOutcome.InitiatorInsufficient)
-    }
-
-    @Test
-    fun `startMatch happy path returns Ok with initiator balance`() {
-        every { userService.getUserById(initiatorId, guildId) } returns userDto(initiatorId, balance = 200L)
-        every { userService.getUserById(opponentId, guildId) } returns userDto(opponentId, balance = 200L)
-        val outcome = service.startMatch(initiatorId, opponentId, guildId, stake = 50L)
-        assertEquals(RpsService.StartOutcome.Ok(200L), outcome)
-    }
-
-    // ---- acceptMatch ----
-
-    @Test
-    fun `acceptMatch with zero stake skips the user-table update path`() {
-        every { userService.getUserById(initiatorId, guildId) } returns userDto(initiatorId, balance = 0L)
-        every { userService.getUserById(opponentId, guildId) } returns userDto(opponentId, balance = 0L)
-        val outcome = service.acceptMatch(initiatorId, opponentId, guildId, stake = 0L)
-        assertEquals(RpsService.AcceptOutcome.Ok(0L, 0L), outcome)
-        // Stake-free path must not lock or write.
-        verify(exactly = 0) { userService.updateUser(any()) }
-    }
-
-    @Test
-    fun `acceptMatch debits both balances on stake-bearing match`() {
-        val initiator = userDto(initiatorId, balance = 100L)
-        val opponent = userDto(opponentId, balance = 200L)
-        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns initiator
-        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns opponent
-
-        val outcome = service.acceptMatch(initiatorId, opponentId, guildId, stake = 50L)
-        assertEquals(RpsService.AcceptOutcome.Ok(50L, 150L), outcome)
-        verify(exactly = 1) { userService.updateUser(match { it.discordId == initiatorId && it.socialCredit == 50L }) }
-        verify(exactly = 1) { userService.updateUser(match { it.discordId == opponentId && it.socialCredit == 150L }) }
-    }
-
-    @Test
-    fun `acceptMatch refuses when balance fell below stake between start and accept`() {
-        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns userDto(initiatorId, balance = 10L)
-        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns userDto(opponentId, balance = 200L)
-        val outcome = service.acceptMatch(initiatorId, opponentId, guildId, stake = 50L)
-        assertTrue(outcome is RpsService.AcceptOutcome.InitiatorInsufficient)
-        verify(exactly = 0) { userService.updateUser(any()) }
-    }
-
-    // ---- resolveMatch: both picked ----
-
-    @Test
-    fun `resolveMatch credits winner and grants XP on clean win`() {
-        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns userDto(initiatorId, balance = 50L)
-        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns userDto(opponentId, balance = 150L)
-        every { xpAwardService.award(initiatorId, guildId, 10L, "rps:win", any(), any(), any()) } returns 10L
+    fun `resolveMatch on first-wins routes to payWinner with the initiator as winner`() {
+        every { pvpWagerService.payWinner(initiatorId, opponentId, 50L, guildId, any(), any()) } returns
+            PvpWagerService.PayResult(150L, 100L, 100L, 0L, 10L)
 
         val outcome = service.resolveMatch(
             initiatorId, opponentId, guildId, stake = 50L,
             initiatorChoice = RpsEngine.Choice.ROCK,
             opponentChoice = RpsEngine.Choice.SCISSORS,
         )
-        // Initiator (winner) gets pot = 100; their balance was 50 (post-accept-debit), so 50 + 100 = 150.
-        assertTrue(outcome is RpsService.ResolveOutcome.Win, "expected Win, got $outcome")
         val win = outcome as RpsService.ResolveOutcome.Win
         assertEquals(initiatorId, win.winnerDiscordId)
         assertEquals(opponentId, win.loserDiscordId)
+        assertEquals(RpsEngine.Choice.ROCK, win.winnerChoice)
+        assertEquals(RpsEngine.Choice.SCISSORS, win.loserChoice)
         assertEquals(150L, win.winnerNewBalance)
         assertEquals(10L, win.xpGranted)
-        verify(exactly = 1) { userService.updateUser(match { it.discordId == initiatorId && it.socialCredit == 150L }) }
-        // Loser was already debited at accept time — NO further update.
-        verify(exactly = 0) { userService.updateUser(match { it.discordId == opponentId }) }
+        verify(exactly = 1) { pvpWagerService.payWinner(initiatorId, opponentId, 50L, guildId, "rps:win", 10L) }
+        verify(exactly = 0) { pvpWagerService.refundBoth(any(), any(), any(), any()) }
     }
 
     @Test
-    fun `resolveMatch refunds both stakes on draw`() {
-        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns userDto(initiatorId, balance = 50L)
-        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns userDto(opponentId, balance = 150L)
+    fun `resolveMatch on second-wins flips the winner and loser ids on payWinner`() {
+        every { pvpWagerService.payWinner(opponentId, initiatorId, 50L, guildId, any(), any()) } returns
+            PvpWagerService.PayResult(250L, 0L, 100L, 0L, 10L)
+
+        val outcome = service.resolveMatch(
+            initiatorId, opponentId, guildId, stake = 50L,
+            initiatorChoice = RpsEngine.Choice.ROCK,
+            opponentChoice = RpsEngine.Choice.PAPER,
+        )
+        val win = outcome as RpsService.ResolveOutcome.Win
+        assertEquals(opponentId, win.winnerDiscordId)
+        assertEquals(initiatorId, win.loserDiscordId)
+    }
+
+    // ---- resolveMatch: draw ----
+
+    @Test
+    fun `resolveMatch on identical-pick routes to refundBoth and does not publish`() {
+        every { pvpWagerService.refundBoth(initiatorId, opponentId, 50L, guildId) } returns
+            PvpWagerService.RefundResult(100L, 200L)
 
         val outcome = service.resolveMatch(
             initiatorId, opponentId, guildId, stake = 50L,
             initiatorChoice = RpsEngine.Choice.PAPER,
             opponentChoice = RpsEngine.Choice.PAPER,
         )
-        assertTrue(outcome is RpsService.ResolveOutcome.Draw, "expected Draw, got $outcome")
         val draw = outcome as RpsService.ResolveOutcome.Draw
-        assertEquals(100L, draw.initiatorNewBalance) // 50 + 50 refund
-        assertEquals(200L, draw.opponentNewBalance) // 150 + 50 refund
-        verify(exactly = 1) { userService.updateUser(match { it.discordId == initiatorId && it.socialCredit == 100L }) }
-        verify(exactly = 1) { userService.updateUser(match { it.discordId == opponentId && it.socialCredit == 200L }) }
-        // No XP grant on draw.
-        verify(exactly = 0) { xpAwardService.award(any(), any(), any(), any(), any(), any(), any()) }
+        assertEquals(RpsEngine.Choice.PAPER, draw.choice)
+        assertEquals(100L, draw.initiatorNewBalance)
+        assertEquals(200L, draw.opponentNewBalance)
+        verify(exactly = 0) { pvpWagerService.payWinner(any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 0) { eventPublisher.publishEvent(any<RpsResolvedEvent>()) }
     }
+
+    // ---- resolveMatch: one-side forfeit ----
 
     @Test
     fun `resolveMatch credits picker when opponent never picked (forfeit)`() {
-        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns userDto(initiatorId, balance = 50L)
-        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns userDto(opponentId, balance = 150L)
+        every { pvpWagerService.payWinner(initiatorId, opponentId, 50L, guildId, any(), any()) } returns
+            PvpWagerService.PayResult(150L, 100L, 100L, 0L, 10L)
 
         val outcome = service.resolveMatch(
             initiatorId, opponentId, guildId, stake = 50L,
             initiatorChoice = RpsEngine.Choice.ROCK,
             opponentChoice = null,
         )
-        assertTrue(outcome is RpsService.ResolveOutcome.Win)
         val win = outcome as RpsService.ResolveOutcome.Win
         assertEquals(initiatorId, win.winnerDiscordId)
-        assertEquals(150L, win.winnerNewBalance)
     }
 
     @Test
-    fun `resolveMatch double-refunds when neither side picked`() {
-        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns userDto(initiatorId, balance = 50L)
-        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns userDto(opponentId, balance = 150L)
+    fun `resolveMatch credits picker when initiator never picked`() {
+        every { pvpWagerService.payWinner(opponentId, initiatorId, 50L, guildId, any(), any()) } returns
+            PvpWagerService.PayResult(250L, 0L, 100L, 0L, 10L)
+
+        val outcome = service.resolveMatch(
+            initiatorId, opponentId, guildId, stake = 50L,
+            initiatorChoice = null,
+            opponentChoice = RpsEngine.Choice.SCISSORS,
+        )
+        val win = outcome as RpsService.ResolveOutcome.Win
+        assertEquals(opponentId, win.winnerDiscordId)
+    }
+
+    // ---- resolveMatch: double-no-pick ----
+
+    @Test
+    fun `resolveMatch double-refunds when neither side picked and does not publish`() {
+        every { pvpWagerService.refundBoth(initiatorId, opponentId, 50L, guildId) } returns
+            PvpWagerService.RefundResult(100L, 200L)
 
         val outcome = service.resolveMatch(
             initiatorId, opponentId, guildId, stake = 50L,
             initiatorChoice = null,
             opponentChoice = null,
         )
-        assertTrue(outcome is RpsService.ResolveOutcome.DoubleRefund)
         val refund = outcome as RpsService.ResolveOutcome.DoubleRefund
         assertEquals(100L, refund.initiatorNewBalance)
         assertEquals(200L, refund.opponentNewBalance)
-        verify(exactly = 1) { userService.updateUser(match { it.discordId == initiatorId && it.socialCredit == 100L }) }
-        verify(exactly = 1) { userService.updateUser(match { it.discordId == opponentId && it.socialCredit == 200L }) }
+        verify(exactly = 0) { eventPublisher.publishEvent(any<RpsResolvedEvent>()) }
     }
 
-    // ---- resolveMatch: free play ----
+    // ---- defensive: payWinner returns null ----
 
     @Test
-    fun `resolveMatch with zero stake skips user updates and only grants XP`() {
-        every { xpAwardService.award(initiatorId, guildId, 10L, "rps:win", any(), any(), any()) } returns 10L
+    fun `resolveMatch surfaces Unknown when payWinner returns null`() {
+        every { pvpWagerService.payWinner(any(), any(), any(), any(), any(), any()) } returns null
+
         val outcome = service.resolveMatch(
-            initiatorId, opponentId, guildId, stake = 0L,
+            initiatorId, opponentId, guildId, stake = 50L,
             initiatorChoice = RpsEngine.Choice.ROCK,
             opponentChoice = RpsEngine.Choice.SCISSORS,
         )
-        assertTrue(outcome is RpsService.ResolveOutcome.Win)
-        val win = outcome as RpsService.ResolveOutcome.Win
-        assertEquals(initiatorId, win.winnerDiscordId)
-        assertEquals(0L, win.pot)
-        assertEquals(10L, win.xpGranted)
-        // No user-table writes on free play.
-        verify(exactly = 0) { userService.updateUser(any()) }
+        assertEquals(RpsService.ResolveOutcome.Unknown, outcome)
+        verify(exactly = 0) { eventPublisher.publishEvent(any<RpsResolvedEvent>()) }
     }
 
-    // ---- achievement event publishing ----
+    // ---- event publishing ----
 
     @Test
     fun `resolveMatch publishes RpsResolvedEvent on a clean win`() {
-        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns userDto(initiatorId, balance = 50L)
-        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns userDto(opponentId, balance = 150L)
+        every { pvpWagerService.payWinner(initiatorId, opponentId, 50L, guildId, any(), any()) } returns
+            PvpWagerService.PayResult(150L, 100L, 100L, 0L, 10L)
 
         service.resolveMatch(
             initiatorId, opponentId, guildId, stake = 50L,
@@ -258,6 +210,9 @@ class RpsServiceTest {
     fun `resolveMatch publishes RpsResolvedEvent on free-play wins too`() {
         // Free-play wins must still fire the event so `first_rps_win`
         // can unlock for players who never bet a credit.
+        every { pvpWagerService.payWinner(initiatorId, opponentId, 0L, guildId, any(), any()) } returns
+            PvpWagerService.PayResult(0L, 0L, 0L, 0L, 10L)
+
         service.resolveMatch(
             initiatorId, opponentId, guildId, stake = 0L,
             initiatorChoice = RpsEngine.Choice.ROCK,
@@ -276,57 +231,46 @@ class RpsServiceTest {
     }
 
     @Test
-    fun `resolveMatch does NOT publish on a draw`() {
-        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns userDto(initiatorId, balance = 50L)
-        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns userDto(opponentId, balance = 150L)
-
-        service.resolveMatch(
-            initiatorId, opponentId, guildId, stake = 50L,
-            initiatorChoice = RpsEngine.Choice.PAPER,
-            opponentChoice = RpsEngine.Choice.PAPER,
-        )
-
-        verify(exactly = 0) { eventPublisher.publishEvent(any<RpsResolvedEvent>()) }
-    }
-
-    @Test
-    fun `resolveMatch does NOT publish on double-no-pick`() {
-        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns userDto(initiatorId, balance = 50L)
-        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns userDto(opponentId, balance = 150L)
-
-        service.resolveMatch(
-            initiatorId, opponentId, guildId, stake = 50L,
-            initiatorChoice = null,
-            opponentChoice = null,
-        )
-
-        verify(exactly = 0) { eventPublisher.publishEvent(any<RpsResolvedEvent>()) }
-    }
-
-    @Test
-    fun `resolveMatch jackpot tribute is deducted from winner payout`() {
-        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns userDto(initiatorId, balance = 50L)
-        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns userDto(opponentId, balance = 150L)
-        // 20% tribute on a 50-credit stake → 10 credits routed to jackpot.
-        every { configService.getConfigByName(ConfigDto.Configurations.JACKPOT_LOSS_TRIBUTE_PCT.configValue, any()) } returns
-            ConfigDto(name = "JACKPOT_LOSS_TRIBUTE_PCT", value = "20", guildId = guildId.toString())
-        every { jackpotService.addToPool(guildId, any()) } returns 10L
-
+    fun `resolveMatch with zero stake routes to payWinner (which handles free-play internally)`() {
+        every { pvpWagerService.payWinner(initiatorId, opponentId, 0L, guildId, any(), any()) } returns
+            PvpWagerService.PayResult(0L, 0L, 0L, 0L, 10L)
         val outcome = service.resolveMatch(
-            initiatorId, opponentId, guildId, stake = 50L,
+            initiatorId, opponentId, guildId, stake = 0L,
             initiatorChoice = RpsEngine.Choice.ROCK,
             opponentChoice = RpsEngine.Choice.SCISSORS,
         )
         val win = outcome as RpsService.ResolveOutcome.Win
-        // Winner balance was 50 post-debit; gets pot (100) minus tribute (10) = 90 → new balance 140.
-        assertEquals(140L, win.winnerNewBalance)
-        assertEquals(10L, win.lossTribute)
-        assertEquals(100L, win.pot)
+        assertEquals(0L, win.pot)
+        assertEquals(10L, win.xpGranted)
+        verify(exactly = 0) { pvpWagerService.refundBoth(any(), any(), any(), any()) }
     }
 
-    private fun userDto(discordId: Long, balance: Long): UserDto = UserDto(
-        discordId = discordId,
-        guildId = guildId,
-        socialCredit = balance,
-    ).also { every { userService.updateUser(it) } answers { firstArg() } }
+    @Test
+    fun `resolveMatch loser-choice placeholder is the move beaten by the winner-choice`() {
+        // Cosmetic: forfeit-win renders "Rock crushes Scissors" — the loser placeholder
+        // must be the choice that the winner's choice actually beats.
+        every { pvpWagerService.payWinner(initiatorId, opponentId, 50L, guildId, any(), any()) } returns
+            PvpWagerService.PayResult(150L, 100L, 100L, 0L, 10L)
+
+        val outcome = service.resolveMatch(
+            initiatorId, opponentId, guildId, stake = 50L,
+            initiatorChoice = RpsEngine.Choice.ROCK,
+            opponentChoice = null,
+        )
+        val win = outcome as RpsService.ResolveOutcome.Win
+        assertEquals(RpsEngine.Choice.SCISSORS, win.loserChoice)
+    }
+
+    @Test
+    fun `loser-choice placeholder for PAPER win is ROCK`() {
+        every { pvpWagerService.payWinner(initiatorId, opponentId, 50L, guildId, any(), any()) } returns
+            PvpWagerService.PayResult(150L, 100L, 100L, 0L, 10L)
+        val outcome = service.resolveMatch(
+            initiatorId, opponentId, guildId, stake = 50L,
+            initiatorChoice = RpsEngine.Choice.PAPER,
+            opponentChoice = null,
+        )
+        val win = outcome as RpsService.ResolveOutcome.Win
+        assertTrue(win.loserChoice == RpsEngine.Choice.ROCK)
+    }
 }

--- a/database/src/test/kotlin/database/service/TicTacToeServiceTest.kt
+++ b/database/src/test/kotlin/database/service/TicTacToeServiceTest.kt
@@ -1,8 +1,6 @@
 package database.service
 
 import common.events.TicTacToeResolvedEvent
-import database.dto.ConfigDto
-import database.dto.UserDto
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -13,10 +11,14 @@ import org.junit.jupiter.api.Test
 import org.springframework.context.ApplicationEventPublisher
 
 /**
- * Behavioural tests for [TicTacToeService]. Covers the three resolve
- * branches (clean win by completed line, forfeit/timeout walkover via
- * explicit winner, draw) plus the preflight + accept guardrails, with
- * both stake-bearing and free-play paths exercised.
+ * Behavioural tests for the TTT-specific branching in [TicTacToeService].
+ * The wager primitives ([PvpWagerService.preflightStart] /
+ * [PvpWagerService.debitBoth] / [PvpWagerService.payWinner] /
+ * [PvpWagerService.refundBoth]) live in PvpWagerService and are
+ * covered by [PvpWagerServiceTest]; this suite mocks them and
+ * verifies that the three resolve cases (clean win, forfeit walkover,
+ * draw) route to the right primitive and the right ResolveOutcome +
+ * event.
  */
 class TicTacToeServiceTest {
 
@@ -24,198 +26,147 @@ class TicTacToeServiceTest {
     private val initiatorId = 1L
     private val opponentId = 2L
 
-    private lateinit var userService: UserService
-    private lateinit var jackpotService: JackpotService
-    private lateinit var configService: ConfigService
-    private lateinit var xpAwardService: XpAwardService
+    private lateinit var pvpWagerService: PvpWagerService
     private lateinit var eventPublisher: ApplicationEventPublisher
     private lateinit var service: TicTacToeService
 
     @BeforeEach
     fun setUp() {
-        userService = mockk(relaxed = true)
-        jackpotService = mockk(relaxed = true)
-        configService = mockk(relaxed = true)
-        xpAwardService = mockk(relaxed = true)
+        pvpWagerService = mockk(relaxed = true)
         eventPublisher = mockk(relaxed = true)
-        service = TicTacToeService(userService, jackpotService, configService, xpAwardService, eventPublisher)
-
-        // Default stake bounds: 0..500.
-        every { configService.getConfigByName(ConfigDto.Configurations.TICTACTOE_MIN_STAKE.configValue, any()) } returns null
-        every { configService.getConfigByName(ConfigDto.Configurations.TICTACTOE_MAX_STAKE.configValue, any()) } returns null
-        // No tribute by default.
-        every { configService.getConfigByName(ConfigDto.Configurations.JACKPOT_LOSS_TRIBUTE_PCT.configValue, any()) } returns
-            ConfigDto(name = "JACKPOT_LOSS_TRIBUTE_PCT", value = "0", guildId = guildId.toString())
-        every { jackpotService.addToPool(any(), any()) } returns 0L
-        every { xpAwardService.award(any(), any(), any(), any(), any(), any(), any()) } returns 0L
+        service = TicTacToeService(pvpWagerService, eventPublisher)
     }
 
-    // ---- startMatch preflight ----
+    // ---- startMatch / acceptMatch are thin pass-throughs ----
 
     @Test
-    fun `startMatch rejects out-of-range stake`() {
-        every { configService.getConfigByName(ConfigDto.Configurations.TICTACTOE_MIN_STAKE.configValue, any()) } returns
-            ConfigDto(name = "TICTACTOE_MIN_STAKE", value = "10", guildId = guildId.toString())
-        val outcome = service.startMatch(initiatorId, opponentId, guildId, stake = 5L)
-        assertTrue(outcome is TicTacToeService.StartOutcome.InvalidStake)
+    fun `startMatch returns whatever preflightStart returns`() {
+        val expected = PvpWagerService.StartOutcome.Ok(200L)
+        every { pvpWagerService.readStakeBounds(any(), any(), any(), any(), any()) } returns (0L to 500L)
+        every { pvpWagerService.preflightStart(initiatorId, opponentId, guildId, 50L, 0L, 500L) } returns expected
+
+        val outcome = service.startMatch(initiatorId, opponentId, guildId, 50L)
+        assertEquals(expected, outcome)
     }
 
     @Test
-    fun `startMatch rejects self-challenge`() {
-        val outcome = service.startMatch(initiatorId, initiatorId, guildId, stake = 0L)
-        assertTrue(outcome is TicTacToeService.StartOutcome.InvalidOpponent)
+    fun `acceptMatch returns whatever debitBoth returns`() {
+        val expected = PvpWagerService.AcceptOutcome.Ok(50L, 150L)
+        every { pvpWagerService.debitBoth(initiatorId, opponentId, guildId, 50L) } returns expected
+
+        val outcome = service.acceptMatch(initiatorId, opponentId, guildId, 50L)
+        assertEquals(expected, outcome)
     }
 
-    @Test
-    fun `startMatch rejects unknown initiator`() {
-        every { userService.getUserById(initiatorId, guildId) } returns null
-        val outcome = service.startMatch(initiatorId, opponentId, guildId, stake = 0L)
-        assertEquals(TicTacToeService.StartOutcome.UnknownInitiator, outcome)
-    }
+    // ---- resolveMatch: clean win / forfeit / timeout (all the same wager path) ----
 
     @Test
-    fun `startMatch rejects insufficient initiator balance`() {
-        every { userService.getUserById(initiatorId, guildId) } returns userDto(initiatorId, balance = 5L)
-        every { userService.getUserById(opponentId, guildId) } returns userDto(opponentId, balance = 100L)
-        val outcome = service.startMatch(initiatorId, opponentId, guildId, stake = 50L)
-        assertTrue(outcome is TicTacToeService.StartOutcome.InitiatorInsufficient)
-    }
-
-    @Test
-    fun `startMatch happy path returns Ok with initiator balance`() {
-        every { userService.getUserById(initiatorId, guildId) } returns userDto(initiatorId, balance = 200L)
-        every { userService.getUserById(opponentId, guildId) } returns userDto(opponentId, balance = 200L)
-        val outcome = service.startMatch(initiatorId, opponentId, guildId, stake = 50L)
-        assertEquals(TicTacToeService.StartOutcome.Ok(200L), outcome)
-    }
-
-    // ---- acceptMatch ----
-
-    @Test
-    fun `acceptMatch with zero stake skips the user-table update path`() {
-        every { userService.getUserById(initiatorId, guildId) } returns userDto(initiatorId, balance = 0L)
-        every { userService.getUserById(opponentId, guildId) } returns userDto(opponentId, balance = 0L)
-        val outcome = service.acceptMatch(initiatorId, opponentId, guildId, stake = 0L)
-        assertEquals(TicTacToeService.AcceptOutcome.Ok(0L, 0L), outcome)
-        verify(exactly = 0) { userService.updateUser(any()) }
-    }
-
-    @Test
-    fun `acceptMatch debits both balances on stake-bearing match`() {
-        val initiator = userDto(initiatorId, balance = 100L)
-        val opponent = userDto(opponentId, balance = 200L)
-        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns initiator
-        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns opponent
-
-        val outcome = service.acceptMatch(initiatorId, opponentId, guildId, stake = 50L)
-        assertEquals(TicTacToeService.AcceptOutcome.Ok(50L, 150L), outcome)
-        verify(exactly = 1) { userService.updateUser(match { it.discordId == initiatorId && it.socialCredit == 50L }) }
-        verify(exactly = 1) { userService.updateUser(match { it.discordId == opponentId && it.socialCredit == 150L }) }
-    }
-
-    @Test
-    fun `acceptMatch refuses when balance fell below stake between start and accept`() {
-        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns userDto(initiatorId, balance = 10L)
-        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns userDto(opponentId, balance = 200L)
-        val outcome = service.acceptMatch(initiatorId, opponentId, guildId, stake = 50L)
-        assertTrue(outcome is TicTacToeService.AcceptOutcome.InitiatorInsufficient)
-        verify(exactly = 0) { userService.updateUser(any()) }
-    }
-
-    // ---- resolveMatch: stake-bearing ----
-
-    @Test
-    fun `resolveMatch credits winner and grants XP on clean win`() {
-        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns userDto(initiatorId, balance = 50L)
-        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns userDto(opponentId, balance = 150L)
-        every { xpAwardService.award(initiatorId, guildId, 10L, "tictactoe:win", any(), any(), any()) } returns 10L
+    fun `resolveMatch with explicit winner routes to payWinner`() {
+        every { pvpWagerService.payWinner(initiatorId, opponentId, 50L, guildId, any(), any()) } returns
+            PvpWagerService.PayResult(150L, 100L, 100L, 0L, 10L)
 
         val outcome = service.resolveMatch(
             initiatorId, opponentId, guildId, stake = 50L,
             winnerDiscordId = initiatorId,
         )
-        assertTrue(outcome is TicTacToeService.ResolveOutcome.Win, "expected Win, got $outcome")
         val win = outcome as TicTacToeService.ResolveOutcome.Win
         assertEquals(initiatorId, win.winnerDiscordId)
         assertEquals(opponentId, win.loserDiscordId)
-        assertEquals(150L, win.winnerNewBalance) // 50 (post-debit) + 100 (pot)
+        assertEquals(150L, win.winnerNewBalance)
         assertEquals(10L, win.xpGranted)
-        verify(exactly = 1) { userService.updateUser(match { it.discordId == initiatorId && it.socialCredit == 150L }) }
-        // Loser was already debited at accept time — no further write.
-        verify(exactly = 0) { userService.updateUser(match { it.discordId == opponentId }) }
+        verify(exactly = 1) { pvpWagerService.payWinner(initiatorId, opponentId, 50L, guildId, "tictactoe:win", 10L) }
+        verify(exactly = 0) { pvpWagerService.refundBoth(any(), any(), any(), any()) }
     }
 
     @Test
-    fun `resolveMatch refunds both stakes on draw`() {
-        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns userDto(initiatorId, balance = 50L)
-        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns userDto(opponentId, balance = 150L)
+    fun `resolveMatch flips winner and loser when opponent is the explicit winner`() {
+        every { pvpWagerService.payWinner(opponentId, initiatorId, 50L, guildId, any(), any()) } returns
+            PvpWagerService.PayResult(250L, 0L, 100L, 0L, 10L)
+
+        val outcome = service.resolveMatch(
+            initiatorId, opponentId, guildId, stake = 50L,
+            winnerDiscordId = opponentId,
+        )
+        val win = outcome as TicTacToeService.ResolveOutcome.Win
+        assertEquals(opponentId, win.winnerDiscordId)
+        assertEquals(initiatorId, win.loserDiscordId)
+    }
+
+    // ---- resolveMatch: draw ----
+
+    @Test
+    fun `resolveMatch with null winner routes to refundBoth and does not publish`() {
+        every { pvpWagerService.refundBoth(initiatorId, opponentId, 50L, guildId) } returns
+            PvpWagerService.RefundResult(100L, 200L)
 
         val outcome = service.resolveMatch(
             initiatorId, opponentId, guildId, stake = 50L,
             winnerDiscordId = null,
         )
-        assertTrue(outcome is TicTacToeService.ResolveOutcome.Draw)
         val draw = outcome as TicTacToeService.ResolveOutcome.Draw
-        assertEquals(100L, draw.initiatorNewBalance) // 50 + 50 refund
-        assertEquals(200L, draw.opponentNewBalance) // 150 + 50 refund
-        verify(exactly = 1) { userService.updateUser(match { it.discordId == initiatorId && it.socialCredit == 100L }) }
-        verify(exactly = 1) { userService.updateUser(match { it.discordId == opponentId && it.socialCredit == 200L }) }
-        verify(exactly = 0) { xpAwardService.award(any(), any(), any(), any(), any(), any(), any()) }
-    }
-
-    @Test
-    fun `resolveMatch credits the explicit winner on a forfeit walkover`() {
-        // Forfeit / timeout collapses to the same wager arithmetic as a
-        // clean win — the button passes the survivor's discord id and
-        // the service pays them the pot.
-        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns userDto(initiatorId, balance = 50L)
-        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns userDto(opponentId, balance = 150L)
-
-        val outcome = service.resolveMatch(
-            initiatorId, opponentId, guildId, stake = 50L,
-            winnerDiscordId = opponentId, // initiator forfeited
-        )
-        assertTrue(outcome is TicTacToeService.ResolveOutcome.Win)
-        val win = outcome as TicTacToeService.ResolveOutcome.Win
-        assertEquals(opponentId, win.winnerDiscordId)
-        assertEquals(initiatorId, win.loserDiscordId)
-        assertEquals(250L, win.winnerNewBalance) // 150 (post-debit) + 100 (pot)
+        assertEquals(100L, draw.initiatorNewBalance)
+        assertEquals(200L, draw.opponentNewBalance)
+        verify(exactly = 0) { pvpWagerService.payWinner(any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 0) { eventPublisher.publishEvent(any<TicTacToeResolvedEvent>()) }
     }
 
     // ---- resolveMatch: free play ----
 
     @Test
-    fun `resolveMatch with zero stake skips user updates and only grants XP`() {
-        every { xpAwardService.award(initiatorId, guildId, 10L, "tictactoe:win", any(), any(), any()) } returns 10L
+    fun `resolveMatch with zero stake routes to payWinner (which handles free-play internally)`() {
+        every { pvpWagerService.payWinner(initiatorId, opponentId, 0L, guildId, any(), any()) } returns
+            PvpWagerService.PayResult(0L, 0L, 0L, 0L, 10L)
+
         val outcome = service.resolveMatch(
             initiatorId, opponentId, guildId, stake = 0L,
             winnerDiscordId = initiatorId,
         )
-        assertTrue(outcome is TicTacToeService.ResolveOutcome.Win)
         val win = outcome as TicTacToeService.ResolveOutcome.Win
-        assertEquals(initiatorId, win.winnerDiscordId)
         assertEquals(0L, win.pot)
         assertEquals(10L, win.xpGranted)
-        verify(exactly = 0) { userService.updateUser(any()) }
     }
 
     @Test
-    fun `resolveMatch with zero stake and null winner returns a free-play draw without XP`() {
+    fun `resolveMatch with zero stake and null winner returns a free-play draw without payout`() {
+        // refundBoth handles the stake=0 short-circuit (returns zeros).
         val outcome = service.resolveMatch(
             initiatorId, opponentId, guildId, stake = 0L,
             winnerDiscordId = null,
         )
         assertTrue(outcome is TicTacToeService.ResolveOutcome.Draw)
-        verify(exactly = 0) { userService.updateUser(any()) }
-        verify(exactly = 0) { xpAwardService.award(any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 0) { pvpWagerService.payWinner(any(), any(), any(), any(), any(), any()) }
     }
 
-    // ---- achievement event publishing ----
+    // ---- defensive: payWinner returns null / unknown winner id ----
+
+    @Test
+    fun `resolveMatch surfaces Unknown when payWinner returns null`() {
+        every { pvpWagerService.payWinner(any(), any(), any(), any(), any(), any()) } returns null
+        val outcome = service.resolveMatch(
+            initiatorId, opponentId, guildId, stake = 50L,
+            winnerDiscordId = initiatorId,
+        )
+        assertEquals(TicTacToeService.ResolveOutcome.Unknown, outcome)
+        verify(exactly = 0) { eventPublisher.publishEvent(any<TicTacToeResolvedEvent>()) }
+    }
+
+    @Test
+    fun `resolveMatch surfaces Unknown when the winner id isn't in this match`() {
+        val outcome = service.resolveMatch(
+            initiatorId, opponentId, guildId, stake = 50L,
+            winnerDiscordId = 9999L,
+        )
+        assertEquals(TicTacToeService.ResolveOutcome.Unknown, outcome)
+        verify(exactly = 0) { pvpWagerService.payWinner(any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 0) { eventPublisher.publishEvent(any<TicTacToeResolvedEvent>()) }
+    }
+
+    // ---- event publishing ----
 
     @Test
     fun `resolveMatch publishes TicTacToeResolvedEvent on a clean win`() {
-        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns userDto(initiatorId, balance = 50L)
-        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns userDto(opponentId, balance = 150L)
+        every { pvpWagerService.payWinner(initiatorId, opponentId, 50L, guildId, any(), any()) } returns
+            PvpWagerService.PayResult(150L, 100L, 100L, 0L, 10L)
 
         service.resolveMatch(
             initiatorId, opponentId, guildId, stake = 50L,
@@ -237,10 +188,14 @@ class TicTacToeServiceTest {
 
     @Test
     fun `resolveMatch publishes TicTacToeResolvedEvent on free-play wins too`() {
+        every { pvpWagerService.payWinner(initiatorId, opponentId, 0L, guildId, any(), any()) } returns
+            PvpWagerService.PayResult(0L, 0L, 0L, 0L, 10L)
+
         service.resolveMatch(
             initiatorId, opponentId, guildId, stake = 0L,
             winnerDiscordId = initiatorId,
         )
+
         verify(exactly = 1) {
             eventPublisher.publishEvent(
                 match<TicTacToeResolvedEvent> {
@@ -251,41 +206,4 @@ class TicTacToeServiceTest {
             )
         }
     }
-
-    @Test
-    fun `resolveMatch does NOT publish on a draw`() {
-        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns userDto(initiatorId, balance = 50L)
-        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns userDto(opponentId, balance = 150L)
-
-        service.resolveMatch(
-            initiatorId, opponentId, guildId, stake = 50L,
-            winnerDiscordId = null,
-        )
-        verify(exactly = 0) { eventPublisher.publishEvent(any<TicTacToeResolvedEvent>()) }
-    }
-
-    @Test
-    fun `resolveMatch jackpot tribute is deducted from winner payout`() {
-        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns userDto(initiatorId, balance = 50L)
-        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns userDto(opponentId, balance = 150L)
-        every { configService.getConfigByName(ConfigDto.Configurations.JACKPOT_LOSS_TRIBUTE_PCT.configValue, any()) } returns
-            ConfigDto(name = "JACKPOT_LOSS_TRIBUTE_PCT", value = "20", guildId = guildId.toString())
-        every { jackpotService.addToPool(guildId, any()) } returns 10L
-
-        val outcome = service.resolveMatch(
-            initiatorId, opponentId, guildId, stake = 50L,
-            winnerDiscordId = initiatorId,
-        )
-        val win = outcome as TicTacToeService.ResolveOutcome.Win
-        // Winner balance was 50 post-debit; gets pot (100) minus tribute (10) = 90 → 140.
-        assertEquals(140L, win.winnerNewBalance)
-        assertEquals(10L, win.lossTribute)
-        assertEquals(100L, win.pot)
-    }
-
-    private fun userDto(discordId: Long, balance: Long): UserDto = UserDto(
-        discordId = discordId,
-        guildId = guildId,
-        socialCredit = balance,
-    ).also { every { userService.updateUser(it) } answers { firstArg() } }
 }

--- a/database/src/test/kotlin/database/service/TicTacToeServiceTest.kt
+++ b/database/src/test/kotlin/database/service/TicTacToeServiceTest.kt
@@ -1,0 +1,291 @@
+package database.service
+
+import common.events.TicTacToeResolvedEvent
+import database.dto.ConfigDto
+import database.dto.UserDto
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
+
+/**
+ * Behavioural tests for [TicTacToeService]. Covers the three resolve
+ * branches (clean win by completed line, forfeit/timeout walkover via
+ * explicit winner, draw) plus the preflight + accept guardrails, with
+ * both stake-bearing and free-play paths exercised.
+ */
+class TicTacToeServiceTest {
+
+    private val guildId = 100L
+    private val initiatorId = 1L
+    private val opponentId = 2L
+
+    private lateinit var userService: UserService
+    private lateinit var jackpotService: JackpotService
+    private lateinit var configService: ConfigService
+    private lateinit var xpAwardService: XpAwardService
+    private lateinit var eventPublisher: ApplicationEventPublisher
+    private lateinit var service: TicTacToeService
+
+    @BeforeEach
+    fun setUp() {
+        userService = mockk(relaxed = true)
+        jackpotService = mockk(relaxed = true)
+        configService = mockk(relaxed = true)
+        xpAwardService = mockk(relaxed = true)
+        eventPublisher = mockk(relaxed = true)
+        service = TicTacToeService(userService, jackpotService, configService, xpAwardService, eventPublisher)
+
+        // Default stake bounds: 0..500.
+        every { configService.getConfigByName(ConfigDto.Configurations.TICTACTOE_MIN_STAKE.configValue, any()) } returns null
+        every { configService.getConfigByName(ConfigDto.Configurations.TICTACTOE_MAX_STAKE.configValue, any()) } returns null
+        // No tribute by default.
+        every { configService.getConfigByName(ConfigDto.Configurations.JACKPOT_LOSS_TRIBUTE_PCT.configValue, any()) } returns
+            ConfigDto(name = "JACKPOT_LOSS_TRIBUTE_PCT", value = "0", guildId = guildId.toString())
+        every { jackpotService.addToPool(any(), any()) } returns 0L
+        every { xpAwardService.award(any(), any(), any(), any(), any(), any(), any()) } returns 0L
+    }
+
+    // ---- startMatch preflight ----
+
+    @Test
+    fun `startMatch rejects out-of-range stake`() {
+        every { configService.getConfigByName(ConfigDto.Configurations.TICTACTOE_MIN_STAKE.configValue, any()) } returns
+            ConfigDto(name = "TICTACTOE_MIN_STAKE", value = "10", guildId = guildId.toString())
+        val outcome = service.startMatch(initiatorId, opponentId, guildId, stake = 5L)
+        assertTrue(outcome is TicTacToeService.StartOutcome.InvalidStake)
+    }
+
+    @Test
+    fun `startMatch rejects self-challenge`() {
+        val outcome = service.startMatch(initiatorId, initiatorId, guildId, stake = 0L)
+        assertTrue(outcome is TicTacToeService.StartOutcome.InvalidOpponent)
+    }
+
+    @Test
+    fun `startMatch rejects unknown initiator`() {
+        every { userService.getUserById(initiatorId, guildId) } returns null
+        val outcome = service.startMatch(initiatorId, opponentId, guildId, stake = 0L)
+        assertEquals(TicTacToeService.StartOutcome.UnknownInitiator, outcome)
+    }
+
+    @Test
+    fun `startMatch rejects insufficient initiator balance`() {
+        every { userService.getUserById(initiatorId, guildId) } returns userDto(initiatorId, balance = 5L)
+        every { userService.getUserById(opponentId, guildId) } returns userDto(opponentId, balance = 100L)
+        val outcome = service.startMatch(initiatorId, opponentId, guildId, stake = 50L)
+        assertTrue(outcome is TicTacToeService.StartOutcome.InitiatorInsufficient)
+    }
+
+    @Test
+    fun `startMatch happy path returns Ok with initiator balance`() {
+        every { userService.getUserById(initiatorId, guildId) } returns userDto(initiatorId, balance = 200L)
+        every { userService.getUserById(opponentId, guildId) } returns userDto(opponentId, balance = 200L)
+        val outcome = service.startMatch(initiatorId, opponentId, guildId, stake = 50L)
+        assertEquals(TicTacToeService.StartOutcome.Ok(200L), outcome)
+    }
+
+    // ---- acceptMatch ----
+
+    @Test
+    fun `acceptMatch with zero stake skips the user-table update path`() {
+        every { userService.getUserById(initiatorId, guildId) } returns userDto(initiatorId, balance = 0L)
+        every { userService.getUserById(opponentId, guildId) } returns userDto(opponentId, balance = 0L)
+        val outcome = service.acceptMatch(initiatorId, opponentId, guildId, stake = 0L)
+        assertEquals(TicTacToeService.AcceptOutcome.Ok(0L, 0L), outcome)
+        verify(exactly = 0) { userService.updateUser(any()) }
+    }
+
+    @Test
+    fun `acceptMatch debits both balances on stake-bearing match`() {
+        val initiator = userDto(initiatorId, balance = 100L)
+        val opponent = userDto(opponentId, balance = 200L)
+        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns initiator
+        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns opponent
+
+        val outcome = service.acceptMatch(initiatorId, opponentId, guildId, stake = 50L)
+        assertEquals(TicTacToeService.AcceptOutcome.Ok(50L, 150L), outcome)
+        verify(exactly = 1) { userService.updateUser(match { it.discordId == initiatorId && it.socialCredit == 50L }) }
+        verify(exactly = 1) { userService.updateUser(match { it.discordId == opponentId && it.socialCredit == 150L }) }
+    }
+
+    @Test
+    fun `acceptMatch refuses when balance fell below stake between start and accept`() {
+        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns userDto(initiatorId, balance = 10L)
+        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns userDto(opponentId, balance = 200L)
+        val outcome = service.acceptMatch(initiatorId, opponentId, guildId, stake = 50L)
+        assertTrue(outcome is TicTacToeService.AcceptOutcome.InitiatorInsufficient)
+        verify(exactly = 0) { userService.updateUser(any()) }
+    }
+
+    // ---- resolveMatch: stake-bearing ----
+
+    @Test
+    fun `resolveMatch credits winner and grants XP on clean win`() {
+        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns userDto(initiatorId, balance = 50L)
+        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns userDto(opponentId, balance = 150L)
+        every { xpAwardService.award(initiatorId, guildId, 10L, "tictactoe:win", any(), any(), any()) } returns 10L
+
+        val outcome = service.resolveMatch(
+            initiatorId, opponentId, guildId, stake = 50L,
+            winnerDiscordId = initiatorId,
+        )
+        assertTrue(outcome is TicTacToeService.ResolveOutcome.Win, "expected Win, got $outcome")
+        val win = outcome as TicTacToeService.ResolveOutcome.Win
+        assertEquals(initiatorId, win.winnerDiscordId)
+        assertEquals(opponentId, win.loserDiscordId)
+        assertEquals(150L, win.winnerNewBalance) // 50 (post-debit) + 100 (pot)
+        assertEquals(10L, win.xpGranted)
+        verify(exactly = 1) { userService.updateUser(match { it.discordId == initiatorId && it.socialCredit == 150L }) }
+        // Loser was already debited at accept time — no further write.
+        verify(exactly = 0) { userService.updateUser(match { it.discordId == opponentId }) }
+    }
+
+    @Test
+    fun `resolveMatch refunds both stakes on draw`() {
+        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns userDto(initiatorId, balance = 50L)
+        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns userDto(opponentId, balance = 150L)
+
+        val outcome = service.resolveMatch(
+            initiatorId, opponentId, guildId, stake = 50L,
+            winnerDiscordId = null,
+        )
+        assertTrue(outcome is TicTacToeService.ResolveOutcome.Draw)
+        val draw = outcome as TicTacToeService.ResolveOutcome.Draw
+        assertEquals(100L, draw.initiatorNewBalance) // 50 + 50 refund
+        assertEquals(200L, draw.opponentNewBalance) // 150 + 50 refund
+        verify(exactly = 1) { userService.updateUser(match { it.discordId == initiatorId && it.socialCredit == 100L }) }
+        verify(exactly = 1) { userService.updateUser(match { it.discordId == opponentId && it.socialCredit == 200L }) }
+        verify(exactly = 0) { xpAwardService.award(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `resolveMatch credits the explicit winner on a forfeit walkover`() {
+        // Forfeit / timeout collapses to the same wager arithmetic as a
+        // clean win — the button passes the survivor's discord id and
+        // the service pays them the pot.
+        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns userDto(initiatorId, balance = 50L)
+        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns userDto(opponentId, balance = 150L)
+
+        val outcome = service.resolveMatch(
+            initiatorId, opponentId, guildId, stake = 50L,
+            winnerDiscordId = opponentId, // initiator forfeited
+        )
+        assertTrue(outcome is TicTacToeService.ResolveOutcome.Win)
+        val win = outcome as TicTacToeService.ResolveOutcome.Win
+        assertEquals(opponentId, win.winnerDiscordId)
+        assertEquals(initiatorId, win.loserDiscordId)
+        assertEquals(250L, win.winnerNewBalance) // 150 (post-debit) + 100 (pot)
+    }
+
+    // ---- resolveMatch: free play ----
+
+    @Test
+    fun `resolveMatch with zero stake skips user updates and only grants XP`() {
+        every { xpAwardService.award(initiatorId, guildId, 10L, "tictactoe:win", any(), any(), any()) } returns 10L
+        val outcome = service.resolveMatch(
+            initiatorId, opponentId, guildId, stake = 0L,
+            winnerDiscordId = initiatorId,
+        )
+        assertTrue(outcome is TicTacToeService.ResolveOutcome.Win)
+        val win = outcome as TicTacToeService.ResolveOutcome.Win
+        assertEquals(initiatorId, win.winnerDiscordId)
+        assertEquals(0L, win.pot)
+        assertEquals(10L, win.xpGranted)
+        verify(exactly = 0) { userService.updateUser(any()) }
+    }
+
+    @Test
+    fun `resolveMatch with zero stake and null winner returns a free-play draw without XP`() {
+        val outcome = service.resolveMatch(
+            initiatorId, opponentId, guildId, stake = 0L,
+            winnerDiscordId = null,
+        )
+        assertTrue(outcome is TicTacToeService.ResolveOutcome.Draw)
+        verify(exactly = 0) { userService.updateUser(any()) }
+        verify(exactly = 0) { xpAwardService.award(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    // ---- achievement event publishing ----
+
+    @Test
+    fun `resolveMatch publishes TicTacToeResolvedEvent on a clean win`() {
+        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns userDto(initiatorId, balance = 50L)
+        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns userDto(opponentId, balance = 150L)
+
+        service.resolveMatch(
+            initiatorId, opponentId, guildId, stake = 50L,
+            winnerDiscordId = initiatorId,
+        )
+
+        verify(exactly = 1) {
+            eventPublisher.publishEvent(
+                match<TicTacToeResolvedEvent> {
+                    it.winnerDiscordId == initiatorId &&
+                        it.loserDiscordId == opponentId &&
+                        it.guildId == guildId &&
+                        it.stake == 50L &&
+                        it.pot == 100L
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `resolveMatch publishes TicTacToeResolvedEvent on free-play wins too`() {
+        service.resolveMatch(
+            initiatorId, opponentId, guildId, stake = 0L,
+            winnerDiscordId = initiatorId,
+        )
+        verify(exactly = 1) {
+            eventPublisher.publishEvent(
+                match<TicTacToeResolvedEvent> {
+                    it.winnerDiscordId == initiatorId &&
+                        it.stake == 0L &&
+                        it.pot == 0L
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `resolveMatch does NOT publish on a draw`() {
+        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns userDto(initiatorId, balance = 50L)
+        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns userDto(opponentId, balance = 150L)
+
+        service.resolveMatch(
+            initiatorId, opponentId, guildId, stake = 50L,
+            winnerDiscordId = null,
+        )
+        verify(exactly = 0) { eventPublisher.publishEvent(any<TicTacToeResolvedEvent>()) }
+    }
+
+    @Test
+    fun `resolveMatch jackpot tribute is deducted from winner payout`() {
+        every { userService.getUserByIdForUpdate(initiatorId, guildId) } returns userDto(initiatorId, balance = 50L)
+        every { userService.getUserByIdForUpdate(opponentId, guildId) } returns userDto(opponentId, balance = 150L)
+        every { configService.getConfigByName(ConfigDto.Configurations.JACKPOT_LOSS_TRIBUTE_PCT.configValue, any()) } returns
+            ConfigDto(name = "JACKPOT_LOSS_TRIBUTE_PCT", value = "20", guildId = guildId.toString())
+        every { jackpotService.addToPool(guildId, any()) } returns 10L
+
+        val outcome = service.resolveMatch(
+            initiatorId, opponentId, guildId, stake = 50L,
+            winnerDiscordId = initiatorId,
+        )
+        val win = outcome as TicTacToeService.ResolveOutcome.Win
+        // Winner balance was 50 post-debit; gets pot (100) minus tribute (10) = 90 → 140.
+        assertEquals(140L, win.winnerNewBalance)
+        assertEquals(10L, win.lossTribute)
+        assertEquals(100L, win.pot)
+    }
+
+    private fun userDto(discordId: Long, balance: Long): UserDto = UserDto(
+        discordId = discordId,
+        guildId = guildId,
+        socialCredit = balance,
+    ).also { every { userService.updateUser(it) } answers { firstArg() } }
+}

--- a/database/src/test/kotlin/database/tictactoe/TicTacToeSessionRegistryTest.kt
+++ b/database/src/test/kotlin/database/tictactoe/TicTacToeSessionRegistryTest.kt
@@ -1,0 +1,269 @@
+package database.tictactoe
+
+import common.tictactoe.TicTacToeEngine
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.ScheduledThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Behavioural tests for [TicTacToeSessionRegistry] — pin race-safety
+ * on the atomic state transitions and the per-move shot-clock
+ * re-arming.
+ */
+class TicTacToeSessionRegistryTest {
+
+    private val guildId = 100L
+    private val initiatorId = 1L
+    private val opponentId = 2L
+
+    @Test
+    fun `register issues monotonic ids`() {
+        val registry = TicTacToeSessionRegistry(scheduler = noopScheduler())
+        val a = registry.register(guildId, initiatorId, opponentId, stake = 10L)
+        val b = registry.register(guildId, initiatorId, opponentId, stake = 10L)
+        assertTrue(b.id > a.id)
+    }
+
+    @Test
+    fun `decline removes a pending session and accept on the same id returns null`() {
+        val registry = TicTacToeSessionRegistry(scheduler = noopScheduler())
+        val session = registry.register(guildId, initiatorId, opponentId, stake = 10L)
+        assertNotNull(registry.decline(session.id))
+        assertNull(registry.accept(session.id))
+    }
+
+    @Test
+    fun `accept transitions PENDING to LIVE and second accept is a no-op`() {
+        val registry = TicTacToeSessionRegistry(scheduler = noopScheduler())
+        val session = registry.register(guildId, initiatorId, opponentId, stake = 10L)
+        val first = registry.accept(session.id)
+        assertNotNull(first)
+        assertEquals(TicTacToeSessionRegistry.Session.State.LIVE, first!!.state)
+        assertNull(registry.accept(session.id))
+    }
+
+    @Test
+    fun `decline of LIVE session is rejected`() {
+        val registry = TicTacToeSessionRegistry(scheduler = noopScheduler())
+        val session = registry.register(guildId, initiatorId, opponentId, stake = 10L)
+        registry.accept(session.id)
+        assertNull(registry.decline(session.id))
+    }
+
+    @Test
+    fun `applyMove places mark and flips current turn`() {
+        val registry = TicTacToeSessionRegistry(scheduler = noopScheduler())
+        val session = registry.register(guildId, initiatorId, opponentId, stake = 10L)
+        registry.accept(session.id)
+        // Initiator (X) goes first.
+        val r = registry.applyMove(session.id, initiatorId, cell = 0)
+        assertTrue(r is TicTacToeEngine.MoveResult.Continued)
+        val refreshed = registry.get(session.id)!!
+        assertEquals(TicTacToeEngine.Mark.X, refreshed.board[0])
+        assertEquals(TicTacToeEngine.Mark.O, refreshed.currentTurn)
+    }
+
+    @Test
+    fun `applyMove rejects out-of-turn play`() {
+        val registry = TicTacToeSessionRegistry(scheduler = noopScheduler())
+        val session = registry.register(guildId, initiatorId, opponentId, stake = 10L)
+        registry.accept(session.id)
+        // Initiator's turn first — opponent attempting to play returns null.
+        assertNull(registry.applyMove(session.id, opponentId, cell = 0))
+    }
+
+    @Test
+    fun `applyMove rejects non-participant`() {
+        val registry = TicTacToeSessionRegistry(scheduler = noopScheduler())
+        val session = registry.register(guildId, initiatorId, opponentId, stake = 10L)
+        registry.accept(session.id)
+        assertNull(registry.applyMove(session.id, discordId = 9999L, cell = 0))
+    }
+
+    @Test
+    fun `applyMove on a PENDING session is rejected`() {
+        val registry = TicTacToeSessionRegistry(scheduler = noopScheduler())
+        val session = registry.register(guildId, initiatorId, opponentId, stake = 10L)
+        // No accept yet — session is still PENDING.
+        assertNull(registry.applyMove(session.id, initiatorId, cell = 0))
+    }
+
+    @Test
+    fun `winning move returns Win and stamps the session's winner and winningLine`() {
+        val registry = TicTacToeSessionRegistry(scheduler = noopScheduler())
+        val session = registry.register(guildId, initiatorId, opponentId, stake = 10L)
+        registry.accept(session.id)
+        // Play X at 0, O at 3, X at 1, O at 4, X at 2 → X wins top row.
+        registry.applyMove(session.id, initiatorId, 0)
+        registry.applyMove(session.id, opponentId, 3)
+        registry.applyMove(session.id, initiatorId, 1)
+        registry.applyMove(session.id, opponentId, 4)
+        val r = registry.applyMove(session.id, initiatorId, 2)
+        assertTrue(r is TicTacToeEngine.MoveResult.Win)
+        val live = registry.get(session.id)!!
+        assertEquals(TicTacToeEngine.Mark.X, live.winner)
+        assertEquals(listOf(0, 1, 2), live.winningLine)
+    }
+
+    @Test
+    fun `consumeForResolution atomic-removes and second call returns null`() {
+        val registry = TicTacToeSessionRegistry(scheduler = noopScheduler())
+        val session = registry.register(guildId, initiatorId, opponentId, stake = 10L)
+        registry.accept(session.id)
+        assertNotNull(registry.consumeForResolution(session.id))
+        assertNull(registry.consumeForResolution(session.id))
+    }
+
+    @Test
+    fun `forfeit atomic-removes and second call returns null`() {
+        val registry = TicTacToeSessionRegistry(scheduler = noopScheduler())
+        val session = registry.register(guildId, initiatorId, opponentId, stake = 10L)
+        registry.accept(session.id)
+        assertNotNull(registry.forfeit(session.id))
+        assertNull(registry.forfeit(session.id))
+    }
+
+    @Test
+    fun `concurrent accept across many threads produces exactly one success`() {
+        val registry = TicTacToeSessionRegistry(scheduler = noopScheduler())
+        val session = registry.register(guildId, initiatorId, opponentId, stake = 10L)
+        val threads = 16
+        val pool = Executors.newFixedThreadPool(threads)
+        val start = CountDownLatch(1)
+        val successes = AtomicInteger(0)
+        repeat(threads) {
+            pool.submit {
+                start.await()
+                if (registry.accept(session.id) != null) successes.incrementAndGet()
+            }
+        }
+        start.countDown()
+        pool.shutdown()
+        pool.awaitTermination(5, TimeUnit.SECONDS)
+        assertEquals(1, successes.get())
+    }
+
+    @Test
+    fun `pending timeout fires its callback exactly once when nothing else consumes the session`() {
+        val scheduler = ScheduledThreadPoolExecutor(1)
+        try {
+            val registry = TicTacToeSessionRegistry(
+                pendingTtl = Duration.ofMillis(100),
+                moveTtl = Duration.ofMinutes(5),
+                scheduler = scheduler,
+            )
+            val fired = AtomicInteger(0)
+            registry.register(guildId, initiatorId, opponentId, stake = 10L) { _ ->
+                fired.incrementAndGet()
+            }
+            Thread.sleep(1_000)
+            assertEquals(1, fired.get())
+        } finally {
+            scheduler.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `pending timeout is a no-op when the session has already accepted`() {
+        val scheduler = ScheduledThreadPoolExecutor(1)
+        try {
+            val registry = TicTacToeSessionRegistry(
+                pendingTtl = Duration.ofMillis(100),
+                moveTtl = Duration.ofMinutes(5),
+                scheduler = scheduler,
+            )
+            val fired = AtomicInteger(0)
+            val session = registry.register(guildId, initiatorId, opponentId, stake = 10L) { _ ->
+                fired.incrementAndGet()
+            }
+            registry.accept(session.id)
+            Thread.sleep(1_000)
+            assertEquals(0, fired.get())
+        } finally {
+            scheduler.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `move clock fires when the current actor doesn't place a mark in time`() {
+        val scheduler = ScheduledThreadPoolExecutor(1)
+        try {
+            val registry = TicTacToeSessionRegistry(
+                pendingTtl = Duration.ofMinutes(5),
+                moveTtl = Duration.ofMillis(150),
+                scheduler = scheduler,
+            )
+            val fired = AtomicInteger(0)
+            val session = registry.register(guildId, initiatorId, opponentId, stake = 10L)
+            registry.accept(session.id) { _ -> fired.incrementAndGet() }
+            Thread.sleep(1_000)
+            assertEquals(1, fired.get(), "move timeout must fire once no one moved within moveTtl")
+        } finally {
+            scheduler.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `move clock is re-armed on each successful move so a fresh actor gets the full window`() {
+        val scheduler = ScheduledThreadPoolExecutor(1)
+        try {
+            val registry = TicTacToeSessionRegistry(
+                pendingTtl = Duration.ofMinutes(5),
+                // Long enough that without re-arming we'd time out
+                // halfway through the test, but short enough that the
+                // test doesn't drag.
+                moveTtl = Duration.ofMillis(300),
+                scheduler = scheduler,
+            )
+            val fired = AtomicInteger(0)
+            val session = registry.register(guildId, initiatorId, opponentId, stake = 10L)
+            registry.accept(session.id) { _ -> fired.incrementAndGet() }
+
+            // Initiator moves within the window → clock re-arms for opponent.
+            Thread.sleep(100)
+            assertNotNull(registry.applyMove(session.id, initiatorId, 0))
+            // Opponent moves within the (re-armed) window → clock re-arms for initiator.
+            Thread.sleep(100)
+            assertNotNull(registry.applyMove(session.id, opponentId, 4))
+
+            // Without re-arming, two stale fires would have happened by
+            // now (totalling 200ms past the original 300ms window). With
+            // re-arming, neither stale fire wakes — the only outstanding
+            // timer is the one armed after the last move.
+            assertEquals(0, fired.get(), "stale timers must NOT fire after re-arm")
+        } finally {
+            scheduler.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `Caffeine maximumSize cap evicts oldest entries to keep memory bounded`() {
+        val registry = TicTacToeSessionRegistry(
+            scheduler = noopScheduler(),
+            maximumSessions = 3L,
+        )
+        val ids = (1..10).map {
+            registry.register(guildId, initiatorId + it, opponentId + it, stake = 0L).id
+        }
+        ids.forEach { registry.get(it) }
+        Thread.sleep(50)
+        val surviving = ids.count { registry.get(it) != null }
+        assertTrue(surviving <= 3, "expected at most 3 survivors with maximumSessions=3, got $surviving")
+    }
+
+    private fun noopScheduler(): ScheduledExecutorService =
+        object : ScheduledThreadPoolExecutor(0) {
+            override fun schedule(command: Runnable, delay: Long, unit: TimeUnit): ScheduledFuture<*> =
+                super.schedule(Runnable { /* no-op */ }, Long.MAX_VALUE, TimeUnit.SECONDS)
+        }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/PvpButtonHelpers.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/PvpButtonHelpers.kt
@@ -1,0 +1,40 @@
+package bot.toby.button.buttons
+
+import database.service.PvpWagerService
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
+
+/**
+ * Cross-game button helpers for the PvP mini-games (`/rps`,
+ * `/tictactoe`, future `/connect4`). Holds the bits that are
+ * identical between the per-game `*Button.kt` handlers — the
+ * "match already resolved" ephemeral reply and the
+ * [PvpWagerService.AcceptOutcome] → user-facing-text mapping.
+ *
+ * Per-game button code (the routing switch, the move/pick handlers,
+ * the win-embed rendering) stays in the per-game `*Button.kt`.
+ */
+object PvpButtonHelpers {
+
+    /**
+     * Ephemeral "this match already resolved or expired" reply, surfaced
+     * when a click lands on a session the registry no longer has —
+     * either it timed out, was forfeited, or another race already
+     * resolved it.
+     */
+    fun ephemeralAlreadyResolved(event: ButtonInteractionEvent) {
+        event.hook.sendMessage("This match already resolved or expired.").setEphemeral(true).queue()
+    }
+
+    /** Per-outcome text shown on the accept-error embed when [PvpWagerService.debitBoth] fails. */
+    fun describeAccept(outcome: PvpWagerService.AcceptOutcome): String = when (outcome) {
+        is PvpWagerService.AcceptOutcome.InitiatorInsufficient ->
+            "The challenger no longer has enough credits to cover the stake."
+        is PvpWagerService.AcceptOutcome.OpponentInsufficient ->
+            "You no longer have enough credits (have ${outcome.have}, need ${outcome.needed})."
+        PvpWagerService.AcceptOutcome.UnknownInitiator ->
+            "We couldn't find the challenger's profile."
+        PvpWagerService.AcceptOutcome.UnknownOpponent ->
+            "We couldn't find your profile."
+        is PvpWagerService.AcceptOutcome.Ok -> "" // never surfaced
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/RpsButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/RpsButton.kt
@@ -1,10 +1,12 @@
 package bot.toby.button.buttons
 
+import bot.toby.command.commands.economy.PvpEmbeds
 import bot.toby.command.commands.economy.RpsEmbeds
 import core.button.Button
 import core.button.ButtonContext
 import database.dto.UserDto
 import database.rps.RpsSessionRegistry
+import database.service.PvpWagerService
 import database.service.RpsService
 import net.dv8tion.jda.api.components.MessageTopLevelComponent
 import net.dv8tion.jda.api.entities.MessageEmbed
@@ -60,7 +62,7 @@ class RpsButton @Autowired constructor(
             return
         }
         val session = rpsSessionRegistry.decline(parsed.sessionId) ?: run {
-            ephemeralAlreadyResolved(event); return
+            PvpButtonHelpers.ephemeralAlreadyResolved(event); return
         }
         event.message.editMessageEmbeds(
             RpsEmbeds.pendingDeclineEmbed(session.initiatorDiscordId, session.opponentDiscordId)
@@ -87,7 +89,7 @@ class RpsButton @Autowired constructor(
             // handles all four branches.
             resolveAndEdit(event, expired)
         } ?: run {
-            ephemeralAlreadyResolved(event); return
+            PvpButtonHelpers.ephemeralAlreadyResolved(event); return
         }
 
         // Debit both stakes now (no-op for stake=0). If insufficient,
@@ -99,9 +101,9 @@ class RpsButton @Autowired constructor(
             guildId = session.guildId,
             stake = session.stake,
         )
-        if (outcome !is RpsService.AcceptOutcome.Ok) {
+        if (outcome !is PvpWagerService.AcceptOutcome.Ok) {
             rpsSessionRegistry.forfeit(session.id) // tear down the LIVE session
-            event.message.editMessageEmbeds(RpsEmbeds.acceptErrorEmbed(describeAccept(outcome)))
+            event.message.editMessageEmbeds(PvpEmbeds.acceptErrorEmbed(PvpButtonHelpers.describeAccept(outcome)))
                 .setComponents(emptyList<MessageTopLevelComponent>()).queue()
             return
         }
@@ -125,7 +127,7 @@ class RpsButton @Autowired constructor(
     ) {
         val choice = RpsEmbeds.choiceFor(parsed.action) ?: return
         val live = rpsSessionRegistry.get(parsed.sessionId) ?: run {
-            ephemeralAlreadyResolved(event); return
+            PvpButtonHelpers.ephemeralAlreadyResolved(event); return
         }
         if (requestingUserDto.discordId != live.initiatorDiscordId &&
             requestingUserDto.discordId != live.opponentDiscordId
@@ -136,7 +138,7 @@ class RpsButton @Autowired constructor(
             return
         }
         val updated = rpsSessionRegistry.recordPick(parsed.sessionId, requestingUserDto.discordId, choice) ?: run {
-            ephemeralAlreadyResolved(event); return
+            PvpButtonHelpers.ephemeralAlreadyResolved(event); return
         }
         // Confirm the pick to the player privately so the opponent
         // doesn't see what they chose.
@@ -168,7 +170,7 @@ class RpsButton @Autowired constructor(
         parsed: RpsEmbeds.ParsedButtonId,
     ) {
         val live = rpsSessionRegistry.get(parsed.sessionId) ?: run {
-            ephemeralAlreadyResolved(event); return
+            PvpButtonHelpers.ephemeralAlreadyResolved(event); return
         }
         if (requestingUserDto.discordId != live.initiatorDiscordId &&
             requestingUserDto.discordId != live.opponentDiscordId
@@ -181,7 +183,7 @@ class RpsButton @Autowired constructor(
         // Forfeit = the other player wins by walkover. Atomically remove
         // the session so the pick-timeout can't double-resolve.
         val consumed = rpsSessionRegistry.forfeit(parsed.sessionId) ?: run {
-            ephemeralAlreadyResolved(event); return
+            PvpButtonHelpers.ephemeralAlreadyResolved(event); return
         }
         // Strip the forfeiter's pick from the snapshot so the resolver
         // sees them as "didn't pick" → opponent wins.
@@ -206,28 +208,13 @@ class RpsButton @Autowired constructor(
             is RpsService.ResolveOutcome.DoubleRefund -> RpsEmbeds.doubleRefundEmbed(
                 session.initiatorDiscordId, session.opponentDiscordId, outcome.stake,
             )
-            else -> RpsEmbeds.acceptErrorEmbed("Couldn't resolve the match — both players' profiles must exist.")
+            RpsService.ResolveOutcome.Unknown -> PvpEmbeds.acceptErrorEmbed(
+                "Couldn't resolve the match — both players' profiles must exist."
+            )
         }
         runCatching {
             event.message.editMessageEmbeds(embed)
                 .setComponents(emptyList<MessageTopLevelComponent>()).queue()
         }
-    }
-
-    private fun ephemeralAlreadyResolved(event: ButtonInteractionEvent) {
-        event.hook.sendMessage("This match already resolved or expired.")
-            .setEphemeral(true).queue()
-    }
-
-    private fun describeAccept(outcome: RpsService.AcceptOutcome): String = when (outcome) {
-        is RpsService.AcceptOutcome.InitiatorInsufficient ->
-            "The challenger no longer has enough credits to cover the stake."
-        is RpsService.AcceptOutcome.OpponentInsufficient ->
-            "You no longer have enough credits (have ${outcome.have}, need ${outcome.needed})."
-        RpsService.AcceptOutcome.UnknownInitiator ->
-            "We couldn't find the challenger's profile."
-        RpsService.AcceptOutcome.UnknownOpponent ->
-            "We couldn't find your profile."
-        is RpsService.AcceptOutcome.Ok -> "" // never surfaced
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/TicTacToeButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/TicTacToeButton.kt
@@ -1,10 +1,12 @@
 package bot.toby.button.buttons
 
+import bot.toby.command.commands.economy.PvpEmbeds
 import bot.toby.command.commands.economy.TicTacToeEmbeds
 import common.tictactoe.TicTacToeEngine
 import core.button.Button
 import core.button.ButtonContext
 import database.dto.UserDto
+import database.service.PvpWagerService
 import database.service.TicTacToeService
 import database.tictactoe.TicTacToeSessionRegistry
 import net.dv8tion.jda.api.components.MessageTopLevelComponent
@@ -65,7 +67,7 @@ class TicTacToeButton @Autowired constructor(
             return
         }
         val session = ticTacToeSessionRegistry.decline(parsed.sessionId) ?: run {
-            ephemeralAlreadyResolved(event); return
+            PvpButtonHelpers.ephemeralAlreadyResolved(event); return
         }
         event.message.editMessageEmbeds(
             TicTacToeEmbeds.pendingDeclineEmbed(session.initiatorDiscordId, session.opponentDiscordId)
@@ -88,7 +90,7 @@ class TicTacToeButton @Autowired constructor(
             // as forfeit by them — opponent wins by walkover.
             resolveTimeout(event, expired)
         } ?: run {
-            ephemeralAlreadyResolved(event); return
+            PvpButtonHelpers.ephemeralAlreadyResolved(event); return
         }
 
         val outcome = ticTacToeService.acceptMatch(
@@ -97,9 +99,9 @@ class TicTacToeButton @Autowired constructor(
             guildId = session.guildId,
             stake = session.stake,
         )
-        if (outcome !is TicTacToeService.AcceptOutcome.Ok) {
+        if (outcome !is PvpWagerService.AcceptOutcome.Ok) {
             ticTacToeSessionRegistry.forfeit(session.id)
-            event.message.editMessageEmbeds(TicTacToeEmbeds.acceptErrorEmbed(describeAccept(outcome)))
+            event.message.editMessageEmbeds(PvpEmbeds.acceptErrorEmbed(PvpButtonHelpers.describeAccept(outcome)))
                 .setComponents(emptyList<MessageTopLevelComponent>()).queue()
             return
         }
@@ -115,7 +117,7 @@ class TicTacToeButton @Autowired constructor(
         cell: Int,
     ) {
         val live = ticTacToeSessionRegistry.get(parsed.sessionId) ?: run {
-            ephemeralAlreadyResolved(event); return
+            PvpButtonHelpers.ephemeralAlreadyResolved(event); return
         }
         if (requestingUserDto.discordId != live.initiatorDiscordId &&
             requestingUserDto.discordId != live.opponentDiscordId
@@ -157,7 +159,7 @@ class TicTacToeButton @Autowired constructor(
         parsed: TicTacToeEmbeds.ParsedButtonId,
     ) {
         val live = ticTacToeSessionRegistry.get(parsed.sessionId) ?: run {
-            ephemeralAlreadyResolved(event); return
+            PvpButtonHelpers.ephemeralAlreadyResolved(event); return
         }
         if (requestingUserDto.discordId != live.initiatorDiscordId &&
             requestingUserDto.discordId != live.opponentDiscordId
@@ -166,7 +168,7 @@ class TicTacToeButton @Autowired constructor(
             return
         }
         val consumed = ticTacToeSessionRegistry.forfeit(parsed.sessionId) ?: run {
-            ephemeralAlreadyResolved(event); return
+            PvpButtonHelpers.ephemeralAlreadyResolved(event); return
         }
         // Stamp the winner: the *other* player wins by walkover.
         val winnerDiscordId = if (requestingUserDto.discordId == consumed.initiatorDiscordId)
@@ -208,27 +210,13 @@ class TicTacToeButton @Autowired constructor(
         val embed: MessageEmbed = when (outcome) {
             is TicTacToeService.ResolveOutcome.Win -> TicTacToeEmbeds.winEmbed(session, outcome, forfeit)
             is TicTacToeService.ResolveOutcome.Draw -> TicTacToeEmbeds.drawEmbed(session, outcome)
-            else -> TicTacToeEmbeds.acceptErrorEmbed("Couldn't resolve the match — both players' profiles must exist.")
+            TicTacToeService.ResolveOutcome.Unknown -> PvpEmbeds.acceptErrorEmbed(
+                "Couldn't resolve the match — both players' profiles must exist."
+            )
         }
         runCatching {
             event.message.editMessageEmbeds(embed)
                 .setComponents(emptyList<MessageTopLevelComponent>()).queue()
         }
-    }
-
-    private fun ephemeralAlreadyResolved(event: ButtonInteractionEvent) {
-        event.hook.sendMessage("This match already resolved or expired.").setEphemeral(true).queue()
-    }
-
-    private fun describeAccept(outcome: TicTacToeService.AcceptOutcome): String = when (outcome) {
-        is TicTacToeService.AcceptOutcome.InitiatorInsufficient ->
-            "The challenger no longer has enough credits to cover the stake."
-        is TicTacToeService.AcceptOutcome.OpponentInsufficient ->
-            "You no longer have enough credits (have ${outcome.have}, need ${outcome.needed})."
-        TicTacToeService.AcceptOutcome.UnknownInitiator ->
-            "We couldn't find the challenger's profile."
-        TicTacToeService.AcceptOutcome.UnknownOpponent ->
-            "We couldn't find your profile."
-        is TicTacToeService.AcceptOutcome.Ok -> "" // never surfaced
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/TicTacToeButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/TicTacToeButton.kt
@@ -1,0 +1,234 @@
+package bot.toby.button.buttons
+
+import bot.toby.command.commands.economy.TicTacToeEmbeds
+import common.tictactoe.TicTacToeEngine
+import core.button.Button
+import core.button.ButtonContext
+import database.dto.UserDto
+import database.service.TicTacToeService
+import database.tictactoe.TicTacToeSessionRegistry
+import net.dv8tion.jda.api.components.MessageTopLevelComponent
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+/**
+ * Routes every `/tictactoe` button click. The component ID prefix is
+ * `"tictactoe"` — [bot.toby.managers.DefaultButtonManager] dispatches
+ * by that prefix to this single bean, which parses the rest of the id
+ * via [TicTacToeEmbeds.parseButtonId] and switches on the action.
+ *
+ * Race safety: every state transition on [TicTacToeSessionRegistry]
+ * uses atomic remove (`decline`, `consumeForResolution`, `forfeit`)
+ * or `synchronized` on the session (`accept`, `applyMove`), so
+ * concurrent clicks / timeouts collapse to "exactly one path wins".
+ */
+@Component
+class TicTacToeButton @Autowired constructor(
+    private val ticTacToeService: TicTacToeService,
+    private val ticTacToeSessionRegistry: TicTacToeSessionRegistry,
+) : Button {
+
+    override val name: String get() = TicTacToeEmbeds.BUTTON_NAME
+    override val description: String get() = "Routes /tictactoe accept/decline + place + forfeit clicks."
+
+    override fun handle(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        val parsed = TicTacToeEmbeds.parseButtonId(event.componentId) ?: run {
+            event.hook.sendMessage("Couldn't parse this Tic-Tac-Toe button.").setEphemeral(true).queue()
+            return
+        }
+        when (parsed.action) {
+            TicTacToeEmbeds.Action.ACCEPT -> handleAccept(event, requestingUserDto, parsed)
+            TicTacToeEmbeds.Action.DECLINE -> handleDecline(event, requestingUserDto, parsed)
+            TicTacToeEmbeds.Action.FORFEIT -> handleForfeit(event, requestingUserDto, parsed)
+            else -> {
+                val cell = TicTacToeEmbeds.cellFor(parsed.action) ?: run {
+                    event.hook.sendMessage("Unknown action.").setEphemeral(true).queue()
+                    return
+                }
+                handlePlace(event, requestingUserDto, parsed, cell)
+            }
+        }
+    }
+
+    private fun handleDecline(
+        event: ButtonInteractionEvent,
+        requestingUserDto: UserDto,
+        parsed: TicTacToeEmbeds.ParsedButtonId,
+    ) {
+        if (requestingUserDto.discordId != parsed.payload) {
+            event.hook.sendMessage(
+                "This isn't your challenge to decline — wait for <@${parsed.payload}> to respond."
+            ).setEphemeral(true).queue()
+            return
+        }
+        val session = ticTacToeSessionRegistry.decline(parsed.sessionId) ?: run {
+            ephemeralAlreadyResolved(event); return
+        }
+        event.message.editMessageEmbeds(
+            TicTacToeEmbeds.pendingDeclineEmbed(session.initiatorDiscordId, session.opponentDiscordId)
+        ).setComponents(emptyList<MessageTopLevelComponent>()).queue()
+    }
+
+    private fun handleAccept(
+        event: ButtonInteractionEvent,
+        requestingUserDto: UserDto,
+        parsed: TicTacToeEmbeds.ParsedButtonId,
+    ) {
+        if (requestingUserDto.discordId != parsed.payload) {
+            event.hook.sendMessage(
+                "This isn't your challenge to accept — wait for <@${parsed.payload}> to respond."
+            ).setEphemeral(true).queue()
+            return
+        }
+        val session = ticTacToeSessionRegistry.accept(parsed.sessionId) { expired ->
+            // Move-clock timeout: current actor never placed. Treat
+            // as forfeit by them — opponent wins by walkover.
+            resolveTimeout(event, expired)
+        } ?: run {
+            ephemeralAlreadyResolved(event); return
+        }
+
+        val outcome = ticTacToeService.acceptMatch(
+            initiatorDiscordId = session.initiatorDiscordId,
+            opponentDiscordId = session.opponentDiscordId,
+            guildId = session.guildId,
+            stake = session.stake,
+        )
+        if (outcome !is TicTacToeService.AcceptOutcome.Ok) {
+            ticTacToeSessionRegistry.forfeit(session.id)
+            event.message.editMessageEmbeds(TicTacToeEmbeds.acceptErrorEmbed(describeAccept(outcome)))
+                .setComponents(emptyList<MessageTopLevelComponent>()).queue()
+            return
+        }
+
+        event.message.editMessageEmbeds(TicTacToeEmbeds.turnEmbed(session))
+            .setComponents(TicTacToeEmbeds.liveButtons(session)).queue()
+    }
+
+    private fun handlePlace(
+        event: ButtonInteractionEvent,
+        requestingUserDto: UserDto,
+        parsed: TicTacToeEmbeds.ParsedButtonId,
+        cell: Int,
+    ) {
+        val live = ticTacToeSessionRegistry.get(parsed.sessionId) ?: run {
+            ephemeralAlreadyResolved(event); return
+        }
+        if (requestingUserDto.discordId != live.initiatorDiscordId &&
+            requestingUserDto.discordId != live.opponentDiscordId
+        ) {
+            event.hook.sendMessage(
+                "This isn't your match — only <@${live.initiatorDiscordId}> and <@${live.opponentDiscordId}> can play."
+            ).setEphemeral(true).queue()
+            return
+        }
+        val result = ticTacToeSessionRegistry.applyMove(parsed.sessionId, requestingUserDto.discordId, cell) { expired ->
+            resolveTimeout(event, expired)
+        }
+        when (result) {
+            null -> {
+                // Either: not their turn, session gone, or some race.
+                event.hook.sendMessage("It's not your turn yet.").setEphemeral(true).queue()
+            }
+            TicTacToeEngine.MoveResult.IllegalCell,
+            TicTacToeEngine.MoveResult.Occupied -> {
+                event.hook.sendMessage("That cell is taken.").setEphemeral(true).queue()
+            }
+            is TicTacToeEngine.MoveResult.Continued -> {
+                // Re-render with the new board + the *other* player's turn.
+                val refreshed = ticTacToeSessionRegistry.get(parsed.sessionId) ?: return
+                event.message.editMessageEmbeds(TicTacToeEmbeds.turnEmbed(refreshed))
+                    .setComponents(TicTacToeEmbeds.liveButtons(refreshed)).queue()
+            }
+            is TicTacToeEngine.MoveResult.Win,
+            is TicTacToeEngine.MoveResult.Draw -> {
+                val consumed = ticTacToeSessionRegistry.consumeForResolution(parsed.sessionId) ?: return
+                resolveAndEdit(event, consumed, forfeit = false)
+            }
+        }
+    }
+
+    private fun handleForfeit(
+        event: ButtonInteractionEvent,
+        requestingUserDto: UserDto,
+        parsed: TicTacToeEmbeds.ParsedButtonId,
+    ) {
+        val live = ticTacToeSessionRegistry.get(parsed.sessionId) ?: run {
+            ephemeralAlreadyResolved(event); return
+        }
+        if (requestingUserDto.discordId != live.initiatorDiscordId &&
+            requestingUserDto.discordId != live.opponentDiscordId
+        ) {
+            event.hook.sendMessage("This isn't your match to forfeit.").setEphemeral(true).queue()
+            return
+        }
+        val consumed = ticTacToeSessionRegistry.forfeit(parsed.sessionId) ?: run {
+            ephemeralAlreadyResolved(event); return
+        }
+        // Stamp the winner: the *other* player wins by walkover.
+        val winnerDiscordId = if (requestingUserDto.discordId == consumed.initiatorDiscordId)
+            consumed.opponentDiscordId else consumed.initiatorDiscordId
+        consumed.winner = consumed.markFor(winnerDiscordId)
+        resolveAndEdit(event, consumed, forfeit = true, explicitWinnerDiscordId = winnerDiscordId)
+    }
+
+    private fun resolveTimeout(event: ButtonInteractionEvent, expired: TicTacToeSessionRegistry.Session) {
+        // Whoever's turn it was timed out — opponent wins by walkover.
+        val winnerDiscordId = if (expired.currentActorDiscordId() == expired.initiatorDiscordId)
+            expired.opponentDiscordId else expired.initiatorDiscordId
+        expired.winner = expired.markFor(winnerDiscordId)
+        resolveAndEdit(event, expired, forfeit = true, explicitWinnerDiscordId = winnerDiscordId)
+    }
+
+    private fun resolveAndEdit(
+        event: ButtonInteractionEvent,
+        session: TicTacToeSessionRegistry.Session,
+        forfeit: Boolean,
+        explicitWinnerDiscordId: Long? = null,
+    ) {
+        // Determine the winner: explicit (forfeit / timeout) or derived
+        // from the session.winner that the engine stamped at terminal.
+        val winnerDiscordId = explicitWinnerDiscordId
+            ?: session.winner?.let {
+                when (it) {
+                    TicTacToeEngine.Mark.X -> session.initiatorDiscordId
+                    TicTacToeEngine.Mark.O -> session.opponentDiscordId
+                }
+            }
+        val outcome = ticTacToeService.resolveMatch(
+            initiatorDiscordId = session.initiatorDiscordId,
+            opponentDiscordId = session.opponentDiscordId,
+            guildId = session.guildId,
+            stake = session.stake,
+            winnerDiscordId = winnerDiscordId,
+        )
+        val embed: MessageEmbed = when (outcome) {
+            is TicTacToeService.ResolveOutcome.Win -> TicTacToeEmbeds.winEmbed(session, outcome, forfeit)
+            is TicTacToeService.ResolveOutcome.Draw -> TicTacToeEmbeds.drawEmbed(session, outcome)
+            else -> TicTacToeEmbeds.acceptErrorEmbed("Couldn't resolve the match — both players' profiles must exist.")
+        }
+        runCatching {
+            event.message.editMessageEmbeds(embed)
+                .setComponents(emptyList<MessageTopLevelComponent>()).queue()
+        }
+    }
+
+    private fun ephemeralAlreadyResolved(event: ButtonInteractionEvent) {
+        event.hook.sendMessage("This match already resolved or expired.").setEphemeral(true).queue()
+    }
+
+    private fun describeAccept(outcome: TicTacToeService.AcceptOutcome): String = when (outcome) {
+        is TicTacToeService.AcceptOutcome.InitiatorInsufficient ->
+            "The challenger no longer has enough credits to cover the stake."
+        is TicTacToeService.AcceptOutcome.OpponentInsufficient ->
+            "You no longer have enough credits (have ${outcome.have}, need ${outcome.needed})."
+        TicTacToeService.AcceptOutcome.UnknownInitiator ->
+            "We couldn't find the challenger's profile."
+        TicTacToeService.AcceptOutcome.UnknownOpponent ->
+            "We couldn't find your profile."
+        is TicTacToeService.AcceptOutcome.Ok -> "" // never surfaced
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/PvpEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/PvpEmbeds.kt
@@ -1,0 +1,95 @@
+package bot.toby.command.commands.economy
+
+import database.service.PvpWagerService
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.components.actionrow.ActionRow
+import net.dv8tion.jda.api.components.buttons.Button
+import net.dv8tion.jda.api.entities.MessageEmbed
+
+/**
+ * Cross-game embed + button factories for the PvP mini-games (`/rps`,
+ * `/tictactoe`, future `/connect4`). Holds the bits that are identical
+ * between the per-game `*Embeds.kt` files — error embeds, pending-decline /
+ * pending-timeout embeds (game-name parameterised), the Accept / Decline
+ * button row, and the stake-line + start-error description text.
+ *
+ * Game-specific embeds (the pick/turn rendering, the win embed with
+ * winner-choice or board-state fields, the per-game decline embed
+ * wording) stay in the per-game `*Embeds.kt`.
+ */
+object PvpEmbeds {
+
+    /** Standard one-line stake summary appended to challenge / turn embeds. */
+    fun stakeLine(stake: Long): String =
+        if (stake > 0L) "\nStake: **${stake}** credits each (winner takes the pot)." else ""
+
+    /**
+     * Standard "challenge expired" embed shown when the opponent didn't
+     * respond before [database.rps.RpsSessionRegistry.pendingTtl] /
+     * [database.tictactoe.TicTacToeSessionRegistry.pendingTtl].
+     */
+    fun pendingTimeoutEmbed(
+        gameName: String,
+        initiatorDiscordId: Long,
+        opponentDiscordId: Long,
+    ): MessageEmbed = EmbedBuilder()
+        .setTitle("⌛ Challenge expired")
+        .setDescription("<@${opponentDiscordId}> didn't respond to <@${initiatorDiscordId}>'s $gameName challenge.")
+        .setColor(0xED4245)
+        .build()
+
+    /** Standard "challenge declined" embed shown when the opponent hits Decline. */
+    fun pendingDeclineEmbed(
+        gameName: String,
+        initiatorDiscordId: Long,
+        opponentDiscordId: Long,
+    ): MessageEmbed = EmbedBuilder()
+        .setTitle("❌ Challenge declined")
+        .setDescription("<@${opponentDiscordId}> declined <@${initiatorDiscordId}>'s $gameName challenge.")
+        .setColor(0xED4245)
+        .build()
+
+    /** Surfaced when [PvpWagerService.preflightStart] rejects the match before posting. */
+    fun startErrorEmbed(message: String): MessageEmbed = EmbedBuilder()
+        .setTitle("❌ Can't start that match")
+        .setDescription(message)
+        .setColor(0xED4245)
+        .build()
+
+    /** Surfaced when [PvpWagerService.debitBoth] fails on the accept-button click. */
+    fun acceptErrorEmbed(message: String): MessageEmbed = EmbedBuilder()
+        .setTitle("❌ Can't accept that match")
+        .setDescription(message)
+        .setColor(0xED4245)
+        .build()
+
+    /**
+     * Accept + Decline button row attached to a PENDING challenge embed.
+     * Each per-game `*Embeds.kt` provides its own button-id encoders
+     * (so the button manager can route by the prefix); this helper just
+     * wraps the two buttons in an [ActionRow].
+     */
+    fun pendingButtons(acceptButtonId: String, declineButtonId: String): ActionRow = ActionRow.of(
+        Button.success(acceptButtonId, "Accept"),
+        Button.danger(declineButtonId, "Decline"),
+    )
+
+    /** Per-game text rendering of a [PvpWagerService.StartOutcome] rejection. */
+    fun describeStartOutcome(outcome: PvpWagerService.StartOutcome): String = when (outcome) {
+        is PvpWagerService.StartOutcome.InvalidStake ->
+            "Stake must be between ${outcome.min} and ${outcome.max} credits for this server."
+        is PvpWagerService.StartOutcome.InvalidOpponent -> when (outcome.reason) {
+            PvpWagerService.StartOutcome.InvalidOpponent.Reason.SELF -> "You can't challenge yourself."
+            PvpWagerService.StartOutcome.InvalidOpponent.Reason.BOT -> "You can't challenge a bot."
+        }
+        is PvpWagerService.StartOutcome.InitiatorInsufficient ->
+            "You need ${outcome.needed} credits but only have ${outcome.have}."
+        is PvpWagerService.StartOutcome.OpponentInsufficient ->
+            "Your opponent only has ${outcome.have} credits but the stake requires ${outcome.needed}."
+        PvpWagerService.StartOutcome.UnknownInitiator ->
+            "We couldn't find your profile — try a credit-earning command first."
+        PvpWagerService.StartOutcome.UnknownOpponent ->
+            "We couldn't find your opponent's profile — they need to be active in the server first."
+        is PvpWagerService.StartOutcome.Ok -> "" // never surfaced — Ok path doesn't render an error embed
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/RpsCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/RpsCommand.kt
@@ -5,8 +5,8 @@ import core.command.Command.Companion.replyEmbedAndDelete
 import core.command.CommandContext
 import database.dto.UserDto
 import database.rps.RpsSessionRegistry
+import database.service.PvpWagerService
 import database.service.RpsService
-import database.service.RpsService.StartOutcome
 import net.dv8tion.jda.api.components.MessageTopLevelComponent
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.interactions.commands.OptionType
@@ -81,8 +81,11 @@ class RpsCommand @Autowired constructor(
             guildId = guild.idLong,
             stake = stake,
         )
-        if (start !is StartOutcome.Ok) {
-            event.hook.replyEmbedAndDelete(RpsEmbeds.startErrorEmbed(describe(start)), deleteDelay)
+        if (start !is PvpWagerService.StartOutcome.Ok) {
+            event.hook.replyEmbedAndDelete(
+                PvpEmbeds.startErrorEmbed(PvpEmbeds.describeStartOutcome(start)),
+                deleteDelay,
+            )
             return
         }
 
@@ -111,24 +114,11 @@ class RpsCommand @Autowired constructor(
             .queue()
     }
 
-    private fun describe(outcome: StartOutcome): String = when (outcome) {
-        is StartOutcome.InvalidStake -> "Stake must be between ${outcome.min} and ${outcome.max} credits for this server."
-        is StartOutcome.InvalidOpponent -> when (outcome.reason) {
-            StartOutcome.InvalidOpponent.Reason.SELF -> "You can't challenge yourself."
-            StartOutcome.InvalidOpponent.Reason.BOT -> "You can't challenge a bot."
-        }
-        is StartOutcome.InitiatorInsufficient -> "You need ${outcome.needed} credits but only have ${outcome.have}."
-        is StartOutcome.OpponentInsufficient -> "Your opponent only has ${outcome.have} credits but the stake requires ${outcome.needed}."
-        StartOutcome.UnknownInitiator -> "We couldn't find your profile — try a credit-earning command first."
-        StartOutcome.UnknownOpponent -> "We couldn't find your opponent's profile — they need to be active in the server first."
-        is StartOutcome.Ok -> "" // never surfaced — Ok path doesn't render an error embed
-    }
-
     private fun replyError(
         event: SlashCommandInteractionEvent,
         message: String,
         deleteDelay: Int,
     ) {
-        event.hook.replyEmbedAndDelete(RpsEmbeds.startErrorEmbed(message), deleteDelay)
+        event.hook.replyEmbedAndDelete(PvpEmbeds.startErrorEmbed(message), deleteDelay)
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/RpsEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/RpsEmbeds.kt
@@ -9,7 +9,11 @@ import net.dv8tion.jda.api.components.buttons.ButtonStyle
 import net.dv8tion.jda.api.entities.MessageEmbed
 
 /**
- * Embed + button rendering for `/rps`.
+ * Embed + button rendering specific to `/rps`. The cross-game bits
+ * (Accept/Decline button row, stake-line text, error / decline /
+ * timeout embeds, start-error description) live in [PvpEmbeds] —
+ * this file only owns the RPS-specific pick buttons + pick/win/draw
+ * embeds.
  *
  * Component IDs are colon-delimited so [DefaultButtonManager] can route
  * by the `"rps"` prefix and this object can parse the rest by index:
@@ -19,18 +23,13 @@ import net.dv8tion.jda.api.entities.MessageEmbed
  * - `action`: ACCEPT / DECLINE during PENDING; PICK_ROCK / PICK_PAPER /
  *   PICK_SCISSORS / FORFEIT during LIVE.
  * - `scopedDiscordId`: the discord id of the *player whose button this
- *   is*. ACCEPT/DECLINE belong to the opponent; PICK belongs to either
- *   player (each player sees the same buttons but the handler routes
- *   the click to the clicking user). FORFEIT belongs to either player.
- *
- * For PICK and FORFEIT buttons we don't actually need to encode the
- * clicker in the id — the click event already carries the user — so
- * we use `0` as a sentinel. Kept in the format for symmetry with the
- * accept-side encoding so the parser is single-shape.
+ *   is*. ACCEPT/DECLINE belong to the opponent; PICK/FORFEIT use `0`
+ *   as a sentinel (clicker is known from the event).
  */
 object RpsEmbeds {
 
     const val BUTTON_NAME = "rps"
+    private const val GAME_NAME = "RPS"
 
     enum class Action {
         ACCEPT,
@@ -89,7 +88,7 @@ object RpsEmbeds {
         else -> null
     }
 
-    // ---- embeds ----
+    // ---- RPS-specific embeds ----
 
     fun pendingEmbed(
         initiatorDiscordId: Long,
@@ -99,7 +98,7 @@ object RpsEmbeds {
         .setTitle("✊ ✋ ✌️  Rock-Paper-Scissors")
         .setDescription(
             "<@${opponentDiscordId}> — <@${initiatorDiscordId}> has challenged you to RPS." +
-                stakeLine(stake) +
+                PvpEmbeds.stakeLine(stake) +
                 "\nAccept to start, or decline to walk away."
         )
         .setColor(0x5B8DEF)
@@ -115,7 +114,7 @@ object RpsEmbeds {
         .setTitle("✊ ✋ ✌️  Make your pick")
         .setDescription(
             "<@${initiatorDiscordId}> vs <@${opponentDiscordId}>" +
-                stakeLine(stake) +
+                PvpEmbeds.stakeLine(stake) +
                 "\n\nClick one of the three moves below — your choice stays hidden until both players have picked." +
                 "\n\n" + pickStatus(initiatorDiscordId, opponentDiscordId, initiatorPicked, opponentPicked)
         )
@@ -159,36 +158,21 @@ object RpsEmbeds {
         .setColor(0xED4245)
         .build()
 
-    fun pendingDeclineEmbed(initiatorDiscordId: Long, opponentDiscordId: Long): MessageEmbed = EmbedBuilder()
-        .setTitle("❌ Challenge declined")
-        .setDescription("<@${opponentDiscordId}> declined <@${initiatorDiscordId}>'s RPS challenge.")
-        .setColor(0xED4245)
-        .build()
+    // ---- shared-embed pass-throughs (game-name pre-filled) ----
 
-    fun pendingTimeoutEmbed(initiatorDiscordId: Long, opponentDiscordId: Long): MessageEmbed = EmbedBuilder()
-        .setTitle("⌛ Challenge expired")
-        .setDescription("<@${opponentDiscordId}> didn't respond to <@${initiatorDiscordId}>'s RPS challenge.")
-        .setColor(0xED4245)
-        .build()
+    fun pendingDeclineEmbed(initiatorDiscordId: Long, opponentDiscordId: Long): MessageEmbed =
+        PvpEmbeds.pendingDeclineEmbed(GAME_NAME, initiatorDiscordId, opponentDiscordId)
 
-    fun startErrorEmbed(message: String): MessageEmbed = EmbedBuilder()
-        .setTitle("❌ Can't start that match")
-        .setDescription(message)
-        .setColor(0xED4245)
-        .build()
-
-    fun acceptErrorEmbed(message: String): MessageEmbed = EmbedBuilder()
-        .setTitle("❌ Can't accept that match")
-        .setDescription(message)
-        .setColor(0xED4245)
-        .build()
+    fun pendingTimeoutEmbed(initiatorDiscordId: Long, opponentDiscordId: Long): MessageEmbed =
+        PvpEmbeds.pendingTimeoutEmbed(GAME_NAME, initiatorDiscordId, opponentDiscordId)
 
     // ---- button rows ----
 
-    fun pendingButtons(sessionId: Long, opponentDiscordId: Long): ActionRow = ActionRow.of(
-        Button.success(acceptButtonId(sessionId, opponentDiscordId), "Accept"),
-        Button.danger(declineButtonId(sessionId, opponentDiscordId), "Decline"),
-    )
+    fun pendingButtons(sessionId: Long, opponentDiscordId: Long): ActionRow =
+        PvpEmbeds.pendingButtons(
+            acceptButtonId = acceptButtonId(sessionId, opponentDiscordId),
+            declineButtonId = declineButtonId(sessionId, opponentDiscordId),
+        )
 
     fun pickButtons(sessionId: Long): List<ActionRow> = listOf(
         ActionRow.of(
@@ -202,9 +186,6 @@ object RpsEmbeds {
     )
 
     // ---- helpers ----
-
-    private fun stakeLine(stake: Long): String =
-        if (stake > 0L) "\nStake: **${stake}** credits each (winner takes the pot)." else ""
 
     private fun pickStatus(
         initiatorDiscordId: Long,

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/TicTacToeCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/TicTacToeCommand.kt
@@ -1,0 +1,129 @@
+package bot.toby.command.commands.economy
+
+import bot.toby.helpers.UserDtoHelper
+import core.command.Command.Companion.replyEmbedAndDelete
+import core.command.CommandContext
+import database.dto.UserDto
+import database.service.TicTacToeService
+import database.service.TicTacToeService.StartOutcome
+import database.tictactoe.TicTacToeSessionRegistry
+import net.dv8tion.jda.api.components.MessageTopLevelComponent
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.interactions.commands.build.OptionData
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+/**
+ * `/tictactoe user:<member> [stake:<int>]` — challenge another user to
+ * a round of Tic-Tac-Toe. Optional wager: when `stake > 0` both players
+ * ante on accept and the winner takes the pot minus the per-guild
+ * jackpot tribute (same model as `/rps`). When `stake` is omitted or
+ * 0, the match is pure-fun and the winner only earns a small XP grant.
+ *
+ * Initiator plays ❌ (moves first); opponent plays ⭕.
+ *
+ * Accept/decline + per-cell place + forfeit clicks are handled by
+ * [bot.toby.button.buttons.TicTacToeButton], which routes through
+ * [TicTacToeSessionRegistry] (in-memory board + turn state) and
+ * [TicTacToeService] (wager arithmetic).
+ */
+@Component
+class TicTacToeCommand @Autowired constructor(
+    private val ticTacToeService: TicTacToeService,
+    private val ticTacToeSessionRegistry: TicTacToeSessionRegistry,
+    private val userDtoHelper: UserDtoHelper,
+) : EconomyCommand {
+
+    override val name: String = "tictactoe"
+    override val description: String =
+        "Challenge another user to Tic-Tac-Toe. Stake is optional — leave it off for free play."
+
+    companion object {
+        private const val OPT_USER = "user"
+        private const val OPT_STAKE = "stake"
+    }
+
+    override val optionData: List<OptionData> = listOf(
+        OptionData(OptionType.USER, OPT_USER, "Opponent", true),
+        OptionData(
+            OptionType.INTEGER,
+            OPT_STAKE,
+            "Credits to wager each (optional; per-guild bounds; 0 = free play)",
+            false,
+        ).setMinValue(0L),
+    )
+
+    override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        event.deferReply().queue()
+
+        val guild = event.guild ?: run {
+            replyError(event, "This command can only be used in a server.", deleteDelay); return
+        }
+        val targetUser = event.getOption(OPT_USER)?.asUser ?: run {
+            replyError(event, "You must specify an opponent.", deleteDelay); return
+        }
+        if (targetUser.isBot) {
+            replyError(event, "You can't challenge a bot.", deleteDelay); return
+        }
+        if (targetUser.idLong == requestingUserDto.discordId) {
+            replyError(event, "You can't challenge yourself.", deleteDelay); return
+        }
+        val stake = event.getOption(OPT_STAKE)?.asLong ?: 0L
+
+        userDtoHelper.calculateUserDto(targetUser.idLong, guild.idLong)
+
+        val start = ticTacToeService.startMatch(
+            initiatorDiscordId = requestingUserDto.discordId,
+            opponentDiscordId = targetUser.idLong,
+            guildId = guild.idLong,
+            stake = stake,
+        )
+        if (start !is StartOutcome.Ok) {
+            event.hook.replyEmbedAndDelete(TicTacToeEmbeds.startErrorEmbed(describe(start)), deleteDelay)
+            return
+        }
+
+        val initiatorId = requestingUserDto.discordId
+        val opponentId = targetUser.idLong
+        val session = ticTacToeSessionRegistry.register(
+            guildId = guild.idLong,
+            initiatorDiscordId = initiatorId,
+            opponentDiscordId = opponentId,
+            stake = stake,
+        ) { expired ->
+            runCatching {
+                event.hook.editOriginalEmbeds(
+                    TicTacToeEmbeds.pendingTimeoutEmbed(expired.initiatorDiscordId, expired.opponentDiscordId)
+                ).setComponents(emptyList<MessageTopLevelComponent>()).queue()
+            }
+        }
+
+        event.hook.sendMessageEmbeds(TicTacToeEmbeds.pendingEmbed(initiatorId, opponentId, stake))
+            .addContent("<@$opponentId>")
+            .addComponents(TicTacToeEmbeds.pendingButtons(session.id, opponentId))
+            .queue()
+    }
+
+    private fun describe(outcome: StartOutcome): String = when (outcome) {
+        is StartOutcome.InvalidStake -> "Stake must be between ${outcome.min} and ${outcome.max} credits for this server."
+        is StartOutcome.InvalidOpponent -> when (outcome.reason) {
+            StartOutcome.InvalidOpponent.Reason.SELF -> "You can't challenge yourself."
+            StartOutcome.InvalidOpponent.Reason.BOT -> "You can't challenge a bot."
+        }
+        is StartOutcome.InitiatorInsufficient -> "You need ${outcome.needed} credits but only have ${outcome.have}."
+        is StartOutcome.OpponentInsufficient -> "Your opponent only has ${outcome.have} credits but the stake requires ${outcome.needed}."
+        StartOutcome.UnknownInitiator -> "We couldn't find your profile — try a credit-earning command first."
+        StartOutcome.UnknownOpponent -> "We couldn't find your opponent's profile — they need to be active in the server first."
+        is StartOutcome.Ok -> ""
+    }
+
+    private fun replyError(
+        event: SlashCommandInteractionEvent,
+        message: String,
+        deleteDelay: Int,
+    ) {
+        event.hook.replyEmbedAndDelete(TicTacToeEmbeds.startErrorEmbed(message), deleteDelay)
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/TicTacToeCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/TicTacToeCommand.kt
@@ -4,8 +4,8 @@ import bot.toby.helpers.UserDtoHelper
 import core.command.Command.Companion.replyEmbedAndDelete
 import core.command.CommandContext
 import database.dto.UserDto
+import database.service.PvpWagerService
 import database.service.TicTacToeService
-import database.service.TicTacToeService.StartOutcome
 import database.tictactoe.TicTacToeSessionRegistry
 import net.dv8tion.jda.api.components.MessageTopLevelComponent
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
@@ -80,8 +80,11 @@ class TicTacToeCommand @Autowired constructor(
             guildId = guild.idLong,
             stake = stake,
         )
-        if (start !is StartOutcome.Ok) {
-            event.hook.replyEmbedAndDelete(TicTacToeEmbeds.startErrorEmbed(describe(start)), deleteDelay)
+        if (start !is PvpWagerService.StartOutcome.Ok) {
+            event.hook.replyEmbedAndDelete(
+                PvpEmbeds.startErrorEmbed(PvpEmbeds.describeStartOutcome(start)),
+                deleteDelay,
+            )
             return
         }
 
@@ -106,24 +109,11 @@ class TicTacToeCommand @Autowired constructor(
             .queue()
     }
 
-    private fun describe(outcome: StartOutcome): String = when (outcome) {
-        is StartOutcome.InvalidStake -> "Stake must be between ${outcome.min} and ${outcome.max} credits for this server."
-        is StartOutcome.InvalidOpponent -> when (outcome.reason) {
-            StartOutcome.InvalidOpponent.Reason.SELF -> "You can't challenge yourself."
-            StartOutcome.InvalidOpponent.Reason.BOT -> "You can't challenge a bot."
-        }
-        is StartOutcome.InitiatorInsufficient -> "You need ${outcome.needed} credits but only have ${outcome.have}."
-        is StartOutcome.OpponentInsufficient -> "Your opponent only has ${outcome.have} credits but the stake requires ${outcome.needed}."
-        StartOutcome.UnknownInitiator -> "We couldn't find your profile — try a credit-earning command first."
-        StartOutcome.UnknownOpponent -> "We couldn't find your opponent's profile — they need to be active in the server first."
-        is StartOutcome.Ok -> ""
-    }
-
     private fun replyError(
         event: SlashCommandInteractionEvent,
         message: String,
         deleteDelay: Int,
     ) {
-        event.hook.replyEmbedAndDelete(TicTacToeEmbeds.startErrorEmbed(message), deleteDelay)
+        event.hook.replyEmbedAndDelete(PvpEmbeds.startErrorEmbed(message), deleteDelay)
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/TicTacToeEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/TicTacToeEmbeds.kt
@@ -1,0 +1,275 @@
+package bot.toby.command.commands.economy
+
+import common.tictactoe.TicTacToeEngine
+import database.service.TicTacToeService
+import database.tictactoe.TicTacToeSessionRegistry
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.components.actionrow.ActionRow
+import net.dv8tion.jda.api.components.buttons.Button
+import net.dv8tion.jda.api.components.buttons.ButtonStyle
+import net.dv8tion.jda.api.entities.MessageEmbed
+
+/**
+ * Embed + button rendering for `/tictactoe`.
+ *
+ * Component IDs are colon-delimited so [DefaultButtonManager] can
+ * route by the `"tictactoe"` prefix and this object can parse the
+ * rest by index:
+ *
+ *   `tictactoe:<action>:<sessionId>:<scopedDiscordIdOrCell>`
+ *
+ * - `action`: ACCEPT / DECLINE during PENDING; PLACE_<0..8> /
+ *   FORFEIT during LIVE.
+ * - `scopedDiscordIdOrCell`: the opponent's discord id for
+ *   ACCEPT/DECLINE; the cell index for PLACE_*; 0 for FORFEIT
+ *   (kept in the format for parser symmetry).
+ *
+ * The board renders inside the embed description as a 3×3 emoji grid
+ * (❌ / ⭕ / ⬜). Underneath sit the cell buttons: each cell is its
+ * own button, disabled if already occupied or the game is over. A
+ * "Forfeit" button sits on its own row.
+ */
+object TicTacToeEmbeds {
+
+    const val BUTTON_NAME = "tictactoe"
+
+    private const val X_EMOJI = "❌"
+    private const val O_EMOJI = "⭕"
+    private const val EMPTY_EMOJI = "⬜"
+    private const val WIN_X_EMOJI = "🟥"
+    private const val WIN_O_EMOJI = "🟦"
+
+    enum class Action {
+        ACCEPT,
+        DECLINE,
+        PLACE_0, PLACE_1, PLACE_2,
+        PLACE_3, PLACE_4, PLACE_5,
+        PLACE_6, PLACE_7, PLACE_8,
+        FORFEIT,
+    }
+
+    data class ParsedButtonId(
+        val action: Action,
+        val sessionId: Long,
+        /** Discord id for ACCEPT/DECLINE; cell index for PLACE_*; 0 for FORFEIT. */
+        val payload: Long,
+    )
+
+    fun acceptButtonId(sessionId: Long, opponentDiscordId: Long): String =
+        encode(Action.ACCEPT, sessionId, opponentDiscordId)
+
+    fun declineButtonId(sessionId: Long, opponentDiscordId: Long): String =
+        encode(Action.DECLINE, sessionId, opponentDiscordId)
+
+    fun placeButtonId(sessionId: Long, cell: Int): String =
+        encode(placeAction(cell), sessionId, cell.toLong())
+
+    fun forfeitButtonId(sessionId: Long): String = encode(Action.FORFEIT, sessionId, 0L)
+
+    private fun encode(action: Action, sessionId: Long, payload: Long): String =
+        listOf(BUTTON_NAME, action.name, sessionId.toString(), payload.toString())
+            .joinToString(":")
+
+    fun parseButtonId(componentId: String): ParsedButtonId? {
+        val parts = componentId.split(':')
+        if (parts.size != 4 || !parts[0].equals(BUTTON_NAME, ignoreCase = true)) return null
+        val action = runCatching { Action.valueOf(parts[1]) }.getOrNull() ?: return null
+        val sessionId = parts[2].toLongOrNull() ?: return null
+        val payload = parts[3].toLongOrNull() ?: return null
+        return ParsedButtonId(action, sessionId, payload)
+    }
+
+    /** Maps PLACE_<n> → cell index `n`; returns null for non-PLACE actions. */
+    fun cellFor(action: Action): Int? = when (action) {
+        Action.PLACE_0 -> 0
+        Action.PLACE_1 -> 1
+        Action.PLACE_2 -> 2
+        Action.PLACE_3 -> 3
+        Action.PLACE_4 -> 4
+        Action.PLACE_5 -> 5
+        Action.PLACE_6 -> 6
+        Action.PLACE_7 -> 7
+        Action.PLACE_8 -> 8
+        else -> null
+    }
+
+    private fun placeAction(cell: Int): Action = when (cell) {
+        0 -> Action.PLACE_0
+        1 -> Action.PLACE_1
+        2 -> Action.PLACE_2
+        3 -> Action.PLACE_3
+        4 -> Action.PLACE_4
+        5 -> Action.PLACE_5
+        6 -> Action.PLACE_6
+        7 -> Action.PLACE_7
+        8 -> Action.PLACE_8
+        else -> error("cell $cell out of range")
+    }
+
+    // ---- embeds ----
+
+    fun pendingEmbed(
+        initiatorDiscordId: Long,
+        opponentDiscordId: Long,
+        stake: Long,
+    ): MessageEmbed = EmbedBuilder()
+        .setTitle("❌ ⭕  Tic-Tac-Toe")
+        .setDescription(
+            "<@${opponentDiscordId}> — <@${initiatorDiscordId}> has challenged you to Tic-Tac-Toe." +
+                stakeLine(stake) +
+                "\nAccept to start, or decline to walk away." +
+                "\n\nWinner gets ❌ (moves first). Loser plays ⭕."
+        )
+        .setColor(0x5B8DEF)
+        .build()
+
+    fun turnEmbed(session: TicTacToeSessionRegistry.Session): MessageEmbed {
+        val title = "❌ ⭕  Tic-Tac-Toe — <@${session.currentActorDiscordId()}>'s turn"
+        val board = renderBoard(session.board, winningLine = null)
+        return EmbedBuilder()
+            .setTitle(title)
+            .setDescription(
+                "<@${session.initiatorDiscordId}> (❌) vs <@${session.opponentDiscordId}> (⭕)" +
+                    stakeLine(session.stake) +
+                    "\n\n" + board
+            )
+            .setColor(0x5B8DEF)
+            .build()
+    }
+
+    fun winEmbed(
+        session: TicTacToeSessionRegistry.Session,
+        outcome: TicTacToeService.ResolveOutcome.Win,
+        forfeit: Boolean,
+    ): MessageEmbed {
+        val winnerMark = session.markFor(outcome.winnerDiscordId)
+        val verb = if (forfeit) "wins by forfeit" else "wins"
+        val markLabel = winnerMark?.let { " (${prettyMark(it)})" } ?: ""
+        val board = renderBoard(session.board, winningLine = session.winningLine)
+        return EmbedBuilder()
+            .setTitle("🏆 Tic-Tac-Toe — <@${outcome.winnerDiscordId}>$markLabel $verb!")
+            .setDescription(
+                board +
+                    if (outcome.pot > 0) {
+                        "\n\nPot: **${outcome.pot}** credits → " +
+                            "winner takes **${outcome.pot - outcome.lossTribute}** " +
+                            "(jackpot tribute: ${outcome.lossTribute})."
+                    } else "" +
+                        if (outcome.xpGranted > 0) "\n+${outcome.xpGranted} XP for the winner." else ""
+            )
+            .setColor(0x57F287)
+            .build()
+    }
+
+    fun drawEmbed(
+        session: TicTacToeSessionRegistry.Session,
+        outcome: TicTacToeService.ResolveOutcome.Draw,
+    ): MessageEmbed = EmbedBuilder()
+        .setTitle("🤝 Tic-Tac-Toe — draw!")
+        .setDescription(
+            renderBoard(session.board, winningLine = null) +
+                "\n\nNo three in a row." +
+                if (outcome.stake > 0) " Stakes refunded to both players." else ""
+        )
+        .setColor(0xFEE75C)
+        .build()
+
+    fun pendingDeclineEmbed(initiatorDiscordId: Long, opponentDiscordId: Long): MessageEmbed = EmbedBuilder()
+        .setTitle("❌ Challenge declined")
+        .setDescription("<@${opponentDiscordId}> declined <@${initiatorDiscordId}>'s Tic-Tac-Toe challenge.")
+        .setColor(0xED4245)
+        .build()
+
+    fun pendingTimeoutEmbed(initiatorDiscordId: Long, opponentDiscordId: Long): MessageEmbed = EmbedBuilder()
+        .setTitle("⌛ Challenge expired")
+        .setDescription("<@${opponentDiscordId}> didn't respond to <@${initiatorDiscordId}>'s Tic-Tac-Toe challenge.")
+        .setColor(0xED4245)
+        .build()
+
+    fun startErrorEmbed(message: String): MessageEmbed = EmbedBuilder()
+        .setTitle("❌ Can't start that match")
+        .setDescription(message)
+        .setColor(0xED4245)
+        .build()
+
+    fun acceptErrorEmbed(message: String): MessageEmbed = EmbedBuilder()
+        .setTitle("❌ Can't accept that match")
+        .setDescription(message)
+        .setColor(0xED4245)
+        .build()
+
+    // ---- button rows ----
+
+    fun pendingButtons(sessionId: Long, opponentDiscordId: Long): ActionRow = ActionRow.of(
+        Button.success(acceptButtonId(sessionId, opponentDiscordId), "Accept"),
+        Button.danger(declineButtonId(sessionId, opponentDiscordId), "Decline"),
+    )
+
+    /**
+     * Cell-grid + forfeit. The 3×3 grid is laid out as three rows of
+     * three buttons. Each cell button is disabled when occupied so the
+     * client surfaces the rule without round-tripping through the bot.
+     */
+    fun liveButtons(session: TicTacToeSessionRegistry.Session): List<ActionRow> {
+        val rows = (0 until 3).map { row ->
+            ActionRow.of(
+                (0 until 3).map { col ->
+                    val cell = row * 3 + col
+                    cellButton(session.id, cell, session.board[cell])
+                }
+            )
+        }
+        val forfeitRow = ActionRow.of(
+            Button.of(ButtonStyle.SECONDARY, forfeitButtonId(session.id), "Forfeit"),
+        )
+        return rows + forfeitRow
+    }
+
+    private fun cellButton(sessionId: Long, cell: Int, mark: TicTacToeEngine.Mark?): Button {
+        val id = placeButtonId(sessionId, cell)
+        return when (mark) {
+            null -> Button.of(ButtonStyle.SECONDARY, id, EMPTY_EMOJI)
+            TicTacToeEngine.Mark.X -> Button.of(ButtonStyle.DANGER, id, X_EMOJI).asDisabled()
+            TicTacToeEngine.Mark.O -> Button.of(ButtonStyle.PRIMARY, id, O_EMOJI).asDisabled()
+        }
+    }
+
+    // ---- helpers ----
+
+    private fun stakeLine(stake: Long): String =
+        if (stake > 0L) "\nStake: **${stake}** credits each (winner takes the pot)." else ""
+
+    /**
+     * Render the 9-cell board as a 3×3 emoji grid. Cells in
+     * [winningLine] are highlighted with team-coloured squares so the
+     * winning row is visually obvious in the final embed.
+     */
+    private fun renderBoard(
+        board: TicTacToeEngine.Board,
+        winningLine: List<Int>?,
+    ): String {
+        val highlight = winningLine?.toSet() ?: emptySet()
+        return buildString {
+            for (row in 0 until 3) {
+                for (col in 0 until 3) {
+                    val cell = row * 3 + col
+                    append(cellEmoji(board[cell], cell in highlight))
+                }
+                append('\n')
+            }
+        }.trimEnd()
+    }
+
+    private fun cellEmoji(mark: TicTacToeEngine.Mark?, winning: Boolean): String = when {
+        mark == TicTacToeEngine.Mark.X && winning -> WIN_X_EMOJI
+        mark == TicTacToeEngine.Mark.O && winning -> WIN_O_EMOJI
+        mark == TicTacToeEngine.Mark.X -> X_EMOJI
+        mark == TicTacToeEngine.Mark.O -> O_EMOJI
+        else -> EMPTY_EMOJI
+    }
+
+    fun prettyMark(mark: TicTacToeEngine.Mark): String = when (mark) {
+        TicTacToeEngine.Mark.X -> "❌"
+        TicTacToeEngine.Mark.O -> "⭕"
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/TicTacToeEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/TicTacToeEmbeds.kt
@@ -10,7 +10,11 @@ import net.dv8tion.jda.api.components.buttons.ButtonStyle
 import net.dv8tion.jda.api.entities.MessageEmbed
 
 /**
- * Embed + button rendering for `/tictactoe`.
+ * Embed + button rendering specific to `/tictactoe`. The cross-game
+ * bits (Accept/Decline button row, stake-line text, error / decline /
+ * timeout embeds, start-error description) live in [PvpEmbeds] —
+ * this file only owns the TTT-specific board rendering, cell buttons,
+ * and turn / win / draw embeds.
  *
  * Component IDs are colon-delimited so [DefaultButtonManager] can
  * route by the `"tictactoe"` prefix and this object can parse the
@@ -21,17 +25,12 @@ import net.dv8tion.jda.api.entities.MessageEmbed
  * - `action`: ACCEPT / DECLINE during PENDING; PLACE_<0..8> /
  *   FORFEIT during LIVE.
  * - `scopedDiscordIdOrCell`: the opponent's discord id for
- *   ACCEPT/DECLINE; the cell index for PLACE_*; 0 for FORFEIT
- *   (kept in the format for parser symmetry).
- *
- * The board renders inside the embed description as a 3×3 emoji grid
- * (❌ / ⭕ / ⬜). Underneath sit the cell buttons: each cell is its
- * own button, disabled if already occupied or the game is over. A
- * "Forfeit" button sits on its own row.
+ *   ACCEPT/DECLINE; the cell index for PLACE_*; 0 for FORFEIT.
  */
 object TicTacToeEmbeds {
 
     const val BUTTON_NAME = "tictactoe"
+    private const val GAME_NAME = "Tic-Tac-Toe"
 
     private const val X_EMOJI = "❌"
     private const val O_EMOJI = "⭕"
@@ -106,7 +105,7 @@ object TicTacToeEmbeds {
         else -> error("cell $cell out of range")
     }
 
-    // ---- embeds ----
+    // ---- TTT-specific embeds ----
 
     fun pendingEmbed(
         initiatorDiscordId: Long,
@@ -116,7 +115,7 @@ object TicTacToeEmbeds {
         .setTitle("❌ ⭕  Tic-Tac-Toe")
         .setDescription(
             "<@${opponentDiscordId}> — <@${initiatorDiscordId}> has challenged you to Tic-Tac-Toe." +
-                stakeLine(stake) +
+                PvpEmbeds.stakeLine(stake) +
                 "\nAccept to start, or decline to walk away." +
                 "\n\nWinner gets ❌ (moves first). Loser plays ⭕."
         )
@@ -130,7 +129,7 @@ object TicTacToeEmbeds {
             .setTitle(title)
             .setDescription(
                 "<@${session.initiatorDiscordId}> (❌) vs <@${session.opponentDiscordId}> (⭕)" +
-                    stakeLine(session.stake) +
+                    PvpEmbeds.stakeLine(session.stake) +
                     "\n\n" + board
             )
             .setColor(0x5B8DEF)
@@ -174,36 +173,21 @@ object TicTacToeEmbeds {
         .setColor(0xFEE75C)
         .build()
 
-    fun pendingDeclineEmbed(initiatorDiscordId: Long, opponentDiscordId: Long): MessageEmbed = EmbedBuilder()
-        .setTitle("❌ Challenge declined")
-        .setDescription("<@${opponentDiscordId}> declined <@${initiatorDiscordId}>'s Tic-Tac-Toe challenge.")
-        .setColor(0xED4245)
-        .build()
+    // ---- shared-embed pass-throughs (game-name pre-filled) ----
 
-    fun pendingTimeoutEmbed(initiatorDiscordId: Long, opponentDiscordId: Long): MessageEmbed = EmbedBuilder()
-        .setTitle("⌛ Challenge expired")
-        .setDescription("<@${opponentDiscordId}> didn't respond to <@${initiatorDiscordId}>'s Tic-Tac-Toe challenge.")
-        .setColor(0xED4245)
-        .build()
+    fun pendingDeclineEmbed(initiatorDiscordId: Long, opponentDiscordId: Long): MessageEmbed =
+        PvpEmbeds.pendingDeclineEmbed(GAME_NAME, initiatorDiscordId, opponentDiscordId)
 
-    fun startErrorEmbed(message: String): MessageEmbed = EmbedBuilder()
-        .setTitle("❌ Can't start that match")
-        .setDescription(message)
-        .setColor(0xED4245)
-        .build()
-
-    fun acceptErrorEmbed(message: String): MessageEmbed = EmbedBuilder()
-        .setTitle("❌ Can't accept that match")
-        .setDescription(message)
-        .setColor(0xED4245)
-        .build()
+    fun pendingTimeoutEmbed(initiatorDiscordId: Long, opponentDiscordId: Long): MessageEmbed =
+        PvpEmbeds.pendingTimeoutEmbed(GAME_NAME, initiatorDiscordId, opponentDiscordId)
 
     // ---- button rows ----
 
-    fun pendingButtons(sessionId: Long, opponentDiscordId: Long): ActionRow = ActionRow.of(
-        Button.success(acceptButtonId(sessionId, opponentDiscordId), "Accept"),
-        Button.danger(declineButtonId(sessionId, opponentDiscordId), "Decline"),
-    )
+    fun pendingButtons(sessionId: Long, opponentDiscordId: Long): ActionRow =
+        PvpEmbeds.pendingButtons(
+            acceptButtonId = acceptButtonId(sessionId, opponentDiscordId),
+            declineButtonId = declineButtonId(sessionId, opponentDiscordId),
+        )
 
     /**
      * Cell-grid + forfeit. The 3×3 grid is laid out as three rows of
@@ -235,9 +219,6 @@ object TicTacToeEmbeds {
     }
 
     // ---- helpers ----
-
-    private fun stakeLine(stake: Long): String =
-        if (stake > 0L) "\nStake: **${stake}** credits each (winner takes the pot)." else ""
 
     /**
      * Render the 9-cell board as a 3×3 emoji grid. Cells in

--- a/discord-bot/src/main/kotlin/bot/toby/handler/AchievementEventHandler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/handler/AchievementEventHandler.kt
@@ -19,6 +19,7 @@ import common.events.PlinkoJackpotEvent
 import common.events.PokerRoyalFlushEvent
 import common.events.RouletteStraightWinEvent
 import common.events.RpsResolvedEvent
+import common.events.TicTacToeResolvedEvent
 import common.events.ScratchJackpotEvent
 import common.events.SlotsJackpotEvent
 import common.events.StreakClaimedEvent
@@ -158,6 +159,31 @@ class AchievementEventHandler(
                 discordId = event.loserDiscordId,
                 guildId = event.guildId,
                 code = "rps_losses_$tier",
+                delta = 1L
+            )
+        }
+    }
+
+    @EventListener
+    fun onTicTacToeResolved(event: TicTacToeResolvedEvent) {
+        achievementService.unlock(
+            discordId = event.winnerDiscordId,
+            guildId = event.guildId,
+            code = "first_tictactoe_win"
+        )
+        TICTACTOE_WIN_TIERS.forEach { tier ->
+            achievementService.progress(
+                discordId = event.winnerDiscordId,
+                guildId = event.guildId,
+                code = "tictactoe_wins_$tier",
+                delta = 1L
+            )
+        }
+        TICTACTOE_LOSS_TIERS.forEach { tier ->
+            achievementService.progress(
+                discordId = event.loserDiscordId,
+                guildId = event.guildId,
+                code = "tictactoe_losses_$tier",
                 delta = 1L
             )
         }
@@ -352,6 +378,8 @@ class AchievementEventHandler(
         private val DUEL_LOSS_TIERS = listOf(5, 25)
         private val RPS_WIN_TIERS = listOf(10, 25)
         private val RPS_LOSS_TIERS = listOf(5)
+        private val TICTACTOE_WIN_TIERS = listOf(10, 25)
+        private val TICTACTOE_LOSS_TIERS = listOf(5)
         private val LOTTERY_WIN_TIERS = listOf(3, 10, 25)
         private val BLACKJACK_NATURAL_TIERS = listOf(5, 25)
         private val TIP_SENT_TIERS = listOf(10, 50)

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/RpsButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/RpsButtonTest.kt
@@ -9,6 +9,7 @@ import bot.toby.command.commands.economy.RpsEmbeds
 import database.dto.UserDto
 import common.rps.RpsEngine
 import database.rps.RpsSessionRegistry
+import database.service.PvpWagerService
 import database.service.RpsService
 import io.mockk.Runs
 import io.mockk.every
@@ -109,7 +110,7 @@ class RpsButtonTest : ButtonTest {
         every { registry.accept(sessionId, any()) } returns liveSession()
         every {
             rpsService.acceptMatch(initiatorId, opponentId, guildId, stake)
-        } returns RpsService.AcceptOutcome.Ok(initiatorNewBalance = 100L, opponentNewBalance = 100L)
+        } returns PvpWagerService.AcceptOutcome.Ok(initiatorNewBalance = 100L, opponentNewBalance = 100L)
 
         button.handle(DefaultButtonContext(event), UserDto(opponentId, guildId), 0)
 
@@ -124,7 +125,7 @@ class RpsButtonTest : ButtonTest {
         every { registry.accept(sessionId, any()) } returns liveSession()
         every {
             rpsService.acceptMatch(initiatorId, opponentId, guildId, stake)
-        } returns RpsService.AcceptOutcome.OpponentInsufficient(have = 10L, needed = 50L)
+        } returns PvpWagerService.AcceptOutcome.OpponentInsufficient(have = 10L, needed = 50L)
 
         button.handle(DefaultButtonContext(event), UserDto(opponentId, guildId), 0)
 

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/TicTacToeButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/TicTacToeButtonTest.kt
@@ -1,0 +1,273 @@
+package bot.toby.button.buttons
+
+import bot.toby.button.ButtonTest
+import bot.toby.button.ButtonTest.Companion.event
+import bot.toby.button.ButtonTest.Companion.mockGuild
+import bot.toby.button.ButtonTest.Companion.mockHook
+import bot.toby.button.DefaultButtonContext
+import bot.toby.command.commands.economy.TicTacToeEmbeds
+import common.tictactoe.TicTacToeEngine
+import database.dto.UserDto
+import database.service.TicTacToeService
+import database.tictactoe.TicTacToeSessionRegistry
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.components.MessageTopLevelComponent
+import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class TicTacToeButtonTest : ButtonTest {
+
+    private lateinit var ticTacToeService: TicTacToeService
+    private lateinit var registry: TicTacToeSessionRegistry
+    private lateinit var button: TicTacToeButton
+
+    private val initiatorId = 1L
+    private val opponentId = 2L
+    private val guildId = 1L
+    private val stake = 50L
+    private val sessionId = 7L
+
+    private lateinit var message: Message
+
+    @BeforeEach
+    override fun setup() {
+        super.setup()
+        every { mockGuild.idLong } returns guildId
+
+        ticTacToeService = mockk(relaxed = true)
+        registry = mockk(relaxed = true)
+        button = TicTacToeButton(ticTacToeService, registry)
+
+        message = mockk(relaxed = true)
+        every { event.message } returns message
+
+        val edit = mockk<net.dv8tion.jda.api.requests.restaction.MessageEditAction>(relaxed = true)
+        every { message.editMessageEmbeds(any<MessageEmbed>()) } returns edit
+        every { edit.setComponents(any<Collection<MessageTopLevelComponent>>()) } returns edit
+        every { edit.setComponents(*anyVararg<MessageTopLevelComponent>()) } returns edit
+        every { edit.queue() } just Runs
+
+        val send = mockk<WebhookMessageCreateAction<Message>>(relaxed = true)
+        every { mockHook.sendMessage(any<String>()) } returns send
+        every { send.setEphemeral(any()) } returns send
+        every { send.queue() } just Runs
+    }
+
+    @AfterEach
+    @Throws(Exception::class)
+    override fun tearDown() {
+        super.tearDown()
+    }
+
+    private fun pendingSession() = TicTacToeSessionRegistry.Session(
+        id = sessionId, guildId = guildId,
+        initiatorDiscordId = initiatorId, opponentDiscordId = opponentId,
+        stake = stake, createdAt = Instant.now(),
+    )
+
+    private fun liveSession() = pendingSession().also { it.state = TicTacToeSessionRegistry.Session.State.LIVE }
+
+    // ---- DECLINE ----
+
+    @Test
+    fun `non-opponent decline gets ephemeral reject`() {
+        every { event.componentId } returns TicTacToeEmbeds.declineButtonId(sessionId, opponentId)
+        button.handle(DefaultButtonContext(event), UserDto(999L, guildId), 0)
+        verify(exactly = 0) { registry.decline(any()) }
+        verify { mockHook.sendMessage(any<String>()) }
+    }
+
+    @Test
+    fun `opponent decline removes the session and edits the message`() {
+        every { event.componentId } returns TicTacToeEmbeds.declineButtonId(sessionId, opponentId)
+        every { registry.decline(sessionId) } returns pendingSession()
+
+        button.handle(DefaultButtonContext(event), UserDto(opponentId, guildId), 0)
+
+        verify(exactly = 1) { registry.decline(sessionId) }
+        verify(exactly = 1) { message.editMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    // ---- ACCEPT ----
+
+    @Test
+    fun `opponent accept transitions to LIVE and posts turn embed`() {
+        every { event.componentId } returns TicTacToeEmbeds.acceptButtonId(sessionId, opponentId)
+        every { registry.accept(sessionId, any()) } returns liveSession()
+        every {
+            ticTacToeService.acceptMatch(initiatorId, opponentId, guildId, stake)
+        } returns TicTacToeService.AcceptOutcome.Ok(initiatorNewBalance = 100L, opponentNewBalance = 100L)
+
+        button.handle(DefaultButtonContext(event), UserDto(opponentId, guildId), 0)
+
+        verify(exactly = 1) { registry.accept(sessionId, any()) }
+        verify(exactly = 1) { ticTacToeService.acceptMatch(initiatorId, opponentId, guildId, stake) }
+        verify(exactly = 1) { message.editMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `accept failure on insufficient balance tears down the live session`() {
+        every { event.componentId } returns TicTacToeEmbeds.acceptButtonId(sessionId, opponentId)
+        every { registry.accept(sessionId, any()) } returns liveSession()
+        every {
+            ticTacToeService.acceptMatch(initiatorId, opponentId, guildId, stake)
+        } returns TicTacToeService.AcceptOutcome.OpponentInsufficient(have = 10L, needed = 50L)
+
+        button.handle(DefaultButtonContext(event), UserDto(opponentId, guildId), 0)
+
+        verify(exactly = 1) { registry.forfeit(sessionId) }
+        verify(exactly = 1) { message.editMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `accept on an already-resolved session sends ephemeral`() {
+        every { event.componentId } returns TicTacToeEmbeds.acceptButtonId(sessionId, opponentId)
+        every { registry.accept(sessionId, any()) } returns null
+
+        button.handle(DefaultButtonContext(event), UserDto(opponentId, guildId), 0)
+
+        verify(exactly = 0) { ticTacToeService.acceptMatch(any(), any(), any(), any()) }
+        verify { mockHook.sendMessage(any<String>()) }
+    }
+
+    // ---- PLACE ----
+
+    @Test
+    fun `place by a non-player is rejected ephemerally`() {
+        every { event.componentId } returns TicTacToeEmbeds.placeButtonId(sessionId, cell = 0)
+        every { registry.get(sessionId) } returns liveSession()
+
+        button.handle(DefaultButtonContext(event), UserDto(999L, guildId), 0)
+
+        verify(exactly = 0) { registry.applyMove(any(), any(), any(), any()) }
+        verify { mockHook.sendMessage(any<String>()) }
+    }
+
+    @Test
+    fun `place on a continued move re-renders the board`() {
+        val live = liveSession()
+        every { event.componentId } returns TicTacToeEmbeds.placeButtonId(sessionId, cell = 0)
+        every { registry.get(sessionId) } returns live
+        every { registry.applyMove(sessionId, initiatorId, 0, any()) } returns
+            TicTacToeEngine.MoveResult.Continued(TicTacToeEngine.empty())
+
+        button.handle(DefaultButtonContext(event), UserDto(initiatorId, guildId), 0)
+
+        verify(exactly = 1) { registry.applyMove(sessionId, initiatorId, 0, any()) }
+        // Continued path doesn't drain or resolve.
+        verify(exactly = 0) { registry.consumeForResolution(any()) }
+        verify(exactly = 0) { ticTacToeService.resolveMatch(any(), any(), any(), any(), any()) }
+        verify(atLeast = 1) { message.editMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `place that lands a Win drains and resolves with the engine winner`() {
+        val live = liveSession().also { it.winner = TicTacToeEngine.Mark.X }
+        every { event.componentId } returns TicTacToeEmbeds.placeButtonId(sessionId, cell = 2)
+        every { registry.get(sessionId) } returns live
+        every { registry.applyMove(sessionId, initiatorId, 2, any()) } returns
+            TicTacToeEngine.MoveResult.Win(TicTacToeEngine.empty(), TicTacToeEngine.Mark.X, listOf(0, 1, 2))
+        every { registry.consumeForResolution(sessionId) } returns live
+        every {
+            ticTacToeService.resolveMatch(initiatorId, opponentId, guildId, stake, initiatorId)
+        } returns TicTacToeService.ResolveOutcome.Win(
+            winnerDiscordId = initiatorId, loserDiscordId = opponentId,
+            stake = stake, pot = 2 * stake,
+            winnerNewBalance = 150L, loserNewBalance = 50L,
+            lossTribute = 0L, xpGranted = 10L,
+        )
+
+        button.handle(DefaultButtonContext(event), UserDto(initiatorId, guildId), 0)
+
+        verify(exactly = 1) { registry.consumeForResolution(sessionId) }
+        verify(exactly = 1) {
+            ticTacToeService.resolveMatch(initiatorId, opponentId, guildId, stake, initiatorId)
+        }
+    }
+
+    @Test
+    fun `place that lands a Draw drains and resolves with null winner`() {
+        val live = liveSession() // winner stays null
+        every { event.componentId } returns TicTacToeEmbeds.placeButtonId(sessionId, cell = 8)
+        every { registry.get(sessionId) } returns live
+        every { registry.applyMove(sessionId, initiatorId, 8, any()) } returns
+            TicTacToeEngine.MoveResult.Draw(TicTacToeEngine.empty())
+        every { registry.consumeForResolution(sessionId) } returns live
+        every {
+            ticTacToeService.resolveMatch(initiatorId, opponentId, guildId, stake, null)
+        } returns TicTacToeService.ResolveOutcome.Draw(stake = stake, initiatorNewBalance = stake, opponentNewBalance = stake)
+
+        button.handle(DefaultButtonContext(event), UserDto(initiatorId, guildId), 0)
+
+        verify(exactly = 1) {
+            ticTacToeService.resolveMatch(initiatorId, opponentId, guildId, stake, null)
+        }
+    }
+
+    @Test
+    fun `place by the wrong player (not their turn) sends ephemeral`() {
+        val live = liveSession()
+        every { event.componentId } returns TicTacToeEmbeds.placeButtonId(sessionId, cell = 0)
+        every { registry.get(sessionId) } returns live
+        // Out-of-turn move → registry returns null.
+        every { registry.applyMove(sessionId, opponentId, 0, any()) } returns null
+
+        button.handle(DefaultButtonContext(event), UserDto(opponentId, guildId), 0)
+
+        verify(exactly = 0) { registry.consumeForResolution(any()) }
+        verify { mockHook.sendMessage(any<String>()) }
+    }
+
+    // ---- FORFEIT ----
+
+    @Test
+    fun `forfeit by a player removes the session and resolves the opponent as winner`() {
+        every { event.componentId } returns TicTacToeEmbeds.forfeitButtonId(sessionId)
+        val live = liveSession()
+        every { registry.get(sessionId) } returns live
+        every { registry.forfeit(sessionId) } returns live
+        every {
+            ticTacToeService.resolveMatch(initiatorId, opponentId, guildId, stake, opponentId)
+        } returns TicTacToeService.ResolveOutcome.Win(
+            winnerDiscordId = opponentId, loserDiscordId = initiatorId,
+            stake = stake, pot = 2 * stake,
+            winnerNewBalance = 250L, loserNewBalance = 0L,
+            lossTribute = 0L, xpGranted = 10L,
+        )
+
+        // Initiator forfeits → opponent wins.
+        button.handle(DefaultButtonContext(event), UserDto(initiatorId, guildId), 0)
+
+        verify(exactly = 1) { registry.forfeit(sessionId) }
+        verify(exactly = 1) {
+            ticTacToeService.resolveMatch(initiatorId, opponentId, guildId, stake, opponentId)
+        }
+    }
+
+    @Test
+    fun `forfeit by a non-player is rejected`() {
+        every { event.componentId } returns TicTacToeEmbeds.forfeitButtonId(sessionId)
+        every { registry.get(sessionId) } returns liveSession()
+
+        button.handle(DefaultButtonContext(event), UserDto(999L, guildId), 0)
+
+        verify(exactly = 0) { registry.forfeit(any()) }
+        verify { mockHook.sendMessage(any<String>()) }
+    }
+
+    @Test
+    fun `unparseable component id sends ephemeral`() {
+        every { event.componentId } returns "garbage"
+        button.handle(DefaultButtonContext(event), UserDto(initiatorId, guildId), 0)
+        verify { mockHook.sendMessage(any<String>()) }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/TicTacToeButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/TicTacToeButtonTest.kt
@@ -8,6 +8,7 @@ import bot.toby.button.DefaultButtonContext
 import bot.toby.command.commands.economy.TicTacToeEmbeds
 import common.tictactoe.TicTacToeEngine
 import database.dto.UserDto
+import database.service.PvpWagerService
 import database.service.TicTacToeService
 import database.tictactoe.TicTacToeSessionRegistry
 import io.mockk.Runs
@@ -105,7 +106,7 @@ class TicTacToeButtonTest : ButtonTest {
         every { registry.accept(sessionId, any()) } returns liveSession()
         every {
             ticTacToeService.acceptMatch(initiatorId, opponentId, guildId, stake)
-        } returns TicTacToeService.AcceptOutcome.Ok(initiatorNewBalance = 100L, opponentNewBalance = 100L)
+        } returns PvpWagerService.AcceptOutcome.Ok(initiatorNewBalance = 100L, opponentNewBalance = 100L)
 
         button.handle(DefaultButtonContext(event), UserDto(opponentId, guildId), 0)
 
@@ -120,7 +121,7 @@ class TicTacToeButtonTest : ButtonTest {
         every { registry.accept(sessionId, any()) } returns liveSession()
         every {
             ticTacToeService.acceptMatch(initiatorId, opponentId, guildId, stake)
-        } returns TicTacToeService.AcceptOutcome.OpponentInsufficient(have = 10L, needed = 50L)
+        } returns PvpWagerService.AcceptOutcome.OpponentInsufficient(have = 10L, needed = 50L)
 
         button.handle(DefaultButtonContext(event), UserDto(opponentId, guildId), 0)
 

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/RpsCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/RpsCommandTest.kt
@@ -9,6 +9,7 @@ import bot.toby.command.DefaultCommandContext
 import bot.toby.helpers.UserDtoHelper
 import database.dto.UserDto
 import database.rps.RpsSessionRegistry
+import database.service.PvpWagerService
 import database.service.RpsService
 import io.mockk.every
 import io.mockk.just
@@ -61,7 +62,7 @@ internal class RpsCommandTest : CommandTest {
         val opponent = stubOpponent(idLong = 2L, isBot = false)
         every { event.getOption("user") } returns opponent
         every { event.getOption("stake") } returns stakeOpt(50L)
-        every { rpsService.startMatch(1L, 2L, 100L, 50L) } returns RpsService.StartOutcome.Ok(initiatorBalance = 500L)
+        every { rpsService.startMatch(1L, 2L, 100L, 50L) } returns PvpWagerService.StartOutcome.Ok(initiatorBalance = 500L)
         every { registry.register(100L, 1L, 2L, 50L, any(), any()) } returns RpsSessionRegistry.Session(
             id = 7L, guildId = 100L, initiatorDiscordId = 1L,
             opponentDiscordId = 2L, stake = 50L, createdAt = java.time.Instant.now(),
@@ -82,7 +83,7 @@ internal class RpsCommandTest : CommandTest {
         val opponent = stubOpponent(idLong = 2L, isBot = false)
         every { event.getOption("user") } returns opponent
         every { event.getOption("stake") } returns null
-        every { rpsService.startMatch(1L, 2L, 100L, 0L) } returns RpsService.StartOutcome.Ok(initiatorBalance = 100L)
+        every { rpsService.startMatch(1L, 2L, 100L, 0L) } returns PvpWagerService.StartOutcome.Ok(initiatorBalance = 100L)
         every { registry.register(100L, 1L, 2L, 0L, any(), any()) } returns RpsSessionRegistry.Session(
             id = 7L, guildId = 100L, initiatorDiscordId = 1L,
             opponentDiscordId = 2L, stake = 0L, createdAt = java.time.Instant.now(),
@@ -119,7 +120,7 @@ internal class RpsCommandTest : CommandTest {
         every { event.getOption("user") } returns opponent
         every { event.getOption("stake") } returns stakeOpt(50L)
         every { rpsService.startMatch(1L, 2L, 100L, 50L) } returns
-            RpsService.StartOutcome.InitiatorInsufficient(have = 10L, needed = 50L)
+            PvpWagerService.StartOutcome.InitiatorInsufficient(have = 10L, needed = 50L)
 
         command.handle(DefaultCommandContext(event), requestingUserDto, 0)
 

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/TicTacToeCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/TicTacToeCommandTest.kt
@@ -8,6 +8,7 @@ import bot.toby.command.CommandTest.Companion.webhookMessageCreateAction
 import bot.toby.command.DefaultCommandContext
 import bot.toby.helpers.UserDtoHelper
 import database.dto.UserDto
+import database.service.PvpWagerService
 import database.service.TicTacToeService
 import database.tictactoe.TicTacToeSessionRegistry
 import io.mockk.every
@@ -61,7 +62,7 @@ internal class TicTacToeCommandTest : CommandTest {
         every { event.getOption("user") } returns opponent
         every { event.getOption("stake") } returns stakeOpt(50L)
         every { ticTacToeService.startMatch(1L, 2L, 100L, 50L) } returns
-            TicTacToeService.StartOutcome.Ok(initiatorBalance = 500L)
+            PvpWagerService.StartOutcome.Ok(initiatorBalance = 500L)
         every { registry.register(100L, 1L, 2L, 50L, any(), any()) } returns TicTacToeSessionRegistry.Session(
             id = 7L, guildId = 100L, initiatorDiscordId = 1L,
             opponentDiscordId = 2L, stake = 50L, createdAt = java.time.Instant.now(),
@@ -83,7 +84,7 @@ internal class TicTacToeCommandTest : CommandTest {
         every { event.getOption("user") } returns opponent
         every { event.getOption("stake") } returns null
         every { ticTacToeService.startMatch(1L, 2L, 100L, 0L) } returns
-            TicTacToeService.StartOutcome.Ok(initiatorBalance = 100L)
+            PvpWagerService.StartOutcome.Ok(initiatorBalance = 100L)
         every { registry.register(100L, 1L, 2L, 0L, any(), any()) } returns TicTacToeSessionRegistry.Session(
             id = 7L, guildId = 100L, initiatorDiscordId = 1L,
             opponentDiscordId = 2L, stake = 0L, createdAt = java.time.Instant.now(),
@@ -120,7 +121,7 @@ internal class TicTacToeCommandTest : CommandTest {
         every { event.getOption("user") } returns opponent
         every { event.getOption("stake") } returns stakeOpt(50L)
         every { ticTacToeService.startMatch(1L, 2L, 100L, 50L) } returns
-            TicTacToeService.StartOutcome.InitiatorInsufficient(have = 10L, needed = 50L)
+            PvpWagerService.StartOutcome.InitiatorInsufficient(have = 10L, needed = 50L)
 
         command.handle(DefaultCommandContext(event), requestingUserDto, 0)
 

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/TicTacToeCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/TicTacToeCommandTest.kt
@@ -1,0 +1,144 @@
+package bot.toby.command.commands.economy
+
+import bot.toby.command.CommandTest
+import bot.toby.command.CommandTest.Companion.event
+import bot.toby.command.CommandTest.Companion.guild
+import bot.toby.command.CommandTest.Companion.requestingUserDto
+import bot.toby.command.CommandTest.Companion.webhookMessageCreateAction
+import bot.toby.command.DefaultCommandContext
+import bot.toby.helpers.UserDtoHelper
+import database.dto.UserDto
+import database.service.TicTacToeService
+import database.tictactoe.TicTacToeSessionRegistry
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.unmockkAll
+import io.mockk.verify
+import net.dv8tion.jda.api.components.actionrow.ActionRow
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.entities.User
+import net.dv8tion.jda.api.interactions.commands.OptionMapping
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class TicTacToeCommandTest : CommandTest {
+
+    private lateinit var ticTacToeService: TicTacToeService
+    private lateinit var registry: TicTacToeSessionRegistry
+    private lateinit var userDtoHelper: UserDtoHelper
+    private lateinit var command: TicTacToeCommand
+
+    @BeforeEach
+    fun setUp() {
+        setUpCommonMocks()
+        ticTacToeService = mockk(relaxed = true)
+        registry = mockk(relaxed = true)
+        userDtoHelper = mockk(relaxed = true)
+        command = TicTacToeCommand(ticTacToeService, registry, userDtoHelper)
+
+        every { guild.idLong } returns 100L
+        every { guild.id } returns "100"
+        every { requestingUserDto.discordId } returns 1L
+
+        every { webhookMessageCreateAction.addContent(any()) } returns webhookMessageCreateAction
+        every { webhookMessageCreateAction.addComponents(any<ActionRow>()) } returns webhookMessageCreateAction
+        every { webhookMessageCreateAction.queue() } just runs
+        every { userDtoHelper.calculateUserDto(any(), any()) } returns mockk<UserDto>(relaxed = true)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        tearDownCommonMocks()
+        unmockkAll()
+    }
+
+    @Test
+    fun `happy path posts the pending embed with accept and decline buttons`() {
+        val opponent = stubOpponent(idLong = 2L, isBot = false)
+        every { event.getOption("user") } returns opponent
+        every { event.getOption("stake") } returns stakeOpt(50L)
+        every { ticTacToeService.startMatch(1L, 2L, 100L, 50L) } returns
+            TicTacToeService.StartOutcome.Ok(initiatorBalance = 500L)
+        every { registry.register(100L, 1L, 2L, 50L, any(), any()) } returns TicTacToeSessionRegistry.Session(
+            id = 7L, guildId = 100L, initiatorDiscordId = 1L,
+            opponentDiscordId = 2L, stake = 50L, createdAt = java.time.Instant.now(),
+        )
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 0)
+
+        verify(exactly = 1) { event.deferReply() }
+        verify(exactly = 1) { ticTacToeService.startMatch(1L, 2L, 100L, 50L) }
+        verify(exactly = 1) { registry.register(100L, 1L, 2L, 50L, any(), any()) }
+        verify(exactly = 1) { event.hook.sendMessageEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 1) { webhookMessageCreateAction.addContent(match<String> { it.contains("<@2>") }) }
+        verify(exactly = 1) { webhookMessageCreateAction.addComponents(any<ActionRow>()) }
+    }
+
+    @Test
+    fun `free-play match (no stake option) starts with stake 0`() {
+        val opponent = stubOpponent(idLong = 2L, isBot = false)
+        every { event.getOption("user") } returns opponent
+        every { event.getOption("stake") } returns null
+        every { ticTacToeService.startMatch(1L, 2L, 100L, 0L) } returns
+            TicTacToeService.StartOutcome.Ok(initiatorBalance = 100L)
+        every { registry.register(100L, 1L, 2L, 0L, any(), any()) } returns TicTacToeSessionRegistry.Session(
+            id = 7L, guildId = 100L, initiatorDiscordId = 1L,
+            opponentDiscordId = 2L, stake = 0L, createdAt = java.time.Instant.now(),
+        )
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 0)
+
+        verify(exactly = 1) { ticTacToeService.startMatch(1L, 2L, 100L, 0L) }
+    }
+
+    @Test
+    fun `bot opponent is rejected`() {
+        val botOpp = stubOpponent(idLong = 99L, isBot = true)
+        every { event.getOption("user") } returns botOpp
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 0)
+
+        verify(exactly = 0) { ticTacToeService.startMatch(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `self-challenge is rejected before service is called`() {
+        val selfOpp = stubOpponent(idLong = 1L, isBot = false)
+        every { event.getOption("user") } returns selfOpp
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 0)
+
+        verify(exactly = 0) { ticTacToeService.startMatch(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `service-side preflight failure surfaces the start-error embed`() {
+        val opponent = stubOpponent(idLong = 2L, isBot = false)
+        every { event.getOption("user") } returns opponent
+        every { event.getOption("stake") } returns stakeOpt(50L)
+        every { ticTacToeService.startMatch(1L, 2L, 100L, 50L) } returns
+            TicTacToeService.StartOutcome.InitiatorInsufficient(have = 10L, needed = 50L)
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 0)
+
+        verify(exactly = 0) { registry.register(any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 1) { event.hook.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    private fun stubOpponent(idLong: Long, isBot: Boolean): OptionMapping {
+        val user = mockk<User>(relaxed = true).also {
+            every { it.idLong } returns idLong
+            every { it.id } returns idLong.toString()
+            every { it.isBot } returns isBot
+            every { it.effectiveName } returns "Opponent-$idLong"
+        }
+        return mockk<OptionMapping>(relaxed = true).also { every { it.asUser } returns user }
+    }
+
+    private fun stakeOpt(value: Long): OptionMapping {
+        return mockk<OptionMapping>(relaxed = true).also { every { it.asLong } returns value }
+    }
+}

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -891,10 +891,11 @@ class ModerationWebService(
                 if (n < 1L) return "Value must be at least 1 credit."
                 n.toString()
             }
-            // RPS_MIN_STAKE allows 0 — `/rps` supports free play out of
-            // the box, the only wager game that does. Validated
-            // separately because the other min-stake keys require >= 1.
-            ConfigDto.Configurations.RPS_MIN_STAKE -> {
+            // RPS_MIN_STAKE and TICTACTOE_MIN_STAKE allow 0 — both PvP
+            // mini-games support free play. Validated separately
+            // because the other min-stake keys require >= 1.
+            ConfigDto.Configurations.RPS_MIN_STAKE,
+            ConfigDto.Configurations.TICTACTOE_MIN_STAKE -> {
                 val n = rawValue.trim().toLongOrNull()
                     ?: return "Value must be a whole number of credits."
                 if (n < 0L) return "Value must be zero (free play) or a positive number of credits."
@@ -917,7 +918,8 @@ class ModerationWebService(
             ConfigDto.Configurations.PLINKO_MAX_STAKE,
             ConfigDto.Configurations.HORSE_RACING_MAX_STAKE,
             ConfigDto.Configurations.WHEEL_OF_FORTUNE_MAX_STAKE,
-            ConfigDto.Configurations.RPS_MAX_STAKE -> {
+            ConfigDto.Configurations.RPS_MAX_STAKE,
+            ConfigDto.Configurations.TICTACTOE_MAX_STAKE -> {
                 val n = rawValue.trim().toLongOrNull()
                     ?: return "Value must be a whole number of credits."
                 if (n < 0L) return "Value must be 0 (unlimited) or a positive number of credits."

--- a/web/src/main/resources/templates/moderation/settings.html
+++ b/web/src/main/resources/templates/moderation/settings.html
@@ -932,6 +932,25 @@
                         <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                     </div>
                 </div>
+                <div class="config-group">
+                    <h4>Tic-Tac-Toe</h4>
+                    <div class="config-row" data-key="TICTACTOE_MIN_STAKE">
+                        <label>Minimum stake (0 = free play allowed; default 0)</label>
+                        <input type="number" min="0"
+                               th:value="${overview.config['TICTACTOE_MIN_STAKE']}"
+                               placeholder="0"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="TICTACTOE_MAX_STAKE">
+                        <label>Maximum stake (0 = unlimited; default 500)</label>
+                        <input type="number" min="0"
+                               th:value="${overview.config['TICTACTOE_MAX_STAKE']}"
+                               placeholder="500"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                </div>
             </div>
         </details>
     </section>

--- a/web/src/test/kotlin/web/template/ModerationTemplateRowsTest.kt
+++ b/web/src/test/kotlin/web/template/ModerationTemplateRowsTest.kt
@@ -132,6 +132,8 @@ class ModerationTemplateRowsTest {
             ConfigDto.Configurations.DUEL_MAX_STAKE,
             ConfigDto.Configurations.RPS_MIN_STAKE,
             ConfigDto.Configurations.RPS_MAX_STAKE,
+            ConfigDto.Configurations.TICTACTOE_MIN_STAKE,
+            ConfigDto.Configurations.TICTACTOE_MAX_STAKE,
             ConfigDto.Configurations.BLACKJACK_MIN_ANTE,
             ConfigDto.Configurations.BLACKJACK_MAX_ANTE,
             ConfigDto.Configurations.POKER_SMALL_BLIND,


### PR DESCRIPTION
## Summary

Adds `/tictactoe @opponent [stake:<int>]` — head-to-head 3×3 Tic-Tac-Toe between two users. Second of the three planned PvP mini-games (after `/rps` in #553; Connect 4 is the next follow-up).

The initiator plays ❌ and moves first; the opponent plays ⭕. Stake-bearing matches debit both players on accept and the winner takes the pot minus the per-guild jackpot tribute (same model as `/rps` and `/duel`). Free-play (stake omitted or 0) is also accepted — winner gets XP, no credits change hands. Draws refund both players.

### Architecture mirrors `/rps`

| Layer | New file |
|---|---|
| Pure logic | `common/tictactoe/TicTacToeEngine.kt` — 9-cell `Board`, `applyMove` returns Continued / Win (with winning line) / Draw / IllegalCell / Occupied |
| Session state | `database/tictactoe/TicTacToeSessionRegistry.kt` — Caffeine `Cache` (`maximumSize` cap + `expireAfterWrite` backstop), PENDING → LIVE state machine, per-move shot-clock that re-arms on every successful move |
| Wager math | `database/service/TicTacToeService.kt` — `startMatch` preflight, `acceptMatch` ascending-id lock + debit, `resolveMatch` settles. Publishes `TicTacToeResolvedEvent` on every winner-bearing match. **No JDA dependency** (per the PR #551 Spring-cycle lesson) |
| Slash / button | `bot/toby/command/commands/economy/TicTacToeCommand.kt` + `TicTacToeEmbeds.kt` + `bot/toby/button/buttons/TicTacToeButton.kt` |
| Achievement event | `common/events/TicTacToeResolvedEvent.kt` — same shape as `RpsResolvedEvent` |

### Hooked into economy + levelling

- Winner credited `2 * stake - lossTribute`; loser's debit at accept-time is final
- Jackpot tribute flows through the existing `JackpotHelper.divertOnLoss`
- XP grant via `XpAwardService.award(..., reason = "tictactoe:win")`
- `AchievementEventHandler.onTicTacToeResolved` unlocks `first_tictactoe_win` and progresses `tictactoe_wins_10/25` for the winner, `tictactoe_losses_5` for the loser. Free-play wins still fire the event so achievements unlock regardless of whether anyone bet. Draws never publish.

### Moderation UI

New "Tic-Tac-Toe" config group under Game stake limits with `TICTACTOE_MIN_STAKE` (default 0, free play allowed — same as `RPS_MIN_STAKE`) and `TICTACTOE_MAX_STAKE` (default 500). Validation in `ModerationWebService.updateConfig` and the bidirectional template guard test both updated.

### Pre-empted CI

- `CommandManagerTest.testCommandManagerFindsAllCommands` ← `TicTacToeCommand::class.java`
- `ButtonManagerTest.testButtonManagerFindsAllButtons` ← `TicTacToeButton::class.java`
- `AchievementCatalogTest` wired-codes set ← four new codes
- `ModerationTemplateRowsTest` stake-keys list ← two new keys

### Version

`7.5-SNAPSHOT` → `7.6-SNAPSHOT` (build.gradle, Procfile, README).

---

## Second commit: `refactor(pvp)` — extract shared wager service + UI helpers

Now that there are two implementations of the PvP wager pattern (RPS and TTT) with `/connect4` next, the duplication is real and the abstraction is clear. Extracted into three new shared components:

| New file | What it owns |
|---|---|
| `database/service/PvpWagerService.kt` | `@Service @Transactional`. Shared `StartOutcome` / `AcceptOutcome` sealed types + `preflightStart` / `debitBoth` / `payWinner` / `refundBoth` / `readStakeBounds` primitives. RPS and TTT services delegate. |
| `bot/toby/command/commands/economy/PvpEmbeds.kt` | Shared embed factories — start/accept error embeds, pending-decline / pending-timeout (game-name parameterised), the Accept/Decline button-row factory taking pre-built ids, the stake-line text, `describeStartOutcome`. |
| `bot/toby/button/buttons/PvpButtonHelpers.kt` | `ephemeralAlreadyResolved`, `describeAccept`. |

`RpsService` and `TicTacToeService` shrink to their genuinely game-specific bits:
- RPS keeps the four-branch hidden-pick resolution (both-picked-clean / draw / one-picked-forfeit / neither-picked) and the cosmetic loser-choice placeholder
- TTT keeps the explicit-winner forfeit/timeout collapse and the draw refund

`RpsService.ResolveOutcome.UnknownInitiator/UnknownOpponent` collapse to a single `.Unknown` variant (the button rendered the same error either way; distinguishing them was dead code).

Tests split too: the wager primitives now live in `PvpWagerServiceTest` (mocking `UserService` / `JackpotService` / etc); `RpsServiceTest` and `TicTacToeServiceTest` mock `PvpWagerService` and cover only the per-game routing + event publication. Per-button + per-command tests updated for the new outcome type namespace.

**No behaviour change** — `/rps` regressions are caught by the kept RpsButton/RpsCommand tests; the shared primitives are independently covered by PvpWagerServiceTest.

This makes Connect 4 (PR 4B) trivial — its service will be the same ~50 lines as TicTacToeService, just calling `resolveMatch(... winnerDiscordId)` from a different terminal condition.

## Test plan

- [x] `:common:test` — green
- [x] `:database:test` — green
- [x] `:discord-bot:test` — green
- [x] `:web:test` — green
- [ ] `:application:test` — Testcontainers-driven, requires Docker; CI will run it
- [ ] Manual end-to-end:
  - [ ] `/tictactoe @opponent stake:50` — accept, alternating placement, winner credited pot − tribute, XP granted, embed edits in place
  - [ ] `/tictactoe @opponent` no stake — same flow, free play, only XP grant
  - [ ] Forfeit mid-game — opponent wins by walkover
  - [ ] Idle past per-move shot-clock — auto-forfeit
  - [ ] `/rps` regression check — RPS continues to work end-to-end through the refactored shared service
  - [ ] Moderation settings page surfaces the new TicTacToe group

https://claude.ai/code/session_017tRi5q6K3NYHvYeZYzLzBD