### PR TITLE
fix(moderation): broken activity page — pre-compute chart view in controller

### DIFF
--- a/web/src/main/kotlin/web/controller/ModerationController.kt
+++ b/web/src/main/kotlin/web/controller/ModerationController.kt
@@ -203,11 +203,11 @@ class ModerationController(
             ra.addFlashAttribute("error", "Bot is not in that server.")
             return@requireForPage "redirect:/moderation/guilds"
         }
-        val messages = activityChartsService.messagesPerDay(guildId)
-        val voiceHours = activityChartsService.voiceHoursPerDay(guildId)
+        val messagesChart = activityChartsService.buildMessagesChart(guildId)
+        val voiceHoursChart = activityChartsService.buildVoiceHoursChart(guildId)
         model.addAttribute("overview", overview)
-        model.addAttribute("messagesPerDay", messages)
-        model.addAttribute("voiceHoursPerDay", voiceHours)
+        model.addAttribute("messagesChart", messagesChart)
+        model.addAttribute("voiceHoursChart", voiceHoursChart)
         model.addAttribute("isOwner", moderationWebService.isOwner(discordId, guildId))
         model.addAttribute("username", user.displayName())
         model.addAttribute("actorDiscordId", discordId.toString())

--- a/web/src/main/kotlin/web/service/ActivityChartsService.kt
+++ b/web/src/main/kotlin/web/service/ActivityChartsService.kt
@@ -9,6 +9,7 @@ import java.time.LocalDate
 import java.time.ZoneOffset
 import kotlin.math.max
 import kotlin.math.min
+import kotlin.math.round
 
 /**
  * Reads the daily activity series feeding the moderation Activity tab.
@@ -23,6 +24,12 @@ import kotlin.math.min
  *
  * Both methods pre-fill empty days with zeros so the template never has
  * to worry about gaps in the X axis.
+ *
+ * The page renders via [ChartView] — a render-ready bundle of pre-
+ * computed polyline + headline numbers + date range — so the template
+ * never has to call helper functions through Thymeleaf SpEL. See
+ * [buildMessagesChart] and [buildVoiceHoursChart] for the controller-
+ * facing entry points.
  */
 @Service
 class ActivityChartsService(
@@ -38,6 +45,38 @@ class ActivityChartsService(
         /** The chart template renders both metrics through a single SVG fragment. */
         val valueLong: Long get() = value.toLong()
     }
+
+    /**
+     * Render-ready bundle for one chart. Everything the template needs
+     * is pre-computed in the service so the Thymeleaf page only has to
+     * read `${chart.field}` — no SpEL static-method calls, no `T(...)`
+     * type references. Matches the moderation-page convention used by
+     * `leveling.html`, `lottery.html`, etc.
+     */
+    data class ChartView(
+        val points: List<DailyPoint>,
+        /** Pre-rendered SVG `points="..."` value for `<polyline>`. */
+        val polyline: String,
+        val total: Double,
+        val max: Double,
+        val viewBoxWidth: Int,
+        val viewBoxHeight: Int,
+        val firstDate: LocalDate?,
+        val lastDate: LocalDate?,
+    ) {
+        /** Display-only int variants for headline strong-tags. */
+        val totalRounded: Long get() = round(total).toLong()
+        val maxRounded: Long get() = round(max).toLong()
+        val isEmpty: Boolean get() = points.isEmpty()
+    }
+
+    /** Build the messages-per-day chart for [guildId]. */
+    fun buildMessagesChart(guildId: Long, days: Int = DEFAULT_DAYS): ChartView =
+        toChartView(messagesPerDay(guildId, days))
+
+    /** Build the voice-hours-per-day chart for [guildId]. */
+    fun buildVoiceHoursChart(guildId: Long, days: Int = DEFAULT_DAYS): ChartView =
+        toChartView(voiceHoursPerDay(guildId, days))
 
     /**
      * Messages-per-day for [guildId] over the trailing [days] calendar
@@ -95,6 +134,42 @@ class ActivityChartsService(
         }
     }
 
+    private fun toChartView(series: List<DailyPoint>): ChartView = ChartView(
+        points = series,
+        polyline = polylinePoints(series),
+        total = series.sumOf { it.value },
+        max = series.maxOfOrNull { it.value } ?: 0.0,
+        viewBoxWidth = CHART_WIDTH,
+        viewBoxHeight = CHART_HEIGHT,
+        firstDate = series.firstOrNull()?.date,
+        lastDate = series.lastOrNull()?.date,
+    )
+
+    /**
+     * Build the `points="..."` value for an `<svg><polyline>` rendering
+     * of [series]. Y-axis normalises to the series max; an all-zero
+     * series renders along the bottom of the chart so the baseline is
+     * always visible. The chart is padded inside the SVG so the top
+     * edge doesn't clip the highest point.
+     *
+     * Internal — the controller never calls this directly; templates
+     * read [ChartView.polyline] from the bundle [buildMessagesChart]
+     * returns.
+     */
+    internal fun polylinePoints(series: List<DailyPoint>): String {
+        if (series.isEmpty()) return ""
+        val padding = 8.0
+        val innerW = CHART_WIDTH - 2 * padding
+        val innerH = CHART_HEIGHT - 2 * padding
+        val maxVal = series.maxOf { it.value }.coerceAtLeast(1.0)
+        val stepX = if (series.size <= 1) 0.0 else innerW / (series.size - 1)
+        return series.mapIndexed { i, point ->
+            val x = padding + i * stepX
+            val y = padding + innerH - (point.value / maxVal) * innerH
+            "%.1f,%.1f".format(x, y)
+        }.joinToString(" ")
+    }
+
     private fun fillRange(since: LocalDate, today: LocalDate): List<LocalDate> {
         val length = Duration.between(
             since.atStartOfDay(ZoneOffset.UTC),
@@ -110,34 +185,5 @@ class ActivityChartsService(
         /** Width / height for the per-chart SVG. Picked to match the moderation panel grid. */
         const val CHART_WIDTH: Int = 600
         const val CHART_HEIGHT: Int = 180
-
-        /**
-         * Build the `points="..."` value for an `<svg><polyline>` rendering
-         * of [series]. Y-axis normalises to the series max; an all-zero
-         * series renders along the bottom of the chart so the baseline
-         * is always visible. The chart is padded inside the SVG so the
-         * top edge doesn't clip the highest point.
-         */
-        fun polylinePoints(series: List<DailyPoint>): String {
-            if (series.isEmpty()) return ""
-            val padding = 8.0
-            val innerW = CHART_WIDTH - 2 * padding
-            val innerH = CHART_HEIGHT - 2 * padding
-            val max = series.maxOf { it.value }.coerceAtLeast(1.0)
-            val stepX = if (series.size <= 1) 0.0 else innerW / (series.size - 1)
-            return series.mapIndexed { i, point ->
-                val x = padding + i * stepX
-                val y = padding + innerH - (point.value / max) * innerH
-                "%.1f,%.1f".format(x, y)
-            }.joinToString(" ")
-        }
-
-        /** Largest value across [series], for the per-chart legend. */
-        fun maxValue(series: List<DailyPoint>): Double =
-            series.maxOfOrNull { it.value } ?: 0.0
-
-        /** Sum of values across [series], for the per-chart legend. */
-        fun totalValue(series: List<DailyPoint>): Double =
-            series.sumOf { it.value }
     }
 }

--- a/web/src/main/resources/templates/moderation/activity.html
+++ b/web/src/main/resources/templates/moderation/activity.html
@@ -23,6 +23,11 @@
             days it touched.
         Both series are pre-padded with zero-days so the SVG always has
         one point per calendar day in the window.
+
+        Render values are pre-computed in ActivityChartsService and
+        passed as `messagesChart` / `voiceHoursChart` ChartView bundles —
+        the template only reads simple `${chart.field}` properties, no
+        SpEL static-type calls.
     -->
     <section class="mod-panel" data-panel="activity">
         <p class="muted mb-4">
@@ -35,25 +40,25 @@
             <h3>💬 Messages per day</h3>
             <p class="muted">
                 Total over window:
-                <strong th:text="${T(java.lang.Math).round(T(web.service.ActivityChartsService).totalValue(messagesPerDay))}">0</strong>
+                <strong th:text="${messagesChart.totalRounded}">0</strong>
                 · Peak day:
-                <strong th:text="${T(java.lang.Math).round(T(web.service.ActivityChartsService).maxValue(messagesPerDay))}">0</strong>
+                <strong th:text="${messagesChart.maxRounded}">0</strong>
             </p>
-            <svg th:if="${not #lists.isEmpty(messagesPerDay)}"
+            <svg th:unless="${messagesChart.empty}"
                  class="activity-chart"
                  role="img"
                  aria-label="Messages per day, 30-day rolling"
-                 th:attr="viewBox=|0 0 ${T(web.service.ActivityChartsService).CHART_WIDTH} ${T(web.service.ActivityChartsService).CHART_HEIGHT}|"
+                 th:attr="viewBox=|0 0 ${messagesChart.viewBoxWidth} ${messagesChart.viewBoxHeight}|"
                  preserveAspectRatio="none">
                 <polyline fill="none"
                           stroke="#5b8def"
                           stroke-width="2"
-                          th:attr="points=${T(web.service.ActivityChartsService).polylinePoints(messagesPerDay)}"/>
+                          th:attr="points=${messagesChart.polyline}"/>
             </svg>
-            <p class="muted small">
-                <span th:text="${messagesPerDay[0].date}">2026-04-23</span>
+            <p class="muted small" th:unless="${messagesChart.empty}">
+                <span th:text="${messagesChart.firstDate}">2026-04-23</span>
                 →
-                <span th:text="${messagesPerDay[#lists.size(messagesPerDay) - 1].date}">2026-05-23</span>
+                <span th:text="${messagesChart.lastDate}">2026-05-23</span>
             </p>
         </div>
 
@@ -61,26 +66,26 @@
             <h3>🎤 Voice hours per day</h3>
             <p class="muted">
                 Total over window:
-                <strong th:text="${#numbers.formatDecimal(T(web.service.ActivityChartsService).totalValue(voiceHoursPerDay), 1, 1)}">0</strong>
+                <strong th:text="${#numbers.formatDecimal(voiceHoursChart.total, 1, 1)}">0</strong>
                 hours · Peak day:
-                <strong th:text="${#numbers.formatDecimal(T(web.service.ActivityChartsService).maxValue(voiceHoursPerDay), 1, 1)}">0</strong>
+                <strong th:text="${#numbers.formatDecimal(voiceHoursChart.max, 1, 1)}">0</strong>
                 hours
             </p>
-            <svg th:if="${not #lists.isEmpty(voiceHoursPerDay)}"
+            <svg th:unless="${voiceHoursChart.empty}"
                  class="activity-chart"
                  role="img"
                  aria-label="Voice hours per day, 30-day rolling"
-                 th:attr="viewBox=|0 0 ${T(web.service.ActivityChartsService).CHART_WIDTH} ${T(web.service.ActivityChartsService).CHART_HEIGHT}|"
+                 th:attr="viewBox=|0 0 ${voiceHoursChart.viewBoxWidth} ${voiceHoursChart.viewBoxHeight}|"
                  preserveAspectRatio="none">
                 <polyline fill="none"
                           stroke="#57f287"
                           stroke-width="2"
-                          th:attr="points=${T(web.service.ActivityChartsService).polylinePoints(voiceHoursPerDay)}"/>
+                          th:attr="points=${voiceHoursChart.polyline}"/>
             </svg>
-            <p class="muted small">
-                <span th:text="${voiceHoursPerDay[0].date}">2026-04-23</span>
+            <p class="muted small" th:unless="${voiceHoursChart.empty}">
+                <span th:text="${voiceHoursChart.firstDate}">2026-04-23</span>
                 →
-                <span th:text="${voiceHoursPerDay[#lists.size(voiceHoursPerDay) - 1].date}">2026-05-23</span>
+                <span th:text="${voiceHoursChart.lastDate}">2026-05-23</span>
             </p>
         </div>
     </section>

--- a/web/src/test/kotlin/web/service/ActivityChartsServiceTest.kt
+++ b/web/src/test/kotlin/web/service/ActivityChartsServiceTest.kt
@@ -7,6 +7,7 @@ import database.service.VoiceSessionService
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.time.Clock
@@ -95,12 +96,13 @@ class ActivityChartsServiceTest {
 
     @Test
     fun `polylinePoints emits one coord pair per day, scaled to the series max`() {
+        val service = serviceWithEmpty()
         val series = listOf(
             ActivityChartsService.DailyPoint(today.minusDays(2), 0.0),
             ActivityChartsService.DailyPoint(today.minusDays(1), 5.0),
             ActivityChartsService.DailyPoint(today, 10.0),
         )
-        val out = ActivityChartsService.polylinePoints(series)
+        val out = service.polylinePoints(series)
         // Three points → three space-separated `x,y` pairs.
         assertEquals(3, out.split(" ").size)
         // Last point's Y sits at the padded top of the chart (highest of the three).
@@ -111,19 +113,70 @@ class ActivityChartsServiceTest {
 
     @Test
     fun `polylinePoints with an empty series returns the empty string`() {
-        assertEquals("", ActivityChartsService.polylinePoints(emptyList()))
+        assertEquals("", serviceWithEmpty().polylinePoints(emptyList()))
     }
 
     @Test
     fun `polylinePoints with all-zero values renders along the baseline`() {
+        val service = serviceWithEmpty()
         val series = (0 until 5).map {
             ActivityChartsService.DailyPoint(today.minusDays((4 - it).toLong()), 0.0)
         }
-        val out = ActivityChartsService.polylinePoints(series)
+        val out = service.polylinePoints(series)
         // All Ys should be identical when the series max is zero (clamp to 1.0).
         val ys = out.split(" ").map { it.split(",")[1] }.toSet()
         assertEquals(1, ys.size, "all-zero series should be one horizontal line")
     }
+
+    // ---- ChartView builders ----
+
+    @Test
+    fun `buildMessagesChart returns a fully-populated ChartView bundle`() {
+        val messages = mockk<MessageDailyCountPersistence> {
+            every { findByGuildSince(any(), any()) } returns listOf(
+                MessageDailyCountDto(guildId = 1L, dayStart = today, count = 12L),
+                MessageDailyCountDto(guildId = 1L, dayStart = today.minusDays(1), count = 8L),
+            )
+        }
+        val service = ActivityChartsService(messages, mockk(relaxed = true), clock)
+
+        val chart = service.buildMessagesChart(guildId = 1L, days = 7)
+        assertEquals(7, chart.points.size)
+        assertEquals(20.0, chart.total)
+        assertEquals(20L, chart.totalRounded)
+        assertEquals(12.0, chart.max)
+        assertEquals(12L, chart.maxRounded)
+        assertEquals(ActivityChartsService.CHART_WIDTH, chart.viewBoxWidth)
+        assertEquals(ActivityChartsService.CHART_HEIGHT, chart.viewBoxHeight)
+        assertEquals(today.minusDays(6), chart.firstDate)
+        assertEquals(today, chart.lastDate)
+        assertTrue(chart.polyline.isNotEmpty(), "polyline must be ready for the template")
+        assertFalse(chart.isEmpty)
+    }
+
+    @Test
+    fun `buildVoiceHoursChart returns a fully-populated ChartView bundle`() {
+        val sessionStart = today.atStartOfDay(ZoneOffset.UTC).plusHours(10).toInstant()
+        val sessionEnd = sessionStart.plusSeconds(3600) // 1 hour exactly
+        val voice = mockk<VoiceSessionService> {
+            every { findClosedOverlapping(any(), any(), any()) } returns listOf(closedSession(sessionStart, sessionEnd))
+        }
+        val service = ActivityChartsService(mockk(relaxed = true), voice, clock)
+
+        val chart = service.buildVoiceHoursChart(guildId = 1L, days = 7)
+        assertEquals(7, chart.points.size)
+        assertEquals(1.0, chart.total, 0.001)
+        assertEquals(1.0, chart.max, 0.001)
+        assertEquals(today.minusDays(6), chart.firstDate)
+        assertEquals(today, chart.lastDate)
+        assertTrue(chart.polyline.isNotEmpty())
+    }
+
+    private fun serviceWithEmpty(): ActivityChartsService = ActivityChartsService(
+        messageDailyCounts = mockk(relaxed = true),
+        voiceSessions = mockk(relaxed = true),
+        clock = clock,
+    )
 
     private fun closedSession(startedAt: Instant, endedAt: Instant): VoiceSessionDto = VoiceSessionDto(
         id = 1L,


### PR DESCRIPTION
## Summary

The Activity sub-page at `/moderation/{guildId}/activity` (added in PR #558) is rendering the bot's generic "Something went wrong / Error 200 — OK" error block mid-page and cutting off the second chart. User reproduced on a deployed guild — screenshot showed the page intro and "MESSAGES PER DAY" heading render correctly, then "Total over window:" with no value, then the error block + footer.

### Root cause

The template called `T(web.service.ActivityChartsService).totalValue(...)`, `.maxValue(...)`, and `.polylinePoints(...)` via Thymeleaf SpEL static-type access. Those helpers lived on the `ActivityChartsService` companion object without `@JvmStatic`, so Kotlin compiles them as instance methods on `Companion` rather than static methods on the outer class. SpEL `T(...)` couldn't resolve them, threw an `EvaluationException` mid-render, and Spring's error resolver substituted the error fragment for the remainder of the response body.

(The `const val CHART_WIDTH / CHART_HEIGHT` references on the same companion *were* working — const vals compile to actual static fields.)

The other moderation sub-pages (`leveling.html`, `lottery.html`, etc.) pre-compute view values in the controller and pass them as model attributes. The activity page was the lone consumer of in-template service-method calls.

### Fix

Match the existing convention.

| Layer | Change |
|---|---|
| `ActivityChartsService.kt` | New `ChartView` data class bundles every value the template needs — pre-rendered polyline string, total/max headlines, viewBox dimensions, first/last date. New `buildMessagesChart(guildId)` / `buildVoiceHoursChart(guildId)` instance methods compose the existing series + the now-private `polylinePoints` helper. |
| `ModerationController.kt` | `activityPage` swaps the two raw-points model attributes (`messagesPerDay`, `voiceHoursPerDay`) for the new ChartView attributes (`messagesChart`, `voiceHoursChart`). |
| `activity.html` | Every `T(...)` call replaced with a plain `${chart.field}` read. Voice formatting keeps using `#numbers.formatDecimal` (Thymeleaf builtin, not a custom SpEL type lookup). |
| `ActivityChartsServiceTest.kt` | Existing polyline edge-case assertions now go through an instance helper (`service.polylinePoints(series)`). Two new cases cover `buildMessagesChart` / `buildVoiceHoursChart` returning fully-populated ChartView bundles. |

### Why pre-compute in the controller rather than `@JvmStatic` the companion

Both fixes work, but matching the existing moderation-page convention removes a category of "this template happens to work because the helper was compiled the right way" failure modes for any future consumer. With everything in the controller, the data flow into the template is visible at the request handler — no Thymeleaf-side service lookups.

## Test plan

- [x] `:web:test` — green (existing polyline cases ported, two new builder cases added)
- [ ] Manual: load `/moderation/{guildId}/activity` on a deployed guild — both charts render, footer follows the second chart, no error block in the middle
- [ ] Spot-check the rendered HTML: `<polyline points="...">` attribute should be a long space-separated `x,y` list

https://claude.ai/code/session_017tRi5q6K3NYHvYeZYzLzBD

---
_Generated by [Claude Code](https://claude.ai/code/session_017tRi5q6K3NYHvYeZYzLzBD)_