### PR TITLE
fix(commands-wiki): drive category visibility from section.hidden, not a hardcoded allowlist

### DIFF
--- a/web/src/main/resources/static/css/commands.css
+++ b/web/src/main/resources/static/css/commands.css
@@ -162,18 +162,10 @@ input.commands-search-input:focus {
 }
 .cat-section { scroll-margin-top: 80px; }
 
-/* Category visibility driven by the [data-active-cat] attribute on the
-   page root — JS only flips that one attribute, the CSS does the rest. */
-.commands-page[data-active-cat="all"] .cat-section,
-.commands-page[data-active-cat="music"] .cat-section[data-cat="music"],
-.commands-page[data-active-cat="dnd"] .cat-section[data-cat="dnd"],
-.commands-page[data-active-cat="moderation"] .cat-section[data-cat="moderation"],
-.commands-page[data-active-cat="economy"] .cat-section[data-cat="economy"],
-.commands-page[data-active-cat="misc"] .cat-section[data-cat="misc"],
-.commands-page[data-active-cat="fetch"] .cat-section[data-cat="fetch"] {
-    display: block;
-}
-.commands-page:not([data-active-cat="all"]) .cat-section { display: none; }
+/* Category visibility is driven by `[hidden]` on each .cat-section,
+   set in commands.js based on the active filter chip and search query.
+   The `.cat-section[hidden]` rule lower in this file does the actual
+   hide. */
 
 .cat-header {
     display: flex;

--- a/web/src/main/resources/static/js/commands.js
+++ b/web/src/main/resources/static/js/commands.js
@@ -1,7 +1,7 @@
 /* commands.js — search, category filter, copy-to-clipboard, and URL hash
-   sync for the commands page. No framework. The CSS handles the category
-   show/hide via [data-active-cat]; this script only filters cards by
-   search text and toggles per-section visibility when a category empties. */
+   sync for the commands page. No framework. JS sets `section.hidden` on
+   each .cat-section based on the active chip + search query; CSS does
+   the hide via the existing `.cat-section[hidden]` rule. */
 (function () {
     'use strict';
 
@@ -47,7 +47,6 @@
     }
 
     function applyFilters() {
-        page.dataset.activeCat = activeCat;
         const needle = query.trim().toLowerCase();
         let visibleTotal = 0;
 
@@ -64,10 +63,12 @@
                 if (show) visibleInSection += 1;
             });
 
-            // Even though CSS already handles category-only hiding, we hide
-            // sections that are empty *because of a search query* (so an
-            // "All" view with a needle doesn't render empty category headers).
-            section.hidden = catMatches && visibleInSection === 0 && needle.length > 0;
+            // Hide a section when the active chip doesn't match it, or
+            // when a search query has emptied it out. Driving visibility
+            // from `section.hidden` (rather than a CSS allowlist keyed on
+            // each category slug) means a new CATEGORY_META entry needs
+            // no CSS edits.
+            section.hidden = !catMatches || (visibleInSection === 0 && needle.length > 0);
             visibleTotal += visibleInSection;
         });
 

--- a/web/src/main/resources/templates/commands.html
+++ b/web/src/main/resources/templates/commands.html
@@ -10,7 +10,7 @@
 <a href="#main" class="skip-link">Skip to content</a>
 <div th:replace="~{fragments/navbar :: navbar}"></div>
 
-<main id="main" class="commands-page" data-active-cat="all">
+<main id="main" class="commands-page">
 
     <header class="commands-hero">
         <span class="section-eyebrow">Commands</span>


### PR DESCRIPTION
## Summary

- Fixes the empty **Games** filter on `/commands/wiki` (regression from #563): the previous CSS enumerated every valid `data-active-cat` slug, the new `games` slug wasn't on the list, so clicking the chip hit the `:not(...)` fallback and hid every section.
- Refactors the visibility model so the bug class can't recur: `applyFilters()` already iterates every section and knows whether each matches the active chip, so it now sets `section.hidden` for the category miss too. The `.cat-section[hidden] { display: none !important; }` rule lower in `commands.css` is the single visibility mechanism. The hardcoded `[data-active-cat="…"] .cat-section[data-cat="…"]` allowlist and the `data-active-cat="all"` attribute on `.commands-page` are gone.
- Net effect: a future `CATEGORY_META` entry in `CommandWikiController` needs **zero CSS or JS edits** to filter correctly.

## Test plan

- [ ] `./gradlew :web:test` (passes locally).
- [ ] Visit `/commands/wiki`, click each chip in order (`All`, `Music`, `D&D`, `Moderation`, `Games`, `Economy`, `Misc`, `Fetch`) and confirm only the matching section is visible, with `All` showing everything. Games should populate with its 19 commands.
- [ ] Load `/commands/wiki#cat=games` directly — page should boot with Games chip active and only the Games section visible.
- [ ] With Games active, type `rps` in the search — only the RPS card should remain; clear search to repopulate the Games section.
- [ ] Pick a chip + a needle that matches nothing — empty state hero should appear; the **clear filters** link should reset to `All` with everything visible.

https://claude.ai/code/session_01Gu12R3U1kygmu5c7qCPmYF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu12R3U1kygmu5c7qCPmYF)_