### PR TITLE
feat(moderation/settings): side-rail nav, stakes table, bulk apply

### DIFF
--- a/web/src/main/resources/static/css/moderation.css
+++ b/web/src/main/resources/static/css/moderation.css
@@ -1423,3 +1423,232 @@ details.config-section.is-hidden { display: none; }
 @media (max-width: 380px) {
     .activity-stats { grid-template-columns: minmax(0, 1fr); }
 }
+
+/* ==============================================================
+   Settings tab — sticky left-rail nav + stake-limits table +
+   bulk "set every game" form. The rail jumps to the matching
+   <details> and an IntersectionObserver in settings.js mirrors
+   the scroll position back into the rail's `.is-active` link.
+   ============================================================== */
+
+.settings-shell {
+    display: grid;
+    grid-template-columns: 220px minmax(0, 1fr);
+    gap: var(--space-6);
+    align-items: start;
+}
+@media (max-width: 768px) {
+    .settings-shell {
+        grid-template-columns: minmax(0, 1fr);
+        gap: var(--space-3);
+    }
+}
+
+.settings-nav {
+    position: sticky;
+    /* Sit just below the page header so the rail never tucks under
+       the moderation chrome when the user scrolls past it. */
+    top: var(--space-4);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+    padding: var(--space-3);
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    max-height: calc(100vh - 80px);
+    overflow-y: auto;
+}
+@media (max-width: 768px) {
+    .settings-nav {
+        position: static;
+        max-height: none;
+        flex-direction: row;
+        flex-wrap: wrap;
+        gap: var(--space-2);
+    }
+}
+
+.settings-nav-group {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+@media (max-width: 768px) {
+    .settings-nav-group { flex: 1 1 auto; min-width: 140px; }
+}
+
+.settings-nav-heading {
+    margin: 0 0 var(--space-1);
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-muted);
+    font-weight: 700;
+}
+
+.settings-nav-link {
+    display: block;
+    padding: 6px 10px;
+    border-radius: var(--radius-sm);
+    color: var(--text-muted);
+    font-size: 0.88rem;
+    text-decoration: none;
+    transition: background 0.15s, color 0.15s;
+    line-height: 1.3;
+}
+.settings-nav-link:hover {
+    color: var(--text);
+    background: var(--bg);
+}
+.settings-nav-link.is-active {
+    color: var(--accent);
+    background: var(--accent-soft);
+    font-weight: 600;
+}
+
+.settings-content {
+    min-width: 0;
+}
+
+/* The .config-pillar headings now live alongside the rail; tighten
+   the in-content rhythm so they don't double-up with the rail's
+   .settings-nav-heading. */
+.settings-content .config-pillar:first-of-type {
+    margin-top: 0;
+}
+
+/* ---- Stake-limits table ----
+   Two columns of editable stake cells, one row per game. The cells
+   wrap the existing `.config-row` markup so the per-row save handler
+   in moderationCommon.js works without modification. The `.btn-sm`
+   override keeps the inline Save button tight inside the cell. */
+.settings-stakes-wrap {
+    margin: 0 var(--space-4) var(--space-4);
+    overflow-x: auto;
+    border-top: 1px solid var(--border);
+}
+.settings-stakes-table {
+    width: 100%;
+    border-collapse: collapse;
+    min-width: 480px;
+}
+.settings-stakes-table thead th {
+    text-align: left;
+    padding: var(--space-3) var(--space-2);
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-muted);
+    font-weight: 600;
+    border-bottom: 1px solid var(--border);
+    background: var(--bg-elevated);
+    position: sticky;
+    top: 0;
+    z-index: 1;
+}
+.settings-stakes-table tbody th {
+    text-align: left;
+    padding: var(--space-3) var(--space-2);
+    font-weight: 600;
+    color: var(--text);
+    font-size: 0.9rem;
+    white-space: nowrap;
+    border-bottom: 1px solid var(--border);
+    width: 1%;
+}
+.settings-stakes-table tbody td {
+    padding: var(--space-2);
+    border-bottom: 1px solid var(--border);
+    vertical-align: middle;
+}
+.settings-stakes-table tbody tr:last-child th,
+.settings-stakes-table tbody tr:last-child td { border-bottom: 0; }
+.settings-stakes-table tbody tr.is-hidden { display: none; }
+.settings-stakes-table tbody tr:hover { background: var(--bg); }
+
+/* Stake cells override .config-row's desktop grid (which was sized
+   for the wide label-on-left layout) — inside a table cell we just
+   want input + Save sitting flush together. */
+.config-row.settings-stake-cell {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: 0;
+    border: 0 !important;
+    background: transparent;
+}
+.config-row.settings-stake-cell input {
+    grid-column: auto;
+    width: auto;
+    flex: 1 1 auto;
+    min-width: 0;
+    max-width: 140px;
+    padding: 6px 8px;
+}
+.config-row.settings-stake-cell .save-config {
+    grid-column: auto;
+    padding: 6px 10px;
+    font-size: 0.82rem;
+}
+
+/* ---- Bulk "set every game" form ----
+   Sits between the section lead paragraph and the stakes table.
+   Three-column layout on desktop (text | fields | submit) collapses
+   to a stack on mobile. */
+.settings-stakes-bulk {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: var(--space-4);
+    align-items: center;
+    margin: 0 var(--space-4) var(--space-4);
+    padding: var(--space-3) var(--space-4);
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+}
+.settings-stakes-bulk-text strong {
+    display: block;
+    margin-bottom: 4px;
+    color: var(--text);
+    font-size: 0.92rem;
+}
+.settings-stakes-bulk-text p {
+    margin: 0;
+    font-size: 0.85rem;
+    line-height: 1.45;
+}
+.settings-stakes-bulk-fields {
+    display: flex;
+    align-items: flex-end;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+    justify-content: flex-end;
+}
+.settings-stakes-bulk-field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    font-weight: 500;
+}
+.settings-stakes-bulk-field input {
+    width: 110px;
+    padding: 6px 8px;
+    background: var(--bg-elevated);
+    color: var(--text);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-sm);
+    font: inherit;
+}
+.settings-stakes-bulk-field input:focus {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+@media (max-width: 768px) {
+    .settings-stakes-bulk { grid-template-columns: minmax(0, 1fr); }
+    .settings-stakes-bulk-fields { justify-content: flex-start; }
+}

--- a/web/src/main/resources/static/js/moderation/settings.js
+++ b/web/src/main/resources/static/js/moderation/settings.js
@@ -1,15 +1,17 @@
-// Settings tab: client-side config search filter. The generic
+// Settings tab: client-side config search filter, side-rail navigation,
+// and the bulk "apply to all games" stake setter. The generic
 // .config-row save handler lives in moderationCommon.js so it works on
-// every page that has config rows; this file only adds the live filter.
+// every page that has config rows; this file owns the settings-tab-only
+// extras.
 (function () {
     'use strict';
 
     const ctx = window.ModerationCommon;
     if (!ctx) return;
 
+    // ---- Search filter -----------------------------------------------
     const input = document.getElementById('config-search');
     const count = document.getElementById('config-search-count');
-    if (!input) return;
 
     // Build a per-row haystack of (label text + data-key) lowercased so a
     // user can type "rtp" (free-text) or "JACKPOT_RTP" (the enum-style
@@ -49,6 +51,15 @@
         rows.forEach(row => {
             const hit = q === '' || (haystackByRow.get(row) || '').includes(q);
             row.classList.toggle('is-hidden', !hit);
+            // Stake rows live inside a <tr>; hide the row too so the
+            // table doesn't keep an empty <tr> behind when both cells
+            // are filtered out.
+            const tableRow = row.closest('tr');
+            if (tableRow) {
+                const stakeCells = tableRow.querySelectorAll('.config-row[data-key]');
+                const anyVisible = Array.from(stakeCells).some(c => !c.classList.contains('is-hidden'));
+                tableRow.classList.toggle('is-hidden', !anyVisible);
+            }
             if (hit) shown++;
         });
         // Hide sections whose rows are all filtered out; force-open the
@@ -89,26 +100,202 @@
         }
     }
 
-    input.addEventListener('input', () => {
-        if (input.value.trim() !== '') snapshotIfNeeded();
-        else restoreSnapshot();
-        apply(input.value);
-    });
-    input.addEventListener('keydown', e => {
-        if (e.key === 'Escape') {
-            input.value = '';
-            restoreSnapshot();
-            apply('');
+    if (input) {
+        input.addEventListener('input', () => {
+            if (input.value.trim() !== '') snapshotIfNeeded();
+            else restoreSnapshot();
+            apply(input.value);
+        });
+        input.addEventListener('keydown', e => {
+            if (e.key === 'Escape') {
+                input.value = '';
+                restoreSnapshot();
+                apply('');
+            }
+        });
+
+        // Restore from URL hash on page load (e.g. someone shares
+        // /moderation/123/settings#search=jackpot). The rail-jump hash
+        // (#settings-section-…) is consumed by the rail handler below
+        // and intentionally skipped here.
+        const initial = (window.location.hash.match(/^#search=(.*)$/) || [])[1];
+        if (initial) {
+            const decoded = decodeURIComponent(initial);
+            input.value = decoded;
+            snapshotIfNeeded();
+            apply(decoded);
         }
+    }
+
+    // ---- Side-rail navigation ---------------------------------------
+    // Each rail link is `href="#settings-section-<slug>"`. Click opens
+    // the matching <details> (so the user lands at the section heading,
+    // not at a closed accordion) and scrolls smoothly into view. An
+    // IntersectionObserver mirrors the currently-visible section back
+    // into the rail's active-link styling so the user has spatial
+    // context while scrolling manually.
+    const railLinks = Array.from(document.querySelectorAll('.settings-nav-link'));
+    const sectionsById = new Map(
+        sections
+            .filter(s => s.id)
+            .map(s => [s.id, s])
+    );
+
+    function openAndScroll(targetId, push) {
+        const target = sectionsById.get(targetId);
+        if (!target) return;
+        target.open = true;
+        // After-open layout is async (the chevron rotation runs); wait
+        // a frame so scrollIntoView measures the expanded height.
+        requestAnimationFrame(() => {
+            target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        });
+        if (push) {
+            try {
+                history.pushState(null, '', '#' + targetId);
+            } catch (e) { /* ignore */ }
+        }
+        setActiveLink(targetId);
+    }
+
+    function setActiveLink(targetId) {
+        railLinks.forEach(link => {
+            const matches = link.getAttribute('href') === '#' + targetId;
+            link.classList.toggle('is-active', matches);
+            if (matches) link.setAttribute('aria-current', 'true');
+            else link.removeAttribute('aria-current');
+        });
+    }
+
+    railLinks.forEach(link => {
+        link.addEventListener('click', (e) => {
+            const href = link.getAttribute('href') || '';
+            if (!href.startsWith('#settings-section-')) return;
+            e.preventDefault();
+            openAndScroll(href.slice(1), true);
+        });
     });
 
-    // Restore from URL hash on page load (e.g. someone shares
-    // /moderation/123/settings#search=jackpot).
-    const initial = (window.location.hash.match(/^#search=(.*)$/) || [])[1];
-    if (initial) {
-        const decoded = decodeURIComponent(initial);
-        input.value = decoded;
-        snapshotIfNeeded();
-        apply(decoded);
+    if (railLinks.length > 0 && 'IntersectionObserver' in window) {
+        const visibility = new Map();
+        const observer = new IntersectionObserver((entries) => {
+            entries.forEach(entry => {
+                visibility.set(entry.target.id, entry.intersectionRatio);
+            });
+            // Highlight the section with the highest visibility ratio
+            // currently above the viewport's halfway mark.
+            let bestId = null;
+            let bestRatio = 0;
+            visibility.forEach((ratio, id) => {
+                if (ratio > bestRatio) {
+                    bestRatio = ratio;
+                    bestId = id;
+                }
+            });
+            if (bestId && bestRatio > 0) setActiveLink(bestId);
+        }, {
+            // Trigger the highlight when the section is at least 25%
+            // through the viewport so the rail tracks where the user
+            // is actually reading, not just where a section first peeks
+            // into view.
+            rootMargin: '-25% 0px -50% 0px',
+            threshold: [0, 0.25, 0.5, 0.75, 1],
+        });
+        sectionsById.forEach(section => observer.observe(section));
+    }
+
+    // Honour an initial `#settings-section-…` hash on page load (e.g.
+    // a deep-link share). Run after the layout settles so scrollIntoView
+    // gets the right offset.
+    const railHashMatch = window.location.hash.match(/^#(settings-section-[a-z0-9-]+)$/);
+    if (railHashMatch) {
+        requestAnimationFrame(() => openAndScroll(railHashMatch[1], false));
+    }
+
+    // ---- Bulk "apply to all games" stake setter ---------------------
+    // Reuses the per-row save endpoint — one POST per (game × min|max)
+    // key, fanned out in parallel. Leaving either input blank skips
+    // that side, so admins can bulk-set just minimums without
+    // clobbering maximums.
+    const bulkForm = document.querySelector('.settings-stakes-bulk');
+    if (bulkForm) {
+        const minInput = bulkForm.querySelector('input[name="bulkMin"]');
+        const maxInput = bulkForm.querySelector('input[name="bulkMax"]');
+        const btn = bulkForm.querySelector('button[type="submit"]');
+
+        bulkForm.addEventListener('submit', (e) => {
+            e.preventDefault();
+            if (!ctx.isOwner) {
+                toast('Only the server owner can change settings.', 'error');
+                return;
+            }
+            const minVal = (minInput?.value || '').trim();
+            const maxVal = (maxInput?.value || '').trim();
+            if (minVal === '' && maxVal === '') {
+                toast('Enter a minimum, a maximum, or both.', 'error');
+                return;
+            }
+
+            // Gather every stake row in the table — `.settings-stake-cell`
+            // is a hook added just for this lookup. Split into MIN / MAX
+            // by the data-key suffix so the same cell loop drives both
+            // sides.
+            const stakeCells = Array.from(document.querySelectorAll('.settings-stake-cell[data-key]'));
+            const targets = [];
+            stakeCells.forEach(cell => {
+                const key = cell.dataset.key || '';
+                if (minVal !== '' && key.endsWith('_MIN_STAKE')) {
+                    targets.push({ key: key, value: minVal, cell: cell });
+                } else if (maxVal !== '' && key.endsWith('_MAX_STAKE')) {
+                    targets.push({ key: key, value: maxVal, cell: cell });
+                }
+            });
+            if (targets.length === 0) {
+                toast('No matching stake rows found.', 'error');
+                return;
+            }
+
+            const summary =
+                'Apply ' +
+                (minVal !== '' ? 'min=' + minVal : '') +
+                (minVal !== '' && maxVal !== '' ? ', ' : '') +
+                (maxVal !== '' ? 'max=' + maxVal : '') +
+                ' to ' + targets.length + ' stake row' + (targets.length === 1 ? '' : 's') + '?';
+            if (!confirm(summary)) return;
+
+            btn.disabled = true;
+            const guildPath = '/moderation/' + ctx.guildId + '/config';
+            const requests = targets.map(t =>
+                ctx.postJson(guildPath, { key: t.key, value: t.value })
+                    .then(r => ({ target: t, ok: !!(r && r.ok), error: r?.error || null }))
+                    .catch(err => ({ target: t, ok: false, error: (err && err.message) || 'Network error' }))
+            );
+            Promise.all(requests).then(results => {
+                btn.disabled = false;
+                let okCount = 0;
+                let failCount = 0;
+                results.forEach(res => {
+                    const cellInput = res.target.cell.querySelector('input');
+                    if (res.ok) {
+                        okCount++;
+                        if (cellInput) {
+                            cellInput.value = res.target.value;
+                            cellInput.defaultValue = res.target.value;
+                        }
+                    } else {
+                        failCount++;
+                    }
+                });
+                if (failCount === 0) {
+                    toast('Updated ' + okCount + ' stake row' + (okCount === 1 ? '' : 's') + '.', 'success');
+                    if (minInput) minInput.value = '';
+                    if (maxInput) maxInput.value = '';
+                } else if (okCount === 0) {
+                    toast('All ' + failCount + ' updates failed.', 'error');
+                } else {
+                    toast(okCount + ' saved, ' + failCount + ' failed.', 'error');
+                }
+            });
+        });
     }
 })();

--- a/web/src/main/resources/templates/moderation/settings.html
+++ b/web/src/main/resources/templates/moderation/settings.html
@@ -12,6 +12,16 @@
 
     <div th:replace="~{fragments/moderationHeader :: moderationHeader(${overview}, ${isOwner}, 'settings')}"></div>
 
+    <!--
+        Settings tab — split into a sticky left-rail nav (pillars and
+        their sections as jump links) and a scrollable content column.
+        Each <details> section carries an id matching its rail link so a
+        click on the rail opens + scrolls to it; an IntersectionObserver
+        in settings.js syncs the rail's active-link state as the user
+        scrolls. The per-row .save-config wiring stays untouched —
+        moderationCommon.js handles every .config-row regardless of where
+        it sits in the page.
+    -->
     <section class="mod-panel" data-panel="settings">
         <div class="alert alert-error" th:if="${!isOwner}" style="margin-bottom: 16px;">
             <strong>Read-only.</strong> Only the server owner can change guild
@@ -21,957 +31,1098 @@
             first.
         </div>
 
-        <div class="mod-search config-search-bar">
-            <label for="config-search" class="sr-only">Search settings</label>
-            <input id="config-search"
-                   type="search"
-                   class="mod-search-input"
-                   placeholder="Search settings (e.g. jackpot, RTP, ante)…"
-                   autocomplete="off"
-                   aria-describedby="config-search-count">
-            <span id="config-search-count" class="mod-search-count" aria-live="polite"></span>
-        </div>
+        <div class="settings-shell">
+            <aside class="settings-nav" aria-label="Settings sections">
+                <div class="settings-nav-group">
+                    <p class="settings-nav-heading">Server</p>
+                    <a href="#settings-section-server-features" class="settings-nav-link">Server features</a>
+                    <a href="#settings-section-messages" class="settings-nav-link">Messages &amp; leaderboards</a>
+                </div>
+                <div class="settings-nav-group">
+                    <p class="settings-nav-heading">Economy</p>
+                    <a href="#settings-section-economy" class="settings-nav-link">Economy</a>
+                </div>
+                <div class="settings-nav-group">
+                    <p class="settings-nav-heading">Casino</p>
+                    <a href="#settings-section-jackpot" class="settings-nav-link">Jackpot</a>
+                    <a href="#settings-section-autoclicker" class="settings-nav-link">Anti-autoclicker</a>
+                    <a href="#settings-section-poker" class="settings-nav-link">Poker</a>
+                    <a href="#settings-section-blackjack" class="settings-nav-link">Blackjack</a>
+                    <a href="#settings-section-stakes" class="settings-nav-link">Game stake limits</a>
+                </div>
+            </aside>
 
-        <h2 class="config-pillar">Server</h2>
+            <div class="settings-content">
+                <div class="mod-search config-search-bar">
+                    <label for="config-search" class="sr-only">Search settings</label>
+                    <input id="config-search"
+                           type="search"
+                           class="mod-search-input"
+                           placeholder="Search settings (e.g. jackpot, RTP, ante)…"
+                           autocomplete="off"
+                           aria-describedby="config-search-count">
+                    <span id="config-search-count" class="mod-search-count" aria-live="polite"></span>
+                </div>
 
-        <details class="config-section" open>
-            <summary>Server features</summary>
-            <div class="config-grid">
-                <div class="config-row" data-key="VOLUME">
-                    <label>Default volume</label>
-                    <input type="number" min="0" max="200"
-                           th:value="${overview.config['VOLUME']}"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-row" data-key="INTRO_VOLUME">
-                    <label>Default intro volume</label>
-                    <input type="number" min="0" max="200"
-                           th:value="${overview.config['INTRO_VOLUME']}"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-row" data-key="MOVE">
-                    <label>Default move channel</label>
-                    <div th:replace="~{fragments/channelPicker :: channelPicker(
-                            name=null,
-                            id=null,
-                            channels=${overview.voiceChannels},
-                            selectedValue=${overview.config['MOVE']},
-                            placeholder='— none —',
-                            emptyLabel='— none —',
-                            required=false,
-                            valuePrefix='',
-                            valueField='name',
-                            disabled=${!isOwner})}"></div>
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <!-- Saving "true" here kicks an ActivityTrackingEnabled event that
-                     fires the first-enable DM flow, matching the Discord
-                     /setconfig behaviour. Default value is "false" when no row
-                     exists yet — matches ActivityTrackingService's read default. -->
-                <div class="config-row" data-key="ACTIVITY_TRACKING">
-                    <label>Game-activity tracking</label>
-                    <select th:disabled="${!isOwner}">
-                        <option value="false"
-                                th:selected="${overview.config['ACTIVITY_TRACKING'] == null or overview.config['ACTIVITY_TRACKING'] == 'false'}">
-                            Disabled
-                        </option>
-                        <option value="true"
-                                th:selected="${overview.config['ACTIVITY_TRACKING'] == 'true'}">
-                            Enabled
-                        </option>
-                    </select>
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-            </div>
-        </details>
+                <h2 class="config-pillar">Server</h2>
 
-        <details class="config-section">
-            <summary>Messages &amp; leaderboards</summary>
-            <div class="config-grid">
-                <div class="config-row" data-key="DELETE_DELAY">
-                    <label>Message delete delay (seconds)</label>
-                    <input type="number" min="0" max="600"
-                           th:value="${overview.config['DELETE_DELAY']}"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-row" data-key="LEADERBOARD_CHANNEL">
-                    <label>Monthly leaderboard channel</label>
-                    <div th:replace="~{fragments/channelPicker :: channelPicker(
-                            name=null,
-                            id=null,
-                            channels=${overview.textChannels},
-                            selectedValue=${overview.config['LEADERBOARD_CHANNEL']},
-                            placeholder='— system channel —',
-                            emptyLabel='— system channel —',
-                            required=false,
-                            valuePrefix='#',
-                            valueField='id',
-                            disabled=${!isOwner})}"></div>
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-create-channel">
-                    <div class="config-create-channel-text">
-                        <strong>Create a read-only leaderboard channel</strong>
-                        <p class="muted">
-                            Creates a new text channel where @everyone can read but only
-                            TobyBot can post; auto-sets the leaderboard channel above to
-                            it. Bot needs the Manage Channels permission.
-                        </p>
-                    </div>
-                    <form class="config-create-channel-form"
-                          data-target-config="LEADERBOARD_CHANNEL"
-                          data-default-name="leaderboard">
-                        <label class="config-create-channel-field">
-                            <span>Channel name</span>
-                            <input type="text" name="name" value="leaderboard"
-                                   maxlength="90" th:disabled="${!isOwner}">
-                        </label>
-                        <label class="config-create-channel-field">
-                            <span>Category</span>
-                            <select name="parentCategoryId" th:disabled="${!isOwner}">
-                                <option value="">&mdash; top-level &mdash;</option>
-                                <option th:each="cat : ${overview.categories}"
-                                        th:value="${cat.id}"
-                                        th:text="${cat.name}"></option>
-                            </select>
-                        </label>
-                        <label class="config-create-channel-field">
-                            <span>or new category name</span>
-                            <input type="text" name="newCategoryName"
-                                   maxlength="100" placeholder="(blank = use existing)"
+                <details id="settings-section-server-features" class="config-section" open>
+                    <summary>Server features</summary>
+                    <div class="config-grid">
+                        <div class="config-row" data-key="VOLUME">
+                            <label>Default volume</label>
+                            <input type="number" min="0" max="200"
+                                   th:value="${overview.config['VOLUME']}"
                                    th:disabled="${!isOwner}">
-                        </label>
-                        <button type="submit" class="btn config-create-channel-btn"
-                                th:disabled="${!isOwner}">Create</button>
-                    </form>
-                </div>
-            </div>
-        </details>
-
-        <h2 class="config-pillar">Economy</h2>
-
-        <details class="config-section">
-            <summary>Economy</summary>
-            <div class="config-grid">
-                <div class="config-row" data-key="UBI_DAILY_AMOUNT">
-                    <label>
-                        UBI daily amount
-                        <span class="config-hint">Credits granted to every user once per UTC day. 0 disables.</span>
-                    </label>
-                    <input type="number" min="0" max="1000"
-                           th:value="${overview.config['UBI_DAILY_AMOUNT']}"
-                           placeholder="0"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-row" data-key="DAILY_CREDIT_CAP">
-                    <label>
-                        Daily credit cap
-                        <span class="config-hint">Voice / command / intro earnings ceiling. Default 90.</span>
-                    </label>
-                    <input type="number" min="0" max="10000"
-                           th:value="${overview.config['DAILY_CREDIT_CAP']}"
-                           placeholder="90"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-row" data-key="TRADE_BUY_FEE_PCT">
-                    <label>
-                        Toby Coin BUY fee
-                        <span class="config-hint">Charged per leg and routed to the jackpot pool.</span>
-                    </label>
-                    <span class="config-input-group">
-                        <input type="number" min="0" max="25" step="0.01"
-                               th:value="${overview.config['TRADE_BUY_FEE_PCT']}"
-                               placeholder="1"
-                               th:disabled="${!isOwner}">
-                        <span class="config-suffix">%</span>
-                    </span>
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-row" data-key="TRADE_SELL_FEE_PCT">
-                    <label>
-                        Toby Coin SELL fee
-                        <span class="config-hint">Charged per leg and routed to the jackpot pool.</span>
-                    </label>
-                    <span class="config-input-group">
-                        <input type="number" min="0" max="25" step="0.01"
-                               th:value="${overview.config['TRADE_SELL_FEE_PCT']}"
-                               placeholder="1"
-                               th:disabled="${!isOwner}">
-                        <span class="config-suffix">%</span>
-                    </span>
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-            </div>
-        </details>
-
-        <h2 class="config-pillar">Casino</h2>
-
-        <details class="config-section">
-            <summary>Jackpot</summary>
-            <p class="muted mb-2">
-                Jackpot pool tuning. The pool grows from loss tributes and
-                trade fees and pays out on a small chance per casino-game win.
-                Use the eligibility gates below (RTP cap, winner cooldown,
-                activity window) to keep the pool from being swept by
-                high-RTP games or low-activity edge cases. Set
-                <code>JACKPOT_WIN_PCT</code> to <code>0</code> to disable
-                jackpot wins entirely; set <code>JACKPOT_RTP_MAX_PCT</code>
-                to a value below a game's canonical RTP to disable jackpots
-                just for that game.
-            </p>
-            <div class="config-grid">
-                <div class="config-row" data-key="JACKPOT_LOSS_TRIBUTE_PCT">
-                    <label>
-                        Loss tribute
-                        <span class="config-hint">% of every lost casino stake routed to the pool. Default 10.</span>
-                    </label>
-                    <span class="config-input-group">
-                        <input type="number" min="0" max="50"
-                               th:value="${overview.config['JACKPOT_LOSS_TRIBUTE_PCT']}"
-                               placeholder="10"
-                               th:disabled="${!isOwner}">
-                        <span class="config-suffix">%</span>
-                    </span>
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-row" data-key="JACKPOT_WIN_PCT">
-                    <label>
-                        Win chance
-                        <span class="config-hint">Per casino-game win; decimals allowed. 0 disables jackpots. Default 1.</span>
-                    </label>
-                    <span class="config-input-group">
-                        <input type="number" min="0" max="50" step="0.01"
-                               th:value="${overview.config['JACKPOT_WIN_PCT']}"
-                               placeholder="1"
-                               th:disabled="${!isOwner}">
-                        <span class="config-suffix">%</span>
-                    </span>
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-row config-row-wide" data-key="JACKPOT_WHEEL_SEGMENTS">
-                    <label>Payout wheel segments</label>
-                    <p class="muted config-explainer">
-                        Each segment is a wedge of the spinning wheel that's
-                        spun when a player wins the jackpot. <strong>Weight</strong>
-                        is how often it's picked (positive integer; relative,
-                        not %). <strong>Payout %</strong> is how much of the pool
-                        the winner takes when the wheel lands there.
-                        Default <code>80:1,10:5,5:10,4:20,1:50</code> — most
-                        wins give a small pity prize, a rare 1-in-100 spin
-                        pays out half the pool. For a flat fixed-percent
-                        payout, set a single segment (e.g. <code>1:30</code>
-                        for "always 30% of the pool").
-                    </p>
-                    <div class="jackpot-wheel-editor"
-                         th:attr="data-current=${overview.config['JACKPOT_WHEEL_SEGMENTS']}">
-                        <div class="jackpot-wheel-editor-rows"></div>
-                        <div class="jackpot-wheel-editor-actions">
-                            <button type="button" class="btn btn-sm jackpot-wheel-add"
-                                    th:disabled="${!isOwner}">+ Add segment</button>
-                            <span class="muted jackpot-wheel-ev"></span>
+                            <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                         </div>
-                        <p class="jackpot-wheel-error error-text" hidden></p>
-                    </div>
-                    <button type="button" class="btn jackpot-wheel-save" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-row" data-key="JACKPOT_RTP_MAX_PCT">
-                    <label>
-                        Max eligible game RTP
-                        <span class="config-hint">
-                            Caps which games can pay the jackpot. 0 disables the gate;
-                            recommended 95 to exclude blackjack / coinflip / baccarat / roulette.
-                        </span>
-                    </label>
-                    <span class="config-input-group">
-                        <input type="number" min="0" max="100"
-                               th:value="${overview.config['JACKPOT_RTP_MAX_PCT']}"
-                               placeholder="0"
-                               th:disabled="${!isOwner}">
-                        <span class="config-suffix">%</span>
-                    </span>
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-row" data-key="JACKPOT_WINNER_COOLDOWN_DAYS">
-                    <label>
-                        Winner cooldown
-                        <span class="config-hint">Days a recent winner is ineligible. 0 disables. Recommended 14.</span>
-                    </label>
-                    <input type="number" min="0" max="365"
-                           th:value="${overview.config['JACKPOT_WINNER_COOLDOWN_DAYS']}"
-                           placeholder="0"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-row" data-key="JACKPOT_ACTIVITY_WINDOW_DAYS">
-                    <label>
-                        Activity window
-                        <span class="config-hint">Trailing-day window for the eligibility check. 0 disables the gate. Recommended 7.</span>
-                    </label>
-                    <input type="number" min="0" max="90"
-                           th:value="${overview.config['JACKPOT_ACTIVITY_WINDOW_DAYS']}"
-                           placeholder="0"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-row" data-key="JACKPOT_ACTIVITY_MIN_DAYS">
-                    <label>
-                        Activity minimum
-                        <span class="config-hint">Distinct active days required within the window. Default 1. Ignored when window is 0.</span>
-                    </label>
-                    <input type="number" min="1" max="90"
-                           th:value="${overview.config['JACKPOT_ACTIVITY_MIN_DAYS']}"
-                           placeholder="1"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-row" data-key="JACKPOT_STAKE_ANCHOR">
-                    <label>
-                        Stake anchor
-                        <span class="config-hint">Reference stake for jackpot probability scaling. Default 500.</span>
-                    </label>
-                    <input type="number" min="1"
-                           th:value="${overview.config['JACKPOT_STAKE_ANCHOR']}"
-                           placeholder="500"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-            </div>
-        </details>
-
-        <details class="config-section">
-            <summary>Anti-autoclicker</summary>
-            <p class="muted config-section-lead">
-                Suspected autoclickers (same screen pixel clicked repeatedly with no cursor
-                motion between bets) get a per-(user, guild) streak that ramps the house
-                edge by 2.5 percentage points per consecutive bot-like click, capped per
-                game by the values below. The cap is the forced-loss probability applied on
-                top of the fair game; the suspect's effective RTP becomes
-                <code>(1 − cap/100) × fair RTP</code>. Default cap is <strong>30 %</strong>;
-                <strong>0 disables</strong> that game's gate. Legitimate play never trips the
-                detector, and Discord call paths are unaffected (no mouse signal).
-            </p>
-            <div class="config-grid">
-                <div class="config-row" data-key="COINFLIP_BOT_EDGE_MAX_PCT">
-                    <label>
-                        Coinflip
-                        <span class="config-hint">Fair RTP 100 %.</span>
-                    </label>
-                    <span class="config-input-group">
-                        <input type="number" min="0" max="50"
-                               th:value="${overview.config['COINFLIP_BOT_EDGE_MAX_PCT']}"
-                               placeholder="30"
-                               th:disabled="${!isOwner}">
-                        <span class="config-suffix">%</span>
-                    </span>
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-row" data-key="DICE_BOT_EDGE_MAX_PCT">
-                    <label>
-                        Dice
-                        <span class="config-hint">Fair RTP ≈ 83 %.</span>
-                    </label>
-                    <span class="config-input-group">
-                        <input type="number" min="0" max="50"
-                               th:value="${overview.config['DICE_BOT_EDGE_MAX_PCT']}"
-                               placeholder="30"
-                               th:disabled="${!isOwner}">
-                        <span class="config-suffix">%</span>
-                    </span>
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-row" data-key="SLOTS_BOT_EDGE_MAX_PCT">
-                    <label>
-                        Slots
-                        <span class="config-hint">Fair RTP ≈ 89 %.</span>
-                    </label>
-                    <span class="config-input-group">
-                        <input type="number" min="0" max="50"
-                               th:value="${overview.config['SLOTS_BOT_EDGE_MAX_PCT']}"
-                               placeholder="30"
-                               th:disabled="${!isOwner}">
-                        <span class="config-suffix">%</span>
-                    </span>
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-row" data-key="PLINKO_BOT_EDGE_MAX_PCT">
-                    <label>
-                        Plinko
-                        <span class="config-hint">Fair RTP ≈ 89 %.</span>
-                    </label>
-                    <span class="config-input-group">
-                        <input type="number" min="0" max="50"
-                               th:value="${overview.config['PLINKO_BOT_EDGE_MAX_PCT']}"
-                               placeholder="30"
-                               th:disabled="${!isOwner}">
-                        <span class="config-suffix">%</span>
-                    </span>
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-row" data-key="WHEEL_OF_FORTUNE_BOT_EDGE_MAX_PCT">
-                    <label>
-                        Wheel of Fortune
-                        <span class="config-hint">Fair RTP ≈ 88 %.</span>
-                    </label>
-                    <span class="config-input-group">
-                        <input type="number" min="0" max="50"
-                               th:value="${overview.config['WHEEL_OF_FORTUNE_BOT_EDGE_MAX_PCT']}"
-                               placeholder="30"
-                               th:disabled="${!isOwner}">
-                        <span class="config-suffix">%</span>
-                    </span>
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-row" data-key="CASINO_MODLOG_CHANNEL_ID">
-                    <label>
-                        Casino mod-log channel
-                        <span class="config-hint">Where anti-autoclicker session embeds post. Falls back to the system channel.</span>
-                    </label>
-                    <div th:replace="~{fragments/channelPicker :: channelPicker(
-                            name=null,
-                            id=null,
-                            channels=${overview.textChannels},
-                            selectedValue=${overview.config['CASINO_MODLOG_CHANNEL_ID']},
-                            placeholder='— system channel —',
-                            emptyLabel='— system channel —',
-                            required=false,
-                            valuePrefix='#',
-                            valueField='id',
-                            disabled=${!isOwner})}"></div>
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-create-channel">
-                    <div class="config-create-channel-text">
-                        <strong>Create a private mod-log channel</strong>
-                        <p class="muted">
-                            Creates a channel only TobyBot and server admins can see —
-                            @everyone is denied <code>VIEW_CHANNEL</code>; admins keep
-                            access via Discord's built-in Administrator-permission rule.
-                            Auto-sets the dropdown above. Bot needs the Manage Channels
-                            permission.
-                        </p>
-                    </div>
-                    <form class="config-create-admin-channel-form"
-                          data-target-config="CASINO_MODLOG_CHANNEL_ID"
-                          data-default-name="casino-modlog">
-                        <label class="config-create-channel-field">
-                            <span>Channel name</span>
-                            <input type="text" name="name" value="casino-modlog"
-                                   maxlength="90" th:disabled="${!isOwner}">
-                        </label>
-                        <label class="config-create-channel-field">
-                            <span>Category</span>
-                            <select name="parentCategoryId" th:disabled="${!isOwner}">
-                                <option value="">&mdash; top-level &mdash;</option>
-                                <option th:each="cat : ${overview.categories}"
-                                        th:value="${cat.id}"
-                                        th:text="${cat.name}"></option>
+                        <div class="config-row" data-key="INTRO_VOLUME">
+                            <label>Default intro volume</label>
+                            <input type="number" min="0" max="200"
+                                   th:value="${overview.config['INTRO_VOLUME']}"
+                                   th:disabled="${!isOwner}">
+                            <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                        </div>
+                        <div class="config-row" data-key="MOVE">
+                            <label>Default move channel</label>
+                            <div th:replace="~{fragments/channelPicker :: channelPicker(
+                                    name=null,
+                                    id=null,
+                                    channels=${overview.voiceChannels},
+                                    selectedValue=${overview.config['MOVE']},
+                                    placeholder='— none —',
+                                    emptyLabel='— none —',
+                                    required=false,
+                                    valuePrefix='',
+                                    valueField='name',
+                                    disabled=${!isOwner})}"></div>
+                            <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                        </div>
+                        <!-- Saving "true" here kicks an ActivityTrackingEnabled event that
+                             fires the first-enable DM flow, matching the Discord
+                             /setconfig behaviour. Default value is "false" when no row
+                             exists yet — matches ActivityTrackingService's read default. -->
+                        <div class="config-row" data-key="ACTIVITY_TRACKING">
+                            <label>Game-activity tracking</label>
+                            <select th:disabled="${!isOwner}">
+                                <option value="false"
+                                        th:selected="${overview.config['ACTIVITY_TRACKING'] == null or overview.config['ACTIVITY_TRACKING'] == 'false'}">
+                                    Disabled
+                                </option>
+                                <option value="true"
+                                        th:selected="${overview.config['ACTIVITY_TRACKING'] == 'true'}">
+                                    Enabled
+                                </option>
                             </select>
-                        </label>
-                        <label class="config-create-channel-field">
-                            <span>or new category name</span>
-                            <input type="text" name="newCategoryName"
-                                   maxlength="100" placeholder="(blank = use existing)"
+                            <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                        </div>
+                    </div>
+                </details>
+
+                <details id="settings-section-messages" class="config-section">
+                    <summary>Messages &amp; leaderboards</summary>
+                    <div class="config-grid">
+                        <div class="config-row" data-key="DELETE_DELAY">
+                            <label>Message delete delay (seconds)</label>
+                            <input type="number" min="0" max="600"
+                                   th:value="${overview.config['DELETE_DELAY']}"
                                    th:disabled="${!isOwner}">
-                        </label>
-                        <button type="submit" class="btn config-create-channel-btn"
-                                th:disabled="${!isOwner}">Create</button>
+                            <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                        </div>
+                        <div class="config-row" data-key="LEADERBOARD_CHANNEL">
+                            <label>Monthly leaderboard channel</label>
+                            <div th:replace="~{fragments/channelPicker :: channelPicker(
+                                    name=null,
+                                    id=null,
+                                    channels=${overview.textChannels},
+                                    selectedValue=${overview.config['LEADERBOARD_CHANNEL']},
+                                    placeholder='— system channel —',
+                                    emptyLabel='— system channel —',
+                                    required=false,
+                                    valuePrefix='#',
+                                    valueField='id',
+                                    disabled=${!isOwner})}"></div>
+                            <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                        </div>
+                        <div class="config-create-channel">
+                            <div class="config-create-channel-text">
+                                <strong>Create a read-only leaderboard channel</strong>
+                                <p class="muted">
+                                    Creates a new text channel where @everyone can read but only
+                                    TobyBot can post; auto-sets the leaderboard channel above to
+                                    it. Bot needs the Manage Channels permission.
+                                </p>
+                            </div>
+                            <form class="config-create-channel-form"
+                                  data-target-config="LEADERBOARD_CHANNEL"
+                                  data-default-name="leaderboard">
+                                <label class="config-create-channel-field">
+                                    <span>Channel name</span>
+                                    <input type="text" name="name" value="leaderboard"
+                                           maxlength="90" th:disabled="${!isOwner}">
+                                </label>
+                                <label class="config-create-channel-field">
+                                    <span>Category</span>
+                                    <select name="parentCategoryId" th:disabled="${!isOwner}">
+                                        <option value="">&mdash; top-level &mdash;</option>
+                                        <option th:each="cat : ${overview.categories}"
+                                                th:value="${cat.id}"
+                                                th:text="${cat.name}"></option>
+                                    </select>
+                                </label>
+                                <label class="config-create-channel-field">
+                                    <span>or new category name</span>
+                                    <input type="text" name="newCategoryName"
+                                           maxlength="100" placeholder="(blank = use existing)"
+                                           th:disabled="${!isOwner}">
+                                </label>
+                                <button type="submit" class="btn config-create-channel-btn"
+                                        th:disabled="${!isOwner}">Create</button>
+                            </form>
+                        </div>
+                    </div>
+                </details>
+
+                <h2 class="config-pillar">Economy</h2>
+
+                <details id="settings-section-economy" class="config-section">
+                    <summary>Economy</summary>
+                    <div class="config-grid">
+                        <div class="config-row" data-key="UBI_DAILY_AMOUNT">
+                            <label>
+                                UBI daily amount
+                                <span class="config-hint">Credits granted to every user once per UTC day. 0 disables.</span>
+                            </label>
+                            <input type="number" min="0" max="1000"
+                                   th:value="${overview.config['UBI_DAILY_AMOUNT']}"
+                                   placeholder="0"
+                                   th:disabled="${!isOwner}">
+                            <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                        </div>
+                        <div class="config-row" data-key="DAILY_CREDIT_CAP">
+                            <label>
+                                Daily credit cap
+                                <span class="config-hint">Voice / command / intro earnings ceiling. Default 90.</span>
+                            </label>
+                            <input type="number" min="0" max="10000"
+                                   th:value="${overview.config['DAILY_CREDIT_CAP']}"
+                                   placeholder="90"
+                                   th:disabled="${!isOwner}">
+                            <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                        </div>
+                        <div class="config-row" data-key="TRADE_BUY_FEE_PCT">
+                            <label>
+                                Toby Coin BUY fee
+                                <span class="config-hint">Charged per leg and routed to the jackpot pool.</span>
+                            </label>
+                            <span class="config-input-group">
+                                <input type="number" min="0" max="25" step="0.01"
+                                       th:value="${overview.config['TRADE_BUY_FEE_PCT']}"
+                                       placeholder="1"
+                                       th:disabled="${!isOwner}">
+                                <span class="config-suffix">%</span>
+                            </span>
+                            <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                        </div>
+                        <div class="config-row" data-key="TRADE_SELL_FEE_PCT">
+                            <label>
+                                Toby Coin SELL fee
+                                <span class="config-hint">Charged per leg and routed to the jackpot pool.</span>
+                            </label>
+                            <span class="config-input-group">
+                                <input type="number" min="0" max="25" step="0.01"
+                                       th:value="${overview.config['TRADE_SELL_FEE_PCT']}"
+                                       placeholder="1"
+                                       th:disabled="${!isOwner}">
+                                <span class="config-suffix">%</span>
+                            </span>
+                            <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                        </div>
+                    </div>
+                </details>
+
+                <h2 class="config-pillar">Casino</h2>
+
+                <details id="settings-section-jackpot" class="config-section">
+                    <summary>Jackpot</summary>
+                    <p class="muted mb-2">
+                        Jackpot pool tuning. The pool grows from loss tributes and
+                        trade fees and pays out on a small chance per casino-game win.
+                        Use the eligibility gates below (RTP cap, winner cooldown,
+                        activity window) to keep the pool from being swept by
+                        high-RTP games or low-activity edge cases. Set
+                        <code>JACKPOT_WIN_PCT</code> to <code>0</code> to disable
+                        jackpot wins entirely; set <code>JACKPOT_RTP_MAX_PCT</code>
+                        to a value below a game's canonical RTP to disable jackpots
+                        just for that game.
+                    </p>
+                    <div class="config-grid">
+                        <div class="config-row" data-key="JACKPOT_LOSS_TRIBUTE_PCT">
+                            <label>
+                                Loss tribute
+                                <span class="config-hint">% of every lost casino stake routed to the pool. Default 10.</span>
+                            </label>
+                            <span class="config-input-group">
+                                <input type="number" min="0" max="50"
+                                       th:value="${overview.config['JACKPOT_LOSS_TRIBUTE_PCT']}"
+                                       placeholder="10"
+                                       th:disabled="${!isOwner}">
+                                <span class="config-suffix">%</span>
+                            </span>
+                            <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                        </div>
+                        <div class="config-row" data-key="JACKPOT_WIN_PCT">
+                            <label>
+                                Win chance
+                                <span class="config-hint">Per casino-game win; decimals allowed. 0 disables jackpots. Default 1.</span>
+                            </label>
+                            <span class="config-input-group">
+                                <input type="number" min="0" max="50" step="0.01"
+                                       th:value="${overview.config['JACKPOT_WIN_PCT']}"
+                                       placeholder="1"
+                                       th:disabled="${!isOwner}">
+                                <span class="config-suffix">%</span>
+                            </span>
+                            <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                        </div>
+                        <div class="config-row config-row-wide" data-key="JACKPOT_WHEEL_SEGMENTS">
+                            <label>Payout wheel segments</label>
+                            <p class="muted config-explainer">
+                                Each segment is a wedge of the spinning wheel that's
+                                spun when a player wins the jackpot. <strong>Weight</strong>
+                                is how often it's picked (positive integer; relative,
+                                not %). <strong>Payout %</strong> is how much of the pool
+                                the winner takes when the wheel lands there.
+                                Default <code>80:1,10:5,5:10,4:20,1:50</code> — most
+                                wins give a small pity prize, a rare 1-in-100 spin
+                                pays out half the pool. For a flat fixed-percent
+                                payout, set a single segment (e.g. <code>1:30</code>
+                                for "always 30% of the pool").
+                            </p>
+                            <div class="jackpot-wheel-editor"
+                                 th:attr="data-current=${overview.config['JACKPOT_WHEEL_SEGMENTS']}">
+                                <div class="jackpot-wheel-editor-rows"></div>
+                                <div class="jackpot-wheel-editor-actions">
+                                    <button type="button" class="btn btn-sm jackpot-wheel-add"
+                                            th:disabled="${!isOwner}">+ Add segment</button>
+                                    <span class="muted jackpot-wheel-ev"></span>
+                                </div>
+                                <p class="jackpot-wheel-error error-text" hidden></p>
+                            </div>
+                            <button type="button" class="btn jackpot-wheel-save" th:disabled="${!isOwner}">Save</button>
+                        </div>
+                        <div class="config-row" data-key="JACKPOT_RTP_MAX_PCT">
+                            <label>
+                                Max eligible game RTP
+                                <span class="config-hint">
+                                    Caps which games can pay the jackpot. 0 disables the gate;
+                                    recommended 95 to exclude blackjack / coinflip / baccarat / roulette.
+                                </span>
+                            </label>
+                            <span class="config-input-group">
+                                <input type="number" min="0" max="100"
+                                       th:value="${overview.config['JACKPOT_RTP_MAX_PCT']}"
+                                       placeholder="0"
+                                       th:disabled="${!isOwner}">
+                                <span class="config-suffix">%</span>
+                            </span>
+                            <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                        </div>
+                        <div class="config-row" data-key="JACKPOT_WINNER_COOLDOWN_DAYS">
+                            <label>
+                                Winner cooldown
+                                <span class="config-hint">Days a recent winner is ineligible. 0 disables. Recommended 14.</span>
+                            </label>
+                            <input type="number" min="0" max="365"
+                                   th:value="${overview.config['JACKPOT_WINNER_COOLDOWN_DAYS']}"
+                                   placeholder="0"
+                                   th:disabled="${!isOwner}">
+                            <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                        </div>
+                        <div class="config-row" data-key="JACKPOT_ACTIVITY_WINDOW_DAYS">
+                            <label>
+                                Activity window
+                                <span class="config-hint">Trailing-day window for the eligibility check. 0 disables the gate. Recommended 7.</span>
+                            </label>
+                            <input type="number" min="0" max="90"
+                                   th:value="${overview.config['JACKPOT_ACTIVITY_WINDOW_DAYS']}"
+                                   placeholder="0"
+                                   th:disabled="${!isOwner}">
+                            <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                        </div>
+                        <div class="config-row" data-key="JACKPOT_ACTIVITY_MIN_DAYS">
+                            <label>
+                                Activity minimum
+                                <span class="config-hint">Distinct active days required within the window. Default 1. Ignored when window is 0.</span>
+                            </label>
+                            <input type="number" min="1" max="90"
+                                   th:value="${overview.config['JACKPOT_ACTIVITY_MIN_DAYS']}"
+                                   placeholder="1"
+                                   th:disabled="${!isOwner}">
+                            <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                        </div>
+                        <div class="config-row" data-key="JACKPOT_STAKE_ANCHOR">
+                            <label>
+                                Stake anchor
+                                <span class="config-hint">Reference stake for jackpot probability scaling. Default 500.</span>
+                            </label>
+                            <input type="number" min="1"
+                                   th:value="${overview.config['JACKPOT_STAKE_ANCHOR']}"
+                                   placeholder="500"
+                                   th:disabled="${!isOwner}">
+                            <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                        </div>
+                    </div>
+                </details>
+
+                <details id="settings-section-autoclicker" class="config-section">
+                    <summary>Anti-autoclicker</summary>
+                    <p class="muted config-section-lead">
+                        Suspected autoclickers (same screen pixel clicked repeatedly with no cursor
+                        motion between bets) get a per-(user, guild) streak that ramps the house
+                        edge by 2.5 percentage points per consecutive bot-like click, capped per
+                        game by the values below. The cap is the forced-loss probability applied on
+                        top of the fair game; the suspect's effective RTP becomes
+                        <code>(1 − cap/100) × fair RTP</code>. Default cap is <strong>30 %</strong>;
+                        <strong>0 disables</strong> that game's gate. Legitimate play never trips the
+                        detector, and Discord call paths are unaffected (no mouse signal).
+                    </p>
+                    <div class="config-grid">
+                        <div class="config-row" data-key="COINFLIP_BOT_EDGE_MAX_PCT">
+                            <label>
+                                Coinflip
+                                <span class="config-hint">Fair RTP 100 %.</span>
+                            </label>
+                            <span class="config-input-group">
+                                <input type="number" min="0" max="50"
+                                       th:value="${overview.config['COINFLIP_BOT_EDGE_MAX_PCT']}"
+                                       placeholder="30"
+                                       th:disabled="${!isOwner}">
+                                <span class="config-suffix">%</span>
+                            </span>
+                            <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                        </div>
+                        <div class="config-row" data-key="DICE_BOT_EDGE_MAX_PCT">
+                            <label>
+                                Dice
+                                <span class="config-hint">Fair RTP ≈ 83 %.</span>
+                            </label>
+                            <span class="config-input-group">
+                                <input type="number" min="0" max="50"
+                                       th:value="${overview.config['DICE_BOT_EDGE_MAX_PCT']}"
+                                       placeholder="30"
+                                       th:disabled="${!isOwner}">
+                                <span class="config-suffix">%</span>
+                            </span>
+                            <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                        </div>
+                        <div class="config-row" data-key="SLOTS_BOT_EDGE_MAX_PCT">
+                            <label>
+                                Slots
+                                <span class="config-hint">Fair RTP ≈ 89 %.</span>
+                            </label>
+                            <span class="config-input-group">
+                                <input type="number" min="0" max="50"
+                                       th:value="${overview.config['SLOTS_BOT_EDGE_MAX_PCT']}"
+                                       placeholder="30"
+                                       th:disabled="${!isOwner}">
+                                <span class="config-suffix">%</span>
+                            </span>
+                            <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                        </div>
+                        <div class="config-row" data-key="PLINKO_BOT_EDGE_MAX_PCT">
+                            <label>
+                                Plinko
+                                <span class="config-hint">Fair RTP ≈ 89 %.</span>
+                            </label>
+                            <span class="config-input-group">
+                                <input type="number" min="0" max="50"
+                                       th:value="${overview.config['PLINKO_BOT_EDGE_MAX_PCT']}"
+                                       placeholder="30"
+                                       th:disabled="${!isOwner}">
+                                <span class="config-suffix">%</span>
+                            </span>
+                            <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                        </div>
+                        <div class="config-row" data-key="WHEEL_OF_FORTUNE_BOT_EDGE_MAX_PCT">
+                            <label>
+                                Wheel of Fortune
+                                <span class="config-hint">Fair RTP ≈ 88 %.</span>
+                            </label>
+                            <span class="config-input-group">
+                                <input type="number" min="0" max="50"
+                                       th:value="${overview.config['WHEEL_OF_FORTUNE_BOT_EDGE_MAX_PCT']}"
+                                       placeholder="30"
+                                       th:disabled="${!isOwner}">
+                                <span class="config-suffix">%</span>
+                            </span>
+                            <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                        </div>
+                        <div class="config-row" data-key="CASINO_MODLOG_CHANNEL_ID">
+                            <label>
+                                Casino mod-log channel
+                                <span class="config-hint">Where anti-autoclicker session embeds post. Falls back to the system channel.</span>
+                            </label>
+                            <div th:replace="~{fragments/channelPicker :: channelPicker(
+                                    name=null,
+                                    id=null,
+                                    channels=${overview.textChannels},
+                                    selectedValue=${overview.config['CASINO_MODLOG_CHANNEL_ID']},
+                                    placeholder='— system channel —',
+                                    emptyLabel='— system channel —',
+                                    required=false,
+                                    valuePrefix='#',
+                                    valueField='id',
+                                    disabled=${!isOwner})}"></div>
+                            <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                        </div>
+                        <div class="config-create-channel">
+                            <div class="config-create-channel-text">
+                                <strong>Create a private mod-log channel</strong>
+                                <p class="muted">
+                                    Creates a channel only TobyBot and server admins can see —
+                                    @everyone is denied <code>VIEW_CHANNEL</code>; admins keep
+                                    access via Discord's built-in Administrator-permission rule.
+                                    Auto-sets the dropdown above. Bot needs the Manage Channels
+                                    permission.
+                                </p>
+                            </div>
+                            <form class="config-create-admin-channel-form"
+                                  data-target-config="CASINO_MODLOG_CHANNEL_ID"
+                                  data-default-name="casino-modlog">
+                                <label class="config-create-channel-field">
+                                    <span>Channel name</span>
+                                    <input type="text" name="name" value="casino-modlog"
+                                           maxlength="90" th:disabled="${!isOwner}">
+                                </label>
+                                <label class="config-create-channel-field">
+                                    <span>Category</span>
+                                    <select name="parentCategoryId" th:disabled="${!isOwner}">
+                                        <option value="">&mdash; top-level &mdash;</option>
+                                        <option th:each="cat : ${overview.categories}"
+                                                th:value="${cat.id}"
+                                                th:text="${cat.name}"></option>
+                                    </select>
+                                </label>
+                                <label class="config-create-channel-field">
+                                    <span>or new category name</span>
+                                    <input type="text" name="newCategoryName"
+                                           maxlength="100" placeholder="(blank = use existing)"
+                                           th:disabled="${!isOwner}">
+                                </label>
+                                <button type="submit" class="btn config-create-channel-btn"
+                                        th:disabled="${!isOwner}">Create</button>
+                            </form>
+                        </div>
+                    </div>
+                </details>
+
+                <details id="settings-section-poker" class="config-section">
+                    <summary>Poker</summary>
+                    <div class="config-grid">
+                        <div class="config-group">
+                            <h4>Table rules</h4>
+                            <div class="config-row" data-key="POKER_RAKE_PCT">
+                                <label>Poker rake (% of every settled pot routed to jackpot; default 5)</label>
+                                <span class="config-input-group">
+                                    <input type="number" min="0" max="20" step="1"
+                                           th:value="${overview.config['POKER_RAKE_PCT']}"
+                                           placeholder="5"
+                                           th:disabled="${!isOwner}">
+                                    <span class="config-suffix">%</span>
+                                </span>
+                                <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                            </div>
+                            <div class="config-row" data-key="POKER_MAX_SEATS">
+                                <label>Max seats per table (2-9; default 6)</label>
+                                <input type="number" min="2" max="9"
+                                       th:value="${overview.config['POKER_MAX_SEATS']}"
+                                       placeholder="6"
+                                       th:disabled="${!isOwner}">
+                                <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                            </div>
+                            <div class="config-row" data-key="POKER_SHOT_CLOCK_SECONDS">
+                                <label>Decision deadline per actor (seconds; 0 disables; default 30)</label>
+                                <input type="number" min="0" max="600"
+                                       th:value="${overview.config['POKER_SHOT_CLOCK_SECONDS']}"
+                                       placeholder="30"
+                                       th:disabled="${!isOwner}">
+                                <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                            </div>
+                        </div>
+                        <div class="config-group">
+                            <h4>Blinds &amp; buy-ins</h4>
+                            <div class="config-row" data-key="POKER_SMALL_BLIND">
+                                <label>Small blind (chips posted by SB seat each hand; default 5)</label>
+                                <input type="number" min="1"
+                                       th:value="${overview.config['POKER_SMALL_BLIND']}"
+                                       placeholder="5"
+                                       th:disabled="${!isOwner}">
+                                <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                            </div>
+                            <div class="config-row" data-key="POKER_BIG_BLIND">
+                                <label>Big blind (chips posted by BB seat each hand; default 10)</label>
+                                <input type="number" min="1"
+                                       th:value="${overview.config['POKER_BIG_BLIND']}"
+                                       placeholder="10"
+                                       th:disabled="${!isOwner}">
+                                <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                            </div>
+                            <div class="config-row" data-key="POKER_SMALL_BET">
+                                <label>Small bet (fixed-limit bet pre-flop &amp; flop; default 10)</label>
+                                <input type="number" min="1"
+                                       th:value="${overview.config['POKER_SMALL_BET']}"
+                                       placeholder="10"
+                                       th:disabled="${!isOwner}">
+                                <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                            </div>
+                            <div class="config-row" data-key="POKER_BIG_BET">
+                                <label>Big bet (fixed-limit bet on turn &amp; river; default 20)</label>
+                                <input type="number" min="1"
+                                       th:value="${overview.config['POKER_BIG_BET']}"
+                                       placeholder="20"
+                                       th:disabled="${!isOwner}">
+                                <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                            </div>
+                            <div class="config-row" data-key="POKER_MIN_BUY_IN">
+                                <label>Minimum buy-in per seat (chips; default 100)</label>
+                                <input type="number" min="1"
+                                       th:value="${overview.config['POKER_MIN_BUY_IN']}"
+                                       placeholder="100"
+                                       th:disabled="${!isOwner}">
+                                <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                            </div>
+                            <div class="config-row" data-key="POKER_MAX_BUY_IN">
+                                <label>Maximum buy-in per seat (chips; 0 = unlimited; default 5000)</label>
+                                <input type="number" min="0"
+                                       th:value="${overview.config['POKER_MAX_BUY_IN']}"
+                                       placeholder="5000"
+                                       th:disabled="${!isOwner}">
+                                <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                            </div>
+                        </div>
+                    </div>
+                </details>
+
+                <details id="settings-section-blackjack" class="config-section">
+                    <summary>Blackjack</summary>
+                    <div class="config-grid">
+                        <div class="config-group">
+                            <h4>Table rules</h4>
+                            <div class="config-row" data-key="BLACKJACK_RAKE_PCT">
+                                <label>Blackjack rake (% of multi-table losers' pool routed to jackpot; default 5)</label>
+                                <span class="config-input-group">
+                                    <input type="number" min="0" max="20" step="1"
+                                           th:value="${overview.config['BLACKJACK_RAKE_PCT']}"
+                                           placeholder="5"
+                                           th:disabled="${!isOwner}">
+                                    <span class="config-suffix">%</span>
+                                </span>
+                                <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                            </div>
+                            <div class="config-row" data-key="BLACKJACK_MAX_SEATS">
+                                <label>Max seats per multi table (2-7; default 5)</label>
+                                <input type="number" min="2" max="7"
+                                       th:value="${overview.config['BLACKJACK_MAX_SEATS']}"
+                                       placeholder="5"
+                                       th:disabled="${!isOwner}">
+                                <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                            </div>
+                            <div class="config-row" data-key="BLACKJACK_SHOT_CLOCK_SECONDS">
+                                <label>Decision deadline per actor (seconds; 0 disables; default 30)</label>
+                                <input type="number" min="0" max="600"
+                                       th:value="${overview.config['BLACKJACK_SHOT_CLOCK_SECONDS']}"
+                                       placeholder="30"
+                                       th:disabled="${!isOwner}">
+                                <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                            </div>
+                            <div class="config-row" data-key="BLACKJACK_DEALER_HITS_SOFT_17">
+                                <label>Dealer rule on soft 17</label>
+                                <select th:disabled="${!isOwner}">
+                                    <option value="false"
+                                            th:selected="${overview.config['BLACKJACK_DEALER_HITS_SOFT_17'] == null or overview.config['BLACKJACK_DEALER_HITS_SOFT_17'] == 'false'}">
+                                        Stand on soft 17 (S17, default — better for the player)
+                                    </option>
+                                    <option value="true"
+                                            th:selected="${overview.config['BLACKJACK_DEALER_HITS_SOFT_17'] == 'true'}">
+                                        Hit soft 17 (H17 — slightly worse for the player)
+                                    </option>
+                                </select>
+                                <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                            </div>
+                            <div class="config-row" data-key="BLACKJACK_BJ_PAYOUT_NUM">
+                                <label>Natural-blackjack payout numerator (e.g. 3 for 3:2; default 3)</label>
+                                <input type="number" min="1" max="10"
+                                       th:value="${overview.config['BLACKJACK_BJ_PAYOUT_NUM']}"
+                                       placeholder="3"
+                                       th:disabled="${!isOwner}">
+                                <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                            </div>
+                            <div class="config-row" data-key="BLACKJACK_BJ_PAYOUT_DEN">
+                                <label>Natural-blackjack payout denominator (e.g. 2 for 3:2; default 2)</label>
+                                <input type="number" min="1" max="10"
+                                       th:value="${overview.config['BLACKJACK_BJ_PAYOUT_DEN']}"
+                                       placeholder="2"
+                                       th:disabled="${!isOwner}">
+                                <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                            </div>
+                        </div>
+                        <div class="config-group">
+                            <h4>Stakes per hand</h4>
+                            <div class="config-row" data-key="BLACKJACK_MIN_ANTE">
+                                <label>Minimum stake per hand (applies to solo &amp; multi; default 10)</label>
+                                <input type="number" min="1"
+                                       th:value="${overview.config['BLACKJACK_MIN_ANTE']}"
+                                       placeholder="10"
+                                       th:disabled="${!isOwner}">
+                                <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                            </div>
+                            <div class="config-row" data-key="BLACKJACK_MAX_ANTE">
+                                <label>Maximum stake per hand (applies to solo &amp; multi; 0 = unlimited; default 500)</label>
+                                <input type="number" min="0"
+                                       th:value="${overview.config['BLACKJACK_MAX_ANTE']}"
+                                       placeholder="500"
+                                       th:disabled="${!isOwner}">
+                                <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                            </div>
+                        </div>
+                    </div>
+                </details>
+
+                <details id="settings-section-stakes" class="config-section">
+                    <summary>Game stake limits</summary>
+                    <p class="muted config-section-lead">
+                        Stake bounds for every simple casino game. Set any maximum to
+                        <code>0</code> to remove the cap. Blackjack ante limits live
+                        in the <strong>Blackjack</strong> section; poker blinds and
+                        buy-ins live in the <strong>Poker</strong> section.
+                    </p>
+
+                    <!--
+                        Bulk "apply to all games" form. Fans out one PATCH per
+                        affected (game × min|max) key under the hood, reusing
+                        the same `/moderation/{guildId}/config` endpoint as the
+                        per-row saves. Leaving either field blank skips that
+                        side, so admins can bulk-set just minimums without
+                        clobbering maximums (or vice versa). Wired in
+                        settings.js — see `.settings-stakes-bulk-form` handler.
+                    -->
+                    <form class="settings-stakes-bulk" th:if="${isOwner}">
+                        <div class="settings-stakes-bulk-text">
+                            <strong>Set every game at once</strong>
+                            <p class="muted">
+                                Applies the chosen value to every row in the table below.
+                                Leave a field blank to skip it. Saves run in parallel —
+                                you'll get a single toast with the result.
+                            </p>
+                        </div>
+                        <div class="settings-stakes-bulk-fields">
+                            <label class="settings-stakes-bulk-field">
+                                <span>All minimums</span>
+                                <input type="number" min="0" name="bulkMin"
+                                       placeholder="(skip)" inputmode="numeric">
+                            </label>
+                            <label class="settings-stakes-bulk-field">
+                                <span>All maximums</span>
+                                <input type="number" min="0" name="bulkMax"
+                                       placeholder="(skip)" inputmode="numeric">
+                            </label>
+                            <button type="submit" class="btn">Apply to all games</button>
+                        </div>
                     </form>
-                </div>
-            </div>
-        </details>
 
-        <details class="config-section">
-            <summary>Poker</summary>
-            <div class="config-grid">
-                <div class="config-group">
-                    <h4>Table rules</h4>
-                    <div class="config-row" data-key="POKER_RAKE_PCT">
-                        <label>Poker rake (% of every settled pot routed to jackpot; default 5)</label>
-                        <span class="config-input-group">
-                            <input type="number" min="0" max="20" step="1"
-                                   th:value="${overview.config['POKER_RAKE_PCT']}"
-                                   placeholder="5"
-                                   th:disabled="${!isOwner}">
-                            <span class="config-suffix">%</span>
-                        </span>
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    <!--
+                        Stake limits live in one wide table — same per-row save
+                        wiring as the rest of the page (`.config-row[data-key]`
+                        with `.save-config` button), just packed two-up per game
+                        instead of stacked vertically. Each min/max cell carries
+                        its own `.config-row` so the existing search filter,
+                        save handler, and aria semantics all keep working.
+                    -->
+                    <div class="settings-stakes-wrap">
+                        <table class="settings-stakes-table">
+                            <thead>
+                                <tr>
+                                    <th scope="col">Game</th>
+                                    <th scope="col">Minimum stake</th>
+                                    <th scope="col">Maximum stake</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <th scope="row">Dice</th>
+                                    <td data-label="Minimum stake">
+                                        <div class="config-row settings-stake-cell" data-key="DICE_MIN_STAKE">
+                                            <label class="sr-only">Dice minimum stake (default 10)</label>
+                                            <input type="number" min="1"
+                                                   th:value="${overview.config['DICE_MIN_STAKE']}"
+                                                   placeholder="10"
+                                                   th:disabled="${!isOwner}">
+                                            <button type="button" class="btn btn-sm save-config" th:disabled="${!isOwner}">Save</button>
+                                        </div>
+                                    </td>
+                                    <td data-label="Maximum stake">
+                                        <div class="config-row settings-stake-cell" data-key="DICE_MAX_STAKE">
+                                            <label class="sr-only">Dice maximum stake (0 = unlimited; default 500)</label>
+                                            <input type="number" min="0"
+                                                   th:value="${overview.config['DICE_MAX_STAKE']}"
+                                                   placeholder="500"
+                                                   th:disabled="${!isOwner}">
+                                            <button type="button" class="btn btn-sm save-config" th:disabled="${!isOwner}">Save</button>
+                                        </div>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th scope="row">Coinflip</th>
+                                    <td data-label="Minimum stake">
+                                        <div class="config-row settings-stake-cell" data-key="COINFLIP_MIN_STAKE">
+                                            <label class="sr-only">Coinflip minimum stake (default 10)</label>
+                                            <input type="number" min="1"
+                                                   th:value="${overview.config['COINFLIP_MIN_STAKE']}"
+                                                   placeholder="10"
+                                                   th:disabled="${!isOwner}">
+                                            <button type="button" class="btn btn-sm save-config" th:disabled="${!isOwner}">Save</button>
+                                        </div>
+                                    </td>
+                                    <td data-label="Maximum stake">
+                                        <div class="config-row settings-stake-cell" data-key="COINFLIP_MAX_STAKE">
+                                            <label class="sr-only">Coinflip maximum stake (0 = unlimited; default 1000)</label>
+                                            <input type="number" min="0"
+                                                   th:value="${overview.config['COINFLIP_MAX_STAKE']}"
+                                                   placeholder="1000"
+                                                   th:disabled="${!isOwner}">
+                                            <button type="button" class="btn btn-sm save-config" th:disabled="${!isOwner}">Save</button>
+                                        </div>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th scope="row">Slots</th>
+                                    <td data-label="Minimum stake">
+                                        <div class="config-row settings-stake-cell" data-key="SLOTS_MIN_STAKE">
+                                            <label class="sr-only">Slots minimum stake (default 10)</label>
+                                            <input type="number" min="1"
+                                                   th:value="${overview.config['SLOTS_MIN_STAKE']}"
+                                                   placeholder="10"
+                                                   th:disabled="${!isOwner}">
+                                            <button type="button" class="btn btn-sm save-config" th:disabled="${!isOwner}">Save</button>
+                                        </div>
+                                    </td>
+                                    <td data-label="Maximum stake">
+                                        <div class="config-row settings-stake-cell" data-key="SLOTS_MAX_STAKE">
+                                            <label class="sr-only">Slots maximum stake (0 = unlimited; default 500)</label>
+                                            <input type="number" min="0"
+                                                   th:value="${overview.config['SLOTS_MAX_STAKE']}"
+                                                   placeholder="500"
+                                                   th:disabled="${!isOwner}">
+                                            <button type="button" class="btn btn-sm save-config" th:disabled="${!isOwner}">Save</button>
+                                        </div>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th scope="row">Highlow</th>
+                                    <td data-label="Minimum stake">
+                                        <div class="config-row settings-stake-cell" data-key="HIGHLOW_MIN_STAKE">
+                                            <label class="sr-only">Highlow minimum stake (default 10)</label>
+                                            <input type="number" min="1"
+                                                   th:value="${overview.config['HIGHLOW_MIN_STAKE']}"
+                                                   placeholder="10"
+                                                   th:disabled="${!isOwner}">
+                                            <button type="button" class="btn btn-sm save-config" th:disabled="${!isOwner}">Save</button>
+                                        </div>
+                                    </td>
+                                    <td data-label="Maximum stake">
+                                        <div class="config-row settings-stake-cell" data-key="HIGHLOW_MAX_STAKE">
+                                            <label class="sr-only">Highlow maximum stake (0 = unlimited; default 500)</label>
+                                            <input type="number" min="0"
+                                                   th:value="${overview.config['HIGHLOW_MAX_STAKE']}"
+                                                   placeholder="500"
+                                                   th:disabled="${!isOwner}">
+                                            <button type="button" class="btn btn-sm save-config" th:disabled="${!isOwner}">Save</button>
+                                        </div>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th scope="row">Baccarat</th>
+                                    <td data-label="Minimum stake">
+                                        <div class="config-row settings-stake-cell" data-key="BACCARAT_MIN_STAKE">
+                                            <label class="sr-only">Baccarat minimum stake (default 10)</label>
+                                            <input type="number" min="1"
+                                                   th:value="${overview.config['BACCARAT_MIN_STAKE']}"
+                                                   placeholder="10"
+                                                   th:disabled="${!isOwner}">
+                                            <button type="button" class="btn btn-sm save-config" th:disabled="${!isOwner}">Save</button>
+                                        </div>
+                                    </td>
+                                    <td data-label="Maximum stake">
+                                        <div class="config-row settings-stake-cell" data-key="BACCARAT_MAX_STAKE">
+                                            <label class="sr-only">Baccarat maximum stake (0 = unlimited; default 500)</label>
+                                            <input type="number" min="0"
+                                                   th:value="${overview.config['BACCARAT_MAX_STAKE']}"
+                                                   placeholder="500"
+                                                   th:disabled="${!isOwner}">
+                                            <button type="button" class="btn btn-sm save-config" th:disabled="${!isOwner}">Save</button>
+                                        </div>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th scope="row">Keno</th>
+                                    <td data-label="Minimum stake">
+                                        <div class="config-row settings-stake-cell" data-key="KENO_MIN_STAKE">
+                                            <label class="sr-only">Keno minimum stake (default 10)</label>
+                                            <input type="number" min="1"
+                                                   th:value="${overview.config['KENO_MIN_STAKE']}"
+                                                   placeholder="10"
+                                                   th:disabled="${!isOwner}">
+                                            <button type="button" class="btn btn-sm save-config" th:disabled="${!isOwner}">Save</button>
+                                        </div>
+                                    </td>
+                                    <td data-label="Maximum stake">
+                                        <div class="config-row settings-stake-cell" data-key="KENO_MAX_STAKE">
+                                            <label class="sr-only">Keno maximum stake (0 = unlimited; default 500)</label>
+                                            <input type="number" min="0"
+                                                   th:value="${overview.config['KENO_MAX_STAKE']}"
+                                                   placeholder="500"
+                                                   th:disabled="${!isOwner}">
+                                            <button type="button" class="btn btn-sm save-config" th:disabled="${!isOwner}">Save</button>
+                                        </div>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th scope="row">Scratch</th>
+                                    <td data-label="Minimum stake">
+                                        <div class="config-row settings-stake-cell" data-key="SCRATCH_MIN_STAKE">
+                                            <label class="sr-only">Scratch minimum stake (default 10)</label>
+                                            <input type="number" min="1"
+                                                   th:value="${overview.config['SCRATCH_MIN_STAKE']}"
+                                                   placeholder="10"
+                                                   th:disabled="${!isOwner}">
+                                            <button type="button" class="btn btn-sm save-config" th:disabled="${!isOwner}">Save</button>
+                                        </div>
+                                    </td>
+                                    <td data-label="Maximum stake">
+                                        <div class="config-row settings-stake-cell" data-key="SCRATCH_MAX_STAKE">
+                                            <label class="sr-only">Scratch maximum stake (0 = unlimited; default 500)</label>
+                                            <input type="number" min="0"
+                                                   th:value="${overview.config['SCRATCH_MAX_STAKE']}"
+                                                   placeholder="500"
+                                                   th:disabled="${!isOwner}">
+                                            <button type="button" class="btn btn-sm save-config" th:disabled="${!isOwner}">Save</button>
+                                        </div>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th scope="row">Roulette</th>
+                                    <td data-label="Minimum stake">
+                                        <div class="config-row settings-stake-cell" data-key="ROULETTE_MIN_STAKE">
+                                            <label class="sr-only">Roulette minimum stake (default 10)</label>
+                                            <input type="number" min="1"
+                                                   th:value="${overview.config['ROULETTE_MIN_STAKE']}"
+                                                   placeholder="10"
+                                                   th:disabled="${!isOwner}">
+                                            <button type="button" class="btn btn-sm save-config" th:disabled="${!isOwner}">Save</button>
+                                        </div>
+                                    </td>
+                                    <td data-label="Maximum stake">
+                                        <div class="config-row settings-stake-cell" data-key="ROULETTE_MAX_STAKE">
+                                            <label class="sr-only">Roulette maximum stake (0 = unlimited; default 500)</label>
+                                            <input type="number" min="0"
+                                                   th:value="${overview.config['ROULETTE_MAX_STAKE']}"
+                                                   placeholder="500"
+                                                   th:disabled="${!isOwner}">
+                                            <button type="button" class="btn btn-sm save-config" th:disabled="${!isOwner}">Save</button>
+                                        </div>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th scope="row">Plinko</th>
+                                    <td data-label="Minimum stake">
+                                        <div class="config-row settings-stake-cell" data-key="PLINKO_MIN_STAKE">
+                                            <label class="sr-only">Plinko minimum stake (default 10)</label>
+                                            <input type="number" min="1"
+                                                   th:value="${overview.config['PLINKO_MIN_STAKE']}"
+                                                   placeholder="10"
+                                                   th:disabled="${!isOwner}">
+                                            <button type="button" class="btn btn-sm save-config" th:disabled="${!isOwner}">Save</button>
+                                        </div>
+                                    </td>
+                                    <td data-label="Maximum stake">
+                                        <div class="config-row settings-stake-cell" data-key="PLINKO_MAX_STAKE">
+                                            <label class="sr-only">Plinko maximum stake (0 = unlimited; default 500)</label>
+                                            <input type="number" min="0"
+                                                   th:value="${overview.config['PLINKO_MAX_STAKE']}"
+                                                   placeholder="500"
+                                                   th:disabled="${!isOwner}">
+                                            <button type="button" class="btn btn-sm save-config" th:disabled="${!isOwner}">Save</button>
+                                        </div>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th scope="row">Horse Racing</th>
+                                    <td data-label="Minimum stake">
+                                        <div class="config-row settings-stake-cell" data-key="HORSE_RACING_MIN_STAKE">
+                                            <label class="sr-only">Horse Racing minimum stake (default 10)</label>
+                                            <input type="number" min="1"
+                                                   th:value="${overview.config['HORSE_RACING_MIN_STAKE']}"
+                                                   placeholder="10"
+                                                   th:disabled="${!isOwner}">
+                                            <button type="button" class="btn btn-sm save-config" th:disabled="${!isOwner}">Save</button>
+                                        </div>
+                                    </td>
+                                    <td data-label="Maximum stake">
+                                        <div class="config-row settings-stake-cell" data-key="HORSE_RACING_MAX_STAKE">
+                                            <label class="sr-only">Horse Racing maximum stake (0 = unlimited; default 500)</label>
+                                            <input type="number" min="0"
+                                                   th:value="${overview.config['HORSE_RACING_MAX_STAKE']}"
+                                                   placeholder="500"
+                                                   th:disabled="${!isOwner}">
+                                            <button type="button" class="btn btn-sm save-config" th:disabled="${!isOwner}">Save</button>
+                                        </div>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th scope="row">Wheel of Fortune</th>
+                                    <td data-label="Minimum stake">
+                                        <div class="config-row settings-stake-cell" data-key="WHEEL_OF_FORTUNE_MIN_STAKE">
+                                            <label class="sr-only">Wheel of Fortune minimum stake (default 10)</label>
+                                            <input type="number" min="1"
+                                                   th:value="${overview.config['WHEEL_OF_FORTUNE_MIN_STAKE']}"
+                                                   placeholder="10"
+                                                   th:disabled="${!isOwner}">
+                                            <button type="button" class="btn btn-sm save-config" th:disabled="${!isOwner}">Save</button>
+                                        </div>
+                                    </td>
+                                    <td data-label="Maximum stake">
+                                        <div class="config-row settings-stake-cell" data-key="WHEEL_OF_FORTUNE_MAX_STAKE">
+                                            <label class="sr-only">Wheel of Fortune maximum stake (0 = unlimited; default 500)</label>
+                                            <input type="number" min="0"
+                                                   th:value="${overview.config['WHEEL_OF_FORTUNE_MAX_STAKE']}"
+                                                   placeholder="500"
+                                                   th:disabled="${!isOwner}">
+                                            <button type="button" class="btn btn-sm save-config" th:disabled="${!isOwner}">Save</button>
+                                        </div>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th scope="row">Casino Hold'em</th>
+                                    <td data-label="Minimum stake">
+                                        <div class="config-row settings-stake-cell" data-key="HOLDEM_MIN_STAKE">
+                                            <label class="sr-only">Casino Hold'em minimum stake (default 10)</label>
+                                            <input type="number" min="1"
+                                                   th:value="${overview.config['HOLDEM_MIN_STAKE']}"
+                                                   placeholder="10"
+                                                   th:disabled="${!isOwner}">
+                                            <button type="button" class="btn btn-sm save-config" th:disabled="${!isOwner}">Save</button>
+                                        </div>
+                                    </td>
+                                    <td data-label="Maximum stake">
+                                        <div class="config-row settings-stake-cell" data-key="HOLDEM_MAX_STAKE">
+                                            <label class="sr-only">Casino Hold'em maximum stake (0 = unlimited; default 500)</label>
+                                            <input type="number" min="0"
+                                                   th:value="${overview.config['HOLDEM_MAX_STAKE']}"
+                                                   placeholder="500"
+                                                   th:disabled="${!isOwner}">
+                                            <button type="button" class="btn btn-sm save-config" th:disabled="${!isOwner}">Save</button>
+                                        </div>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th scope="row">Duel</th>
+                                    <td data-label="Minimum stake">
+                                        <div class="config-row settings-stake-cell" data-key="DUEL_MIN_STAKE">
+                                            <label class="sr-only">Duel minimum stake (default 10)</label>
+                                            <input type="number" min="1"
+                                                   th:value="${overview.config['DUEL_MIN_STAKE']}"
+                                                   placeholder="10"
+                                                   th:disabled="${!isOwner}">
+                                            <button type="button" class="btn btn-sm save-config" th:disabled="${!isOwner}">Save</button>
+                                        </div>
+                                    </td>
+                                    <td data-label="Maximum stake">
+                                        <div class="config-row settings-stake-cell" data-key="DUEL_MAX_STAKE">
+                                            <label class="sr-only">Duel maximum stake (0 = unlimited; default 500)</label>
+                                            <input type="number" min="0"
+                                                   th:value="${overview.config['DUEL_MAX_STAKE']}"
+                                                   placeholder="500"
+                                                   th:disabled="${!isOwner}">
+                                            <button type="button" class="btn btn-sm save-config" th:disabled="${!isOwner}">Save</button>
+                                        </div>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th scope="row">Rock-Paper-Scissors</th>
+                                    <td data-label="Minimum stake">
+                                        <div class="config-row settings-stake-cell" data-key="RPS_MIN_STAKE">
+                                            <label class="sr-only">Rock-Paper-Scissors minimum stake (0 = free play allowed; default 0)</label>
+                                            <input type="number" min="0"
+                                                   th:value="${overview.config['RPS_MIN_STAKE']}"
+                                                   placeholder="0"
+                                                   th:disabled="${!isOwner}">
+                                            <button type="button" class="btn btn-sm save-config" th:disabled="${!isOwner}">Save</button>
+                                        </div>
+                                    </td>
+                                    <td data-label="Maximum stake">
+                                        <div class="config-row settings-stake-cell" data-key="RPS_MAX_STAKE">
+                                            <label class="sr-only">Rock-Paper-Scissors maximum stake (0 = unlimited; default 500)</label>
+                                            <input type="number" min="0"
+                                                   th:value="${overview.config['RPS_MAX_STAKE']}"
+                                                   placeholder="500"
+                                                   th:disabled="${!isOwner}">
+                                            <button type="button" class="btn btn-sm save-config" th:disabled="${!isOwner}">Save</button>
+                                        </div>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th scope="row">Tic-Tac-Toe</th>
+                                    <td data-label="Minimum stake">
+                                        <div class="config-row settings-stake-cell" data-key="TICTACTOE_MIN_STAKE">
+                                            <label class="sr-only">Tic-Tac-Toe minimum stake (0 = free play allowed; default 0)</label>
+                                            <input type="number" min="0"
+                                                   th:value="${overview.config['TICTACTOE_MIN_STAKE']}"
+                                                   placeholder="0"
+                                                   th:disabled="${!isOwner}">
+                                            <button type="button" class="btn btn-sm save-config" th:disabled="${!isOwner}">Save</button>
+                                        </div>
+                                    </td>
+                                    <td data-label="Maximum stake">
+                                        <div class="config-row settings-stake-cell" data-key="TICTACTOE_MAX_STAKE">
+                                            <label class="sr-only">Tic-Tac-Toe maximum stake (0 = unlimited; default 500)</label>
+                                            <input type="number" min="0"
+                                                   th:value="${overview.config['TICTACTOE_MAX_STAKE']}"
+                                                   placeholder="500"
+                                                   th:disabled="${!isOwner}">
+                                            <button type="button" class="btn btn-sm save-config" th:disabled="${!isOwner}">Save</button>
+                                        </div>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th scope="row">Connect 4</th>
+                                    <td data-label="Minimum stake">
+                                        <div class="config-row settings-stake-cell" data-key="CONNECT4_MIN_STAKE">
+                                            <label class="sr-only">Connect 4 minimum stake (0 = free play allowed; default 0)</label>
+                                            <input type="number" min="0"
+                                                   th:value="${overview.config['CONNECT4_MIN_STAKE']}"
+                                                   placeholder="0"
+                                                   th:disabled="${!isOwner}">
+                                            <button type="button" class="btn btn-sm save-config" th:disabled="${!isOwner}">Save</button>
+                                        </div>
+                                    </td>
+                                    <td data-label="Maximum stake">
+                                        <div class="config-row settings-stake-cell" data-key="CONNECT4_MAX_STAKE">
+                                            <label class="sr-only">Connect 4 maximum stake (0 = unlimited; default 500)</label>
+                                            <input type="number" min="0"
+                                                   th:value="${overview.config['CONNECT4_MAX_STAKE']}"
+                                                   placeholder="500"
+                                                   th:disabled="${!isOwner}">
+                                            <button type="button" class="btn btn-sm save-config" th:disabled="${!isOwner}">Save</button>
+                                        </div>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
                     </div>
-                    <div class="config-row" data-key="POKER_MAX_SEATS">
-                        <label>Max seats per table (2-9; default 6)</label>
-                        <input type="number" min="2" max="9"
-                               th:value="${overview.config['POKER_MAX_SEATS']}"
-                               placeholder="6"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                    <div class="config-row" data-key="POKER_SHOT_CLOCK_SECONDS">
-                        <label>Decision deadline per actor (seconds; 0 disables; default 30)</label>
-                        <input type="number" min="0" max="600"
-                               th:value="${overview.config['POKER_SHOT_CLOCK_SECONDS']}"
-                               placeholder="30"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                </div>
-                <div class="config-group">
-                    <h4>Blinds &amp; buy-ins</h4>
-                    <div class="config-row" data-key="POKER_SMALL_BLIND">
-                        <label>Small blind (chips posted by SB seat each hand; default 5)</label>
-                        <input type="number" min="1"
-                               th:value="${overview.config['POKER_SMALL_BLIND']}"
-                               placeholder="5"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                    <div class="config-row" data-key="POKER_BIG_BLIND">
-                        <label>Big blind (chips posted by BB seat each hand; default 10)</label>
-                        <input type="number" min="1"
-                               th:value="${overview.config['POKER_BIG_BLIND']}"
-                               placeholder="10"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                    <div class="config-row" data-key="POKER_SMALL_BET">
-                        <label>Small bet (fixed-limit bet pre-flop &amp; flop; default 10)</label>
-                        <input type="number" min="1"
-                               th:value="${overview.config['POKER_SMALL_BET']}"
-                               placeholder="10"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                    <div class="config-row" data-key="POKER_BIG_BET">
-                        <label>Big bet (fixed-limit bet on turn &amp; river; default 20)</label>
-                        <input type="number" min="1"
-                               th:value="${overview.config['POKER_BIG_BET']}"
-                               placeholder="20"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                    <div class="config-row" data-key="POKER_MIN_BUY_IN">
-                        <label>Minimum buy-in per seat (chips; default 100)</label>
-                        <input type="number" min="1"
-                               th:value="${overview.config['POKER_MIN_BUY_IN']}"
-                               placeholder="100"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                    <div class="config-row" data-key="POKER_MAX_BUY_IN">
-                        <label>Maximum buy-in per seat (chips; 0 = unlimited; default 5000)</label>
-                        <input type="number" min="0"
-                               th:value="${overview.config['POKER_MAX_BUY_IN']}"
-                               placeholder="5000"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                </div>
+                </details>
             </div>
-        </details>
-
-        <details class="config-section">
-            <summary>Blackjack</summary>
-            <div class="config-grid">
-                <div class="config-group">
-                    <h4>Table rules</h4>
-                    <div class="config-row" data-key="BLACKJACK_RAKE_PCT">
-                        <label>Blackjack rake (% of multi-table losers' pool routed to jackpot; default 5)</label>
-                        <span class="config-input-group">
-                            <input type="number" min="0" max="20" step="1"
-                                   th:value="${overview.config['BLACKJACK_RAKE_PCT']}"
-                                   placeholder="5"
-                                   th:disabled="${!isOwner}">
-                            <span class="config-suffix">%</span>
-                        </span>
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                    <div class="config-row" data-key="BLACKJACK_MAX_SEATS">
-                        <label>Max seats per multi table (2-7; default 5)</label>
-                        <input type="number" min="2" max="7"
-                               th:value="${overview.config['BLACKJACK_MAX_SEATS']}"
-                               placeholder="5"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                    <div class="config-row" data-key="BLACKJACK_SHOT_CLOCK_SECONDS">
-                        <label>Decision deadline per actor (seconds; 0 disables; default 30)</label>
-                        <input type="number" min="0" max="600"
-                               th:value="${overview.config['BLACKJACK_SHOT_CLOCK_SECONDS']}"
-                               placeholder="30"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                    <div class="config-row" data-key="BLACKJACK_DEALER_HITS_SOFT_17">
-                        <label>Dealer rule on soft 17</label>
-                        <select th:disabled="${!isOwner}">
-                            <option value="false"
-                                    th:selected="${overview.config['BLACKJACK_DEALER_HITS_SOFT_17'] == null or overview.config['BLACKJACK_DEALER_HITS_SOFT_17'] == 'false'}">
-                                Stand on soft 17 (S17, default — better for the player)
-                            </option>
-                            <option value="true"
-                                    th:selected="${overview.config['BLACKJACK_DEALER_HITS_SOFT_17'] == 'true'}">
-                                Hit soft 17 (H17 — slightly worse for the player)
-                            </option>
-                        </select>
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                    <div class="config-row" data-key="BLACKJACK_BJ_PAYOUT_NUM">
-                        <label>Natural-blackjack payout numerator (e.g. 3 for 3:2; default 3)</label>
-                        <input type="number" min="1" max="10"
-                               th:value="${overview.config['BLACKJACK_BJ_PAYOUT_NUM']}"
-                               placeholder="3"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                    <div class="config-row" data-key="BLACKJACK_BJ_PAYOUT_DEN">
-                        <label>Natural-blackjack payout denominator (e.g. 2 for 3:2; default 2)</label>
-                        <input type="number" min="1" max="10"
-                               th:value="${overview.config['BLACKJACK_BJ_PAYOUT_DEN']}"
-                               placeholder="2"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                </div>
-                <div class="config-group">
-                    <h4>Stakes per hand</h4>
-                    <div class="config-row" data-key="BLACKJACK_MIN_ANTE">
-                        <label>Minimum stake per hand (applies to solo &amp; multi; default 10)</label>
-                        <input type="number" min="1"
-                               th:value="${overview.config['BLACKJACK_MIN_ANTE']}"
-                               placeholder="10"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                    <div class="config-row" data-key="BLACKJACK_MAX_ANTE">
-                        <label>Maximum stake per hand (applies to solo &amp; multi; 0 = unlimited; default 500)</label>
-                        <input type="number" min="0"
-                               th:value="${overview.config['BLACKJACK_MAX_ANTE']}"
-                               placeholder="500"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                </div>
-            </div>
-        </details>
-
-        <details class="config-section">
-            <summary>Game stake limits</summary>
-            <p class="muted mb-2">
-                Stake bounds for every simple casino game. Set any maximum to
-                <code>0</code> to remove the cap. Blackjack ante limits live
-                in the <strong>Blackjack</strong> section; poker blinds and
-                buy-ins live in the <strong>Poker</strong> section.
-            </p>
-            <div class="config-grid">
-                <div class="config-group">
-                    <h4>Dice</h4>
-                    <div class="config-row" data-key="DICE_MIN_STAKE">
-                        <label>Minimum stake (default 10)</label>
-                        <input type="number" min="1"
-                               th:value="${overview.config['DICE_MIN_STAKE']}"
-                               placeholder="10"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                    <div class="config-row" data-key="DICE_MAX_STAKE">
-                        <label>Maximum stake (0 = unlimited; default 500)</label>
-                        <input type="number" min="0"
-                               th:value="${overview.config['DICE_MAX_STAKE']}"
-                               placeholder="500"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                </div>
-                <div class="config-group">
-                    <h4>Coinflip</h4>
-                    <div class="config-row" data-key="COINFLIP_MIN_STAKE">
-                        <label>Minimum stake (default 10)</label>
-                        <input type="number" min="1"
-                               th:value="${overview.config['COINFLIP_MIN_STAKE']}"
-                               placeholder="10"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                    <div class="config-row" data-key="COINFLIP_MAX_STAKE">
-                        <label>Maximum stake (0 = unlimited; default 1000)</label>
-                        <input type="number" min="0"
-                               th:value="${overview.config['COINFLIP_MAX_STAKE']}"
-                               placeholder="1000"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                </div>
-                <div class="config-group">
-                    <h4>Slots</h4>
-                    <div class="config-row" data-key="SLOTS_MIN_STAKE">
-                        <label>Minimum stake (default 10)</label>
-                        <input type="number" min="1"
-                               th:value="${overview.config['SLOTS_MIN_STAKE']}"
-                               placeholder="10"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                    <div class="config-row" data-key="SLOTS_MAX_STAKE">
-                        <label>Maximum stake (0 = unlimited; default 500)</label>
-                        <input type="number" min="0"
-                               th:value="${overview.config['SLOTS_MAX_STAKE']}"
-                               placeholder="500"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                </div>
-                <div class="config-group">
-                    <h4>Highlow</h4>
-                    <div class="config-row" data-key="HIGHLOW_MIN_STAKE">
-                        <label>Minimum stake (default 10)</label>
-                        <input type="number" min="1"
-                               th:value="${overview.config['HIGHLOW_MIN_STAKE']}"
-                               placeholder="10"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                    <div class="config-row" data-key="HIGHLOW_MAX_STAKE">
-                        <label>Maximum stake (0 = unlimited; default 500)</label>
-                        <input type="number" min="0"
-                               th:value="${overview.config['HIGHLOW_MAX_STAKE']}"
-                               placeholder="500"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                </div>
-                <div class="config-group">
-                    <h4>Baccarat</h4>
-                    <div class="config-row" data-key="BACCARAT_MIN_STAKE">
-                        <label>Minimum stake (default 10)</label>
-                        <input type="number" min="1"
-                               th:value="${overview.config['BACCARAT_MIN_STAKE']}"
-                               placeholder="10"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                    <div class="config-row" data-key="BACCARAT_MAX_STAKE">
-                        <label>Maximum stake (0 = unlimited; default 500)</label>
-                        <input type="number" min="0"
-                               th:value="${overview.config['BACCARAT_MAX_STAKE']}"
-                               placeholder="500"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                </div>
-                <div class="config-group">
-                    <h4>Keno</h4>
-                    <div class="config-row" data-key="KENO_MIN_STAKE">
-                        <label>Minimum stake (default 10)</label>
-                        <input type="number" min="1"
-                               th:value="${overview.config['KENO_MIN_STAKE']}"
-                               placeholder="10"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                    <div class="config-row" data-key="KENO_MAX_STAKE">
-                        <label>Maximum stake (0 = unlimited; default 500)</label>
-                        <input type="number" min="0"
-                               th:value="${overview.config['KENO_MAX_STAKE']}"
-                               placeholder="500"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                </div>
-                <div class="config-group">
-                    <h4>Scratch</h4>
-                    <div class="config-row" data-key="SCRATCH_MIN_STAKE">
-                        <label>Minimum stake (default 10)</label>
-                        <input type="number" min="1"
-                               th:value="${overview.config['SCRATCH_MIN_STAKE']}"
-                               placeholder="10"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                    <div class="config-row" data-key="SCRATCH_MAX_STAKE">
-                        <label>Maximum stake (0 = unlimited; default 500)</label>
-                        <input type="number" min="0"
-                               th:value="${overview.config['SCRATCH_MAX_STAKE']}"
-                               placeholder="500"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                </div>
-                <div class="config-group">
-                    <h4>Roulette</h4>
-                    <div class="config-row" data-key="ROULETTE_MIN_STAKE">
-                        <label>Minimum stake (default 10)</label>
-                        <input type="number" min="1"
-                               th:value="${overview.config['ROULETTE_MIN_STAKE']}"
-                               placeholder="10"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                    <div class="config-row" data-key="ROULETTE_MAX_STAKE">
-                        <label>Maximum stake (0 = unlimited; default 500)</label>
-                        <input type="number" min="0"
-                               th:value="${overview.config['ROULETTE_MAX_STAKE']}"
-                               placeholder="500"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                </div>
-                <div class="config-group">
-                    <h4>Plinko</h4>
-                    <div class="config-row" data-key="PLINKO_MIN_STAKE">
-                        <label>Minimum stake (default 10)</label>
-                        <input type="number" min="1"
-                               th:value="${overview.config['PLINKO_MIN_STAKE']}"
-                               placeholder="10"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                    <div class="config-row" data-key="PLINKO_MAX_STAKE">
-                        <label>Maximum stake (0 = unlimited; default 500)</label>
-                        <input type="number" min="0"
-                               th:value="${overview.config['PLINKO_MAX_STAKE']}"
-                               placeholder="500"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                </div>
-                <div class="config-group">
-                    <h4>Horse Racing</h4>
-                    <div class="config-row" data-key="HORSE_RACING_MIN_STAKE">
-                        <label>Minimum stake (default 10)</label>
-                        <input type="number" min="1"
-                               th:value="${overview.config['HORSE_RACING_MIN_STAKE']}"
-                               placeholder="10"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                    <div class="config-row" data-key="HORSE_RACING_MAX_STAKE">
-                        <label>Maximum stake (0 = unlimited; default 500)</label>
-                        <input type="number" min="0"
-                               th:value="${overview.config['HORSE_RACING_MAX_STAKE']}"
-                               placeholder="500"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                </div>
-                <div class="config-group">
-                    <h4>Wheel of Fortune</h4>
-                    <div class="config-row" data-key="WHEEL_OF_FORTUNE_MIN_STAKE">
-                        <label>Minimum stake (default 10)</label>
-                        <input type="number" min="1"
-                               th:value="${overview.config['WHEEL_OF_FORTUNE_MIN_STAKE']}"
-                               placeholder="10"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                    <div class="config-row" data-key="WHEEL_OF_FORTUNE_MAX_STAKE">
-                        <label>Maximum stake (0 = unlimited; default 500)</label>
-                        <input type="number" min="0"
-                               th:value="${overview.config['WHEEL_OF_FORTUNE_MAX_STAKE']}"
-                               placeholder="500"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                </div>
-                <div class="config-group">
-                    <h4>Casino Hold'em</h4>
-                    <div class="config-row" data-key="HOLDEM_MIN_STAKE">
-                        <label>Minimum stake (default 10)</label>
-                        <input type="number" min="1"
-                               th:value="${overview.config['HOLDEM_MIN_STAKE']}"
-                               placeholder="10"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                    <div class="config-row" data-key="HOLDEM_MAX_STAKE">
-                        <label>Maximum stake (0 = unlimited; default 500)</label>
-                        <input type="number" min="0"
-                               th:value="${overview.config['HOLDEM_MAX_STAKE']}"
-                               placeholder="500"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                </div>
-                <div class="config-group">
-                    <h4>Duel</h4>
-                    <div class="config-row" data-key="DUEL_MIN_STAKE">
-                        <label>Minimum stake (default 10)</label>
-                        <input type="number" min="1"
-                               th:value="${overview.config['DUEL_MIN_STAKE']}"
-                               placeholder="10"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                    <div class="config-row" data-key="DUEL_MAX_STAKE">
-                        <label>Maximum stake (0 = unlimited; default 500)</label>
-                        <input type="number" min="0"
-                               th:value="${overview.config['DUEL_MAX_STAKE']}"
-                               placeholder="500"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                </div>
-                <div class="config-group">
-                    <h4>Rock-Paper-Scissors</h4>
-                    <div class="config-row" data-key="RPS_MIN_STAKE">
-                        <label>Minimum stake (0 = free play allowed; default 0)</label>
-                        <input type="number" min="0"
-                               th:value="${overview.config['RPS_MIN_STAKE']}"
-                               placeholder="0"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                    <div class="config-row" data-key="RPS_MAX_STAKE">
-                        <label>Maximum stake (0 = unlimited; default 500)</label>
-                        <input type="number" min="0"
-                               th:value="${overview.config['RPS_MAX_STAKE']}"
-                               placeholder="500"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                </div>
-                <div class="config-group">
-                    <h4>Tic-Tac-Toe</h4>
-                    <div class="config-row" data-key="TICTACTOE_MIN_STAKE">
-                        <label>Minimum stake (0 = free play allowed; default 0)</label>
-                        <input type="number" min="0"
-                               th:value="${overview.config['TICTACTOE_MIN_STAKE']}"
-                               placeholder="0"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                    <div class="config-row" data-key="TICTACTOE_MAX_STAKE">
-                        <label>Maximum stake (0 = unlimited; default 500)</label>
-                        <input type="number" min="0"
-                               th:value="${overview.config['TICTACTOE_MAX_STAKE']}"
-                               placeholder="500"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                </div>
-                <div class="config-group">
-                    <h4>Connect 4</h4>
-                    <div class="config-row" data-key="CONNECT4_MIN_STAKE">
-                        <label>Minimum stake (0 = free play allowed; default 0)</label>
-                        <input type="number" min="0"
-                               th:value="${overview.config['CONNECT4_MIN_STAKE']}"
-                               placeholder="0"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                    <div class="config-row" data-key="CONNECT4_MAX_STAKE">
-                        <label>Maximum stake (0 = unlimited; default 500)</label>
-                        <input type="number" min="0"
-                               th:value="${overview.config['CONNECT4_MAX_STAKE']}"
-                               placeholder="500"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                </div>
-            </div>
-        </details>
+        </div>
     </section>
 </main>
 

--- a/web/src/test/kotlin/web/template/ModerationTemplateRowsTest.kt
+++ b/web/src/test/kotlin/web/template/ModerationTemplateRowsTest.kt
@@ -162,22 +162,23 @@ class ModerationTemplateRowsTest {
     }
 
     @Test
-    fun `game stake limits card sub-groups every game with an h4 heading`() {
-        // The card is too long without sub-headings — admins scan by game.
-        // Asserting on a sample of headings so a flatten regression is
-        // obvious without making the test enumerate every group.
-        // Blackjack and Poker headings now live in their dedicated game
-        // sections under "Stakes per hand" / "Blinds & buy-ins"
-        // subgroups, so this card only carries the simple games.
-        val headings = listOf(
-            "<h4>Dice</h4>",
-            "<h4>Coinflip</h4>",
-            "<h4>Duel</h4>",
+    fun `game stake limits table labels every game row with its name`() {
+        // Stake limits live in a table so each game's min + max sit side by
+        // side instead of stacked. Admins still scan by game — the row
+        // header replaces the old h4 sub-grouping. Sample three games
+        // (a simple one, a chance game, and Duel) so a flatten regression
+        // or accidentally-dropped row trips a single assertion.
+        // Blackjack and Poker rows live in their dedicated game sections
+        // under "Stakes per hand" / "Blinds & buy-ins" subgroups.
+        val rowHeaders = listOf(
+            "<th scope=\"row\">Dice</th>",
+            "<th scope=\"row\">Coinflip</th>",
+            "<th scope=\"row\">Duel</th>",
         )
-        for (h in headings) {
+        for (h in rowHeaders) {
             assertTrue(
                 settingsHtml.contains(h),
-                "expected $h sub-heading inside the Game stake limits card"
+                "expected $h row inside the Game stake limits table"
             )
         }
     }


### PR DESCRIPTION
## Summary

Phase 3 of the moderation dashboard refresh — the Settings tab. Replaces the ~986-line wall of stacked `<details>` accordions with a navigable layout, a real stake-limits table, and a bulk "set every game at once" widget that lets admins update many keys in one shot.

- **Sticky left-rail navigation** lists every section grouped by pillar (Server / Economy / Casino). Clicking a rail link opens the matching `<details>` and smooth-scrolls to it; an `IntersectionObserver` mirrors the scroll position back into the rail's `.is-active` link. Each section carries a stable `id` so deep links survive page-load.
- **Stake-limits table** replaces the 16-game `.config-group` stack (32 `.config-row` blocks across 16 sub-cards) with one `<table>` — one row per game, side-by-side min/max cells. Per-row save wiring is preserved (each cell still wraps a `.config-row[data-key]` with its own Save button), so the shared `moderationCommon.js` handler keeps working untouched.
- **"Set every game at once" widget** above the stake table. Two number inputs (All minimums / All maximums); blank skips that side. Submit fans out one `POST /config` per affected `(game × side)` key in parallel, reports back with a single toast carrying the success/fail counts, and updates the visible inputs in place so the admin sees the new defaults without a page reload. This is the compromise version of the planned Phase 3b batch-save — scoped tightly to one table so it doesn't risk unsaved-input data loss elsewhere on the page.
- **CSS additions** to `moderation.css`: `.settings-shell` grid, sticky `.settings-nav`, `.settings-stakes-table`, `.settings-stakes-bulk`. All new `max-width` breakpoints land on `768px` to satisfy the project's canonical breakpoint allowlist.
- **Test update**: `ModerationTemplateRowsTest` now asserts `<th scope="row">Dice</th>` (etc.) inside the stake table instead of `<h4>Dice</h4>` — the per-game-scannability contract is preserved through the row header rather than the dropped `<h4>` sub-grouping.

**Deferred from the original Phase 3 plan**: a full section-level batch-save with dirty tracking and a sticky footer per section. That change would touch the shared `moderationCommon.js` wiring used by the lottery and leveling tabs and carries real unsaved-data risk (admins navigating away mid-edit, etc.). Worth shipping separately if you decide you want it.

## Test plan

- [x] `./gradlew :web:test` — full web test suite, including `ModerationTemplateRowsTest` exercising the updated stake-table contract
- [x] `npm run lint:css` — stylelint passes (all `max-width` breakpoints are canonical)
- [x] `npm test` — full JS test suite (623 tests), including the `responsive` contract that enforces canonical breakpoints
- [ ] Visit `/moderation/{guildId}/settings` and confirm: rail renders left of the content; clicking a rail link opens the section and scrolls to it; rail active-link tracks the scroll position; stake table renders 16 game rows with side-by-side min/max cells; per-row Save still works
- [ ] Try the bulk widget: enter `All minimums = 25` and submit → toast reports "Updated 16 stake rows", and every min input now shows `25`; entering both fields hits 32 rows
- [ ] Mobile DevTools (375px): rail collapses to a wrap-to-rows top strip; stake table scrolls horizontally; bulk form stacks vertically
- [ ] Try a deep link like `/moderation/{guildId}/settings#settings-section-jackpot` — page loads with the Jackpot section open and scrolled into view

https://claude.ai/code/session_01NgJUqmuDnJWZp5WrSTXcfn

---
_Generated by [Claude Code](https://claude.ai/code/session_01NgJUqmuDnJWZp5WrSTXcfn)_