### PR TITLE
feat(moderation): unified dashboard header + .mod-page-intro shell

### DIFF
--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -206,6 +206,7 @@ class ModerationWebService(
             categories = categories,
             config = configByKey,
             lotteryIncentives = incentives,
+            guildIconUrl = guild.iconUrl,
         )
     }
 
@@ -1592,6 +1593,7 @@ data class GuildOverview(
     val categories: List<CategoryInfo> = emptyList(),
     val config: Map<String, String?>,
     val lotteryIncentives: LotteryIncentivesView = LotteryIncentivesView.empty(),
+    val guildIconUrl: String? = null,
 )
 
 data class ModeratedMember(

--- a/web/src/main/resources/static/css/moderation.css
+++ b/web/src/main/resources/static/css/moderation.css
@@ -108,7 +108,11 @@ details.config-section.is-hidden { display: none; }
     gap: var(--space-3);
     margin-bottom: var(--space-4);
 }
-.mod-page-header__back { margin-bottom: 0; }
+/* base.css gives `.back-link` an 8px bottom margin so it doesn't sit
+   flush against the H1 on simpler pages. Inside this flex column the
+   parent's `gap` already provides the spacing, so the extra margin
+   double-counts. Zero it out for the moderation header. */
+.mod-page-header > .back-link { margin-bottom: 0; }
 .mod-page-header__row {
     display: flex;
     align-items: flex-start;

--- a/web/src/main/resources/static/css/moderation.css
+++ b/web/src/main/resources/static/css/moderation.css
@@ -95,6 +95,139 @@ details.config-section.is-hidden { display: none; }
 
 .mod-panel { display: block; }
 
+/* ---- Moderation page header ----
+   Shared identity strip used by every tab via fragments/moderationHeader.
+   Replaces the old "title + lede" stack with a guild-avatar + eyebrow
+   (server name) + h1 (active tab name) + one-line subtitle (per-tab
+   description), plus an owner/superuser badge pinned to the right. The
+   page-header / mod-header rules in base.css still apply elsewhere (the
+   moderation pages don't use them anymore). */
+.mod-page-header {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    margin-bottom: var(--space-4);
+}
+.mod-page-header__back { margin-bottom: 0; }
+.mod-page-header__row {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--space-4);
+    flex-wrap: wrap;
+}
+.mod-page-header__identity {
+    display: flex;
+    align-items: center;
+    gap: var(--space-4);
+    min-width: 0;
+    flex: 1 1 auto;
+}
+.mod-page-header__avatar {
+    flex: 0 0 auto;
+    width: 56px;
+    height: 56px;
+    border-radius: var(--radius-md);
+    border: 1px solid var(--border);
+    background: var(--bg-elevated);
+    object-fit: cover;
+    display: block;
+}
+.mod-page-header__avatar--initial {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.4rem;
+    font-weight: 700;
+    color: var(--accent);
+    background: var(--accent-soft);
+    border-color: var(--accent-soft);
+}
+.mod-page-header__titles {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
+.mod-page-header__eyebrow {
+    margin: 0;
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+    font-weight: 600;
+    line-height: 1.2;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.mod-page-header__title {
+    margin: 0;
+    font-size: 1.6rem;
+    line-height: 1.15;
+    color: var(--text);
+}
+.mod-page-header__subtitle {
+    margin: 4px 0 0;
+    color: var(--text-muted);
+    line-height: 1.5;
+    max-width: 60ch;
+    font-size: 0.95rem;
+}
+.mod-page-header__badges {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    flex: 0 0 auto;
+    flex-wrap: wrap;
+}
+.mod-page-header__badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    border: 1px solid transparent;
+    white-space: nowrap;
+}
+.mod-page-header__badge--owner {
+    background: var(--accent-soft);
+    color: var(--accent);
+    border-color: var(--accent-soft);
+}
+.mod-page-header__badge--super {
+    background: rgba(87, 242, 135, 0.12);
+    color: #57f287;
+    border-color: rgba(87, 242, 135, 0.18);
+}
+
+@media (max-width: 600px) {
+    .mod-page-header__row {
+        align-items: stretch;
+    }
+    .mod-page-header__identity { gap: var(--space-3); }
+    .mod-page-header__avatar { width: 44px; height: 44px; }
+    .mod-page-header__title { font-size: 1.3rem; }
+    .mod-page-header__subtitle { font-size: 0.9rem; }
+    .mod-page-header__badges { width: 100%; }
+}
+
+/* ---- Page-intro paragraph ----
+   Standardised lead paragraph that sits between the page header and the
+   first content card/section. Replaces the ad-hoc `<p class="muted mb-4">`
+   pattern that every tab used to copy-paste with slightly different
+   spacing. */
+.mod-page-intro {
+    color: var(--text-muted);
+    line-height: 1.6;
+    max-width: 70ch;
+    margin: 0 0 var(--space-5);
+}
+
 /* Sub-section heading inside a moderation panel (e.g. "Move members"
    below the voice-channel grid). Replaces inline `class="mt-5"` so
    every sub-section uses the same rhythm. */
@@ -615,6 +748,8 @@ details.config-section.is-hidden { display: none; }
     display: flex;
     flex-direction: column;
     gap: var(--space-2);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.18),
+                0 4px 12px rgba(0, 0, 0, 0.18);
 }
 .mod-card-wide { max-width: none; }
 .mod-card h3 {

--- a/web/src/main/resources/templates/fragments/moderationHeader.html
+++ b/web/src/main/resources/templates/fragments/moderationHeader.html
@@ -42,7 +42,7 @@
         guildInitial=${overview.guildName != null and !overview.guildName.isEmpty() ? overview.guildName.substring(0, 1).toUpperCase() : 'G'}">
 
     <header class="mod-page-header">
-        <a class="back-link mod-page-header__back" th:href="@{/moderation/guilds(pick=true)}">&larr; All servers</a>
+        <a class="back-link" th:href="@{/moderation/guilds(pick=true)}">&larr; All servers</a>
         <div class="mod-page-header__row">
             <div class="mod-page-header__identity">
                 <img th:if="${overview.guildIconUrl != null}"

--- a/web/src/main/resources/templates/fragments/moderationHeader.html
+++ b/web/src/main/resources/templates/fragments/moderationHeader.html
@@ -2,21 +2,71 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <body>
 <!--
-    Per-guild moderation page header. Each split sub-page (users, actions,
-    settings, voice, poll, casino, lottery) embeds this fragment so the
-    back link, guild name, owner/superuser banner, alerts include, and
-    sub-nav are laid out identically. The `active` arg is the slug of the
-    currently rendered sub-page (users / actions / settings / voice / poll
-    / casino / lottery); the matching link gets the .active class +
-    aria-current so the user knows where they are.
+    Per-guild moderation page header. Every split sub-page (users, actions,
+    settings, voice, poll, casino, lottery, leveling, activity, welcome)
+    embeds this fragment so back-link, guild title, active-tab subtitle,
+    owner/superuser badge, alerts, and sub-nav are laid out identically.
+    `active` is the slug of the current sub-page; the matching link gets
+    .active + aria-current, and the H1 + lede pull from the local
+    `tabLabels` / `tabDescs` maps so each tab has its own page title and
+    one-line description without round-tripping through the controller.
 -->
-<div th:fragment="moderationHeader(overview, isOwner, active)">
-    <div class="page-header mod-header">
-        <a class="back-link" th:href="@{/moderation/guilds(pick=true)}">&larr; All servers</a>
-        <h1 th:text="${overview.guildName}">Guild Name</h1>
-        <p class="lede" th:if="${isOwner}">You are the server owner.</p>
-        <p class="lede" th:unless="${isOwner}">You are a TobyBot superuser.</p>
-    </div>
+<div th:fragment="moderationHeader(overview, isOwner, active)"
+     th:with="
+        tabLabels=${ {
+            'users':'Users',
+            'actions':'Actions',
+            'settings':'Settings',
+            'voice':'Voice',
+            'poll':'Poll',
+            'casino':'Casino',
+            'lottery':'Lottery',
+            'leveling':'Leveling',
+            'activity':'Activity',
+            'welcome':'Welcome'
+        } },
+        tabDescs=${ {
+            'users':'Toggle TobyBot permissions and adjust social credit per member.',
+            'actions':'Kick, ban, timeout, lock, slowmode, and purge — all audit-logged.',
+            'settings':'Per-guild knobs for economy, casino, leveling, and shared bot behaviour.',
+            'voice':'See who is in voice and shuffle members between channels.',
+            'poll':'Post an emoji-reaction poll into any text channel.',
+            'casino':'Jackpot pool admin, refunds, and casino-wide controls.',
+            'lottery':'Bulk-buy bonuses, multiplier tiers, milestone draws, force-draw.',
+            'leveling':'XP tuning, role rewards, level-gated titles, and streak rewards.',
+            'activity':'30-day rolling server activity — messages per day and voice hours.',
+            'welcome':'Welcome-channel routing and auto-roles for new members.'
+        } },
+        tabLabel=${tabLabels[active] ?: 'Moderation'},
+        tabDesc=${tabDescs[active] ?: ''},
+        guildInitial=${overview.guildName != null and !overview.guildName.isEmpty() ? overview.guildName.substring(0, 1).toUpperCase() : 'G'}">
+
+    <header class="mod-page-header">
+        <a class="back-link mod-page-header__back" th:href="@{/moderation/guilds(pick=true)}">&larr; All servers</a>
+        <div class="mod-page-header__row">
+            <div class="mod-page-header__identity">
+                <img th:if="${overview.guildIconUrl != null}"
+                     th:src="${overview.guildIconUrl}"
+                     th:alt="${overview.guildName + ' icon'}"
+                     class="mod-page-header__avatar">
+                <span th:unless="${overview.guildIconUrl != null}"
+                      class="mod-page-header__avatar mod-page-header__avatar--initial"
+                      aria-hidden="true"
+                      th:text="${guildInitial}">G</span>
+                <div class="mod-page-header__titles">
+                    <p class="mod-page-header__eyebrow" th:text="${overview.guildName}">Guild Name</p>
+                    <h1 class="mod-page-header__title" th:text="${tabLabel}">Section</h1>
+                    <p class="mod-page-header__subtitle" th:if="${tabDesc != null and !tabDesc.isEmpty()}" th:text="${tabDesc}">
+                        Short description of this tab.
+                    </p>
+                </div>
+            </div>
+            <div class="mod-page-header__badges">
+                <span class="mod-page-header__badge mod-page-header__badge--owner" th:if="${isOwner}">Server owner</span>
+                <span class="mod-page-header__badge mod-page-header__badge--super" th:unless="${isOwner}">TobyBot superuser</span>
+            </div>
+        </div>
+    </header>
 
     <div th:replace="~{fragments/alerts :: error}"></div>
 

--- a/web/src/main/resources/templates/moderation/actions.html
+++ b/web/src/main/resources/templates/moderation/actions.html
@@ -13,7 +13,7 @@
     <div th:replace="~{fragments/moderationHeader :: moderationHeader(${overview}, ${isOwner}, 'actions')}"></div>
 
     <section class="mod-panel" data-panel="actions">
-        <p class="muted mb-4">
+        <p class="mod-page-intro">
             Run Discord moderation actions without leaving the dashboard. You
             need the matching Discord permission (Ban / Kick / Moderate /
             Manage) on the bot AND on yourself for each action.

--- a/web/src/main/resources/templates/moderation/casino.html
+++ b/web/src/main/resources/templates/moderation/casino.html
@@ -13,7 +13,7 @@
     <div th:replace="~{fragments/moderationHeader :: moderationHeader(${overview}, ${isOwner}, 'casino')}"></div>
 
     <section class="mod-panel" data-panel="casino">
-        <p class="muted mb-4">
+        <p class="mod-page-intro">
             Casino remediation. Use these when a player has farmed the
             jackpot via spam or another exploit. Per-stake jackpot
             scaling is in place, but you can still drain a contaminated

--- a/web/src/main/resources/templates/moderation/leveling.html
+++ b/web/src/main/resources/templates/moderation/leveling.html
@@ -22,7 +22,7 @@
         role-reward + title-gate widgets are wired in /js/moderation/leveling.js.
     -->
     <section class="mod-panel" data-panel="leveling">
-        <p class="muted mb-4">
+        <p class="mod-page-intro">
             Engagement XP is awarded by message activity, slash commands,
             and voice sessions, subject to a per-guild daily cap. Hitting
             a level threshold can grant a Discord role and unlock titles

--- a/web/src/main/resources/templates/moderation/lottery.html
+++ b/web/src/main/resources/templates/moderation/lottery.html
@@ -26,7 +26,7 @@
         is read-only and the admin can't actually persist anything.
     -->
     <section class="mod-panel" data-panel="lottery">
-        <p class="muted mb-4">
+        <p class="mod-page-intro">
             Auto-runs at 00:00 UTC: closes the prior day's draw, pays prizes,
             opens a fresh one seeded from the jackpot pool. Doubles as a credit
             sink — a configurable slice of every ticket sale routes back to the

--- a/web/src/main/resources/templates/moderation/poll.html
+++ b/web/src/main/resources/templates/moderation/poll.html
@@ -13,7 +13,7 @@
     <div th:replace="~{fragments/moderationHeader :: moderationHeader(${overview}, ${isOwner}, 'poll')}"></div>
 
     <section class="mod-panel" data-panel="poll">
-        <p class="muted mb-4">
+        <p class="mod-page-intro">
             Post an emoji-reaction poll in a text channel. Up to 4 options.
         </p>
         <form class="poll-form">

--- a/web/src/main/resources/templates/moderation/users.html
+++ b/web/src/main/resources/templates/moderation/users.html
@@ -13,7 +13,7 @@
     <div th:replace="~{fragments/moderationHeader :: moderationHeader(${overview}, ${isOwner}, 'users')}"></div>
 
     <section class="mod-panel" data-panel="users">
-        <p class="muted mb-4">
+        <p class="mod-page-intro">
             Toggle TobyBot permissions for members of this server. Server owners
             can also toggle SUPERUSER and adjust social credit. Kick / ban /
             timeout and other moderation actions live on the

--- a/web/src/main/resources/templates/moderation/voice.html
+++ b/web/src/main/resources/templates/moderation/voice.html
@@ -13,7 +13,7 @@
     <div th:replace="~{fragments/moderationHeader :: moderationHeader(${overview}, ${isOwner}, 'voice')}"></div>
 
     <section class="mod-panel" data-panel="voice">
-        <p class="muted mb-4">
+        <p class="mod-page-intro">
             Move voice-channel occupants between channels. Requires the bot
             and you to have the Move Members permission.
         </p>

--- a/web/src/main/resources/templates/moderation/welcome.html
+++ b/web/src/main/resources/templates/moderation/welcome.html
@@ -21,7 +21,7 @@
         message templates: {user}, {user.name}, {server}, {membercount}.
     -->
     <section class="mod-panel" data-panel="welcome">
-        <p class="muted mb-4">
+        <p class="mod-page-intro">
             Greet new members and acknowledge departures with a configurable
             announcement, and auto-assign roles the moment someone joins.
             Each announcement is independently toggleable; both fall back


### PR DESCRIPTION
## Summary

Phase 2 of the moderation dashboard refresh — unifies the shared chrome across all 10 tabs so each page reads as part of one designed dashboard instead of 10 stitched-together tabs.

- **New `.mod-page-header`** in `fragments/moderationHeader.html`: guild avatar (fed from a new `GuildOverview.guildIconUrl`, with a coloured-initial fallback when the guild has no icon) + "Server name" eyebrow + H1 with the active tab's label + a per-tab one-line description, plus a right-pinned owner/superuser badge. Tab labels and descriptions live as Thymeleaf maps inside the fragment — no controller plumbing required.
- **`.mod-page-intro`** replaces the ad-hoc `<p class="muted mb-4">` lead paragraph that every tab had copy-pasted with slightly different spacing. Applied to all 8 tabs that had one (Users, Actions, Voice, Poll, Casino, Lottery, Leveling, Welcome).
- **`.mod-card` shadow refresh** — subtle two-layer box-shadow so cards read as elevated rather than flat, lifting every tab that uses the card pattern without restructuring it.
- **`ModerationWebService.GuildOverview`** gains `guildIconUrl: String?` (defaulted), populated from `guild.iconUrl`. The one test that constructs `GuildOverview` directly uses named args, so the default keeps it passing.

Settings tab still has its existing "Read-only" alert as its lead (no `mod-page-intro` swap there); Activity tab already has its custom `.activity-intro` from PR #567 and is untouched here.

This builds on Phase 1 (#567) and clears the way for Phase 3 (Settings restructure) and Phase 4 (per-tab polish).

## Test plan

- [x] `./gradlew :web:compileKotlin` — passes
- [x] `./gradlew :web:test` — full web test suite passes (including `WelcomeTemplateRenderTest`, which renders welcome.html through the real Thymeleaf engine and exercises the new `moderationHeader` fragment + map-literal lookups)
- [ ] Visit `/moderation/{guildId}/users` (and any other tab) in a browser to confirm: guild avatar + name eyebrow + tab H1 + description render; owner/superuser badge sits top-right; sub-nav highlights the active tab in pill style; cards have subtle elevation
- [ ] Mobile DevTools (375px): identity strip stacks cleanly, avatar shrinks to 44px, badges drop below
- [ ] Open a guild whose Discord icon URL is null and confirm the coloured-initial fallback renders

https://claude.ai/code/session_01NgJUqmuDnJWZp5WrSTXcfn

---
_Generated by [Claude Code](https://claude.ai/code/session_01NgJUqmuDnJWZp5WrSTXcfn)_