### PR TITLE
fix(leaderboard): left-align mobile XP + client-side sort the Members tab

### DIFF
--- a/web/src/main/resources/static/css/base.css
+++ b/web/src/main/resources/static/css/base.css
@@ -1214,11 +1214,11 @@ td { font-size: 0.95rem; }
     }
     /* XP gets its own full-width row below the other metrics so the
        Credits/Month/Voice strip stays the visual hero of the card.
-       Centered to balance the 3-cell row above. */
+       Left-aligned under the Credits column to anchor the eye to a
+       single vertical reading line rather than floating in the centre. */
     .lb-standings-table.mod-table td[data-label="XP"] {
         grid-area: m4;
-        align-items: center;
-        text-align: center;
+        align-items: flex-start;
     }
     .lb-standings-table.mod-table td[data-label="Credits"]::before,
     .lb-standings-table.mod-table td[data-label="TOBY"]::before,

--- a/web/src/main/resources/static/js/leaderboard.js
+++ b/web/src/main/resources/static/js/leaderboard.js
@@ -130,4 +130,73 @@
     document.addEventListener('keydown', (e) => {
         if (e.key === 'Escape') closeTooltip(openTooltip);
     });
+
+    // ===================================================================
+    // Client-side sort for the Members tab.
+    //
+    // The sort chips stay as <a href> for the no-JS case (full page reload
+    // re-runs the server-side sort on table + podium). When JS is on we
+    // hijack the click and re-order the standings <tbody> in place. The
+    // URL stays untouched and the podium (rendered for the URL's sort
+    // initially) is not re-sorted — treat chip-click as "re-order the
+    // table I'm looking at", not "navigate to a different view".
+    // Refreshing the page restores the canonical URL-driven sort.
+    // ===================================================================
+    const sortNav = document.querySelector('.lb-sort');
+    const tbody = document.querySelector('.lb-standings-table tbody');
+    if (sortNav && tbody) {
+        const valueAttr = {
+            month: 'data-credits-month',
+            lifetime: 'data-credits-total',
+            xp: 'data-xp',
+        };
+        const rankClass = (rank) =>
+            rank === 1 ? 'lb-rank-1'
+                : rank === 2 ? 'lb-rank-2'
+                    : rank === 3 ? 'lb-rank-3'
+                        : '';
+
+        function applySort(sortKey) {
+            const attr = valueAttr[sortKey];
+            if (!attr) return;
+
+            // Stable numeric-desc sort. Detach, sort, re-append.
+            const rows = Array.from(tbody.querySelectorAll('tr'));
+            rows.sort((a, b) => {
+                const av = Number(a.getAttribute(attr)) || 0;
+                const bv = Number(b.getAttribute(attr)) || 0;
+                return bv - av;
+            });
+            const frag = document.createDocumentFragment();
+            rows.forEach((tr, i) => {
+                const newRank = i + 1;
+                const rankEl = tr.querySelector('.lb-rank');
+                if (rankEl) {
+                    rankEl.textContent = String(newRank);
+                    rankEl.classList.remove('lb-rank-1', 'lb-rank-2', 'lb-rank-3');
+                    const cls = rankClass(newRank);
+                    if (cls) rankEl.classList.add(cls);
+                }
+                frag.appendChild(tr);
+            });
+            tbody.appendChild(frag);
+
+            // Toggle the active state on the chips so the visible
+            // selection follows the user's click.
+            sortNav.querySelectorAll('.lb-sort-option').forEach((c) => {
+                const isActive = c.dataset.sort === sortKey;
+                c.classList.toggle('active', isActive);
+                c.setAttribute('aria-selected', isActive ? 'true' : 'false');
+            });
+        }
+
+        sortNav.querySelectorAll('.lb-sort-option').forEach((chip) => {
+            chip.addEventListener('click', (e) => {
+                const sortKey = chip.dataset.sort;
+                if (!sortKey || !valueAttr[sortKey]) return; // fall through to href
+                e.preventDefault();
+                applySort(sortKey);
+            });
+        });
+    }
 })();

--- a/web/src/main/resources/templates/leaderboard.html
+++ b/web/src/main/resources/templates/leaderboard.html
@@ -171,6 +171,7 @@
         <a th:href="@{/leaderboard/{id}(id=${guildId}, sort='month')}"
            role="tab"
            class="lb-sort-option"
+           data-sort="month"
            th:classappend="${view.sort.name() == 'THIS_MONTH' ? 'active' : ''}"
            th:aria-selected="${view.sort.name() == 'THIS_MONTH'}">
             💰 Credits this month
@@ -178,6 +179,7 @@
         <a th:href="@{/leaderboard/{id}(id=${guildId}, sort='lifetime')}"
            role="tab"
            class="lb-sort-option"
+           data-sort="lifetime"
            th:classappend="${view.sort.name() == 'LIFETIME' ? 'active' : ''}"
            th:aria-selected="${view.sort.name() == 'LIFETIME'}">
             💰 Lifetime credits
@@ -185,6 +187,7 @@
         <a th:href="@{/leaderboard/{id}(id=${guildId}, sort='xp')}"
            role="tab"
            class="lb-sort-option"
+           data-sort="xp"
            th:classappend="${view.sort.name() == 'XP' ? 'active' : ''}"
            th:aria-selected="${view.sort.name() == 'XP'}">
             ✨ XP
@@ -224,7 +227,10 @@
                     </tr>
                     </thead>
                     <tbody>
-                    <tr th:each="row : ${view.standings}">
+                    <tr th:each="row : ${view.standings}"
+                        th:attr="data-credits-month=${row.creditsEarnedThisMonth},
+                                 data-credits-total=${row.socialCredit},
+                                 data-xp=${row.xp}">
                         <td data-label="#">
                             <span class="lb-rank"
                                   th:classappend="${row.rank == 1 ? 'lb-rank-1' : (row.rank == 2 ? 'lb-rank-2' : (row.rank == 3 ? 'lb-rank-3' : ''))}"


### PR DESCRIPTION
## Summary

Two follow-ups on the Members tab from screenshot review:

### 1. Mobile XP card — left-align under Credits

PR #560 added the XP cell as a third row spanning all three grid columns, centred. User reported it "still looks wonky" and wanted XP aligned under the Credits column instead. One-rule CSS change in `base.css`: drop `text-align: center` and switch `align-items` from `center` to `flex-start`, mirroring the m1 / Credits alignment. The cell still spans the full row; only the content shifts to the left edge.

### 2. Client-side sort for the standings table

The three sort chips (💰 Credits this month / 💰 Lifetime credits / ✨ XP) were `<a href>` links that triggered a full page reload to re-render with the new sort. The user asked if they could swap "without invoking a page refresh". With all rows already loaded server-side, in-page sort is straightforward.

**Progressive enhancement.** Chips keep their `<a href>` shape so no-JS users (and right-click "open in new tab" / share-link / refresh) still get the canonical server-rendered view. JS hijacks the click:

- Each `<tr>` carries `data-credits-month` / `data-credits-total` / `data-xp` so the handler can sort numerically without re-parsing cell text
- Each chip carries `data-sort="month|lifetime|xp"` so the handler doesn't have to parse the href
- `leaderboard.js` sorts the `<tbody>` in place desc, walks the new order to update `.lb-rank` text + the `lb-rank-1` / `lb-rank-2` / `lb-rank-3` gold/silver/bronze classes, and toggles `.active` + `aria-selected` on the chip nav

The URL stays untouched and the podium (rendered for the URL's sort initially) is **not** re-sorted client-side. Treating the chip as "re-order the table I'm looking at" rather than "navigate to a different view" keeps the URL canonical, avoids chasing the avatar-laden podium re-render, and means refresh restores a consistent state.

## Critical files

```
web/src/main/resources/static/css/base.css                   (one rule — left-align XP)
web/src/main/resources/templates/leaderboard.html            (data-* attrs on rows + chips)
web/src/main/resources/static/js/leaderboard.js              (onSortChipClick handler, ~45 lines)
```

No Kotlin changes; existing `LeaderboardWebService`/`LeaderboardSort` tests still cover the server-side path.

## Test plan

- [x] `:web:test` — green (no Kotlin changes, but build sanity)
- [ ] Manual desktop: click each chip → table re-sorts in place, chip becomes active, ranks renumber, gold/silver/bronze classes move, URL stays put
- [ ] Manual mobile: XP card sits at bottom-left of each row (vertically under the Credits column); sort chips still work without page navigation
- [ ] No-JS smoke test (DevTools "Disable JavaScript"): chip clicks fall back to full page reload via `href`, server re-renders with new sort (legacy behaviour preserved)
- [ ] Refresh after client-side sort: page repaints from the URL's original sort, podium consistent

https://claude.ai/code/session_017tRi5q6K3NYHvYeZYzLzBD

---
_Generated by [Claude Code](https://claude.ai/code/session_017tRi5q6K3NYHvYeZYzLzBD)_