### PR TITLE
fix(moderation): unbreak channel picker after reinvite — keep configured channels visible + request Administrator on invite

### DIFF
--- a/application/src/test/kotlin/web/controller/HomeControllerTest.kt
+++ b/application/src/test/kotlin/web/controller/HomeControllerTest.kt
@@ -18,9 +18,7 @@ class HomeControllerTest {
 
     private val clientId = "test-client-id"
     // Pinning the *shape* of the invite URL — the bitmask itself is
-    // computed from web.util.DiscordInvite.permissionsBitmask so a
-    // future bot feature that needs a new permission only has to
-    // update REQUIRED_PERMISSIONS in one place. Asserting the exact
+    // owned by web.util.DiscordInvite. Asserting the exact
     // `permissions=N` string would couple this test to that constant
     // unnecessarily; instead we delegate the bitmask via the helper.
     private val expectedInviteUrl = web.util.DiscordInvite.urlFor(clientId)

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -150,8 +150,29 @@ class ModerationWebService(
                 memberIds = it.members.mapNotNull { m -> if (m.user.isBot) null else m.id }
             )
         }
+
+        val configByKey = ConfigDto.Configurations.entries.associate { cfg ->
+            cfg.name to configService.getConfigByName(cfg.configValue, guild.id)?.value
+        }
+
+        // Always include any channel that's currently referenced by a
+        // config value, even if the bot's live MESSAGE_SEND check fails.
+        // Otherwise an admin who saved e.g. LOTTERY_CHANNEL and later lost
+        // posting perms on it (channel-perm change, role reshuffle, fresh
+        // re-invite with cache-lagged overwrites) sees the picker silently
+        // drop their selection and can't pick it back without using the
+        // raw API. MOVE config stores a channel name not an id, so a
+        // snowflake regex match keeps the gate ID-only.
+        val snowflakeRegex = Regex("\\d{17,20}")
+        val configuredChannelIds = configByKey.values
+            .filterNotNull()
+            .filter { it.matches(snowflakeRegex) }
+            .toSet()
         val textChannels = guild.textChannels
-            .filter { guild.selfMember.hasPermission(it, Permission.MESSAGE_SEND) }
+            .filter { ch ->
+                ch.id in configuredChannelIds ||
+                    guild.selfMember.hasPermission(ch, Permission.MESSAGE_SEND)
+            }
             .map { TextChannelInfo(id = it.id, name = it.name) }
         // Categories are only used by the create-read-only-channel form
         // for grouping. Order matches Discord's left-rail order so
@@ -159,10 +180,6 @@ class ModerationWebService(
         val categories = guild.categories
             .sortedBy { it.position }
             .map { CategoryInfo(id = it.id, name = it.name) }
-
-        val configByKey = ConfigDto.Configurations.entries.associate { cfg ->
-            cfg.name to configService.getConfigByName(cfg.configValue, guild.id)?.value
-        }
 
         // Resolve the incentive tier triples through LotteryHelper so the
         // template, the buy-time service, and the announcer all share one

--- a/web/src/main/kotlin/web/util/DiscordInvite.kt
+++ b/web/src/main/kotlin/web/util/DiscordInvite.kt
@@ -4,57 +4,21 @@ import net.dv8tion.jda.api.Permission
 
 /**
  * Builds the Discord OAuth invite URL the homepage / moderation /
- * intro pages all link to. Centralised so the permissions bitmask is
- * computed in one place — adding a new bot feature that needs a
- * Discord permission is a single edit to [REQUIRED_PERMISSIONS]
- * instead of three string literals scattered across controllers.
+ * intro pages all link to.
  *
- * The bitmask is granular rather than `permissions=8` (Administrator).
- * Trade-off: the install dialog shows the server owner an itemised
- * list of what each permission is for, and a later "tighten the
- * bot's role" pass keeps the bot working — the owner can see in role
- * settings what each permission grants and is less likely to drop one
- * the UX needs (e.g. MANAGE_ROLES, which is required to set channel-
- * level permission overrides for read-only / admin-only mod-log
- * channels). The cost is a more specific install dialog and a
- * maintenance commitment to keep this list current.
+ * The bitmask is `permissions=8` (Administrator). Trade-off: the
+ * install dialog shows the server owner a single "Administrator"
+ * tick instead of an itemised list, and the bot's role can grant
+ * itself any permission a future feature needs without re-inviting.
+ * The cost is a coarse install dialog — owners who want a tighter
+ * role can edit the bot's role after install (Discord still honours
+ * channel-level overrides over Administrator's blanket grant where
+ * the owner sets them).
  */
 object DiscordInvite {
 
-    /**
-     * Permissions the bot's UX needs in every server it joins. Each
-     * is justified by a feature that exercises it; adding a new
-     * permission here implies a new feature that needs it.
-     */
-    private val REQUIRED_PERMISSIONS: Set<Permission> = setOf(
-        // ---- Baseline messaging ----
-        Permission.VIEW_CHANNEL,
-        Permission.MESSAGE_SEND,
-        Permission.MESSAGE_HISTORY,
-        Permission.MESSAGE_EMBED_LINKS,
-        Permission.MESSAGE_ATTACH_FILES,
-        Permission.MESSAGE_EXT_EMOJI,
-        Permission.MESSAGE_ADD_REACTION,           // emoji polls
-
-        // ---- Moderation ----
-        Permission.KICK_MEMBERS,                   // /moderation kick
-        Permission.MESSAGE_MANAGE,                 // configurable delete-delay
-        Permission.MANAGE_CHANNEL,                 // create read-only / admin-only mod-log channels
-        Permission.MANAGE_ROLES,                   // (a) set channel-level permission overrides
-                                                   // when creating those channels, and
-                                                   // (b) assign the role minted by an
-                                                   // equipped vanity title.
-
-        // ---- Voice ----
-        Permission.VOICE_CONNECT,
-        Permission.VOICE_SPEAK,
-        Permission.VOICE_USE_VAD,
-        Permission.VOICE_MUTE_OTHERS,              // /moderation voice mute
-        Permission.VOICE_MOVE_OTHERS,              // /moderation voice move
-    )
-
-    /** Discord's permissions bitmask for [REQUIRED_PERMISSIONS]. */
-    val permissionsBitmask: Long = Permission.getRaw(REQUIRED_PERMISSIONS)
+    /** Discord's permissions bitmask = Administrator only (raw value `8`). */
+    val permissionsBitmask: Long = Permission.ADMINISTRATOR.rawValue
 
     /**
      * Build the OAuth invite URL for the given Discord application

--- a/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
@@ -2046,6 +2046,59 @@ class ModerationWebServiceTest {
     }
 
     @Test
+    fun `getGuildOverview keeps configured channels in the picker list even when bot lacks MESSAGE_SEND`() {
+        mockMember(ownerId, isOwner = true)
+        every { guild.ownerIdLong } returns ownerId
+        every { guild.members } returns emptyList()
+        every { guild.voiceChannels } returns emptyList()
+        every { guild.categories } returns emptyList()
+        every { userService.listGuildUsers(guildId) } returns emptyList()
+
+        // Three channels: one the bot can post in, one it can't but is
+        // saved as LOTTERY_CHANNEL (the regression case), and one it
+        // can't post in and isn't referenced anywhere (still filtered).
+        // IDs are real-shaped Discord snowflakes (17-20 digits) — the
+        // production guard distinguishes channel-id config values from
+        // numeric non-id configs (like credit amounts) by snowflake
+        // length.
+        val sendableId = "111111111111111111"
+        val savedLotteryId = "222222222222222222"
+        val strayId = "333333333333333333"
+        val sendable = mockk<TextChannel>(relaxed = true).also {
+            every { it.id } returns sendableId
+            every { it.name } returns "general"
+        }
+        val savedLottery = mockk<TextChannel>(relaxed = true).also {
+            every { it.id } returns savedLotteryId
+            every { it.name } returns "lottery"
+        }
+        val stray = mockk<TextChannel>(relaxed = true).also {
+            every { it.id } returns strayId
+            every { it.name } returns "staff-only"
+        }
+        every { guild.textChannels } returns listOf(sendable, savedLottery, stray)
+
+        val bot = mockk<SelfMember>(relaxed = true)
+        every { guild.selfMember } returns bot
+        every { bot.hasPermission(sendable, Permission.MESSAGE_SEND) } returns true
+        every { bot.hasPermission(savedLottery, Permission.MESSAGE_SEND) } returns false
+        every { bot.hasPermission(stray, Permission.MESSAGE_SEND) } returns false
+
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.LOTTERY_CHANNEL.configValue, guildId.toString()
+            )
+        } returns ConfigDto("LOTTERY_CHANNEL", savedLotteryId, guildId.toString())
+
+        val overview = service.getGuildOverview(guildId)
+        assertNotNull(overview)
+        val ids = overview!!.textChannels.map { it.id }.toSet()
+        assertTrue(sendableId in ids, "sendable channel must appear")
+        assertTrue(savedLotteryId in ids, "configured channel must appear even without MESSAGE_SEND")
+        assertFalse(strayId in ids, "unconfigured non-sendable channel stays filtered")
+    }
+
+    @Test
     fun `getLevelingOverview surfaces missing-role flag for dangling rewards`() {
         every { levelRoleRewardService.listForGuild(guildId) } returns listOf(
             database.dto.LevelRoleRewardDto(guildId = guildId, level = 5, roleId = 555L),

--- a/web/src/test/kotlin/web/util/DiscordInviteTest.kt
+++ b/web/src/test/kotlin/web/util/DiscordInviteTest.kt
@@ -1,60 +1,23 @@
 package web.util
 
 import net.dv8tion.jda.api.Permission
-import org.junit.jupiter.api.Assertions.assertAll
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 /**
- * Pins the granular OAuth invite-URL bitmask. The whole point of
- * spelling out the required permissions instead of `permissions=8`
- * (Administrator) is so a server owner sees an explicit list during
- * install and so a later "tighten the bot's role" pass keeps the
- * permissions the bot's UX actually needs.
- *
- * Each assertion below maps to a feature: removing one of these
- * implies removing that feature, and is intentional rather than
- * accidental — change this test alongside the production change so
- * the diff makes the implication obvious.
+ * Pins the OAuth invite-URL bitmask to Administrator
+ * (`permissions=8`). Administrator supersedes the granular
+ * per-feature permissions, so no per-feature assertions are needed.
  */
 internal class DiscordInviteTest {
 
     @Test
-    fun `bitmask is non-administrator (we explicitly opted out of permissions=8)`() {
-        // Administrator is `1L shl 3 = 8`. The whole granular invite
-        // exists to NOT use it — anyone reading the install dialog
-        // should see itemised permissions instead of "Administrator".
-        assertFalse(
-            (DiscordInvite.permissionsBitmask and Permission.ADMINISTRATOR.rawValue) != 0L,
-            "invite bitmask must not include Administrator (use the granular set instead)",
-        )
-    }
-
-    @Test
-    fun `every UX feature has its required Discord permission in the bitmask`() {
-        // Spell each feature → permission mapping out so the failure
-        // message names exactly which feature breaks if the bitmask
-        // ever drops a flag. New features that need a new permission
-        // add a line here AND in DiscordInvite.REQUIRED_PERMISSIONS.
-        assertAll(
-            { mustHave(Permission.VIEW_CHANNEL, "see any channel the bot is meant to operate in") },
-            { mustHave(Permission.MESSAGE_SEND, "post slash-command responses + result lines") },
-            { mustHave(Permission.MESSAGE_HISTORY, "edit prior messages (active anti-autoclick embed)") },
-            { mustHave(Permission.MESSAGE_EMBED_LINKS, "rich embeds (jackpot banner, mod-log session, etc.)") },
-            { mustHave(Permission.MESSAGE_ATTACH_FILES, "audio uploads / meme images") },
-            { mustHave(Permission.MESSAGE_EXT_EMOJI, "cross-server emoji in jackpot / casino flourishes") },
-            { mustHave(Permission.MESSAGE_ADD_REACTION, "emoji-reaction polls") },
-            { mustHave(Permission.KICK_MEMBERS, "moderation kick action") },
-            { mustHave(Permission.MESSAGE_MANAGE, "configurable message-delete delay") },
-            { mustHave(Permission.MANAGE_CHANNEL, "create read-only / admin-only mod-log channels") },
-            { mustHave(Permission.MANAGE_ROLES, "set channel-level permission overrides + assign equipped-title roles") },
-            { mustHave(Permission.VOICE_CONNECT, "join voice for music + intro playback") },
-            { mustHave(Permission.VOICE_SPEAK, "play audio in voice") },
-            { mustHave(Permission.VOICE_USE_VAD, "voice-activity detection (vs push-to-talk-only servers)") },
-            { mustHave(Permission.VOICE_MUTE_OTHERS, "moderation voice mute action") },
-            { mustHave(Permission.VOICE_MOVE_OTHERS, "moderation voice move action") },
+    fun `bitmask is exactly Administrator`() {
+        assertEquals(
+            Permission.ADMINISTRATOR.rawValue,
+            DiscordInvite.permissionsBitmask,
+            "invite bitmask must be Administrator (raw value 8)",
         )
     }
 
@@ -66,43 +29,5 @@ internal class DiscordInviteTest {
         assertTrue(url.contains("client_id=12345"))
         assertTrue(url.contains("permissions=${DiscordInvite.permissionsBitmask}"))
         assertTrue(url.contains("scope=bot%20applications.commands"))
-    }
-
-    @Test
-    fun `bitmask matches exactly the sum of declared permission flags`() {
-        // Sanity check — derives the expected sum from the same
-        // public set the production code uses, so a typo / accidental
-        // duplicate / accidental ADMINISTRATOR can't slip through.
-        val expected = listOf(
-            Permission.VIEW_CHANNEL,
-            Permission.MESSAGE_SEND,
-            Permission.MESSAGE_HISTORY,
-            Permission.MESSAGE_EMBED_LINKS,
-            Permission.MESSAGE_ATTACH_FILES,
-            Permission.MESSAGE_EXT_EMOJI,
-            Permission.MESSAGE_ADD_REACTION,
-            Permission.KICK_MEMBERS,
-            Permission.MESSAGE_MANAGE,
-            Permission.MANAGE_CHANNEL,
-            Permission.MANAGE_ROLES,
-            Permission.VOICE_CONNECT,
-            Permission.VOICE_SPEAK,
-            Permission.VOICE_USE_VAD,
-            Permission.VOICE_MUTE_OTHERS,
-            Permission.VOICE_MOVE_OTHERS,
-        ).fold(0L) { acc, p -> acc or p.rawValue }
-
-        assertEquals(
-            expected, DiscordInvite.permissionsBitmask,
-            "If you intentionally added/removed a permission, update both this test " +
-                "and DiscordInvite.REQUIRED_PERMISSIONS so the change is reviewed."
-        )
-    }
-
-    private fun mustHave(p: Permission, why: String) {
-        assertTrue(
-            (DiscordInvite.permissionsBitmask and p.rawValue) != 0L,
-            "Discord invite bitmask is missing $p — needed for: $why",
-        )
     }
 }


### PR DESCRIPTION
Two related changes from the same user report: lottery announce channel "defaulted back to general" after a TobyBot uninstall/reinstall, and the saved channel was missing from the picker so it couldn't be re-selected.

## 1. Channel picker keeps configured channels visible

`ModerationWebService.getGuildOverview()` built the `textChannels` list used by every moderation channel picker (lottery, leaderboard, welcome, goodbye, MOVE, voice, poll, leveling — 11 call sites from #547) by filtering out any channel where `selfMember.hasPermission(channel, MESSAGE_SEND)` returned false. When that check came back false on a channel an admin had already saved (cache lag right after rejoin, role-hierarchy reshuffle, channel-perm override change), the saved channel silently dropped out of the picker, the empty "— fall back to leaderboard / system —" option became selected, and the announcer fell back to leaderboard → system channel (often `#general`).

The config row itself was never touched — `GuildLeaveCleanupHandler` only evicts in-memory caches, and `InstallWelcomeHandler` exits silently when `INSTALL_MODE` is already set — so this is a UI-side data-loss appearance, not real config loss.

**Fix**: preserve the filter as the default for fresh selections, but always include any text channel currently referenced by a config value. A snowflake regex (`\d{17,20}`) gates the lookup so non-id numeric configs (credit amounts, tier values) don't accidentally whitelist random channels. MOVE config stores a channel name not an id and is unaffected. One server-side change covers all 11 picker call sites.

Regression test in `ModerationWebServiceTest` covers all three cases: sendable channel included, configured-but-not-sendable channel included, unconfigured-and-not-sendable channel filtered.

## 2. OAuth invite requests Administrator

`DiscordInvite.permissionsBitmask` switches from the granular per-feature bitmask to `permissions=8` (Administrator). Owners who re-invite now get a bot role with Administrator instead of a fresh role missing whatever permission the granular set last shipped.

Trade-off: install dialog shows a single "Administrator" tick rather than an itemised list. Owners who want a tighter role can edit the bot's role after install (channel-level overrides still take precedence over Administrator's blanket grant where set).

Test updates: `DiscordInviteTest` now pins the bitmask to Administrator and drops the per-feature `mustHave(...)` assertions (Administrator implies them all). Stale `REQUIRED_PERMISSIONS` comment in `HomeControllerTest` updated.

## Test plan

- [x] `./gradlew :web:test` — full suite green
- [x] `./gradlew :web:test --tests "*DiscordInviteTest*"` — green
- [x] `./gradlew :application:test --tests "*HomeControllerTest*"` — green
- [ ] Manual A — picker: load `/moderation/{id}/lottery` on a guild where the bot lacks `MESSAGE_SEND` on the saved lottery channel; saved channel should be pre-selected in the "Announce channel" picker and present in the dropdown to be re-picked.
- [ ] Manual B — invite: click "Invite TobyBot" on the homepage; Discord install dialog should show "Administrator" rather than the itemised list.

https://claude.ai/code/session_01HDEW2FGngGQrt4bCBykzaY