### PR TITLE
fix(leaderboard): label XP on mobile leaderboard cards

### DIFF
--- a/web/src/main/resources/static/css/base.css
+++ b/web/src/main/resources/static/css/base.css
@@ -1143,7 +1143,8 @@ td { font-size: 0.95rem; }
         grid-template-columns: auto 1fr auto;
         grid-template-areas:
             "rank   member  title"
-            "m1     m2      m3";
+            "m1     m2      m3"
+            "m4     m4      m4";
         align-items: center;
         column-gap: 10px;
         row-gap: 6px;
@@ -1189,7 +1190,8 @@ td { font-size: 0.95rem; }
     .lb-standings-table.mod-table td[data-label="TOBY"],
     .lb-standings-table.mod-table td[data-label="This month"],
     .lb-standings-table.mod-table td[data-label="Voice"],
-    .lb-standings-table.mod-table td[data-label="Portfolio"] {
+    .lb-standings-table.mod-table td[data-label="Portfolio"],
+    .lb-standings-table.mod-table td[data-label="XP"] {
         display: flex;
         flex-direction: column;
         gap: 1px;
@@ -1210,11 +1212,20 @@ td { font-size: 0.95rem; }
         align-items: flex-end;
         text-align: right;
     }
+    /* XP gets its own full-width row below the other metrics so the
+       Credits/Month/Voice strip stays the visual hero of the card.
+       Centered to balance the 3-cell row above. */
+    .lb-standings-table.mod-table td[data-label="XP"] {
+        grid-area: m4;
+        align-items: center;
+        text-align: center;
+    }
     .lb-standings-table.mod-table td[data-label="Credits"]::before,
     .lb-standings-table.mod-table td[data-label="TOBY"]::before,
     .lb-standings-table.mod-table td[data-label="This month"]::before,
     .lb-standings-table.mod-table td[data-label="Voice"]::before,
-    .lb-standings-table.mod-table td[data-label="Portfolio"]::before {
+    .lb-standings-table.mod-table td[data-label="Portfolio"]::before,
+    .lb-standings-table.mod-table td[data-label="XP"]::before {
         display: block;
         content: attr(data-label);
         font-size: 0.6rem;


### PR DESCRIPTION
## Summary

PR #558 added an XP column to the Members standings table but missed updating the mobile card view (≤ 600px). The standings table collapses to a CSS-grid card per row on mobile; the XP cell had `data-label="XP"` set in the template but no `grid-area` rule and wasn't in the `::before { content: attr(data-label) }` allow-list. CSS Grid auto-placed it into row 3 col 1 as a bare unlabelled number floating below the three labelled metric cells.

User confirmed via screenshot — the leaderboard card on mobile showed `CREDITS / 315082` · `THIS MONTH / +312270` · `VOICE / 21h 27m` and then `3500` orphaned at the bottom-left with no label.

CSS-only fix to `base.css` inside the existing `@media (max-width: 600px)` block:

1. Extend `grid-template-areas` from a 2-row to a 3-row template, adding an `m4` row that spans all three columns
2. Add `td[data-label="XP"]` to the labelled-metric layout block (`display: flex; flex-direction: column; gap: 1px`) and slot it into `m4` with centred alignment
3. Add `td[data-label="XP"]::before` to the metric-label `::before` rule so the small uppercase "XP" caption appears above the value, matching the four other labelled metrics

Net effect on the screenshot: the bottom row reads `XP / 3500` instead of just a stray `3500`.

Desktop view (>600px) unchanged — all new rules are inside the existing mobile breakpoint.

## Test plan

- [x] CSS-only change; existing tests untouched
- [ ] Manual: open `/leaderboard/{guildId}` on a viewport ≤600px (or dev-tools mobile emulation), confirm each member card now reads `XP / 3500` below the existing three-metric strip
- [ ] Desktop check: confirm the wide-viewport standings table is unchanged

https://claude.ai/code/session_017tRi5q6K3NYHvYeZYzLzBD

---
_Generated by [Claude Code](https://claude.ai/code/session_017tRi5q6K3NYHvYeZYzLzBD)_