### PR TITLE
docs(leaderboard): clarify Members-tab sort chips with metric name

### DIFF
--- a/web/src/main/resources/templates/leaderboard.html
+++ b/web/src/main/resources/templates/leaderboard.html
@@ -173,21 +173,21 @@
            class="lb-sort-option"
            th:classappend="${view.sort.name() == 'THIS_MONTH' ? 'active' : ''}"
            th:aria-selected="${view.sort.name() == 'THIS_MONTH'}">
-            This month
+            💰 Credits this month
         </a>
         <a th:href="@{/leaderboard/{id}(id=${guildId}, sort='lifetime')}"
            role="tab"
            class="lb-sort-option"
            th:classappend="${view.sort.name() == 'LIFETIME' ? 'active' : ''}"
            th:aria-selected="${view.sort.name() == 'LIFETIME'}">
-            Current total
+            💰 Lifetime credits
         </a>
         <a th:href="@{/leaderboard/{id}(id=${guildId}, sort='xp')}"
            role="tab"
            class="lb-sort-option"
            th:classappend="${view.sort.name() == 'XP' ? 'active' : ''}"
            th:aria-selected="${view.sort.name() == 'XP'}">
-            XP
+            ✨ XP
         </a>
     </nav>
 


### PR DESCRIPTION
## Summary

The Members-tab sort chips on `/leaderboards` used to read "This month / Current total / XP". The first two were unambiguous when both meant social credit, but sitting next to "XP" they read as if any of the three could be ranking any metric — nothing on the chip says what's being sorted.

Rename to "💰 Credits this month / 💰 Lifetime credits / ✨ XP" so the metric is clear from the chip text alone. Behaviour unchanged — same URL params, same sort logic.

## Test plan

- [x] `:web:test` — green (no logic changed)
- [ ] Manual: visit `/leaderboard/{guildId}` and confirm the three Members-tab sort chips now read "💰 Credits this month / 💰 Lifetime credits / ✨ XP"

https://claude.ai/code/session_017tRi5q6K3NYHvYeZYzLzBD

---
_Generated by [Claude Code](https://claude.ai/code/session_017tRi5q6K3NYHvYeZYzLzBD)_