### PR TITLE
feat(moderation): redesign Activity tab + pill-style sub-nav

### DIFF
--- a/web/src/main/kotlin/web/service/ActivityChartsService.kt
+++ b/web/src/main/kotlin/web/service/ActivityChartsService.kt
@@ -26,10 +26,10 @@ import kotlin.math.round
  * to worry about gaps in the X axis.
  *
  * The page renders via [ChartView] — a render-ready bundle of pre-
- * computed polyline + headline numbers + date range — so the template
- * never has to call helper functions through Thymeleaf SpEL. See
- * [buildMessagesChart] and [buildVoiceHoursChart] for the controller-
- * facing entry points.
+ * computed polyline + area polygon + axis labels + headline numbers —
+ * so the template never has to call helper functions through Thymeleaf
+ * SpEL. See [buildMessagesChart] and [buildVoiceHoursChart] for the
+ * controller-facing entry points.
  */
 @Service
 class ActivityChartsService(
@@ -46,6 +46,20 @@ class ActivityChartsService(
         val valueLong: Long get() = value.toLong()
     }
 
+    /** One pre-computed `<circle>` marker for the chart. */
+    data class Marker(
+        val x: Double,
+        val y: Double,
+        val date: LocalDate,
+        val value: Double,
+    )
+
+    /** One Y-axis gridline with its rendered value + the SVG y-coordinate. */
+    data class GridLine(
+        val value: Double,
+        val y: Double,
+    )
+
     /**
      * Render-ready bundle for one chart. Everything the template needs
      * is pre-computed in the service so the Thymeleaf page only has to
@@ -57,8 +71,18 @@ class ActivityChartsService(
         val points: List<DailyPoint>,
         /** Pre-rendered SVG `points="..."` value for `<polyline>`. */
         val polyline: String,
+        /** Polyline + baseline corners — drops straight into `<polygon points="...">`. */
+        val areaPolygon: String,
+        /** Per-day markers for hover-tooltip targeting. */
+        val markers: List<Marker>,
+        /** Three Y-axis gridlines: 0, mid, max. Pre-positioned in SVG units. */
+        val gridLines: List<GridLine>,
+        /** Three X-axis tick dates: first, middle, last. */
+        val axisDates: List<LocalDate>,
         val total: Double,
         val max: Double,
+        val dailyAverage: Double,
+        val nonZeroDays: Int,
         val viewBoxWidth: Int,
         val viewBoxHeight: Int,
         val firstDate: LocalDate?,
@@ -67,7 +91,7 @@ class ActivityChartsService(
         /** Display-only int variants for headline strong-tags. */
         val totalRounded: Long get() = round(total).toLong()
         val maxRounded: Long get() = round(max).toLong()
-        val isEmpty: Boolean get() = points.isEmpty()
+        val isEmpty: Boolean get() = points.isEmpty() || points.all { it.value == 0.0 }
     }
 
     /** Build the messages-per-day chart for [guildId]. */
@@ -134,40 +158,95 @@ class ActivityChartsService(
         }
     }
 
-    private fun toChartView(series: List<DailyPoint>): ChartView = ChartView(
-        points = series,
-        polyline = polylinePoints(series),
-        total = series.sumOf { it.value },
-        max = series.maxOfOrNull { it.value } ?: 0.0,
-        viewBoxWidth = CHART_WIDTH,
-        viewBoxHeight = CHART_HEIGHT,
-        firstDate = series.firstOrNull()?.date,
-        lastDate = series.lastOrNull()?.date,
-    )
+    private fun toChartView(series: List<DailyPoint>): ChartView {
+        val coords = pointCoords(series)
+        val markers = coords.mapIndexed { i, (x, y) ->
+            Marker(x = x, y = y, date = series[i].date, value = series[i].value)
+        }
+        val polyline = coords.joinToString(" ") { (x, y) -> "%.1f,%.1f".format(x, y) }
+        val areaPolygon = if (coords.isEmpty()) {
+            ""
+        } else {
+            val baseY = (CHART_HEIGHT - CHART_PADDING).toDouble()
+            val firstX = coords.first().first
+            val lastX = coords.last().first
+            polyline +
+                " %.1f,%.1f".format(lastX, baseY) +
+                " %.1f,%.1f".format(firstX, baseY)
+        }
+        val total = series.sumOf { it.value }
+        val maxVal = series.maxOfOrNull { it.value } ?: 0.0
+        val nonZero = series.count { it.value > 0.0 }
+        val average = if (series.isEmpty()) 0.0 else total / series.size
+        return ChartView(
+            points = series,
+            polyline = polyline,
+            areaPolygon = areaPolygon,
+            markers = markers,
+            gridLines = gridLines(maxVal),
+            axisDates = axisDates(series),
+            total = total,
+            max = maxVal,
+            dailyAverage = average,
+            nonZeroDays = nonZero,
+            viewBoxWidth = CHART_WIDTH,
+            viewBoxHeight = CHART_HEIGHT,
+            firstDate = series.firstOrNull()?.date,
+            lastDate = series.lastOrNull()?.date,
+        )
+    }
+
+    /**
+     * One `(x, y)` pair per data point in [series], padded inside the
+     * chart's viewBox. Single source of truth used by the polyline,
+     * area polygon, and per-point markers.
+     *
+     * Y-axis normalises to the series max so an all-zero series sits
+     * flat on the baseline (max is clamped to 1.0 to avoid div-by-zero).
+     */
+    private fun pointCoords(series: List<DailyPoint>): List<Pair<Double, Double>> {
+        if (series.isEmpty()) return emptyList()
+        val innerW = CHART_WIDTH - 2 * CHART_PADDING
+        val innerH = CHART_HEIGHT - 2 * CHART_PADDING
+        val maxVal = series.maxOf { it.value }.coerceAtLeast(1.0)
+        val stepX = if (series.size <= 1) 0.0 else innerW.toDouble() / (series.size - 1)
+        return series.mapIndexed { i, point ->
+            val x = CHART_PADDING + i * stepX
+            val y = CHART_PADDING + innerH - (point.value / maxVal) * innerH
+            x to y
+        }
+    }
 
     /**
      * Build the `points="..."` value for an `<svg><polyline>` rendering
-     * of [series]. Y-axis normalises to the series max; an all-zero
-     * series renders along the bottom of the chart so the baseline is
-     * always visible. The chart is padded inside the SVG so the top
-     * edge doesn't clip the highest point.
-     *
-     * Internal — the controller never calls this directly; templates
-     * read [ChartView.polyline] from the bundle [buildMessagesChart]
-     * returns.
+     * of [series]. Kept as an internal helper so the existing test
+     * suite (and any future template that wants the raw polyline) still
+     * has a thin entry point, but the implementation delegates to
+     * [pointCoords] so geometry stays in one place.
      */
-    internal fun polylinePoints(series: List<DailyPoint>): String {
-        if (series.isEmpty()) return ""
-        val padding = 8.0
-        val innerW = CHART_WIDTH - 2 * padding
-        val innerH = CHART_HEIGHT - 2 * padding
-        val maxVal = series.maxOf { it.value }.coerceAtLeast(1.0)
-        val stepX = if (series.size <= 1) 0.0 else innerW / (series.size - 1)
-        return series.mapIndexed { i, point ->
-            val x = padding + i * stepX
-            val y = padding + innerH - (point.value / maxVal) * innerH
-            "%.1f,%.1f".format(x, y)
-        }.joinToString(" ")
+    internal fun polylinePoints(series: List<DailyPoint>): String =
+        pointCoords(series).joinToString(" ") { (x, y) -> "%.1f,%.1f".format(x, y) }
+
+    /** Three Y-axis ticks — 0, mid, max — pre-positioned in SVG coords. */
+    private fun gridLines(maxVal: Double): List<GridLine> {
+        if (maxVal <= 0.0) return emptyList()
+        val innerH = CHART_HEIGHT - 2 * CHART_PADDING
+        val baseY = CHART_PADDING + innerH
+        val topY = CHART_PADDING.toDouble()
+        val midY = (baseY + topY) / 2.0
+        return listOf(
+            GridLine(value = maxVal, y = topY),
+            GridLine(value = maxVal / 2.0, y = midY),
+            GridLine(value = 0.0, y = baseY.toDouble()),
+        )
+    }
+
+    /** First, middle, and last dates in the series — used for X-axis labels. */
+    private fun axisDates(series: List<DailyPoint>): List<LocalDate> = when {
+        series.isEmpty() -> emptyList()
+        series.size == 1 -> listOf(series[0].date)
+        series.size == 2 -> listOf(series[0].date, series[1].date)
+        else -> listOf(series.first().date, series[series.size / 2].date, series.last().date)
     }
 
     private fun fillRange(since: LocalDate, today: LocalDate): List<LocalDate> {
@@ -185,5 +264,8 @@ class ActivityChartsService(
         /** Width / height for the per-chart SVG. Picked to match the moderation panel grid. */
         const val CHART_WIDTH: Int = 600
         const val CHART_HEIGHT: Int = 180
+
+        /** Inner padding so the polyline and markers never touch the chart edge. */
+        private const val CHART_PADDING: Int = 12
     }
 }

--- a/web/src/main/resources/static/css/moderation.css
+++ b/web/src/main/resources/static/css/moderation.css
@@ -51,12 +51,15 @@ details.config-section.is-hidden { display: none; }
 .mod-subnav {
     display: flex;
     flex-wrap: nowrap;
-    gap: 4px;
+    gap: var(--space-1);
     overflow-x: auto;
     overflow-y: hidden;
     scrollbar-width: thin;
     -webkit-overflow-scrolling: touch;
-    border-bottom: 1px solid var(--border);
+    padding: var(--space-1);
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
     margin-bottom: var(--space-5);
 }
 .mod-subnav::-webkit-scrollbar { height: 4px; }
@@ -77,14 +80,17 @@ details.config-section.is-hidden { display: none; }
     padding: var(--space-2) var(--space-4);
     text-decoration: none;
     font-size: inherit;
-    border-bottom: 2px solid transparent;
-    margin-bottom: -1px;
-    transition: color 0.15s, border-color 0.15s;
+    border-radius: var(--radius-sm);
+    transition: color 0.15s, background-color 0.15s;
 }
-.mod-subnav-link:hover { color: var(--text); }
+.mod-subnav-link:hover {
+    color: var(--text);
+    background: var(--accent-soft);
+}
 .mod-subnav-link.active {
     color: var(--accent);
-    border-bottom-color: var(--accent);
+    background: var(--accent-soft);
+    font-weight: 600;
 }
 
 .mod-panel { display: block; }
@@ -1064,4 +1070,217 @@ details.config-section.is-hidden { display: none; }
     .welcome-autorole-add label {
         flex: 1 1 100%;
     }
+}
+
+/* ==============================================================
+   Activity tab — stat tiles + polished area charts with axes,
+   gridlines, markers, and hover tooltips. Layered as:
+     .activity-block (one per metric)
+       └─ .activity-stats  → grid of .activity-stat tiles
+       └─ .activity-chart-card → chart container with axes + svg
+   The chart card hosts the SVG plus absolutely-positioned axis
+   labels and the floating .activity-tooltip; the tooltip is driven
+   by /js/moderation/activity.js.
+   ============================================================== */
+
+:root {
+    --activity-msg: #5b8def;
+    --activity-voice: #57f287;
+}
+
+.activity-panel { display: flex; flex-direction: column; gap: var(--space-6); }
+
+.activity-intro {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-4);
+    flex-wrap: wrap;
+}
+.activity-intro p { margin: 0; max-width: 60ch; }
+.activity-date-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: 4px var(--space-3);
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    font-size: 0.82rem;
+    font-variant-numeric: tabular-nums;
+    color: var(--text-muted);
+    white-space: nowrap;
+}
+
+.activity-block {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+}
+
+.activity-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: var(--space-3);
+}
+.activity-stat {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--activity-color, var(--accent));
+    border-radius: var(--radius-md);
+    padding: var(--space-3) var(--space-4);
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+.activity-stat-label {
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-weight: 600;
+    color: var(--text-muted);
+}
+.activity-stat-value {
+    font-size: 1.6rem;
+    font-weight: 700;
+    color: var(--text);
+    line-height: 1.1;
+    font-variant-numeric: tabular-nums;
+}
+.activity-stat-sub {
+    font-size: 0.78rem;
+    color: var(--text-dim);
+}
+
+.activity-chart-card {
+    /* Position context for the floating .activity-tooltip. */
+    position: relative;
+    gap: var(--space-3);
+}
+.activity-chart-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3);
+}
+.activity-chart-head h3 {
+    /* Larger than the default .mod-card h3 — this is the chart's primary label. */
+    font-size: 1rem;
+    text-transform: none;
+    letter-spacing: 0;
+    color: var(--text);
+    font-weight: 600;
+}
+
+.activity-chart-body {
+    position: relative;
+    padding-left: 44px;   /* leave room for the Y-axis labels */
+    padding-bottom: 22px; /* and the X-axis labels */
+}
+.activity-chart {
+    display: block;
+    width: 100%;
+    height: 220px;
+    overflow: visible;
+}
+.activity-grid-line {
+    stroke: var(--border);
+    stroke-width: 1;
+    stroke-dasharray: 2 4;
+    opacity: 0.6;
+}
+.activity-area {
+    pointer-events: none;
+}
+.activity-line {
+    stroke: var(--activity-color, var(--accent));
+    pointer-events: none;
+}
+.activity-marker {
+    fill: var(--activity-color, var(--accent));
+    opacity: 0;
+    transition: opacity 0.12s, r 0.12s;
+    pointer-events: none;
+}
+.activity-marker.is-active {
+    opacity: 1;
+    r: 4.5;
+}
+
+.activity-axis-y,
+.activity-axis-x {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    font-size: 0.72rem;
+    color: var(--text-dim);
+    font-variant-numeric: tabular-nums;
+    pointer-events: none;
+}
+.activity-axis-y {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 40px;
+    height: 220px;
+}
+.activity-axis-y li {
+    position: absolute;
+    right: 6px;
+    transform: translateY(-50%);
+}
+.activity-axis-x {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 4px;
+    padding: 0 4px;
+}
+
+.activity-tooltip {
+    position: absolute;
+    pointer-events: none;
+    transform: translate(-50%, calc(-100% - 12px));
+    background: var(--bg);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-sm);
+    padding: 6px var(--space-2);
+    font-size: 0.78rem;
+    line-height: 1.3;
+    color: var(--text);
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
+    white-space: nowrap;
+    z-index: 4;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+.activity-tooltip[hidden] { display: none; }
+.activity-tooltip-value {
+    font-weight: 600;
+    color: var(--text);
+    font-variant-numeric: tabular-nums;
+}
+.activity-tooltip-date {
+    color: var(--text-muted);
+    font-size: 0.7rem;
+}
+
+.activity-empty {
+    margin: 0;
+    padding: var(--space-6) var(--space-4);
+    text-align: center;
+    color: var(--text-muted);
+    background: var(--bg);
+    border: 1px dashed var(--border);
+    border-radius: var(--radius-md);
+}
+
+@media (max-width: 600px) {
+    .activity-chart { height: 180px; }
+    .activity-axis-y { height: 180px; }
+    .activity-stats { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .activity-stat-value { font-size: 1.35rem; }
+}
+@media (max-width: 380px) {
+    .activity-stats { grid-template-columns: minmax(0, 1fr); }
 }

--- a/web/src/main/resources/static/js/moderation/activity.js
+++ b/web/src/main/resources/static/js/moderation/activity.js
@@ -1,0 +1,95 @@
+/*
+ * Moderation → Activity tab: per-chart hover tooltip + marker
+ * highlight. Server has already rendered every `<circle>` marker with
+ * its date / value baked into `data-` attributes, so this is a pure
+ * progressive-enhancement layer — without the script the chart still
+ * reads as a static area chart, just without the floating tooltip.
+ */
+(function () {
+    'use strict';
+
+    function setup(card) {
+        var body = card.querySelector('.activity-chart-body');
+        if (!body) return;
+        var svg = body.querySelector('.activity-chart');
+        var tooltip = body.querySelector('.activity-tooltip');
+        if (!svg || !tooltip) return;
+        var markers = Array.prototype.slice.call(svg.querySelectorAll('.activity-marker'));
+        if (markers.length === 0) return;
+
+        // Pre-read marker geometry / data so we don't touch the DOM on every mousemove.
+        var points = markers.map(function (m) {
+            return {
+                node: m,
+                cx: parseFloat(m.getAttribute('cx')),
+                cy: parseFloat(m.getAttribute('cy')),
+                date: m.getAttribute('data-date'),
+                value: m.getAttribute('data-value'),
+                unit: m.getAttribute('data-unit') || ''
+            };
+        });
+        var viewBox = svg.viewBox.baseVal;
+
+        function findClosest(svgX) {
+            var best = points[0];
+            var bestDx = Math.abs(svgX - best.cx);
+            for (var i = 1; i < points.length; i++) {
+                var dx = Math.abs(svgX - points[i].cx);
+                if (dx < bestDx) {
+                    best = points[i];
+                    bestDx = dx;
+                }
+            }
+            return best;
+        }
+
+        function clearActive() {
+            for (var i = 0; i < points.length; i++) {
+                points[i].node.classList.remove('is-active');
+            }
+        }
+
+        svg.addEventListener('mousemove', function (event) {
+            var rect = svg.getBoundingClientRect();
+            if (rect.width === 0) return;
+            var svgX = ((event.clientX - rect.left) / rect.width) * viewBox.width;
+            var point = findClosest(svgX);
+
+            clearActive();
+            point.node.classList.add('is-active');
+
+            tooltip.innerHTML =
+                '<span class="activity-tooltip-value">' +
+                escapeHtml(point.value) + ' ' + escapeHtml(point.unit) +
+                '</span>' +
+                '<span class="activity-tooltip-date">' + escapeHtml(point.date) + '</span>';
+            tooltip.hidden = false;
+
+            // Tooltip is absolutely positioned inside .activity-chart-body (the
+            // nearest positioned ancestor), so the math has to use the body rect,
+            // not the card rect.
+            var bodyRect = body.getBoundingClientRect();
+            tooltip.style.left = (event.clientX - bodyRect.left) + 'px';
+            tooltip.style.top = (event.clientY - bodyRect.top) + 'px';
+        });
+
+        svg.addEventListener('mouseleave', function () {
+            clearActive();
+            tooltip.hidden = true;
+        });
+    }
+
+    function escapeHtml(value) {
+        if (value == null) return '';
+        return String(value)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;');
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        var cards = document.querySelectorAll('.activity-chart-card');
+        for (var i = 0; i < cards.length; i++) setup(cards[i]);
+    });
+})();

--- a/web/src/main/resources/templates/moderation/activity.html
+++ b/web/src/main/resources/templates/moderation/activity.html
@@ -13,80 +13,194 @@
     <div th:replace="~{fragments/moderationHeader :: moderationHeader(${overview}, ${isOwner}, 'activity')}"></div>
 
     <!--
-        Server-wide activity charts. 30-day rolling window, UTC-bucketed.
-        Two metrics:
-          - Messages/day: from `message_daily_count`, populated by
-            `MessageActivityBuffer` (in-memory accumulator flushed once
-            a minute off the JDA dispatch thread).
-          - Voice hours/day: aggregated at query time over closed
-            voice sessions, splitting each session across the calendar
-            days it touched.
-        Both series are pre-padded with zero-days so the SVG always has
-        one point per calendar day in the window.
-
-        Render values are pre-computed in ActivityChartsService and
-        passed as `messagesChart` / `voiceHoursChart` ChartView bundles —
-        the template only reads simple `${chart.field}` properties, no
-        SpEL static-type calls.
+        Server-wide activity dashboard. 30-day rolling window, UTC-bucketed.
+        Two metrics — messages/day and voice-hours/day — each rendered as
+        a stat-tile row + a polished SVG area chart with gridlines, axis
+        labels, and hover tooltips (see /js/moderation/activity.js).
+        Render values come pre-computed off ActivityChartsService.ChartView;
+        the template only reads simple `${chart.field}` properties.
     -->
-    <section class="mod-panel" data-panel="activity">
-        <p class="muted mb-4">
-            30-day rolling activity for this server. Messages start being
-            counted once the bot is rolled out with this feature — historical
-            messages from before deployment are not backfilled.
-        </p>
-
-        <div class="mod-card mod-card-wide">
-            <h3>💬 Messages per day</h3>
+    <section class="mod-panel activity-panel" data-panel="activity">
+        <div class="activity-intro">
             <p class="muted">
-                Total over window:
-                <strong th:text="${messagesChart.totalRounded}">0</strong>
-                · Peak day:
-                <strong th:text="${messagesChart.maxRounded}">0</strong>
+                30-day rolling activity for this server. Messages start being
+                counted once the bot is rolled out with this feature —
+                historical messages from before deployment are not backfilled.
             </p>
-            <svg th:unless="${messagesChart.empty}"
-                 class="activity-chart"
-                 role="img"
-                 aria-label="Messages per day, 30-day rolling"
-                 th:attr="viewBox=|0 0 ${messagesChart.viewBoxWidth} ${messagesChart.viewBoxHeight}|"
-                 preserveAspectRatio="none">
-                <polyline fill="none"
-                          stroke="#5b8def"
-                          stroke-width="2"
-                          th:attr="points=${messagesChart.polyline}"/>
-            </svg>
-            <p class="muted small" th:unless="${messagesChart.empty}">
+            <span class="activity-date-pill"
+                  th:if="${messagesChart.firstDate != null}">
                 <span th:text="${messagesChart.firstDate}">2026-04-23</span>
-                →
+                <span aria-hidden="true">→</span>
                 <span th:text="${messagesChart.lastDate}">2026-05-23</span>
-            </p>
+            </span>
         </div>
 
-        <div class="mod-card mod-card-wide">
-            <h3>🎤 Voice hours per day</h3>
-            <p class="muted">
-                Total over window:
-                <strong th:text="${#numbers.formatDecimal(voiceHoursChart.total, 1, 1)}">0</strong>
-                hours · Peak day:
-                <strong th:text="${#numbers.formatDecimal(voiceHoursChart.max, 1, 1)}">0</strong>
-                hours
-            </p>
-            <svg th:unless="${voiceHoursChart.empty}"
-                 class="activity-chart"
-                 role="img"
-                 aria-label="Voice hours per day, 30-day rolling"
-                 th:attr="viewBox=|0 0 ${voiceHoursChart.viewBoxWidth} ${voiceHoursChart.viewBoxHeight}|"
-                 preserveAspectRatio="none">
-                <polyline fill="none"
-                          stroke="#57f287"
-                          stroke-width="2"
-                          th:attr="points=${voiceHoursChart.polyline}"/>
-            </svg>
-            <p class="muted small" th:unless="${voiceHoursChart.empty}">
-                <span th:text="${voiceHoursChart.firstDate}">2026-04-23</span>
-                →
-                <span th:text="${voiceHoursChart.lastDate}">2026-05-23</span>
-            </p>
+        <!-- Messages -->
+        <div class="activity-block" data-metric="messages"
+             style="--activity-color: var(--activity-msg);">
+            <div class="activity-stats">
+                <div class="activity-stat">
+                    <span class="activity-stat-label">Total messages</span>
+                    <span class="activity-stat-value"
+                          th:text="${#numbers.formatInteger(messagesChart.totalRounded, 1, 'COMMA')}">0</span>
+                    <span class="activity-stat-sub">past 30 days</span>
+                </div>
+                <div class="activity-stat">
+                    <span class="activity-stat-label">Average / day</span>
+                    <span class="activity-stat-value"
+                          th:text="${#numbers.formatDecimal(messagesChart.dailyAverage, 1, 1)}">0</span>
+                    <span class="activity-stat-sub">messages</span>
+                </div>
+                <div class="activity-stat">
+                    <span class="activity-stat-label">Peak day</span>
+                    <span class="activity-stat-value"
+                          th:text="${#numbers.formatInteger(messagesChart.maxRounded, 1, 'COMMA')}">0</span>
+                    <span class="activity-stat-sub">messages</span>
+                </div>
+                <div class="activity-stat">
+                    <span class="activity-stat-label">Active days</span>
+                    <span class="activity-stat-value"
+                          th:text="${messagesChart.nonZeroDays}">0</span>
+                    <span class="activity-stat-sub">of <span th:text="${#lists.size(messagesChart.points)}">30</span></span>
+                </div>
+            </div>
+
+            <div class="activity-chart-card mod-card mod-card-wide">
+                <div class="activity-chart-head">
+                    <h3>💬 Messages per day</h3>
+                </div>
+                <div class="activity-chart-body" th:unless="${messagesChart.empty}">
+                    <svg class="activity-chart"
+                         role="img"
+                         aria-label="Messages per day, 30-day rolling"
+                         th:attr="viewBox=|0 0 ${messagesChart.viewBoxWidth} ${messagesChart.viewBoxHeight}|"
+                         preserveAspectRatio="none">
+                        <defs>
+                            <linearGradient id="activityGradMessages" x1="0" x2="0" y1="0" y2="1">
+                                <stop offset="0%" style="stop-color: var(--activity-color); stop-opacity: 0.35;"/>
+                                <stop offset="100%" style="stop-color: var(--activity-color); stop-opacity: 0;"/>
+                            </linearGradient>
+                        </defs>
+                        <g class="activity-grid">
+                            <line th:each="g : ${messagesChart.gridLines}"
+                                  class="activity-grid-line"
+                                  x1="0" x2="600"
+                                  th:attr="y1=${g.y},y2=${g.y}"/>
+                        </g>
+                        <polygon class="activity-area"
+                                 th:attr="points=${messagesChart.areaPolygon}"
+                                 fill="url(#activityGradMessages)"/>
+                        <polyline class="activity-line"
+                                  fill="none"
+                                  stroke-width="2"
+                                  stroke-linejoin="round"
+                                  stroke-linecap="round"
+                                  th:attr="points=${messagesChart.polyline}"/>
+                        <g class="activity-markers">
+                            <circle th:each="m : ${messagesChart.markers}"
+                                    class="activity-marker"
+                                    r="3"
+                                    th:attr="cx=${m.x},cy=${m.y},data-date=${m.date},data-value=${#numbers.formatDecimal(m.value, 1, 0)},data-unit='messages'"/>
+                        </g>
+                    </svg>
+                    <ul class="activity-axis-y" aria-hidden="true">
+                        <li th:each="g : ${messagesChart.gridLines}"
+                            th:style="|top: ${(g.y / messagesChart.viewBoxHeight) * 100}%;|"
+                            th:text="${#numbers.formatDecimal(g.value, 1, 0)}">0</li>
+                    </ul>
+                    <ul class="activity-axis-x" aria-hidden="true">
+                        <li th:each="d : ${messagesChart.axisDates}" th:text="${d}">2026-04-23</li>
+                    </ul>
+                    <div class="activity-tooltip" hidden></div>
+                </div>
+                <p class="activity-empty" th:if="${messagesChart.empty}">
+                    No messages recorded in the last 30 days.
+                </p>
+            </div>
+        </div>
+
+        <!-- Voice -->
+        <div class="activity-block" data-metric="voice"
+             style="--activity-color: var(--activity-voice);">
+            <div class="activity-stats">
+                <div class="activity-stat">
+                    <span class="activity-stat-label">Total voice hours</span>
+                    <span class="activity-stat-value"
+                          th:text="${#numbers.formatDecimal(voiceHoursChart.total, 1, 1)}">0</span>
+                    <span class="activity-stat-sub">past 30 days</span>
+                </div>
+                <div class="activity-stat">
+                    <span class="activity-stat-label">Average / day</span>
+                    <span class="activity-stat-value"
+                          th:text="${#numbers.formatDecimal(voiceHoursChart.dailyAverage, 1, 1)}">0</span>
+                    <span class="activity-stat-sub">hours</span>
+                </div>
+                <div class="activity-stat">
+                    <span class="activity-stat-label">Peak day</span>
+                    <span class="activity-stat-value"
+                          th:text="${#numbers.formatDecimal(voiceHoursChart.max, 1, 1)}">0</span>
+                    <span class="activity-stat-sub">hours</span>
+                </div>
+                <div class="activity-stat">
+                    <span class="activity-stat-label">Active days</span>
+                    <span class="activity-stat-value"
+                          th:text="${voiceHoursChart.nonZeroDays}">0</span>
+                    <span class="activity-stat-sub">of <span th:text="${#lists.size(voiceHoursChart.points)}">30</span></span>
+                </div>
+            </div>
+
+            <div class="activity-chart-card mod-card mod-card-wide">
+                <div class="activity-chart-head">
+                    <h3>🎤 Voice hours per day</h3>
+                </div>
+                <div class="activity-chart-body" th:unless="${voiceHoursChart.empty}">
+                    <svg class="activity-chart"
+                         role="img"
+                         aria-label="Voice hours per day, 30-day rolling"
+                         th:attr="viewBox=|0 0 ${voiceHoursChart.viewBoxWidth} ${voiceHoursChart.viewBoxHeight}|"
+                         preserveAspectRatio="none">
+                        <defs>
+                            <linearGradient id="activityGradVoice" x1="0" x2="0" y1="0" y2="1">
+                                <stop offset="0%" style="stop-color: var(--activity-color); stop-opacity: 0.35;"/>
+                                <stop offset="100%" style="stop-color: var(--activity-color); stop-opacity: 0;"/>
+                            </linearGradient>
+                        </defs>
+                        <g class="activity-grid">
+                            <line th:each="g : ${voiceHoursChart.gridLines}"
+                                  class="activity-grid-line"
+                                  x1="0" x2="600"
+                                  th:attr="y1=${g.y},y2=${g.y}"/>
+                        </g>
+                        <polygon class="activity-area"
+                                 th:attr="points=${voiceHoursChart.areaPolygon}"
+                                 fill="url(#activityGradVoice)"/>
+                        <polyline class="activity-line"
+                                  fill="none"
+                                  stroke-width="2"
+                                  stroke-linejoin="round"
+                                  stroke-linecap="round"
+                                  th:attr="points=${voiceHoursChart.polyline}"/>
+                        <g class="activity-markers">
+                            <circle th:each="m : ${voiceHoursChart.markers}"
+                                    class="activity-marker"
+                                    r="3"
+                                    th:attr="cx=${m.x},cy=${m.y},data-date=${m.date},data-value=${#numbers.formatDecimal(m.value, 1, 1)},data-unit='hours'"/>
+                        </g>
+                    </svg>
+                    <ul class="activity-axis-y" aria-hidden="true">
+                        <li th:each="g : ${voiceHoursChart.gridLines}"
+                            th:style="|top: ${(g.y / voiceHoursChart.viewBoxHeight) * 100}%;|"
+                            th:text="${#numbers.formatDecimal(g.value, 1, 1)}">0</li>
+                    </ul>
+                    <ul class="activity-axis-x" aria-hidden="true">
+                        <li th:each="d : ${voiceHoursChart.axisDates}" th:text="${d}">2026-04-23</li>
+                    </ul>
+                    <div class="activity-tooltip" hidden></div>
+                </div>
+                <p class="activity-empty" th:if="${voiceHoursChart.empty}">
+                    No voice activity recorded in the last 30 days.
+                </p>
+            </div>
         </div>
     </section>
 </main>
@@ -94,5 +208,7 @@
 <script th:src="@{/js/api.js}"></script>
 <script th:src="@{/js/toasts.js}"></script>
 <script th:src="@{/js/moderationCommon.js}"></script>
+<script th:src="@{/js/moderation/activity.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/test/kotlin/web/service/ActivityChartsServiceTest.kt
+++ b/web/src/test/kotlin/web/service/ActivityChartsServiceTest.kt
@@ -155,6 +155,60 @@ class ActivityChartsServiceTest {
     }
 
     @Test
+    fun `ChartView pre-computes markers, area polygon, gridlines, axis dates, and average`() {
+        val messages = mockk<MessageDailyCountPersistence> {
+            every { findByGuildSince(any(), any()) } returns listOf(
+                MessageDailyCountDto(guildId = 1L, dayStart = today, count = 10L),
+                MessageDailyCountDto(guildId = 1L, dayStart = today.minusDays(2), count = 6L),
+            )
+        }
+        val service = ActivityChartsService(messages, mockk(relaxed = true), clock)
+
+        val chart = service.buildMessagesChart(guildId = 1L, days = 5)
+
+        // One marker per data point, in series order.
+        assertEquals(chart.points.size, chart.markers.size)
+        assertEquals(today.minusDays(4), chart.markers.first().date)
+        assertEquals(today, chart.markers.last().date)
+        // Marker on the peak day sits higher (smaller Y) than the zero days.
+        val peakMarker = chart.markers.first { it.date == today }
+        val zeroMarker = chart.markers.first { it.value == 0.0 }
+        assertTrue(peakMarker.y < zeroMarker.y, "peak marker should sit above zero marker")
+
+        // Area polygon = polyline points + two closing corners along the baseline.
+        val polylineCount = chart.polyline.split(" ").size
+        val areaCount = chart.areaPolygon.split(" ").size
+        assertEquals(polylineCount + 2, areaCount, "area polygon should close back to the baseline")
+
+        // Three gridlines (top/mid/baseline), ordered top→bottom in SVG units (ascending Y).
+        assertEquals(3, chart.gridLines.size)
+        val ys = chart.gridLines.map { it.y }
+        assertEquals(ys.sorted(), ys, "gridlines should be ordered top → baseline")
+        assertEquals(0.0, chart.gridLines.last().value)
+        assertEquals(chart.max, chart.gridLines.first().value)
+
+        // Axis dates: first / middle / last.
+        assertEquals(listOf(today.minusDays(4), today.minusDays(2), today), chart.axisDates)
+
+        // Averages and active-day count match the series.
+        assertEquals(16.0 / 5.0, chart.dailyAverage, 0.0001)
+        assertEquals(2, chart.nonZeroDays)
+    }
+
+    @Test
+    fun `ChartView treats an all-zero series as empty for layout purposes`() {
+        val messages = mockk<MessageDailyCountPersistence> {
+            every { findByGuildSince(any(), any()) } returns emptyList()
+        }
+        val service = ActivityChartsService(messages, mockk(relaxed = true), clock)
+
+        val chart = service.buildMessagesChart(guildId = 1L, days = 5)
+        assertTrue(chart.isEmpty, "zero-only series should render the empty-state card")
+        assertEquals(0, chart.nonZeroDays)
+        assertEquals(0.0, chart.dailyAverage)
+    }
+
+    @Test
     fun `buildVoiceHoursChart returns a fully-populated ChartView bundle`() {
         val sessionStart = today.atStartOfDay(ZoneOffset.UTC).plusHours(10).toInstant()
         val sessionEnd = sessionStart.plusSeconds(3600) // 1 hour exactly


### PR DESCRIPTION
## Summary

The Moderation → Activity tab was previously two bare SVG polylines with a one-line "total · peak" caption — accurate but flat. This PR turns it into a small dashboard and gives the shared moderation sub-nav a chrome refresh that lifts every tab.

### Activity tab

- **Stat-tile row per metric**: Total · Average/day · Peak day · Active days, for both messages and voice hours.
- **Polished area charts**: gradient fill under the line, dashed Y-axis gridlines, Y/X axis labels, per-point markers that highlight on hover.
- **Hover tooltip** (`/js/moderation/activity.js`, ~80 lines vanilla JS) shows date + value as you move across the chart. Pure progressive enhancement — the chart is fully readable without it.
- **In-card empty state** instead of the chart silently collapsing when a series has no data.
- All chart geometry pre-computed in `ActivityChartsService.ChartView` (area polygon, markers, gridlines, axis dates, daily average, active-day count) so the template stays SpEL-free, matching the existing leveling / lottery convention. Single `pointCoords` helper is the only source of (x, y) math.

### Shared sub-nav

`.mod-subnav` swaps the underline-tab look for a pill-style group inside a rounded container. Active tab gets `accent-soft` background + bold weight, so it reads at a glance — applies across all 10 moderation tabs through the shared `moderationHeader` fragment.

### Out of scope (follow-ups)

The plan also explored a deeper dashboard-wide redesign — unified page header with per-tab descriptions, `.mod-page` shell, Settings tab restructure (left-rail nav + section-level batch save to replace the ~50 inline Save buttons), and a lighter pass on the remaining tabs. Those are bigger structural changes; happy to open a follow-up PR for them.

## Test plan

- [x] `./gradlew :web:test --tests "web.service.ActivityChartsServiceTest"` — passes, including new coverage for markers / area polygon / gridlines / axis dates / daily average / all-zero empty state.
- [x] `./gradlew :web:test` — full module green.
- [ ] Manually verify Activity tab on a guild with real data: stat tiles populated, gradient + gridlines render, hover tooltip + marker highlight work, layout holds down to 380px.
- [ ] Manually verify the empty-state card renders for a guild with no activity in the last 30 days.
- [ ] Spot-check the new pill sub-nav across a few other tabs (Users, Settings, Leveling) to confirm nothing regressed visually.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NgJUqmuDnJWZp5WrSTXcfn)_