### PR TITLE
feat(leaderboard,moderation): Champions tab + XP ranking + Activity charts

### DIFF
--- a/database/src/main/kotlin/database/dto/MessageDailyCountDto.kt
+++ b/database/src/main/kotlin/database/dto/MessageDailyCountDto.kt
@@ -1,0 +1,60 @@
+package database.dto
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.IdClass
+import jakarta.persistence.NamedQueries
+import jakarta.persistence.NamedQuery
+import jakarta.persistence.Table
+import org.springframework.transaction.annotation.Transactional
+import java.io.Serializable
+import java.time.Instant
+import java.time.LocalDate
+
+/**
+ * Per-guild per-day message counter feeding the moderation Activity tab.
+ * One row per `(guildId, dayStart)`; the counter is incremented by
+ * `MessageActivityBuffer` in batches (in-memory accumulation flushed
+ * once a minute) so individual messages don't round-trip to Postgres.
+ *
+ * Composite primary key matches the natural shape of the data and lets
+ * the 30-day window query do an index-only scan.
+ */
+@NamedQueries(
+    NamedQuery(
+        name = "MessageDailyCountDto.findByGuildSince",
+        query = "select m from MessageDailyCountDto m " +
+                "where m.guildId = :guildId and m.dayStart >= :since " +
+                "order by m.dayStart asc"
+    ),
+    NamedQuery(
+        name = "MessageDailyCountDto.findByGuildAndDay",
+        query = "select m from MessageDailyCountDto m " +
+                "where m.guildId = :guildId and m.dayStart = :dayStart"
+    ),
+)
+@Entity
+@Table(name = "message_daily_count", schema = "public")
+@IdClass(MessageDailyCountId::class)
+@Transactional
+class MessageDailyCountDto(
+    @Id
+    @Column(name = "guild_id")
+    var guildId: Long = 0,
+
+    @Id
+    @Column(name = "day_start")
+    var dayStart: LocalDate = LocalDate.now(),
+
+    @Column(name = "count", nullable = false)
+    var count: Long = 0,
+
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: Instant = Instant.now(),
+) : Serializable
+
+data class MessageDailyCountId(
+    var guildId: Long = 0,
+    var dayStart: LocalDate = LocalDate.now(),
+) : Serializable

--- a/database/src/main/kotlin/database/persistence/AchievementPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/AchievementPersistence.kt
@@ -17,4 +17,22 @@ interface AchievementPersistence {
     fun getProgress(discordId: Long, guildId: Long, achievementId: Long): AchievementProgressDto?
     fun listProgressByUser(discordId: Long, guildId: Long): List<AchievementProgressDto>
     fun upsertProgress(row: AchievementProgressDto): AchievementProgressDto
+
+    /**
+     * Per-(discordId, code) progress values for every user in [guildId] whose
+     * progress on any of [codes] is > 0. Returned rows are flat
+     * `(discordId, code, progress)` triples — the caller aggregates as it
+     * sees fit (e.g. total-wins-across-games for the leaderboard).
+     *
+     * Used by the leaderboard "Champions" tab to surface top PvP winners
+     * without N round-trips through [getProgress].
+     */
+    fun progressByCodesForGuild(guildId: Long, codes: Collection<String>): List<ProgressByCodeRow>
 }
+
+/** Flat projection used by [AchievementPersistence.progressByCodesForGuild]. */
+data class ProgressByCodeRow(
+    val discordId: Long,
+    val code: String,
+    val progress: Long,
+)

--- a/database/src/main/kotlin/database/persistence/MessageDailyCountPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/MessageDailyCountPersistence.kt
@@ -1,0 +1,22 @@
+package database.persistence
+
+import database.dto.MessageDailyCountDto
+import java.time.LocalDate
+
+/**
+ * Read + upsert plumbing for the per-guild per-day message counter
+ * powering the moderation Activity tab. Writes are upserts so the
+ * `MessageActivityBuffer` flush loop can hand in `(guildId, day, delta)`
+ * without worrying about whether the row already exists.
+ */
+interface MessageDailyCountPersistence {
+    /** Counters for [guildId] on dates `>= since`, ascending by day. */
+    fun findByGuildSince(guildId: Long, since: LocalDate): List<MessageDailyCountDto>
+
+    /**
+     * Add [delta] to the counter for `(guildId, dayStart)`, creating the
+     * row if it doesn't exist. The counter is monotonic — pass a positive
+     * delta. `updatedAt` is bumped on every call.
+     */
+    fun increment(guildId: Long, dayStart: LocalDate, delta: Long)
+}

--- a/database/src/main/kotlin/database/persistence/VoiceSessionPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/VoiceSessionPersistence.kt
@@ -11,4 +11,13 @@ interface VoiceSessionPersistence {
     fun sumCountedSecondsInRange(guildId: Long, discordId: Long, from: Instant, until: Instant): Long
     fun sumCountedSecondsInRangeByUser(guildId: Long, from: Instant, until: Instant): Map<Long, Long>
     fun sumCountedSecondsLifetimeByUser(guildId: Long): Map<Long, Long>
+
+    /**
+     * Closed sessions for [guildId] that overlap the [from, until) window
+     * — i.e. `joinedAt < until AND leftAt >= from`. Used by the moderation
+     * Activity tab to split each session across the calendar days it
+     * actually touched (a session 23:50→00:10 splits 10 minutes into each
+     * day).
+     */
+    fun findClosedOverlapping(guildId: Long, from: Instant, until: Instant): List<VoiceSessionDto>
 }

--- a/database/src/main/kotlin/database/persistence/impl/DefaultAchievementPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultAchievementPersistence.kt
@@ -4,6 +4,7 @@ import database.dto.AchievementDto
 import database.dto.AchievementProgressDto
 import database.dto.UserAchievementDto
 import database.persistence.AchievementPersistence
+import database.persistence.ProgressByCodeRow
 import jakarta.persistence.EntityManager
 import jakarta.persistence.PersistenceContext
 import jakarta.persistence.TypedQuery
@@ -89,5 +90,32 @@ class DefaultAchievementPersistence : AchievementPersistence {
             updatedAt = row.updatedAt
         } ?: row
         return entityManager.saveOrMerge(target, isNew = { existing == null })
+    }
+
+    override fun progressByCodesForGuild(
+        guildId: Long,
+        codes: Collection<String>,
+    ): List<ProgressByCodeRow> {
+        if (codes.isEmpty()) return emptyList()
+        // One pass: join progress + catalog, filter by code, keep non-zero so the
+        // result set scales with active winners rather than members × codes.
+        val jpql = "select p.discordId, a.code, p.progress " +
+            "from AchievementProgressDto p, AchievementDto a " +
+            "where a.id = p.achievementId " +
+            "and p.guildId = :guildId " +
+            "and a.code in :codes " +
+            "and p.progress > 0"
+        val query = entityManager.createQuery(jpql)
+        query.setParameter("guildId", guildId)
+        query.setParameter("codes", codes)
+        @Suppress("UNCHECKED_CAST")
+        val rows = query.resultList as List<Array<Any?>>
+        return rows.map { cols ->
+            ProgressByCodeRow(
+                discordId = (cols[0] as Number).toLong(),
+                code = cols[1] as String,
+                progress = (cols[2] as Number).toLong(),
+            )
+        }
     }
 }

--- a/database/src/main/kotlin/database/persistence/impl/DefaultMessageDailyCountPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultMessageDailyCountPersistence.kt
@@ -1,0 +1,55 @@
+package database.persistence.impl
+
+import database.dto.MessageDailyCountDto
+import database.persistence.MessageDailyCountPersistence
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import jakarta.persistence.TypedQuery
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+import java.time.LocalDate
+
+@Repository
+@Transactional
+class DefaultMessageDailyCountPersistence : MessageDailyCountPersistence {
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    override fun findByGuildSince(guildId: Long, since: LocalDate): List<MessageDailyCountDto> {
+        val query: TypedQuery<MessageDailyCountDto> =
+            entityManager.createNamedQuery("MessageDailyCountDto.findByGuildSince", MessageDailyCountDto::class.java)
+        query.setParameter("guildId", guildId)
+        query.setParameter("since", since)
+        return query.resultList
+    }
+
+    override fun increment(guildId: Long, dayStart: LocalDate, delta: Long) {
+        if (delta <= 0L) return
+        val existing = findByGuildAndDay(guildId, dayStart)
+        if (existing != null) {
+            existing.count += delta
+            existing.updatedAt = Instant.now()
+            entityManager.saveOrMerge(existing, isNew = { false })
+        } else {
+            entityManager.saveOrMerge(
+                MessageDailyCountDto(
+                    guildId = guildId,
+                    dayStart = dayStart,
+                    count = delta,
+                    updatedAt = Instant.now(),
+                ),
+                isNew = { true },
+            )
+        }
+    }
+
+    private fun findByGuildAndDay(guildId: Long, dayStart: LocalDate): MessageDailyCountDto? {
+        val query: TypedQuery<MessageDailyCountDto> =
+            entityManager.createNamedQuery("MessageDailyCountDto.findByGuildAndDay", MessageDailyCountDto::class.java)
+        query.setParameter("guildId", guildId)
+        query.setParameter("dayStart", dayStart)
+        return query.resultList.firstOrNull()
+    }
+}

--- a/database/src/main/kotlin/database/persistence/impl/DefaultVoiceSessionPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultVoiceSessionPersistence.kt
@@ -86,5 +86,28 @@ class DefaultVoiceSessionPersistence : VoiceSessionPersistence {
         }
     }
 
+    override fun findClosedOverlapping(
+        guildId: Long,
+        from: Instant,
+        until: Instant,
+    ): List<VoiceSessionDto> {
+        // Inline JPQL — no NamedQuery on the entity since this is the only
+        // call site and the overlap predicate would lock readers into the
+        // exact column choice for a future tweak.
+        val q: TypedQuery<VoiceSessionDto> = entityManager.createQuery(
+            "select s from VoiceSessionDto s " +
+                "where s.guildId = :guildId " +
+                "and s.leftAt is not null " +
+                "and s.joinedAt < :until " +
+                "and s.leftAt >= :from " +
+                "order by s.joinedAt asc",
+            VoiceSessionDto::class.java,
+        )
+        q.setParameter("guildId", guildId)
+        q.setParameter("from", from)
+        q.setParameter("until", until)
+        return q.resultList
+    }
+
     private fun Long?.orZero(): Long = this ?: 0L
 }

--- a/database/src/main/kotlin/database/service/AchievementService.kt
+++ b/database/src/main/kotlin/database/service/AchievementService.kt
@@ -59,6 +59,20 @@ interface AchievementService {
      */
     fun listFor(discordId: Long, guildId: Long): List<AchievementView>
 
+    /**
+     * Per-(discordId, code) progress values for every user in [guildId]
+     * whose progress on any of [codes] is > 0. Used by the leaderboard
+     * "Champions" tab to surface top winners across multiple PvP games
+     * with one query.
+     */
+    fun progressByCodesForGuild(guildId: Long, codes: Collection<String>): List<ProgressByCode>
+
+    data class ProgressByCode(
+        val discordId: Long,
+        val code: String,
+        val progress: Long,
+    )
+
     data class ProgressResult(
         val achievement: AchievementDto?,
         val newProgress: Long,

--- a/database/src/main/kotlin/database/service/MessageActivityBuffer.kt
+++ b/database/src/main/kotlin/database/service/MessageActivityBuffer.kt
@@ -1,0 +1,106 @@
+package database.service
+
+import database.configuration.RegistryScheduler
+import database.persistence.MessageDailyCountPersistence
+import jakarta.annotation.PostConstruct
+import jakarta.annotation.PreDestroy
+import org.springframework.stereotype.Component
+import java.time.Clock
+import java.time.Duration
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * In-memory accumulator for per-guild per-day message counts. The
+ * `MessageChatListener` calls [record] on every non-bot message; a
+ * scheduled job flushes the buffer to [MessageDailyCountPersistence]
+ * every [flushInterval]. This is the same shape `MessageChatListener`
+ * already uses for XP-award debouncing — no per-message round-trip to
+ * Postgres, no risk of blocking the JDA dispatch thread on a slow DB.
+ *
+ * The buffer is keyed on `(guildId, dayStart)` using UTC dates so the
+ * cutover from one day to the next is consistent regardless of where
+ * the bot is hosted. A message sent at 23:59 UTC and the next message
+ * at 00:01 UTC land in different days.
+ *
+ * Lost-on-restart cost: any messages buffered between the last flush
+ * and a shutdown are dropped. Acceptable for a coarse activity chart;
+ * the worst case (a hard kill seconds after a flush) loses the same
+ * order of magnitude the XP cooldown loses on the same path.
+ */
+@Component
+class MessageActivityBuffer(
+    private val persistence: MessageDailyCountPersistence,
+    private val clock: Clock = Clock.systemUTC(),
+    private val scheduler: ScheduledExecutorService = RegistryScheduler.instance,
+    val flushInterval: Duration = DEFAULT_FLUSH_INTERVAL,
+) {
+
+    private val pending = ConcurrentHashMap<Pair<Long, LocalDate>, AtomicLong>()
+    private var flushTask: ScheduledFuture<*>? = null
+
+    @PostConstruct
+    fun start() {
+        if (flushTask != null) return
+        flushTask = scheduler.scheduleAtFixedRate(
+            { runCatching { flush() } },
+            flushInterval.toMillis(),
+            flushInterval.toMillis(),
+            TimeUnit.MILLISECONDS,
+        )
+    }
+
+    @PreDestroy
+    fun stop() {
+        flushTask?.cancel(false)
+        flushTask = null
+        // Best-effort drain on shutdown so the very last batch isn't lost.
+        runCatching { flush() }
+    }
+
+    /** Record one message for [guildId]. Bucketed under today's UTC date. */
+    fun record(guildId: Long) {
+        val day = LocalDate.now(clock.withZone(ZoneOffset.UTC))
+        pending.computeIfAbsent(guildId to day) { AtomicLong(0L) }.incrementAndGet()
+    }
+
+    /**
+     * Drain the buffer into the persistence layer. Atomically swaps
+     * each `(guildId, day)` counter to 0 before issuing the upsert so a
+     * concurrent [record] call doesn't lose increments. Public for tests;
+     * production code goes through the scheduled task.
+     */
+    fun flush() {
+        // Snapshot keys first — `pending.keys` is a live view, so iterating
+        // while incrementing would behave oddly if we removed entries we'd
+        // already counted.
+        val keys = pending.keys.toList()
+        for (key in keys) {
+            val counter = pending[key] ?: continue
+            val delta = counter.getAndSet(0L)
+            if (delta <= 0L) continue
+            runCatching { persistence.increment(key.first, key.second, delta) }
+                .onFailure { restore(key, delta) }
+        }
+    }
+
+    private fun restore(key: Pair<Long, LocalDate>, delta: Long) {
+        // Persistence rejected the upsert — roll the delta back into the
+        // buffer so the next flush retries it instead of dropping the count.
+        pending.computeIfAbsent(key) { AtomicLong(0L) }.addAndGet(delta)
+    }
+
+    companion object {
+        /**
+         * Once per minute keeps the chart fresh enough that admins see
+         * "today" tick up in near-real-time without hammering Postgres
+         * on a busy guild.
+         */
+        val DEFAULT_FLUSH_INTERVAL: Duration = Duration.ofMinutes(1)
+    }
+}

--- a/database/src/main/kotlin/database/service/VoiceSessionService.kt
+++ b/database/src/main/kotlin/database/service/VoiceSessionService.kt
@@ -11,4 +11,13 @@ interface VoiceSessionService {
     fun sumCountedSecondsInRange(guildId: Long, discordId: Long, from: Instant, until: Instant): Long
     fun sumCountedSecondsInRangeByUser(guildId: Long, from: Instant, until: Instant): Map<Long, Long>
     fun sumCountedSecondsLifetimeByUser(guildId: Long): Map<Long, Long>
+
+    /**
+     * Closed sessions for [guildId] that overlap the [from, until)
+     * window. Used by the moderation Activity tab to split each session
+     * across the calendar days it actually touched (a 23:50→00:10 session
+     * contributes 10 minutes to each of two days). Plumbing pass-through
+     * to [database.persistence.VoiceSessionPersistence.findClosedOverlapping].
+     */
+    fun findClosedOverlapping(guildId: Long, from: Instant, until: Instant): List<VoiceSessionDto>
 }

--- a/database/src/main/kotlin/database/service/impl/DefaultAchievementService.kt
+++ b/database/src/main/kotlin/database/service/impl/DefaultAchievementService.kt
@@ -153,6 +153,18 @@ class DefaultAchievementService(
             }
     }
 
+    override fun progressByCodesForGuild(
+        guildId: Long,
+        codes: Collection<String>,
+    ): List<AchievementService.ProgressByCode> =
+        persistence.progressByCodesForGuild(guildId, codes).map { row ->
+            AchievementService.ProgressByCode(
+                discordId = row.discordId,
+                code = row.code,
+                progress = row.progress,
+            )
+        }
+
     private fun finalizeUnlock(
         discordId: Long,
         guildId: Long,

--- a/database/src/main/kotlin/database/service/impl/DefaultVoiceSessionService.kt
+++ b/database/src/main/kotlin/database/service/impl/DefaultVoiceSessionService.kt
@@ -52,4 +52,10 @@ class DefaultVoiceSessionService @Autowired constructor(
 
     override fun sumCountedSecondsLifetimeByUser(guildId: Long): Map<Long, Long> =
         persistence.sumCountedSecondsLifetimeByUser(guildId)
+
+    override fun findClosedOverlapping(
+        guildId: Long,
+        from: Instant,
+        until: Instant
+    ): List<VoiceSessionDto> = persistence.findClosedOverlapping(guildId, from, until)
 }

--- a/database/src/main/resources/db/migration/V44__message_daily_count.sql
+++ b/database/src/main/resources/db/migration/V44__message_daily_count.sql
@@ -1,0 +1,22 @@
+-- Per-guild per-day message counter feeding the moderation Activity tab
+-- (messages-per-day chart). Composite-keyed on (guild_id, day_start) so
+-- a single row per guild per UTC date is enough for the 30-day-rolling
+-- view. Messages are buffered in memory and flushed in batches by
+-- MessageActivityBuffer, so the write path is upserts (`INSERT ... ON
+-- CONFLICT DO UPDATE SET count = count + EXCLUDED.count`) rather than a
+-- per-message round trip. Hibernate handles the SELECT/UPDATE for now;
+-- if write throughput becomes a hot spot, swap to a native upsert.
+CREATE TABLE IF NOT EXISTS message_daily_count (
+    guild_id   BIGINT NOT NULL,
+    day_start  DATE   NOT NULL,
+    count      BIGINT NOT NULL DEFAULT 0,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    CONSTRAINT pk_message_daily_count PRIMARY KEY (guild_id, day_start)
+);
+
+-- 30-day window queries filter on (guild_id, day_start >= since). The
+-- composite primary key already serves this access path, but an
+-- explicit btree on day_start helps Postgres choose an index-only scan
+-- when the planner sees the date range first.
+CREATE INDEX IF NOT EXISTS idx_message_daily_count_day_start
+    ON message_daily_count (day_start);

--- a/database/src/test/kotlin/database/achievement/AchievementSeederTest.kt
+++ b/database/src/test/kotlin/database/achievement/AchievementSeederTest.kt
@@ -117,5 +117,9 @@ class AchievementSeederTest {
         override fun getProgress(discordId: Long, guildId: Long, achievementId: Long): AchievementProgressDto? = null
         override fun listProgressByUser(discordId: Long, guildId: Long): List<AchievementProgressDto> = emptyList()
         override fun upsertProgress(row: AchievementProgressDto): AchievementProgressDto = row
+        override fun progressByCodesForGuild(
+            guildId: Long,
+            codes: Collection<String>,
+        ): List<database.persistence.ProgressByCodeRow> = emptyList()
     }
 }

--- a/database/src/test/kotlin/database/service/AchievementServiceTest.kt
+++ b/database/src/test/kotlin/database/service/AchievementServiceTest.kt
@@ -312,6 +312,20 @@ class AchievementServiceTest {
             progress[Triple(row.discordId, row.guildId, row.achievementId)] = row
             return row
         }
+        override fun progressByCodesForGuild(
+            guildId: Long,
+            codes: Collection<String>,
+        ): List<database.persistence.ProgressByCodeRow> {
+            val codesSet = codes.toSet()
+            return progress.values.asSequence()
+                .filter { it.guildId == guildId }
+                .mapNotNull { p ->
+                    val code = catalogue[p.achievementId]?.code ?: return@mapNotNull null
+                    if (code !in codesSet || p.progress <= 0L) return@mapNotNull null
+                    database.persistence.ProgressByCodeRow(p.discordId, code, p.progress)
+                }
+                .toList()
+        }
     }
 
     private class RecordingEventPublisher : ApplicationEventPublisher {

--- a/database/src/test/kotlin/database/service/MessageActivityBufferTest.kt
+++ b/database/src/test/kotlin/database/service/MessageActivityBufferTest.kt
@@ -1,0 +1,139 @@
+package database.service
+
+import database.dto.MessageDailyCountDto
+import database.persistence.MessageDailyCountPersistence
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.ScheduledThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Tests for the in-memory message-counter buffer. The scheduled flush
+ * path is exercised via direct [MessageActivityBuffer.flush] calls so
+ * the tests don't sleep on a real wall-clock.
+ */
+class MessageActivityBufferTest {
+
+    private lateinit var persistence: RecordingPersistence
+    private lateinit var buffer: MessageActivityBuffer
+
+    private val fixedDay: LocalDate = LocalDate.of(2026, 5, 23)
+    private val fixedClock: Clock = Clock.fixed(
+        fixedDay.atStartOfDay(ZoneOffset.UTC).toInstant().plusSeconds(60 * 60 * 12),
+        ZoneOffset.UTC,
+    )
+
+    @BeforeEach
+    fun setUp() {
+        persistence = RecordingPersistence()
+        buffer = MessageActivityBuffer(
+            persistence = persistence,
+            clock = fixedClock,
+            scheduler = noopScheduler(),
+        )
+    }
+
+    @Test
+    fun `record increments the in-memory counter and flush drains it once`() {
+        buffer.record(guildId = 100L)
+        buffer.record(guildId = 100L)
+        buffer.record(guildId = 100L)
+
+        // Nothing flushed yet — persistence is untouched.
+        assertEquals(0, persistence.increments.size)
+
+        buffer.flush()
+        assertEquals(listOf(Triple(100L, fixedDay, 3L)), persistence.increments)
+
+        // Second flush with no new records is a no-op.
+        persistence.increments.clear()
+        buffer.flush()
+        assertEquals(emptyList<Triple<Long, LocalDate, Long>>(), persistence.increments)
+    }
+
+    @Test
+    fun `record buckets per guild and per day`() {
+        buffer.record(guildId = 100L)
+        buffer.record(guildId = 200L)
+        buffer.record(guildId = 100L)
+        buffer.flush()
+        assertEquals(2, persistence.increments.size)
+        val byGuild = persistence.increments.associate { it.first to it.third }
+        assertEquals(2L, byGuild[100L])
+        assertEquals(1L, byGuild[200L])
+    }
+
+    @Test
+    fun `record under concurrent load doesn't lose increments`() {
+        // 8 threads × 1000 records each → 8000 records into one guild.
+        // The buffer flushes once at the end; total must equal the input.
+        val threads = 8
+        val perThread = 1000
+        val pool = Executors.newFixedThreadPool(threads)
+        val start = CountDownLatch(1)
+        repeat(threads) {
+            pool.submit {
+                start.await()
+                repeat(perThread) { buffer.record(guildId = 100L) }
+            }
+        }
+        start.countDown()
+        pool.shutdown()
+        pool.awaitTermination(5, TimeUnit.SECONDS)
+        buffer.flush()
+        val total = persistence.increments.sumOf { it.third }
+        assertEquals((threads * perThread).toLong(), total)
+    }
+
+    @Test
+    fun `flush retries on persistence failure by restoring the delta`() {
+        buffer.record(guildId = 100L)
+        buffer.record(guildId = 100L)
+        persistence.failNext = 1
+
+        buffer.flush()
+        // The failed upsert rolled back into the buffer, so the second flush retries.
+        assertTrue(persistence.increments.isEmpty(), "first flush failure should not record")
+        buffer.flush()
+        assertEquals(listOf(Triple(100L, fixedDay, 2L)), persistence.increments)
+    }
+
+    private class RecordingPersistence : MessageDailyCountPersistence {
+        val increments = mutableListOf<Triple<Long, LocalDate, Long>>()
+        var failNext: Int = 0
+
+        override fun findByGuildSince(guildId: Long, since: LocalDate): List<MessageDailyCountDto> =
+            emptyList()
+
+        override fun increment(guildId: Long, dayStart: LocalDate, delta: Long) {
+            if (failNext > 0) {
+                failNext -= 1
+                throw IllegalStateException("simulated persistence failure")
+            }
+            increments.add(Triple(guildId, dayStart, delta))
+        }
+    }
+
+    private fun noopScheduler(): ScheduledExecutorService =
+        object : ScheduledThreadPoolExecutor(0) {
+            override fun schedule(command: Runnable, delay: Long, unit: TimeUnit): ScheduledFuture<*> =
+                super.schedule(Runnable { /* no-op */ }, Long.MAX_VALUE, TimeUnit.SECONDS)
+            override fun scheduleAtFixedRate(
+                command: Runnable, initialDelay: Long, period: Long, unit: TimeUnit,
+            ): ScheduledFuture<*> =
+                super.schedule(Runnable { /* no-op */ }, Long.MAX_VALUE, TimeUnit.SECONDS)
+        }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/handler/MessageChatListener.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/handler/MessageChatListener.kt
@@ -3,6 +3,7 @@ package bot.toby.handler
 import bot.toby.emote.Emotes
 import com.github.benmanes.caffeine.cache.Caffeine
 import common.logging.DiscordLogger
+import database.service.MessageActivityBuffer
 import database.service.XpAwardService
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
@@ -24,7 +25,8 @@ import java.util.concurrent.TimeUnit
  */
 @Service
 class MessageChatListener @Autowired constructor(
-    private val xpAwardService: XpAwardService
+    private val xpAwardService: XpAwardService,
+    private val messageActivityBuffer: MessageActivityBuffer,
 ) : ListenerAdapter() {
 
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
@@ -46,6 +48,11 @@ class MessageChatListener @Autowired constructor(
             val guild = event.guild
             val member = event.member
             if (author.isBot || event.isWebhookMessage) return
+
+            // Coarse per-guild per-day counter feeding the moderation Activity
+            // chart. Runs before awardMessageXp so even a user past their daily
+            // XP cap still shows up in the messages-per-day total.
+            messageActivityBuffer.record(guild.idLong)
 
             awardMessageXp(event)
 

--- a/discord-bot/src/test/kotlin/bot/toby/handler/MessageChatListenerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/handler/MessageChatListenerTest.kt
@@ -21,7 +21,8 @@ import io.mockk.junit5.MockKExtension
 class MessageChatListenerTest {
 
     private val xpAwardService: XpAwardService = mockk(relaxed = true)
-    private val listener = spyk(MessageChatListener(xpAwardService))
+    private val messageActivityBuffer: database.service.MessageActivityBuffer = mockk(relaxed = true)
+    private val listener = spyk(MessageChatListener(xpAwardService, messageActivityBuffer))
 
     @Test
     fun `onMessageReceived should respond correctly to toby message`() {

--- a/web/src/main/kotlin/web/controller/ModerationController.kt
+++ b/web/src/main/kotlin/web/controller/ModerationController.kt
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.service.ActivityChartsService
 import web.service.ModerationWebService
 import web.util.DefaultGuildCookie
 import web.util.DefaultGuildRedirect
@@ -32,6 +33,7 @@ import web.util.displayName
 @RequestMapping("/moderation")
 class ModerationController(
     private val moderationWebService: ModerationWebService,
+    private val activityChartsService: ActivityChartsService,
     @param:Value($$"${spring.security.oauth2.client.registration.discord.client-id}")
     private val discordClientId: String
 ) {
@@ -184,6 +186,32 @@ class ModerationController(
         model.addAttribute("username", user.displayName())
         model.addAttribute("actorDiscordId", discordId.toString())
         "moderation/leveling"
+    }
+
+    @GetMapping("/{guildId}/activity")
+    fun activityPage(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+        model: Model,
+        ra: RedirectAttributes
+    ): String = WebGuildAccess.requireForPage(
+        user, guildId, ra, lobbyPath = "/moderation/guilds",
+        check = moderationWebService::canModerate,
+        deniedMessage = "You are not allowed to moderate that server.",
+    ) { discordId ->
+        val overview = moderationWebService.getGuildOverview(guildId) ?: run {
+            ra.addFlashAttribute("error", "Bot is not in that server.")
+            return@requireForPage "redirect:/moderation/guilds"
+        }
+        val messages = activityChartsService.messagesPerDay(guildId)
+        val voiceHours = activityChartsService.voiceHoursPerDay(guildId)
+        model.addAttribute("overview", overview)
+        model.addAttribute("messagesPerDay", messages)
+        model.addAttribute("voiceHoursPerDay", voiceHours)
+        model.addAttribute("isOwner", moderationWebService.isOwner(discordId, guildId))
+        model.addAttribute("username", user.displayName())
+        model.addAttribute("actorDiscordId", discordId.toString())
+        "moderation/activity"
     }
 
     /**

--- a/web/src/main/kotlin/web/service/ActivityChartsService.kt
+++ b/web/src/main/kotlin/web/service/ActivityChartsService.kt
@@ -1,0 +1,143 @@
+package web.service
+
+import database.persistence.MessageDailyCountPersistence
+import database.service.VoiceSessionService
+import org.springframework.stereotype.Service
+import java.time.Clock
+import java.time.Duration
+import java.time.LocalDate
+import java.time.ZoneOffset
+import kotlin.math.max
+import kotlin.math.min
+
+/**
+ * Reads the daily activity series feeding the moderation Activity tab.
+ * Two charts, both 30-day-rolling, both bucketed by UTC date:
+ *
+ *  - [messagesPerDay] reads the dedicated `message_daily_count` counter
+ *    (filled by [database.service.MessageActivityBuffer] in batches off
+ *    the JDA dispatch thread)
+ *  - [voiceHoursPerDay] aggregates closed voice sessions at query time;
+ *    sessions that straddle midnight UTC are split proportionally across
+ *    both days they touched so the rendered line reflects actual presence
+ *
+ * Both methods pre-fill empty days with zeros so the template never has
+ * to worry about gaps in the X axis.
+ */
+@Service
+class ActivityChartsService(
+    private val messageDailyCounts: MessageDailyCountPersistence,
+    private val voiceSessions: VoiceSessionService,
+    private val clock: Clock = Clock.systemUTC(),
+) {
+
+    data class DailyPoint(
+        val date: LocalDate,
+        val value: Double,
+    ) {
+        /** The chart template renders both metrics through a single SVG fragment. */
+        val valueLong: Long get() = value.toLong()
+    }
+
+    /**
+     * Messages-per-day for [guildId] over the trailing [days] calendar
+     * dates (UTC), ascending. Missing days are pre-filled with 0 so
+     * the polyline has one point per day regardless of activity.
+     */
+    fun messagesPerDay(guildId: Long, days: Int = DEFAULT_DAYS): List<DailyPoint> {
+        val today = LocalDate.now(clock.withZone(ZoneOffset.UTC))
+        val since = today.minusDays((days - 1).toLong())
+        val rowsByDay = messageDailyCounts.findByGuildSince(guildId, since)
+            .associate { it.dayStart to it.count.toDouble() }
+        return fillRange(since, today).map { day ->
+            DailyPoint(day, rowsByDay[day] ?: 0.0)
+        }
+    }
+
+    /**
+     * Voice-hours-per-day for [guildId] over the trailing [days]
+     * calendar dates (UTC), ascending. Each closed session is split
+     * across the calendar days it touched — a 23:50→00:10 session
+     * contributes ~10 minutes to two consecutive days, not 20 minutes
+     * to whichever day it "belongs" to.
+     */
+    fun voiceHoursPerDay(guildId: Long, days: Int = DEFAULT_DAYS): List<DailyPoint> {
+        val today = LocalDate.now(clock.withZone(ZoneOffset.UTC))
+        val since = today.minusDays((days - 1).toLong())
+        val fromInstant = since.atStartOfDay(ZoneOffset.UTC).toInstant()
+        val untilInstant = today.plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant()
+        val sessions = voiceSessions.findClosedOverlapping(guildId, fromInstant, untilInstant)
+
+        val secondsByDay = mutableMapOf<LocalDate, Long>()
+        for (session in sessions) {
+            val sessionStart = session.joinedAt
+            val sessionEnd = session.leftAt ?: continue
+            // Walk day-by-day from the session's start day to its end day,
+            // adding the overlap with each [day, day+1) bucket.
+            var cursor = sessionStart.atZone(ZoneOffset.UTC).toLocalDate()
+            val endDay = sessionEnd.atZone(ZoneOffset.UTC).toLocalDate()
+            while (cursor <= endDay) {
+                val bucketStart = cursor.atStartOfDay(ZoneOffset.UTC).toInstant()
+                val bucketEnd = cursor.plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant()
+                val overlapStart = max(sessionStart.epochSecond, bucketStart.epochSecond)
+                val overlapEnd = min(sessionEnd.epochSecond, bucketEnd.epochSecond)
+                val overlapSeconds = overlapEnd - overlapStart
+                if (overlapSeconds > 0 && cursor in since..today) {
+                    secondsByDay.merge(cursor, overlapSeconds) { a, b -> a + b }
+                }
+                cursor = cursor.plusDays(1)
+            }
+        }
+
+        return fillRange(since, today).map { day ->
+            val seconds = secondsByDay[day] ?: 0L
+            DailyPoint(day, seconds / SECONDS_PER_HOUR)
+        }
+    }
+
+    private fun fillRange(since: LocalDate, today: LocalDate): List<LocalDate> {
+        val length = Duration.between(
+            since.atStartOfDay(ZoneOffset.UTC),
+            today.plusDays(1).atStartOfDay(ZoneOffset.UTC),
+        ).toDays().toInt()
+        return (0 until length).map { since.plusDays(it.toLong()) }
+    }
+
+    companion object {
+        const val DEFAULT_DAYS: Int = 30
+        private const val SECONDS_PER_HOUR: Double = 3600.0
+
+        /** Width / height for the per-chart SVG. Picked to match the moderation panel grid. */
+        const val CHART_WIDTH: Int = 600
+        const val CHART_HEIGHT: Int = 180
+
+        /**
+         * Build the `points="..."` value for an `<svg><polyline>` rendering
+         * of [series]. Y-axis normalises to the series max; an all-zero
+         * series renders along the bottom of the chart so the baseline
+         * is always visible. The chart is padded inside the SVG so the
+         * top edge doesn't clip the highest point.
+         */
+        fun polylinePoints(series: List<DailyPoint>): String {
+            if (series.isEmpty()) return ""
+            val padding = 8.0
+            val innerW = CHART_WIDTH - 2 * padding
+            val innerH = CHART_HEIGHT - 2 * padding
+            val max = series.maxOf { it.value }.coerceAtLeast(1.0)
+            val stepX = if (series.size <= 1) 0.0 else innerW / (series.size - 1)
+            return series.mapIndexed { i, point ->
+                val x = padding + i * stepX
+                val y = padding + innerH - (point.value / max) * innerH
+                "%.1f,%.1f".format(x, y)
+            }.joinToString(" ")
+        }
+
+        /** Largest value across [series], for the per-chart legend. */
+        fun maxValue(series: List<DailyPoint>): Double =
+            series.maxOfOrNull { it.value } ?: 0.0
+
+        /** Sum of values across [series], for the per-chart legend. */
+        fun totalValue(series: List<DailyPoint>): Double =
+            series.sumOf { it.value }
+    }
+}

--- a/web/src/main/kotlin/web/service/LeaderboardWebService.kt
+++ b/web/src/main/kotlin/web/service/LeaderboardWebService.kt
@@ -1,5 +1,6 @@
 package web.service
 
+import database.service.AchievementService
 import database.service.ActivityMonthlyRollupService
 import database.service.MonthlyCreditSnapshotService
 import database.service.TitleService
@@ -23,6 +24,7 @@ class LeaderboardWebService(
     private val snapshotService: MonthlyCreditSnapshotService,
     private val membership: GuildMembership,
     private val rollupService: ActivityMonthlyRollupService,
+    private val achievementService: AchievementService,
 ) {
 
     companion object {
@@ -35,6 +37,31 @@ class LeaderboardWebService(
         const val HISTORY_MONTHS = 12
         const val SPARK_WIDTH = 80
         const val SPARK_HEIGHT = 20
+
+        /**
+         * Per-game win-counter codes consumed by the Champions tab. Each
+         * code is the smallest-tier counter on the achievement catalog
+         * (`*_wins_10`); every PvP match resolution increments all tiers
+         * of the same game by 1, so reading the `_wins_10` counter gives
+         * the user's total wins regardless of whether higher tiers have
+         * unlocked.
+         */
+        val CHAMPIONS_WIN_CODES: List<String> = listOf(
+            "duel_wins_10",
+            "rps_wins_10",
+            "tictactoe_wins_10",
+            "connect4_wins_10",
+        )
+
+        /** UI labels for each champion-tracked game, indexed by the win-counter code. */
+        val CHAMPION_GAME_LABELS: Map<String, String> = mapOf(
+            "duel_wins_10" to "Duel",
+            "rps_wins_10" to "RPS",
+            "tictactoe_wins_10" to "Tic-Tac-Toe",
+            "connect4_wins_10" to "Connect 4",
+        )
+
+        const val CHAMPIONS_LIMIT = 10
     }
 
     fun getGuildsWhereUserCanView(accessToken: String, discordId: Long): List<LeaderboardGuildCard> {
@@ -78,6 +105,7 @@ class LeaderboardWebService(
         val resorted = when (sort) {
             LeaderboardSort.THIS_MONTH -> rawRows.sortedByDescending { it.creditsEarnedThisMonth }
             LeaderboardSort.LIFETIME -> rawRows
+            LeaderboardSort.XP -> rawRows.sortedByDescending { it.xp }
         }.mapIndexed { i, r -> r.copy(rank = i + 1) }
 
         val totalCreditsThisMonth = rawRows.sumOf { it.creditsEarnedThisMonth }
@@ -110,7 +138,52 @@ class LeaderboardWebService(
             topGames = topGamesPanel.rows,
             topGamesMonth = topGamesPanel.selectedMonth,
             topGamesMonthOptions = topGamesPanel.monthOptions,
+            champions = buildChampions(guild, guildId),
         )
+    }
+
+    /**
+     * Top [CHAMPIONS_LIMIT] users by total PvP wins across the four games
+     * (`/duel`, `/rps`, `/tictactoe`, `/connect4`). Reads the `_wins_10`
+     * achievement counter for each game — every match resolution
+     * increments all tiers of the same game by 1, so the lowest-tier
+     * counter holds the user's total wins.
+     */
+    private fun buildChampions(
+        guild: net.dv8tion.jda.api.entities.Guild,
+        guildId: Long,
+    ): List<ChampionRow> {
+        val rows = runCatching {
+            achievementService.progressByCodesForGuild(guildId, CHAMPIONS_WIN_CODES)
+        }.getOrElse { return emptyList() }
+        if (rows.isEmpty()) return emptyList()
+        val byUser: Map<Long, Map<String, Long>> = rows
+            .groupBy { it.discordId }
+            .mapValues { (_, ownerRows) ->
+                ownerRows.associate { it.code to it.progress }
+            }
+        return byUser.entries.asSequence()
+            .map { (discordId, perCode) ->
+                val totalWins = perCode.values.sum()
+                val member = guild.getMemberById(discordId)
+                ChampionRow(
+                    rank = 0, // assigned after sorting
+                    discordId = discordId.toString(),
+                    name = member?.effectiveName ?: "Unknown",
+                    avatarUrl = member?.effectiveAvatarUrl,
+                    totalWins = totalWins,
+                    perGame = CHAMPIONS_WIN_CODES.map { code ->
+                        ChampionGameWinCount(
+                            label = CHAMPION_GAME_LABELS[code] ?: code,
+                            wins = perCode[code] ?: 0L,
+                        )
+                    },
+                )
+            }
+            .sortedByDescending { it.totalWins }
+            .take(CHAMPIONS_LIMIT)
+            .mapIndexed { index, row -> row.copy(rank = index + 1) }
+            .toList()
     }
 
     private data class TopGamesPanel(
@@ -350,6 +423,7 @@ data class LeaderboardGuildView(
     val topGames: List<TopGameRow> = emptyList(),
     val topGamesMonth: LocalDate? = null,
     val topGamesMonthOptions: List<MonthOption> = emptyList(),
+    val champions: List<ChampionRow> = emptyList(),
 ) {
     @Suppress("unused") // consumed by templates/leaderboard.html via Thymeleaf
     val totalVoiceThisMonthDisplay: String get() = formatDuration(totalVoiceThisMonth)
@@ -363,7 +437,8 @@ data class LeaderboardGuildView(
 
 enum class LeaderboardSort(val queryValue: String) {
     THIS_MONTH("month"),
-    LIFETIME("lifetime");
+    LIFETIME("lifetime"),
+    XP("xp");
 
     companion object {
         fun fromQuery(s: String?): LeaderboardSort =
@@ -427,4 +502,22 @@ data class MonthOption(
     val label: String,
     val isSelected: Boolean,
     val hasData: Boolean,
+)
+
+/**
+ * One row on the Champions tab — a user with a total PvP-wins count
+ * across the four games plus the per-game breakdown for the badge stack.
+ */
+data class ChampionRow(
+    val rank: Int,
+    val discordId: String,
+    val name: String,
+    val avatarUrl: String?,
+    val totalWins: Long,
+    val perGame: List<ChampionGameWinCount>,
+)
+
+data class ChampionGameWinCount(
+    val label: String,
+    val wins: Long,
 )

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -266,6 +266,7 @@ class ModerationWebService(
                     socialCredit = current,
                     title = title,
                     level = common.leveling.LevelCurve.progress(dto.xp).level,
+                    xp = dto.xp,
                     voiceSecondsLifetime = lifetimeVoice[dto.discordId] ?: 0L,
                     voiceSecondsThisMonth = thisMonthVoice[dto.discordId] ?: 0L,
                     creditsEarnedThisMonth = creditsDelta
@@ -1681,6 +1682,7 @@ data class LeaderboardRow(
     val socialCredit: Long,
     val title: String? = null,
     val level: Int = 0,
+    val xp: Long = 0L,
     val voiceSecondsLifetime: Long = 0,
     val voiceSecondsThisMonth: Long = 0,
     val creditsEarnedThisMonth: Long = 0

--- a/web/src/main/resources/templates/fragments/moderationHeader.html
+++ b/web/src/main/resources/templates/fragments/moderationHeader.html
@@ -53,6 +53,10 @@
            class="mod-subnav-link"
            th:classappend="${active == 'leveling'} ? ' active'"
            th:attr="aria-current=${active == 'leveling'} ? 'page'">Leveling</a>
+        <a th:href="@{/moderation/{id}/activity(id=${overview.guildId})}"
+           class="mod-subnav-link"
+           th:classappend="${active == 'activity'} ? ' active'"
+           th:attr="aria-current=${active == 'activity'} ? 'page'">Activity</a>
         <a th:href="@{/moderation/{id}/welcome(id=${overview.guildId})}"
            class="mod-subnav-link"
            th:classappend="${active == 'welcome'} ? ' active'"

--- a/web/src/main/resources/templates/leaderboard.html
+++ b/web/src/main/resources/templates/leaderboard.html
@@ -157,6 +157,12 @@
             <span class="lb-section-tab-label">🎮 Games</span>
             <span class="lb-section-tab-count" th:text="|${#lists.size(view.topGames)} games|">0 games</span>
         </button>
+        <button type="button" role="tab" class="lb-sort-option" data-tab="champions"
+                aria-selected="false"
+                th:if="${not #lists.isEmpty(view.champions)}">
+            <span class="lb-section-tab-label">⚔️ Champions</span>
+            <span class="lb-section-tab-count" th:text="|${#lists.size(view.champions)} winners|">0 winners</span>
+        </button>
     </nav>
 
     <div class="lb-tab-panel" data-tab-panel="members" role="tabpanel">
@@ -175,6 +181,13 @@
            th:classappend="${view.sort.name() == 'LIFETIME' ? 'active' : ''}"
            th:aria-selected="${view.sort.name() == 'LIFETIME'}">
             Current total
+        </a>
+        <a th:href="@{/leaderboard/{id}(id=${guildId}, sort='xp')}"
+           role="tab"
+           class="lb-sort-option"
+           th:classappend="${view.sort.name() == 'XP' ? 'active' : ''}"
+           th:aria-selected="${view.sort.name() == 'XP'}">
+            XP
         </a>
     </nav>
 
@@ -196,6 +209,10 @@
                         <th class="lb-col-rank">#</th>
                         <th>Member</th>
                         <th>Prestige</th>
+                        <th class="lb-col-value"
+                            th:attr="aria-sort=${view.sort.name() == 'XP' ? 'descending' : 'none'}">
+                            ✨ XP
+                        </th>
                         <th class="lb-col-value"
                             th:attr="aria-sort=${view.sort.name() == 'LIFETIME' ? 'descending' : 'none'}">
                             💰 Credits
@@ -223,6 +240,9 @@
                                       th:text="'LVL ' + ${row.level}">LVL 0</span>
                                 <span th:if="${row.title != null}" class="lb-title-pill" th:text="${row.title}"></span>
                             </div>
+                        </td>
+                        <td data-label="XP" class="lb-col-value">
+                            <span class="lb-value" th:text="${row.xp}">0</span>
                         </td>
                         <td data-label="Credits" class="lb-col-value">
                             <strong class="lb-value lb-value-credits" th:text="${row.socialCredit}">0</strong>
@@ -416,6 +436,59 @@
     </div>
 
     </div><!-- /lb-tab-panel topgames -->
+
+    <div class="lb-tab-panel" data-tab-panel="champions" role="tabpanel" hidden
+         th:if="${not #lists.isEmpty(view.champions)}">
+
+    <details class="lb-collapse" data-section="champions" open>
+        <summary class="lb-collapse-header">
+            <span class="lb-collapse-icon" aria-hidden="true">⚔️</span>
+            <span class="lb-collapse-title">PvP champions</span>
+            <span class="lb-collapse-count" th:text="${#lists.size(view.champions)} + ' winners'">0 winners</span>
+            <span class="lb-collapse-caret" aria-hidden="true">
+                <svg viewBox="0 0 20 20" width="18" height="18"><path fill="currentColor" d="M6 4l8 6-8 6V4z"/></svg>
+            </span>
+        </summary>
+        <div class="lb-collapse-body">
+            <div class="mod-table-wrap">
+                <table class="mod-table lb-standings-table">
+                    <thead>
+                    <tr>
+                        <th class="lb-col-rank">#</th>
+                        <th>Member</th>
+                        <th class="lb-col-value" aria-sort="descending">🏆 Total wins</th>
+                        <th>Per game</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr th:each="row : ${view.champions}">
+                        <td data-label="#">
+                            <span class="lb-rank"
+                                  th:classappend="${row.rank == 1 ? 'lb-rank-1' : (row.rank == 2 ? 'lb-rank-2' : (row.rank == 3 ? 'lb-rank-3' : ''))}"
+                                  th:text="${row.rank}">1</span>
+                        </td>
+                        <td data-label="Member">
+                            <div th:replace="~{fragments/memberCell :: cellLink(${row.name}, ${row.avatarUrl}, @{/profile/{g}/{d}(g=${guildId}, d=${row.discordId})})}"></div>
+                        </td>
+                        <td data-label="Total wins" class="lb-col-value">
+                            <strong class="lb-value" th:text="${row.totalWins}">0</strong>
+                        </td>
+                        <td data-label="Per game">
+                            <div class="lb-prestige">
+                                <span class="lb-title-pill"
+                                      th:each="g : ${row.perGame}"
+                                      th:if="${g.wins > 0}"
+                                      th:text="${g.label} + ': ' + ${g.wins}">Duel: 0</span>
+                            </div>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </details>
+
+    </div><!-- /lb-tab-panel champions -->
 
     <div class="empty-hero" th:if="${#lists.isEmpty(view.podium) and #lists.isEmpty(view.standings)}">
         <span class="emoji" aria-hidden="true">🏁</span>

--- a/web/src/main/resources/templates/moderation/activity.html
+++ b/web/src/main/resources/templates/moderation/activity.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: head('TobyBot - Moderation: Activity', '/css/moderation.css')}"></head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<main id="main" class="container"
+      th:attr="data-guild-id=${overview.guildId},
+               data-actor-id=${actorDiscordId},
+               data-is-owner=${isOwner}">
+
+    <div th:replace="~{fragments/moderationHeader :: moderationHeader(${overview}, ${isOwner}, 'activity')}"></div>
+
+    <!--
+        Server-wide activity charts. 30-day rolling window, UTC-bucketed.
+        Two metrics:
+          - Messages/day: from `message_daily_count`, populated by
+            `MessageActivityBuffer` (in-memory accumulator flushed once
+            a minute off the JDA dispatch thread).
+          - Voice hours/day: aggregated at query time over closed
+            voice sessions, splitting each session across the calendar
+            days it touched.
+        Both series are pre-padded with zero-days so the SVG always has
+        one point per calendar day in the window.
+    -->
+    <section class="mod-panel" data-panel="activity">
+        <p class="muted mb-4">
+            30-day rolling activity for this server. Messages start being
+            counted once the bot is rolled out with this feature — historical
+            messages from before deployment are not backfilled.
+        </p>
+
+        <div class="mod-card mod-card-wide">
+            <h3>💬 Messages per day</h3>
+            <p class="muted">
+                Total over window:
+                <strong th:text="${T(java.lang.Math).round(T(web.service.ActivityChartsService).totalValue(messagesPerDay))}">0</strong>
+                · Peak day:
+                <strong th:text="${T(java.lang.Math).round(T(web.service.ActivityChartsService).maxValue(messagesPerDay))}">0</strong>
+            </p>
+            <svg th:if="${not #lists.isEmpty(messagesPerDay)}"
+                 class="activity-chart"
+                 role="img"
+                 aria-label="Messages per day, 30-day rolling"
+                 th:attr="viewBox=|0 0 ${T(web.service.ActivityChartsService).CHART_WIDTH} ${T(web.service.ActivityChartsService).CHART_HEIGHT}|"
+                 preserveAspectRatio="none">
+                <polyline fill="none"
+                          stroke="#5b8def"
+                          stroke-width="2"
+                          th:attr="points=${T(web.service.ActivityChartsService).polylinePoints(messagesPerDay)}"/>
+            </svg>
+            <p class="muted small">
+                <span th:text="${messagesPerDay[0].date}">2026-04-23</span>
+                →
+                <span th:text="${messagesPerDay[#lists.size(messagesPerDay) - 1].date}">2026-05-23</span>
+            </p>
+        </div>
+
+        <div class="mod-card mod-card-wide">
+            <h3>🎤 Voice hours per day</h3>
+            <p class="muted">
+                Total over window:
+                <strong th:text="${#numbers.formatDecimal(T(web.service.ActivityChartsService).totalValue(voiceHoursPerDay), 1, 1)}">0</strong>
+                hours · Peak day:
+                <strong th:text="${#numbers.formatDecimal(T(web.service.ActivityChartsService).maxValue(voiceHoursPerDay), 1, 1)}">0</strong>
+                hours
+            </p>
+            <svg th:if="${not #lists.isEmpty(voiceHoursPerDay)}"
+                 class="activity-chart"
+                 role="img"
+                 aria-label="Voice hours per day, 30-day rolling"
+                 th:attr="viewBox=|0 0 ${T(web.service.ActivityChartsService).CHART_WIDTH} ${T(web.service.ActivityChartsService).CHART_HEIGHT}|"
+                 preserveAspectRatio="none">
+                <polyline fill="none"
+                          stroke="#57f287"
+                          stroke-width="2"
+                          th:attr="points=${T(web.service.ActivityChartsService).polylinePoints(voiceHoursPerDay)}"/>
+            </svg>
+            <p class="muted small">
+                <span th:text="${voiceHoursPerDay[0].date}">2026-04-23</span>
+                →
+                <span th:text="${voiceHoursPerDay[#lists.size(voiceHoursPerDay) - 1].date}">2026-05-23</span>
+            </p>
+        </div>
+    </section>
+</main>
+
+<script th:src="@{/js/api.js}"></script>
+<script th:src="@{/js/toasts.js}"></script>
+<script th:src="@{/js/moderationCommon.js}"></script>
+</body>
+</html>

--- a/web/src/test/kotlin/web/controller/ModerationControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/ModerationControllerTest.kt
@@ -30,7 +30,7 @@ class ModerationControllerTest {
             every { getAttribute<String>("id") } returns actorId.toString()
             every { getAttribute<String>("username") } returns "tester"
         }
-        controller = ModerationController(moderationWebService, "test-client-id")
+        controller = ModerationController(moderationWebService, mockk(relaxed = true), "test-client-id")
     }
 
     // ---- ban ----

--- a/web/src/test/kotlin/web/controller/ModerationControllerWelcomeTest.kt
+++ b/web/src/test/kotlin/web/controller/ModerationControllerWelcomeTest.kt
@@ -36,7 +36,7 @@ class ModerationControllerWelcomeTest {
             every { getAttribute<String>("id") } returns actorId.toString()
             every { getAttribute<String>("username") } returns "tester"
         }
-        controller = ModerationController(moderationWebService, "test-client-id")
+        controller = ModerationController(moderationWebService, mockk(relaxed = true), "test-client-id")
     }
 
     // ---- addAutoRole ----

--- a/web/src/test/kotlin/web/service/ActivityChartsServiceTest.kt
+++ b/web/src/test/kotlin/web/service/ActivityChartsServiceTest.kt
@@ -1,0 +1,138 @@
+package web.service
+
+import database.dto.MessageDailyCountDto
+import database.dto.VoiceSessionDto
+import database.persistence.MessageDailyCountPersistence
+import database.service.VoiceSessionService
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+class ActivityChartsServiceTest {
+
+    private val today: LocalDate = LocalDate.of(2026, 5, 23)
+    private val clock: Clock = Clock.fixed(
+        today.atStartOfDay(ZoneOffset.UTC).toInstant().plusSeconds(60 * 60 * 12),
+        ZoneOffset.UTC,
+    )
+
+    @Test
+    fun `messagesPerDay pre-fills every day in the window with zero`() {
+        val messages = mockk<MessageDailyCountPersistence> {
+            every { findByGuildSince(any(), any()) } returns emptyList()
+        }
+        val voice = mockk<VoiceSessionService>(relaxed = true)
+        val service = ActivityChartsService(messages, voice, clock)
+
+        val series = service.messagesPerDay(guildId = 1L, days = 7)
+        assertEquals(7, series.size)
+        assertTrue(series.all { it.value == 0.0 })
+        assertEquals(today.minusDays(6), series.first().date)
+        assertEquals(today, series.last().date)
+    }
+
+    @Test
+    fun `messagesPerDay maps stored counters onto their dates`() {
+        val messages = mockk<MessageDailyCountPersistence> {
+            every { findByGuildSince(any(), any()) } returns listOf(
+                MessageDailyCountDto(guildId = 1L, dayStart = today, count = 42L),
+                MessageDailyCountDto(guildId = 1L, dayStart = today.minusDays(2), count = 7L),
+            )
+        }
+        val voice = mockk<VoiceSessionService>(relaxed = true)
+        val service = ActivityChartsService(messages, voice, clock)
+
+        val series = service.messagesPerDay(guildId = 1L, days = 5)
+        val byDate = series.associate { it.date to it.value }
+        assertEquals(42.0, byDate[today])
+        assertEquals(7.0, byDate[today.minusDays(2)])
+        assertEquals(0.0, byDate[today.minusDays(4)]) // pre-filled
+    }
+
+    @Test
+    fun `voiceHoursPerDay sums seconds across the matching calendar day`() {
+        val sessionStart = today.atStartOfDay(ZoneOffset.UTC).plusHours(10).toInstant()
+        val sessionEnd = sessionStart.plusSeconds(3600) // 1 hour exactly
+        val session = closedSession(sessionStart, sessionEnd)
+        val service = ActivityChartsService(
+            messageDailyCounts = mockk(relaxed = true),
+            voiceSessions = mockk { every { findClosedOverlapping(any(), any(), any()) } returns listOf(session) },
+            clock = clock,
+        )
+
+        val series = service.voiceHoursPerDay(guildId = 1L, days = 7)
+        val byDate = series.associate { it.date to it.value }
+        assertEquals(1.0, byDate[today], "1 hour entirely on `today`")
+        assertEquals(0.0, byDate[today.minusDays(1)])
+    }
+
+    @Test
+    fun `voiceHoursPerDay splits a session that crosses midnight across two days`() {
+        // 23:50 today through 00:10 tomorrow = 10 minutes today + 10 minutes tomorrow.
+        // We anchor the "today" of the chart to be one day past the split so both days fall in-window.
+        val startInstant = today.minusDays(1).atStartOfDay(ZoneOffset.UTC)
+            .plusHours(23).plusMinutes(50).toInstant()
+        val endInstant = today.atStartOfDay(ZoneOffset.UTC).plusMinutes(10).toInstant()
+        val session = closedSession(startInstant, endInstant)
+        val service = ActivityChartsService(
+            messageDailyCounts = mockk(relaxed = true),
+            voiceSessions = mockk { every { findClosedOverlapping(any(), any(), any()) } returns listOf(session) },
+            clock = clock,
+        )
+
+        val series = service.voiceHoursPerDay(guildId = 1L, days = 7)
+        val byDate = series.associate { it.date to it.value }
+        val tenMinutesInHours = 10.0 / 60.0
+        assertEquals(tenMinutesInHours, byDate[today.minusDays(1)]!!, 0.001)
+        assertEquals(tenMinutesInHours, byDate[today]!!, 0.001)
+    }
+
+    @Test
+    fun `polylinePoints emits one coord pair per day, scaled to the series max`() {
+        val series = listOf(
+            ActivityChartsService.DailyPoint(today.minusDays(2), 0.0),
+            ActivityChartsService.DailyPoint(today.minusDays(1), 5.0),
+            ActivityChartsService.DailyPoint(today, 10.0),
+        )
+        val out = ActivityChartsService.polylinePoints(series)
+        // Three points → three space-separated `x,y` pairs.
+        assertEquals(3, out.split(" ").size)
+        // Last point's Y sits at the padded top of the chart (highest of the three).
+        val lastY = out.split(" ").last().split(",")[1].toDouble()
+        val firstY = out.split(" ").first().split(",")[1].toDouble()
+        assertTrue(lastY < firstY, "max value should sit higher on the SVG (smaller Y)")
+    }
+
+    @Test
+    fun `polylinePoints with an empty series returns the empty string`() {
+        assertEquals("", ActivityChartsService.polylinePoints(emptyList()))
+    }
+
+    @Test
+    fun `polylinePoints with all-zero values renders along the baseline`() {
+        val series = (0 until 5).map {
+            ActivityChartsService.DailyPoint(today.minusDays((4 - it).toLong()), 0.0)
+        }
+        val out = ActivityChartsService.polylinePoints(series)
+        // All Ys should be identical when the series max is zero (clamp to 1.0).
+        val ys = out.split(" ").map { it.split(",")[1] }.toSet()
+        assertEquals(1, ys.size, "all-zero series should be one horizontal line")
+    }
+
+    private fun closedSession(startedAt: Instant, endedAt: Instant): VoiceSessionDto = VoiceSessionDto(
+        id = 1L,
+        discordId = 99L,
+        guildId = 1L,
+        channelId = 100L,
+        joinedAt = startedAt,
+        leftAt = endedAt,
+        countedSeconds = endedAt.epochSecond - startedAt.epochSecond,
+        creditsAwarded = 0L,
+    )
+}

--- a/web/src/test/kotlin/web/service/LeaderboardWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/LeaderboardWebServiceTest.kt
@@ -1,5 +1,6 @@
 package web.service
 
+import database.service.AchievementService
 import database.service.TobyCoinMarketService
 import database.service.UserService
 import io.mockk.every
@@ -22,6 +23,7 @@ class LeaderboardWebServiceTest {
     private lateinit var moderationWebService: ModerationWebService
     private lateinit var userService: UserService
     private lateinit var marketService: TobyCoinMarketService
+    private lateinit var achievementService: AchievementService
     private lateinit var service: LeaderboardWebService
 
     private val guildId = 42L
@@ -34,13 +36,15 @@ class LeaderboardWebServiceTest {
         moderationWebService = mockk(relaxed = true)
         userService = mockk(relaxed = true)
         marketService = mockk(relaxed = true)
+        achievementService = mockk(relaxed = true)
         // Real GuildMembership over the mocked JDA — keeps the existing
         // `isMember` tests black-boxed against JDA, not against the helper.
         service = LeaderboardWebService(
             jda, introWebService, moderationWebService, userService, marketService,
             mockk(relaxed = true), mockk(relaxed = true),
             GuildMembership(jda),
-            mockk(relaxed = true)
+            mockk(relaxed = true),
+            achievementService,
         )
     }
 
@@ -251,8 +255,74 @@ class LeaderboardWebServiceTest {
     fun `LeaderboardSort fromQuery maps tokens and falls back to THIS_MONTH`() {
         assertEquals(LeaderboardSort.THIS_MONTH, LeaderboardSort.fromQuery("month"))
         assertEquals(LeaderboardSort.LIFETIME, LeaderboardSort.fromQuery("lifetime"))
+        assertEquals(LeaderboardSort.XP, LeaderboardSort.fromQuery("xp"))
         assertEquals(LeaderboardSort.THIS_MONTH, LeaderboardSort.fromQuery(null))
         assertEquals(LeaderboardSort.THIS_MONTH, LeaderboardSort.fromQuery(""))
         assertEquals(LeaderboardSort.THIS_MONTH, LeaderboardSort.fromQuery("garbage"))
+    }
+
+    @Test
+    fun `getGuildView builds champions from achievement progress sorted by total wins`() {
+        val guild = mockk<Guild>(relaxed = true)
+        every { jda.getGuildById(guildId) } returns guild
+        every { guild.name } returns "Champions test"
+        every { moderationWebService.getLeaderboard(guildId) } returns emptyList()
+        // Discord 1 = 5 RPS + 3 TTT = 8 wins. Discord 2 = 10 duel wins.
+        // Discord 3 = 1 connect4 win. Sorted desc: 2 (10), 1 (8), 3 (1).
+        every { achievementService.progressByCodesForGuild(guildId, LeaderboardWebService.CHAMPIONS_WIN_CODES) } returns listOf(
+            AchievementService.ProgressByCode(discordId = 1L, code = "rps_wins_10", progress = 5L),
+            AchievementService.ProgressByCode(discordId = 1L, code = "tictactoe_wins_10", progress = 3L),
+            AchievementService.ProgressByCode(discordId = 2L, code = "duel_wins_10", progress = 10L),
+            AchievementService.ProgressByCode(discordId = 3L, code = "connect4_wins_10", progress = 1L),
+        )
+        every { guild.getMemberById(any<Long>()) } returns null
+
+        val view = service.getGuildView(guildId)!!
+
+        assertEquals(3, view.champions.size, "all three users with non-zero wins show up")
+        assertEquals(2L, view.champions[0].discordId.toLong())
+        assertEquals(10L, view.champions[0].totalWins)
+        assertEquals(1, view.champions[0].rank)
+        assertEquals(1L, view.champions[1].discordId.toLong())
+        assertEquals(8L, view.champions[1].totalWins)
+        assertEquals(3L, view.champions[2].discordId.toLong())
+        assertEquals(1L, view.champions[2].totalWins)
+    }
+
+    @Test
+    fun `getGuildView returns empty champions when achievement service fails`() {
+        val guild = mockk<Guild>(relaxed = true)
+        every { jda.getGuildById(guildId) } returns guild
+        every { guild.name } returns "Failure test"
+        every { moderationWebService.getLeaderboard(guildId) } returns emptyList()
+        every { achievementService.progressByCodesForGuild(any(), any()) } throws RuntimeException("DB down")
+
+        // The view must still render — Champions becomes empty rather than 500-ing the page.
+        val view = service.getGuildView(guildId)!!
+        assertTrue(view.champions.isEmpty())
+    }
+
+    @Test
+    fun `getGuildView with XP sort ranks by xp desc and reassigns ranks`() {
+        val guild = mockk<Guild>(relaxed = true)
+        every { jda.getGuildById(guildId) } returns guild
+        every { guild.name } returns "XP sort test"
+        // Alice has the most credits, Carol has the most XP — XP sort surfaces Carol.
+        every { moderationWebService.getLeaderboard(guildId) } returns listOf(
+            LeaderboardRow(rank = 1, discordId = "1", name = "Alice", avatarUrl = null,
+                socialCredit = 1_000, xp = 100L, creditsEarnedThisMonth = 10),
+            LeaderboardRow(rank = 2, discordId = "2", name = "Bob", avatarUrl = null,
+                socialCredit = 500, xp = 500L, creditsEarnedThisMonth = 0),
+            LeaderboardRow(rank = 3, discordId = "3", name = "Carol", avatarUrl = null,
+                socialCredit = 200, xp = 5_000L, creditsEarnedThisMonth = 0)
+        )
+
+        val view = service.getGuildView(guildId, LeaderboardSort.XP)!!
+
+        assertEquals(LeaderboardSort.XP, view.sort)
+        assertEquals("Carol", view.podium[0].name)
+        assertEquals(1, view.podium[0].rank)
+        assertEquals("Bob", view.podium[1].name)
+        assertEquals("Alice", view.podium[2].name)
     }
 }

--- a/web/src/test/kotlin/web/service/LeaderboardWebServiceTobyCoinTest.kt
+++ b/web/src/test/kotlin/web/service/LeaderboardWebServiceTobyCoinTest.kt
@@ -56,6 +56,7 @@ class LeaderboardWebServiceTobyCoinTest {
             snapshotService = snapshotService,
             membership = GuildMembership(jda),
             rollupService = mockk(relaxed = true),
+            achievementService = mockk(relaxed = true),
         )
     }
 

--- a/web/src/test/kotlin/web/service/LeaderboardWebServiceTopGamesTest.kt
+++ b/web/src/test/kotlin/web/service/LeaderboardWebServiceTopGamesTest.kt
@@ -55,6 +55,7 @@ class LeaderboardWebServiceTopGamesTest {
             snapshotService = mockk(relaxed = true),
             membership = GuildMembership(jda),
             rollupService = rollupService,
+            achievementService = mockk(relaxed = true),
         )
     }
 


### PR DESCRIPTION
## Summary

Three additive gaps in the existing leaderboard + moderation surface, all leveraging data that's already in the database.

### 1. Champions tab on `/leaderboards`

Fourth tab that ranks users by total PvP wins across `/duel`, `/rps`, `/tictactoe`, `/connect4`. Reads the smallest-tier `*_wins_10` achievement counters — each counter holds the user's actual win count for that game regardless of higher-tier unlocks, so a single per-guild aggregation query produces the leaderboard. Per-game subtotals are rendered as pill badges next to the total so admins can see who's strong in which game.

### 2. XP column + sort on the Members tab

`LeaderboardRow` now carries the raw `xp` field (previously `UserDto.xp` was only used to compute the level pill — the underlying number wasn't surfaced). New `XP` column next to Prestige, new `LeaderboardSort.XP` option, new "XP" link in the Members nav. The existing `?sort=month|lifetime` URL plumbing extends to `?sort=xp`.

### 3. Activity sub-page on `/moderation/{guildId}/activity`

New tab between Leveling and Welcome with two 30-day-rolling SVG line charts:

| Metric | Source |
|---|---|
| **Messages/day** | A new `message_daily_count` table populated by `MessageActivityBuffer` — an in-memory accumulator that batches per-guild per-UTC-date counts and flushes once a minute on the shared `RegistryScheduler`. No per-message round-trip to Postgres; same shape `MessageChatListener` already uses for XP-award debouncing. |
| **Voice hours/day** | Aggregated at query time over the existing `voice_session` rows. Sessions that span midnight UTC split proportionally across both days they touched (a 23:50→00:10 session contributes 10 minutes to each calendar day). No schema change — uses a new `findClosedOverlapping` query on `VoiceSessionPersistence`. |

Both series pre-fill missing days with zero so the polyline always has one point per calendar day in the window. Charts render as inline SVG `<polyline>`s with a service-side `polylinePoints()` helper that normalises to the series max + pads inside the viewBox.

## Critical files

**New:**
```
database/src/main/kotlin/database/dto/MessageDailyCountDto.kt
database/src/main/kotlin/database/persistence/MessageDailyCountPersistence.kt
database/src/main/kotlin/database/persistence/impl/DefaultMessageDailyCountPersistence.kt
database/src/main/kotlin/database/service/MessageActivityBuffer.kt
database/src/main/resources/db/migration/V44__message_daily_count.sql

web/src/main/kotlin/web/service/ActivityChartsService.kt
web/src/main/resources/templates/moderation/activity.html

database/src/test/kotlin/database/service/MessageActivityBufferTest.kt
web/src/test/kotlin/web/service/ActivityChartsServiceTest.kt
```

**Modified:**
```
database/src/main/kotlin/database/persistence/AchievementPersistence.kt           (+ progressByCodesForGuild)
database/src/main/kotlin/database/persistence/impl/DefaultAchievementPersistence.kt
database/src/main/kotlin/database/service/AchievementService.kt
database/src/main/kotlin/database/service/impl/DefaultAchievementService.kt
database/src/main/kotlin/database/persistence/VoiceSessionPersistence.kt          (+ findClosedOverlapping)
database/src/main/kotlin/database/persistence/impl/DefaultVoiceSessionPersistence.kt
database/src/main/kotlin/database/service/VoiceSessionService.kt
database/src/main/kotlin/database/service/impl/DefaultVoiceSessionService.kt

discord-bot/src/main/kotlin/bot/toby/handler/MessageChatListener.kt               (hook MessageActivityBuffer.record)

web/src/main/kotlin/web/controller/ModerationController.kt                        (+ activityPage endpoint)
web/src/main/kotlin/web/service/LeaderboardWebService.kt                          (achievementService, buildChampions, XP sort)
web/src/main/kotlin/web/service/ModerationWebService.kt                           (xp on LeaderboardRow)
web/src/main/resources/templates/fragments/moderationHeader.html                  (+ Activity tab)
web/src/main/resources/templates/leaderboard.html                                 (Champions tab + XP column)
```

Existing test fakes / constructor calls updated for the new wiring:
```
database/.../AchievementSeederTest.kt, AchievementServiceTest.kt   (new fake method)
discord-bot/.../MessageChatListenerTest.kt                          (new constructor arg)
web/.../ModerationControllerTest.kt, ModerationControllerWelcomeTest.kt  (new constructor arg)
web/.../LeaderboardWebServiceTest.kt + TobyCoinTest + TopGamesTest  (new constructor arg)
```

## Tests

- `MessageActivityBufferTest` — single-flush drain, multi-guild bucketing, concurrent-record race (8 threads × 1000 records → no lost increments), persistence-failure retry (rolls the delta back so the next flush retries).
- `ActivityChartsServiceTest` — pre-fills empty days, maps stored counters onto their dates, voice session inside one day, voice session that splits across midnight UTC (10/10 minute split), `polylinePoints` normalisation edge cases (empty series, all-zero series).
- `LeaderboardWebServiceTest` — new cases for Champions ranking (cross-game sum, per-game subtotals, sorted desc, ranks reassigned), the defensive "achievement service throws → empty champions" path so a DB hiccup doesn't 500 the leaderboard page, and the XP sort branch (Members ranked by `xp` desc).

## Test plan

- [x] `:common:test` — green
- [x] `:database:test` — green (covers MessageActivityBuffer)
- [x] `:discord-bot:test` — green (MessageChatListener wiring intact)
- [x] `:web:test` — green (ActivityChartsService, Leaderboard champion/XP)
- [ ] `:application:test` — Testcontainers-driven, requires Docker; CI will run it. Validates the new Flyway migration + the JPA mapping on `MessageDailyCountDto` against real Postgres.
- [ ] Manual end-to-end:
  - [ ] Visit `/leaderboards/{guildId}`, switch to Champions tab — confirm top-N users with per-game breakdown
  - [ ] Click the new "XP" sort link in Members — confirm rankings flip
  - [ ] Send messages on a test guild, wait ~60s, refresh `/moderation/{guildId}/activity` — messages line ticks up
  - [ ] Join/leave a voice channel, refresh — voice line ticks up
  - [ ] Confirm Activity tab is in the moderation nav (between Leveling and Welcome)

## What's deferred

- Backfilling messages/day before this PR ships — counter starts at deployment day; admins see a growing 30-day window after rollout.
- A per-game leaderboard tab for each individual PvP game — premature until we see how the combined Champions tab gets used.
- Per-user activity on the moderation Activity tab — leaderboard tabs already cover per-user rankings.

https://claude.ai/code/session_017tRi5q6K3NYHvYeZYzLzBD

---
_Generated by [Claude Code](https://claude.ai/code/session_017tRi5q6K3NYHvYeZYzLzBD)_