### PR TITLE
feat(moderation/actions): group forms into Member / Channel card grids

### DIFF
--- a/web/src/main/resources/static/css/moderation.css
+++ b/web/src/main/resources/static/css/moderation.css
@@ -1021,17 +1021,14 @@ details.config-section.is-hidden { display: none; }
     margin-left: auto;
 }
 
-/* Moderation Actions tab: stacked forms for ban / timeout / purge etc.
-   Each form is a block laid out with a column of labels + a submit row. */
+/* Moderation Actions tab: each action lives inside a .mod-card, so the
+   form itself just handles the column layout for its labels and submit
+   button — the surrounding card provides background, border, padding,
+   and the elevation shadow. */
 .mod-action-form {
     display: flex;
     flex-direction: column;
     gap: var(--space-3);
-    padding: var(--space-3);
-    margin-bottom: var(--space-4);
-    background: var(--bg-elevated);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-md);
 }
 .mod-action-form label {
     display: flex;
@@ -1072,11 +1069,25 @@ details.config-section.is-hidden { display: none; }
     display: flex;
     gap: var(--space-2);
 }
-.action-explainer {
-    margin: calc(var(--space-2) * -1) 0 var(--space-3);
-    font-size: 0.9rem;
-    line-height: 1.5;
-    max-width: 70ch;
+
+/* Section group on the Actions tab — wraps a .mod-card-grid with a
+   sibling <h2 class="mod-section-title">. Adds breathing room between
+   the two action groups (Member actions / Channel actions) so they
+   read as distinct modules. */
+.mod-section + .mod-section { margin-top: var(--space-6); }
+
+/* The shared .mod-card h3 rule renders the title as a small uppercase
+   eyebrow — that's right for KPI cards (e.g. casino's "JACKPOT POOL"
+   above a big-number) but reads as a label, not a title, on the
+   Actions tab where the h3 is the card's own heading. Promote it to
+   a real heading scoped to this tab only so the rest of the
+   dashboard's KPI cards stay on the eyebrow style. */
+[data-panel="actions"] .mod-card h3 {
+    font-size: 1rem;
+    text-transform: none;
+    letter-spacing: 0;
+    color: var(--text);
+    font-weight: 600;
 }
 
 /* ==============================================================

--- a/web/src/main/resources/templates/moderation/actions.html
+++ b/web/src/main/resources/templates/moderation/actions.html
@@ -12,6 +12,16 @@
 
     <div th:replace="~{fragments/moderationHeader :: moderationHeader(${overview}, ${isOwner}, 'actions')}"></div>
 
+    <!--
+        Moderation Actions tab. Eight forms split into two purpose
+        groups (Member actions / Channel actions), each rendered as a
+        .mod-card so the page reads as a dashboard rather than a flat
+        scroll of forms. Cards lay out in a .mod-card-grid that
+        auto-fits 1 / 2 / 3 columns to viewport width. The forms
+        themselves are unchanged — actions.js keys off the data-action
+        attribute on each <form> and doesn't care about the surrounding
+        markup.
+    -->
     <section class="mod-panel" data-panel="actions">
         <p class="mod-page-intro">
             Run Discord moderation actions without leaving the dashboard. You
@@ -19,211 +29,241 @@
             Manage) on the bot AND on yourself for each action.
         </p>
 
-        <h2 class="mod-section-title">Kick member</h2>
-        <p class="muted action-explainer">
-            Remove a member from the server. They can rejoin via an
-            invite link. Requires the Kick Members permission.
-        </p>
-        <form class="mod-action-form" data-action="kick">
-            <label>Member
-                <div th:replace="~{fragments/userPicker :: userPicker(
-                        name='targetDiscordId',
-                        id='kick-target',
-                        members=${overview.members},
-                        selectedId=null,
-                        placeholder='Pick a member…',
-                        emptyLabel=null,
-                        required=true,
-                        multiple=false,
-                        showSocialCredit=false)}"></div>
-            </label>
-            <label>Reason (optional)
-                <input type="text" name="reason" maxlength="512">
-            </label>
-            <button type="submit" class="btn-danger">Kick</button>
-        </form>
+        <section class="mod-section">
+            <h2 class="mod-section-title">Member actions</h2>
+            <div class="mod-card-grid">
 
-        <h2 class="mod-section-title">Ban member</h2>
-        <p class="muted action-explainer">
-            Remove a member and prevent them rejoining until they're
-            unbanned. Optionally delete their messages from the past N days
-            (0-7). Requires the Ban Members permission.
-        </p>
-        <form class="mod-action-form" data-action="ban">
-            <label>Member
-                <div th:replace="~{fragments/userPicker :: userPicker(
-                        name='targetDiscordId',
-                        id='ban-target',
-                        members=${overview.members},
-                        selectedId=null,
-                        placeholder='Pick a member…',
-                        emptyLabel=null,
-                        required=true,
-                        multiple=false,
-                        showSocialCredit=false)}"></div>
-            </label>
-            <label>Reason (optional)
-                <input type="text" name="reason" maxlength="512">
-            </label>
-            <label>Delete recent messages (days, 0-7)
-                <input type="number" name="deleteDays" min="0" max="7" value="0">
-            </label>
-            <button type="submit" class="btn-danger">Ban</button>
-        </form>
+                <div class="mod-card mod-card-wide">
+                    <h3>Kick member</h3>
+                    <p class="muted">
+                        Remove a member from the server. They can rejoin via an
+                        invite link. Requires the Kick Members permission.
+                    </p>
+                    <form class="mod-action-form" data-action="kick">
+                        <label>Member
+                            <div th:replace="~{fragments/userPicker :: userPicker(
+                                    name='targetDiscordId',
+                                    id='kick-target',
+                                    members=${overview.members},
+                                    selectedId=null,
+                                    placeholder='Pick a member…',
+                                    emptyLabel=null,
+                                    required=true,
+                                    multiple=false,
+                                    showSocialCredit=false)}"></div>
+                        </label>
+                        <label>Reason (optional)
+                            <input type="text" name="reason" maxlength="512">
+                        </label>
+                        <button type="submit" class="btn-danger">Kick</button>
+                    </form>
+                </div>
 
-        <h2 class="mod-section-title">Unban user by ID</h2>
-        <p class="muted action-explainer">
-            Lift a ban so a previously-banned user can rejoin. Discord
-            user IDs are 17-19 digit numbers; right-click a user in
-            Discord with Developer Mode on to copy theirs.
-        </p>
-        <form class="mod-action-form" data-action="unban">
-            <label>Discord user ID
-                <input type="text" name="targetDiscordId" required pattern="[0-9]+">
-            </label>
-            <button type="submit" class="btn">Unban</button>
-        </form>
+                <div class="mod-card mod-card-wide">
+                    <h3>Ban member</h3>
+                    <p class="muted">
+                        Remove a member and prevent them rejoining until they're
+                        unbanned. Optionally delete their messages from the past N
+                        days (0-7). Requires the Ban Members permission.
+                    </p>
+                    <form class="mod-action-form" data-action="ban">
+                        <label>Member
+                            <div th:replace="~{fragments/userPicker :: userPicker(
+                                    name='targetDiscordId',
+                                    id='ban-target',
+                                    members=${overview.members},
+                                    selectedId=null,
+                                    placeholder='Pick a member…',
+                                    emptyLabel=null,
+                                    required=true,
+                                    multiple=false,
+                                    showSocialCredit=false)}"></div>
+                        </label>
+                        <label>Reason (optional)
+                            <input type="text" name="reason" maxlength="512">
+                        </label>
+                        <label>Delete recent messages (days, 0-7)
+                            <input type="number" name="deleteDays" min="0" max="7" value="0">
+                        </label>
+                        <button type="submit" class="btn-danger">Ban</button>
+                    </form>
+                </div>
 
-        <h2 class="mod-section-title">Timeout member</h2>
-        <p class="muted action-explainer">
-            Mute a member across every channel for a set duration — they
-            can still see messages but can't send, react, or speak in
-            voice. Discord caps timeouts at 28 days (40320 minutes).
-            Requires the Moderate Members permission.
-        </p>
-        <form class="mod-action-form" data-action="timeout">
-            <label>Member
-                <div th:replace="~{fragments/userPicker :: userPicker(
-                        name='targetDiscordId',
-                        id='timeout-target',
-                        members=${overview.members},
-                        selectedId=null,
-                        placeholder='Pick a member…',
-                        emptyLabel=null,
-                        required=true,
-                        multiple=false,
-                        showSocialCredit=false)}"></div>
-            </label>
-            <label>Duration (minutes, 1-40320)
-                <input type="number" name="minutes" min="1" max="40320" value="10" required>
-            </label>
-            <label>Reason (optional)
-                <input type="text" name="reason" maxlength="512">
-            </label>
-            <button type="submit" class="btn">Timeout</button>
-        </form>
+                <div class="mod-card mod-card-wide">
+                    <h3>Unban user by ID</h3>
+                    <p class="muted">
+                        Lift a ban so a previously-banned user can rejoin. Discord
+                        user IDs are 17-19 digit numbers; right-click a user in
+                        Discord with Developer Mode on to copy theirs.
+                    </p>
+                    <form class="mod-action-form" data-action="unban">
+                        <label>Discord user ID
+                            <input type="text" name="targetDiscordId" required pattern="[0-9]+">
+                        </label>
+                        <button type="submit" class="btn">Unban</button>
+                    </form>
+                </div>
 
-        <h2 class="mod-section-title">Remove timeout</h2>
-        <p class="muted action-explainer">
-            Clear an active timeout early so the member can talk again.
-        </p>
-        <form class="mod-action-form" data-action="untimeout">
-            <label>Member
-                <div th:replace="~{fragments/userPicker :: userPicker(
-                        name='targetDiscordId',
-                        id='untimeout-target',
-                        members=${overview.members},
-                        selectedId=null,
-                        placeholder='Pick a member…',
-                        emptyLabel=null,
-                        required=true,
-                        multiple=false,
-                        showSocialCredit=false)}"></div>
-            </label>
-            <button type="submit" class="btn">Untimeout</button>
-        </form>
+                <div class="mod-card mod-card-wide">
+                    <h3>Timeout member</h3>
+                    <p class="muted">
+                        Mute a member across every channel for a set duration — they
+                        can still see messages but can't send, react, or speak in
+                        voice. Discord caps timeouts at 28 days (40320 minutes).
+                        Requires the Moderate Members permission.
+                    </p>
+                    <form class="mod-action-form" data-action="timeout">
+                        <label>Member
+                            <div th:replace="~{fragments/userPicker :: userPicker(
+                                    name='targetDiscordId',
+                                    id='timeout-target',
+                                    members=${overview.members},
+                                    selectedId=null,
+                                    placeholder='Pick a member…',
+                                    emptyLabel=null,
+                                    required=true,
+                                    multiple=false,
+                                    showSocialCredit=false)}"></div>
+                        </label>
+                        <label>Duration (minutes, 1-40320)
+                            <input type="number" name="minutes" min="1" max="40320" value="10" required>
+                        </label>
+                        <label>Reason (optional)
+                            <input type="text" name="reason" maxlength="512">
+                        </label>
+                        <button type="submit" class="btn">Timeout</button>
+                    </form>
+                </div>
 
-        <h2 class="mod-section-title">Purge messages</h2>
-        <p class="muted action-explainer">
-            Bulk-delete the last N messages in a channel (max 100),
-            optionally filtered to a single user. Discord only allows
-            bulk-deleting messages from the last 14 days — older ones
-            are skipped automatically. Requires Manage Messages.
-        </p>
-        <form class="mod-action-form" data-action="purge">
-            <label>Channel
-                <div th:replace="~{fragments/channelPicker :: channelPicker(
-                        name='channelId',
-                        id='purge-channel',
-                        channels=${overview.textChannels},
-                        selectedValue=null,
-                        placeholder='— choose —',
-                        emptyLabel=null,
-                        required=true,
-                        valuePrefix='#',
-                        valueField='id',
-                        disabled=false)}"></div>
-            </label>
-            <label>Count (1-100)
-                <input type="number" name="count" min="1" max="100" value="10" required>
-            </label>
-            <label>Filter to user (optional)
-                <div th:replace="~{fragments/userPicker :: userPicker(
-                        name='filterUserId',
-                        id='purge-filter',
-                        members=${overview.members},
-                        selectedId=null,
-                        placeholder='Any user',
-                        emptyLabel='Any user',
-                        required=false,
-                        multiple=false,
-                        showSocialCredit=false)}"></div>
-            </label>
-            <button type="submit" class="btn-danger">Purge</button>
-        </form>
+                <div class="mod-card mod-card-wide">
+                    <h3>Remove timeout</h3>
+                    <p class="muted">
+                        Clear an active timeout early so the member can talk again.
+                    </p>
+                    <form class="mod-action-form" data-action="untimeout">
+                        <label>Member
+                            <div th:replace="~{fragments/userPicker :: userPicker(
+                                    name='targetDiscordId',
+                                    id='untimeout-target',
+                                    members=${overview.members},
+                                    selectedId=null,
+                                    placeholder='Pick a member…',
+                                    emptyLabel=null,
+                                    required=true,
+                                    multiple=false,
+                                    showSocialCredit=false)}"></div>
+                        </label>
+                        <button type="submit" class="btn">Untimeout</button>
+                    </form>
+                </div>
 
-        <h2 class="mod-section-title">Lock / unlock channel</h2>
-        <p class="muted action-explainer">
-            Toggle whether @everyone can send messages in a text channel.
-            "Lock" denies Send Messages on @everyone's permission
-            override; "Unlock" clears the override so the role default
-            applies again. Requires Manage Permissions.
-        </p>
-        <form class="mod-action-form" data-action="lock">
-            <label>Channel
-                <div th:replace="~{fragments/channelPicker :: channelPicker(
-                        name='channelId',
-                        id='lock-channel',
-                        channels=${overview.textChannels},
-                        selectedValue=null,
-                        placeholder='— choose —',
-                        emptyLabel=null,
-                        required=true,
-                        valuePrefix='#',
-                        valueField='id',
-                        disabled=false)}"></div>
-            </label>
-            <div class="lock-actions">
-                <button type="button" class="btn-danger" data-lock="true">Lock</button>
-                <button type="button" class="btn" data-lock="false">Unlock</button>
             </div>
-        </form>
+        </section>
 
-        <h2 class="mod-section-title">Slowmode</h2>
-        <p class="muted action-explainer">
-            Force a minimum delay between each user's messages in a
-            channel. Set to 0 to disable. Max 21600 seconds (6 hours).
-            Requires Manage Channel.
-        </p>
-        <form class="mod-action-form" data-action="slowmode">
-            <label>Channel
-                <div th:replace="~{fragments/channelPicker :: channelPicker(
-                        name='channelId',
-                        id='slowmode-channel',
-                        channels=${overview.textChannels},
-                        selectedValue=null,
-                        placeholder='— choose —',
-                        emptyLabel=null,
-                        required=true,
-                        valuePrefix='#',
-                        valueField='id',
-                        disabled=false)}"></div>
-            </label>
-            <label>Seconds (0-21600, 0 to disable)
-                <input type="number" name="seconds" min="0" max="21600" value="0" required>
-            </label>
-            <button type="submit" class="btn">Apply</button>
-        </form>
+        <section class="mod-section">
+            <h2 class="mod-section-title">Channel actions</h2>
+            <div class="mod-card-grid">
+
+                <div class="mod-card mod-card-wide">
+                    <h3>Purge messages</h3>
+                    <p class="muted">
+                        Bulk-delete the last N messages in a channel (max 100),
+                        optionally filtered to a single user. Discord only allows
+                        bulk-deleting messages from the last 14 days — older ones
+                        are skipped automatically. Requires Manage Messages.
+                    </p>
+                    <form class="mod-action-form" data-action="purge">
+                        <label>Channel
+                            <div th:replace="~{fragments/channelPicker :: channelPicker(
+                                    name='channelId',
+                                    id='purge-channel',
+                                    channels=${overview.textChannels},
+                                    selectedValue=null,
+                                    placeholder='— choose —',
+                                    emptyLabel=null,
+                                    required=true,
+                                    valuePrefix='#',
+                                    valueField='id',
+                                    disabled=false)}"></div>
+                        </label>
+                        <label>Count (1-100)
+                            <input type="number" name="count" min="1" max="100" value="10" required>
+                        </label>
+                        <label>Filter to user (optional)
+                            <div th:replace="~{fragments/userPicker :: userPicker(
+                                    name='filterUserId',
+                                    id='purge-filter',
+                                    members=${overview.members},
+                                    selectedId=null,
+                                    placeholder='Any user',
+                                    emptyLabel='Any user',
+                                    required=false,
+                                    multiple=false,
+                                    showSocialCredit=false)}"></div>
+                        </label>
+                        <button type="submit" class="btn-danger">Purge</button>
+                    </form>
+                </div>
+
+                <div class="mod-card mod-card-wide">
+                    <h3>Lock / unlock channel</h3>
+                    <p class="muted">
+                        Toggle whether @everyone can send messages in a text channel.
+                        "Lock" denies Send Messages on @everyone's permission
+                        override; "Unlock" clears the override so the role default
+                        applies again. Requires Manage Permissions.
+                    </p>
+                    <form class="mod-action-form" data-action="lock">
+                        <label>Channel
+                            <div th:replace="~{fragments/channelPicker :: channelPicker(
+                                    name='channelId',
+                                    id='lock-channel',
+                                    channels=${overview.textChannels},
+                                    selectedValue=null,
+                                    placeholder='— choose —',
+                                    emptyLabel=null,
+                                    required=true,
+                                    valuePrefix='#',
+                                    valueField='id',
+                                    disabled=false)}"></div>
+                        </label>
+                        <div class="lock-actions">
+                            <button type="button" class="btn-danger" data-lock="true">Lock</button>
+                            <button type="button" class="btn" data-lock="false">Unlock</button>
+                        </div>
+                    </form>
+                </div>
+
+                <div class="mod-card mod-card-wide">
+                    <h3>Slowmode</h3>
+                    <p class="muted">
+                        Force a minimum delay between each user's messages in a
+                        channel. Set to 0 to disable. Max 21600 seconds (6 hours).
+                        Requires Manage Channel.
+                    </p>
+                    <form class="mod-action-form" data-action="slowmode">
+                        <label>Channel
+                            <div th:replace="~{fragments/channelPicker :: channelPicker(
+                                    name='channelId',
+                                    id='slowmode-channel',
+                                    channels=${overview.textChannels},
+                                    selectedValue=null,
+                                    placeholder='— choose —',
+                                    emptyLabel=null,
+                                    required=true,
+                                    valuePrefix='#',
+                                    valueField='id',
+                                    disabled=false)}"></div>
+                        </label>
+                        <label>Seconds (0-21600, 0 to disable)
+                            <input type="number" name="seconds" min="0" max="21600" value="0" required>
+                        </label>
+                        <button type="submit" class="btn">Apply</button>
+                    </form>
+                </div>
+
+            </div>
+        </section>
     </section>
 </main>
 


### PR DESCRIPTION
## Summary

Phase 4 of the moderation dashboard refresh — Actions tab. The audit of the eight tabs that didn't get a deeper pass in earlier phases turned up just one outlier worth touching: **actions.html**. The other seven (users, voice, poll, casino, lottery, leveling, welcome) already compose cleanly under the new chrome.

Actions was the last moderation tab still rendered as a flat scroll of forms. This pass groups it the same way the rest of the dashboard reads, without changing any submit behaviour.

- **Two purpose groups** wrap the eight forms in `<section class="mod-section">` blocks:
  - Member actions (Kick, Ban, Unban, Timeout, Untimeout)
  - Channel actions (Purge, Lock / unlock, Slowmode)
- **Each form lives in a `.mod-card.mod-card-wide`** — the card carries the title (`h3`) + one-line explainer (`<p class="muted">`) + form + submit. The `<form class="mod-action-form" data-action="…">` element is unchanged; `actions.js` keys off `data-action` and doesn't see the surrounding markup.
- **`.mod-card-grid`** wraps each section's cards so they auto-fit 1/2/3 columns to viewport (the same grid already used by `casino.html`).
- **CSS adjustments**:
  - `.mod-action-form` trimmed — it used to give the form its own background/border/padding/margin (acting as a pseudo-card), which conflicted with the new `.mod-card` wrapper. Now it's just the flex column layout.
  - `.action-explainer` rule deleted; the only consumer was actions.html and the new card layout replaces it.
  - `.mod-section + .mod-section { margin-top: var(--space-6) }` so the two group sections breathe.
  - `[data-panel="actions"] .mod-card h3` promoted from the shared small-uppercase eyebrow style to a real heading, scoped to this tab only — the shared eyebrow style stays right for KPI label cards (casino's "JACKPOT POOL" → big number) on other tabs.
- **No JS, no Kotlin, no controller changes.**

## Test plan

- [x] `./gradlew :web:test` — full web test suite passes
- [x] `npm test` (web/) — 623 JS tests pass
- [x] `npm run lint:css` — stylelint passes
- [ ] Visit `/moderation/{guildId}/actions` and confirm: two group headings render; each action is a card with title + explainer + form + submit; the member-actions row auto-fits 1/2/3 columns to viewport; per-form submit still works end-to-end (try Kick on a test member, Slowmode=0 on a test channel)
- [ ] Mobile DevTools (375px): cards stack single-column, headings stay visible, no horizontal scroll
- [ ] Visit the other 7 tabs (Users, Voice, Poll, Casino, Lottery, Leveling, Welcome) — they should look identical to before this PR (verifies the `.mod-action-form` rule change and the `[data-panel="actions"]` h3 override are correctly scoped and don't leak)

This is the last phase of the dashboard refresh plan. The originally-planned Phase 3b (section-level batch-save with dirty tracking) remains deferred — call it out if you want to revive it.

https://claude.ai/code/session_01NgJUqmuDnJWZp5WrSTXcfn

---
_Generated by [Claude Code](https://claude.ai/code/session_01NgJUqmuDnJWZp5WrSTXcfn)_