### PR TITLE
feat(pvp): TicTacToe + Connect 4 web backends

### DIFF
--- a/database/src/main/kotlin/database/boardgame/TurnBasedBoardSessionRegistry.kt
+++ b/database/src/main/kotlin/database/boardgame/TurnBasedBoardSessionRegistry.kt
@@ -183,6 +183,41 @@ abstract class TurnBasedBoardSessionRegistry<TSession : TurnBasedBoardSessionReg
     fun get(id: Long): TSession? = sessions[id]
 
     /**
+     * List PENDING offers where [discordId] is the opponent — the web
+     * inbox feed. Scans the Caffeine map (O(n), capped at
+     * [MAX_SESSIONS]); fine because n is bounded and the alternative
+     * (a parallel index) would have to be kept in sync through every
+     * state transition. Same approach as the per-game RPS / Duel
+     * registries.
+     */
+    fun pendingForOpponent(discordId: Long, guildId: Long): List<TSession> =
+        sessions.values.filter {
+            it.state == Session.State.PENDING &&
+                it.guildId == guildId &&
+                it.opponentDiscordId == discordId
+        }
+
+    /** Mirror of [pendingForOpponent] for outgoing offers (web outbox). */
+    fun pendingForInitiator(discordId: Long, guildId: Long): List<TSession> =
+        sessions.values.filter {
+            it.state == Session.State.PENDING &&
+                it.guildId == guildId &&
+                it.initiatorDiscordId == discordId
+        }
+
+    /**
+     * List LIVE sessions where [discordId] is one of the two participants
+     * — the web active-game feed. Used by the polling endpoint that
+     * keeps the board in sync between Discord and web surfaces.
+     */
+    fun liveFor(discordId: Long, guildId: Long): List<TSession> =
+        sessions.values.filter {
+            it.state == Session.State.LIVE &&
+                it.guildId == guildId &&
+                (it.initiatorDiscordId == discordId || it.opponentDiscordId == discordId)
+        }
+
+    /**
      * Cancel any pending move clock for [session] and arm a fresh one
      * keyed on the session's current [Session.moveNumber]. If the
      * scheduled task fires after another move has already advanced

--- a/web/src/main/kotlin/web/casino/StakeBounds.kt
+++ b/web/src/main/kotlin/web/casino/StakeBounds.kt
@@ -15,6 +15,7 @@ import common.economy.WheelOfFortune
 import common.blackjack.Blackjack
 import common.poker.CasinoHoldem
 import database.service.ConfigService
+import database.boardgame.TurnBasedBoardWagerService
 import database.service.DuelService
 import database.service.RpsService
 import database.service.cfgLong
@@ -152,6 +153,22 @@ class StakeBounds(
         ConfigDto.Configurations.RPS_MAX_STAKE,
         RpsService.MIN_STAKE,
         RpsService.MAX_STAKE,
+    )
+
+    fun ticTacToe(guildId: Long): Pair<Long, Long> = read(
+        guildId,
+        ConfigDto.Configurations.TICTACTOE_MIN_STAKE,
+        ConfigDto.Configurations.TICTACTOE_MAX_STAKE,
+        TurnBasedBoardWagerService.DEFAULT_MIN_STAKE,
+        TurnBasedBoardWagerService.DEFAULT_MAX_STAKE,
+    )
+
+    fun connect4(guildId: Long): Pair<Long, Long> = read(
+        guildId,
+        ConfigDto.Configurations.CONNECT4_MIN_STAKE,
+        ConfigDto.Configurations.CONNECT4_MAX_STAKE,
+        TurnBasedBoardWagerService.DEFAULT_MIN_STAKE,
+        TurnBasedBoardWagerService.DEFAULT_MAX_STAKE,
     )
 
     private fun read(

--- a/web/src/main/kotlin/web/controller/PvpController.kt
+++ b/web/src/main/kotlin/web/controller/PvpController.kt
@@ -1,13 +1,20 @@
 package web.controller
 
+import common.connect4.Connect4Engine
+import common.tictactoe.TicTacToeEngine
+import database.boardgame.TurnBasedBoardWagerService
+import database.connect4.Connect4SessionRegistry
 import database.duel.PendingDuelRegistry
 import database.rps.RpsSessionRegistry
+import database.service.Connect4Service
 import database.service.DuelService
 import database.service.DuelService.AcceptOutcome
 import database.service.DuelService.StartOutcome
 import database.service.RpsService
 import database.service.PvpWagerService
+import database.service.TicTacToeService
 import database.service.UserService
+import database.tictactoe.TicTacToeSessionRegistry
 import jakarta.servlet.http.HttpServletRequest
 import net.dv8tion.jda.api.JDA
 import org.springframework.context.ApplicationEventPublisher
@@ -52,6 +59,10 @@ class PvpController(
     private val duelService: DuelService,
     private val rpsService: RpsService,
     private val rpsSessionRegistry: RpsSessionRegistry,
+    private val ticTacToeService: TicTacToeService,
+    private val ticTacToeSessionRegistry: TicTacToeSessionRegistry,
+    private val connect4Service: Connect4Service,
+    private val connect4SessionRegistry: Connect4SessionRegistry,
     private val pvpWebService: PvpWebService,
     private val pvpSseService: PvpSseService,
     private val pendingDuelRegistry: PendingDuelRegistry,
@@ -117,6 +128,12 @@ class PvpController(
         val (rpsMinStake, rpsMaxStake) = stakeBounds.rps(guildId)
         model.addAttribute("rpsMinStake", rpsMinStake)
         model.addAttribute("rpsMaxStake", rpsMaxStake)
+        val (tttMinStake, tttMaxStake) = stakeBounds.ticTacToe(guildId)
+        model.addAttribute("tttMinStake", tttMinStake)
+        model.addAttribute("tttMaxStake", tttMaxStake)
+        val (c4MinStake, c4MaxStake) = stakeBounds.connect4(guildId)
+        model.addAttribute("c4MinStake", c4MinStake)
+        model.addAttribute("c4MaxStake", c4MaxStake)
         model.addAttribute("pending", pending)
         model.addAttribute("outgoing", outgoing)
         model.addAttribute("ttlLabel", PendingDuelRegistry.formatTtl(pendingDuelRegistry.ttl))
@@ -684,6 +701,576 @@ class PvpController(
         RpsService.ResolveOutcome.Unknown -> null
     }
 
+    private fun translateBoardOutcome(
+        outcome: TurnBasedBoardWagerService.ResolveOutcome,
+    ): PvpWebService.PvpResolutionOutcome? = when (outcome) {
+        is TurnBasedBoardWagerService.ResolveOutcome.Win -> PvpWebService.PvpResolutionOutcome.boardWin(outcome)
+        is TurnBasedBoardWagerService.ResolveOutcome.Draw -> PvpWebService.PvpResolutionOutcome.boardDraw(outcome)
+        TurnBasedBoardWagerService.ResolveOutcome.Unknown -> null
+    }
+
+    // ─── TicTacToe ────────────────────────────────────────────────────
+
+    @GetMapping("/{guildId}/tictactoe/pending")
+    @ResponseBody
+    fun tttPendingForMe(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<List<PvpWebService.TicTacToePendingView>> = WebGuildAccess.requireMemberForJsonNoBody(
+        user, guildId, economyWebService
+    ) { discordId -> ResponseEntity.ok(pvpWebService.ticTacToePendingForOpponent(discordId, guildId)) }
+
+    @GetMapping("/{guildId}/tictactoe/outgoing")
+    @ResponseBody
+    fun tttOutgoingForMe(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<List<PvpWebService.TicTacToePendingView>> = WebGuildAccess.requireMemberForJsonNoBody(
+        user, guildId, economyWebService
+    ) { discordId -> ResponseEntity.ok(pvpWebService.ticTacToePendingForInitiator(discordId, guildId)) }
+
+    @GetMapping("/{guildId}/tictactoe/active")
+    @ResponseBody
+    fun tttActiveForMe(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<List<PvpWebService.TicTacToeSessionView>> = WebGuildAccess.requireMemberForJsonNoBody(
+        user, guildId, economyWebService
+    ) { discordId -> ResponseEntity.ok(pvpWebService.ticTacToeActiveFor(discordId, guildId)) }
+
+    @GetMapping("/{guildId}/tictactoe/{sessionId}")
+    @ResponseBody
+    fun tttSession(
+        @PathVariable guildId: Long,
+        @PathVariable sessionId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<PvpWebService.TicTacToeSessionView> = WebGuildAccess.requireMemberForJsonNoBody(
+        user, guildId, economyWebService
+    ) { discordId ->
+        val view = pvpWebService.ticTacToeSessionView(sessionId, discordId)
+            ?: return@requireMemberForJsonNoBody ResponseEntity.status(404).build()
+        ResponseEntity.ok(view)
+    }
+
+    @PostMapping("/{guildId}/tictactoe/challenge")
+    @ResponseBody
+    fun tttChallenge(
+        @PathVariable guildId: Long,
+        @RequestBody request: ChallengeRequest,
+        @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<PvpActionResponse> = boardChallenge(
+        guildId, request, user, gameLabel = "tic-tac-toe",
+        start = { initId -> ticTacToeService.startMatch(initId, request.opponentDiscordId.toLong(), guildId, request.stake) },
+        register = { initId, oppId, stake -> ticTacToeSessionRegistry.register(guildId, initId, oppId, stake) },
+        sseEventName = "tictactoe.offered",
+    )
+
+    @PostMapping("/{guildId}/tictactoe/{sessionId}/accept")
+    @ResponseBody
+    fun tttAccept(
+        @PathVariable guildId: Long,
+        @PathVariable sessionId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<PvpActionResponse> = boardAccept(
+        guildId, sessionId, user,
+        get = { ticTacToeSessionRegistry.get(it) },
+        accept = { ticTacToeSessionRegistry.accept(it) { s -> resolveTttOnMoveTimeout(s) } },
+        debit = { initId, oppId, stake -> ticTacToeService.acceptMatch(initId, oppId, guildId, stake) },
+        forfeitOnDebitFail = { ticTacToeSessionRegistry.forfeit(it) },
+        sseAcceptedEvent = "tictactoe.accepted",
+        sseRemovedEvent = "tictactoe.removed",
+    )
+
+    @PostMapping("/{guildId}/tictactoe/{sessionId}/decline")
+    @ResponseBody
+    fun tttDecline(
+        @PathVariable guildId: Long, @PathVariable sessionId: Long, @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<PvpActionResponse> = boardCloseOffer(
+        guildId, sessionId, user, isInitiator = false, friendlyName = "decline",
+        get = { ticTacToeSessionRegistry.get(it) },
+        decline = { ticTacToeSessionRegistry.decline(it) },
+        sseEventName = "tictactoe.removed",
+    )
+
+    @PostMapping("/{guildId}/tictactoe/{sessionId}/cancel")
+    @ResponseBody
+    fun tttCancel(
+        @PathVariable guildId: Long, @PathVariable sessionId: Long, @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<PvpActionResponse> = boardCloseOffer(
+        guildId, sessionId, user, isInitiator = true, friendlyName = "cancel",
+        get = { ticTacToeSessionRegistry.get(it) },
+        decline = { ticTacToeSessionRegistry.decline(it) },
+        sseEventName = "tictactoe.removed",
+    )
+
+    @PostMapping("/{guildId}/tictactoe/{sessionId}/move")
+    @ResponseBody
+    fun tttMove(
+        @PathVariable guildId: Long,
+        @PathVariable sessionId: Long,
+        @RequestBody request: BoardMoveRequest,
+        @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<PvpActionResponse> {
+        val discordId = user.discordIdOrNull()
+            ?: return ResponseEntity.status(401).body(PvpActionResponse(false, error = "Not signed in."))
+        val session = ticTacToeSessionRegistry.get(sessionId)
+            ?: return ResponseEntity.status(410).body(PvpActionResponse(false, error = "Match already ended."))
+        if (session.guildId != guildId) {
+            return ResponseEntity.badRequest().body(PvpActionResponse(false, error = "Wrong guild for this match."))
+        }
+        if (discordId != session.initiatorDiscordId && discordId != session.opponentDiscordId) {
+            return ResponseEntity.status(403).body(PvpActionResponse(false, error = "You aren't in this match."))
+        }
+        val cell = request.move
+            ?: return ResponseEntity.badRequest().body(PvpActionResponse(false, error = "Missing cell."))
+        if (cell < 0 || cell > 8) {
+            return ResponseEntity.badRequest().body(PvpActionResponse(false, error = "Cell must be 0–8."))
+        }
+        val result = ticTacToeSessionRegistry.applyMove(sessionId, discordId, cell) { s -> resolveTttOnMoveTimeout(s) }
+            ?: return ResponseEntity.status(409).body(PvpActionResponse(false, error = "Not your turn."))
+        return handleTttResult(guildId, sessionId, session, result)
+    }
+
+    @PostMapping("/{guildId}/tictactoe/{sessionId}/forfeit")
+    @ResponseBody
+    fun tttForfeit(
+        @PathVariable guildId: Long, @PathVariable sessionId: Long, @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<PvpActionResponse> = boardForfeit(
+        guildId, sessionId, user,
+        get = { ticTacToeSessionRegistry.get(it) },
+        forfeit = { ticTacToeSessionRegistry.forfeit(it) },
+        resolveWithWinner = { init, opp, stake, winner ->
+            ticTacToeService.resolveMatch(init, opp, guildId, stake, winner)
+        },
+        sseEventName = "tictactoe.resolved",
+    )
+
+    private fun handleTttResult(
+        guildId: Long,
+        sessionId: Long,
+        session: TicTacToeSessionRegistry.Session,
+        result: TicTacToeEngine.MoveResult,
+    ): ResponseEntity<PvpActionResponse> {
+        return when (result) {
+            is TicTacToeEngine.MoveResult.Continued -> {
+                // Tell the other side it's their turn — they refetch the
+                // session state from the embedded sessionView payload.
+                val viewer = session.initiatorDiscordId // viewer-agnostic; the recipient resolves myMark/myTurn from cells + currentActor
+                val view = pvpWebService.ticTacToeSessionView(sessionId, viewer)
+                pvpSseService.fanOutToBoth(
+                    guildId, session.initiatorDiscordId, session.opponentDiscordId, "tictactoe.moved",
+                    mapOf("sessionId" to sessionId, "view" to (view ?: emptyMap<String, Any>())),
+                )
+                ResponseEntity.ok(PvpActionResponse(ok = true, sessionId = sessionId))
+            }
+            is TicTacToeEngine.MoveResult.Win -> {
+                val consumed = ticTacToeSessionRegistry.consumeForResolution(sessionId) ?: session
+                val winnerDiscordId = consumed.currentActorDiscordIdForWinner(result.winner)
+                val outcome = ticTacToeService.resolveMatch(
+                    consumed.initiatorDiscordId, consumed.opponentDiscordId, guildId, consumed.stake, winnerDiscordId,
+                )
+                val resolution = translateBoardOutcome(outcome)
+                pvpSseService.fanOutToBoth(
+                    guildId, consumed.initiatorDiscordId, consumed.opponentDiscordId, "tictactoe.resolved",
+                    mapOf("sessionId" to sessionId, "outcome" to (resolution as Any? ?: emptyMap<String, Any>())),
+                )
+                ResponseEntity.ok(PvpActionResponse(ok = true, sessionId = sessionId, outcome = resolution))
+            }
+            is TicTacToeEngine.MoveResult.Draw -> {
+                val consumed = ticTacToeSessionRegistry.consumeForResolution(sessionId) ?: session
+                val outcome = ticTacToeService.resolveMatch(
+                    consumed.initiatorDiscordId, consumed.opponentDiscordId, guildId, consumed.stake, null,
+                )
+                val resolution = translateBoardOutcome(outcome)
+                pvpSseService.fanOutToBoth(
+                    guildId, consumed.initiatorDiscordId, consumed.opponentDiscordId, "tictactoe.resolved",
+                    mapOf("sessionId" to sessionId, "outcome" to (resolution as Any? ?: emptyMap<String, Any>())),
+                )
+                ResponseEntity.ok(PvpActionResponse(ok = true, sessionId = sessionId, outcome = resolution))
+            }
+            TicTacToeEngine.MoveResult.IllegalCell ->
+                ResponseEntity.badRequest().body(PvpActionResponse(false, error = "Cell must be 0–8."))
+            TicTacToeEngine.MoveResult.Occupied ->
+                ResponseEntity.badRequest().body(PvpActionResponse(false, error = "That cell is already taken."))
+        }
+    }
+
+    private fun TicTacToeSessionRegistry.Session.currentActorDiscordIdForWinner(winner: TicTacToeEngine.Mark): Long =
+        when (winner) {
+            TicTacToeEngine.Mark.X -> initiatorDiscordId
+            TicTacToeEngine.Mark.O -> opponentDiscordId
+        }
+
+    private fun resolveTttOnMoveTimeout(session: TicTacToeSessionRegistry.Session) {
+        // The on-clock player just lost by timeout. The opponent takes the pot.
+        val opponentDiscordId = if (session.currentActorDiscordId() == session.initiatorDiscordId)
+            session.opponentDiscordId else session.initiatorDiscordId
+        val outcome = ticTacToeService.resolveMatch(
+            session.initiatorDiscordId, session.opponentDiscordId, session.guildId, session.stake, opponentDiscordId,
+        )
+        val resolution = translateBoardOutcome(outcome)
+        pvpSseService.fanOutToBoth(
+            session.guildId, session.initiatorDiscordId, session.opponentDiscordId, "tictactoe.resolved",
+            mapOf(
+                "sessionId" to session.id, "reason" to "move_timeout",
+                "outcome" to (resolution as Any? ?: emptyMap<String, Any>()),
+            ),
+        )
+    }
+
+    // ─── Connect 4 ────────────────────────────────────────────────────
+
+    @GetMapping("/{guildId}/connect4/pending")
+    @ResponseBody
+    fun c4PendingForMe(
+        @PathVariable guildId: Long, @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<List<PvpWebService.Connect4PendingView>> = WebGuildAccess.requireMemberForJsonNoBody(
+        user, guildId, economyWebService
+    ) { discordId -> ResponseEntity.ok(pvpWebService.connect4PendingForOpponent(discordId, guildId)) }
+
+    @GetMapping("/{guildId}/connect4/outgoing")
+    @ResponseBody
+    fun c4OutgoingForMe(
+        @PathVariable guildId: Long, @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<List<PvpWebService.Connect4PendingView>> = WebGuildAccess.requireMemberForJsonNoBody(
+        user, guildId, economyWebService
+    ) { discordId -> ResponseEntity.ok(pvpWebService.connect4PendingForInitiator(discordId, guildId)) }
+
+    @GetMapping("/{guildId}/connect4/active")
+    @ResponseBody
+    fun c4ActiveForMe(
+        @PathVariable guildId: Long, @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<List<PvpWebService.Connect4SessionView>> = WebGuildAccess.requireMemberForJsonNoBody(
+        user, guildId, economyWebService
+    ) { discordId -> ResponseEntity.ok(pvpWebService.connect4ActiveFor(discordId, guildId)) }
+
+    @GetMapping("/{guildId}/connect4/{sessionId}")
+    @ResponseBody
+    fun c4Session(
+        @PathVariable guildId: Long,
+        @PathVariable sessionId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<PvpWebService.Connect4SessionView> = WebGuildAccess.requireMemberForJsonNoBody(
+        user, guildId, economyWebService
+    ) { discordId ->
+        val view = pvpWebService.connect4SessionView(sessionId, discordId)
+            ?: return@requireMemberForJsonNoBody ResponseEntity.status(404).build()
+        ResponseEntity.ok(view)
+    }
+
+    @PostMapping("/{guildId}/connect4/challenge")
+    @ResponseBody
+    fun c4Challenge(
+        @PathVariable guildId: Long,
+        @RequestBody request: ChallengeRequest,
+        @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<PvpActionResponse> = boardChallenge(
+        guildId, request, user, gameLabel = "connect 4",
+        start = { initId -> connect4Service.startMatch(initId, request.opponentDiscordId.toLong(), guildId, request.stake) },
+        register = { initId, oppId, stake -> connect4SessionRegistry.register(guildId, initId, oppId, stake) },
+        sseEventName = "connect4.offered",
+    )
+
+    @PostMapping("/{guildId}/connect4/{sessionId}/accept")
+    @ResponseBody
+    fun c4Accept(
+        @PathVariable guildId: Long,
+        @PathVariable sessionId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<PvpActionResponse> = boardAccept(
+        guildId, sessionId, user,
+        get = { connect4SessionRegistry.get(it) },
+        accept = { connect4SessionRegistry.accept(it) { s -> resolveC4OnMoveTimeout(s) } },
+        debit = { initId, oppId, stake -> connect4Service.acceptMatch(initId, oppId, guildId, stake) },
+        forfeitOnDebitFail = { connect4SessionRegistry.forfeit(it) },
+        sseAcceptedEvent = "connect4.accepted",
+        sseRemovedEvent = "connect4.removed",
+    )
+
+    @PostMapping("/{guildId}/connect4/{sessionId}/decline")
+    @ResponseBody
+    fun c4Decline(
+        @PathVariable guildId: Long, @PathVariable sessionId: Long, @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<PvpActionResponse> = boardCloseOffer(
+        guildId, sessionId, user, isInitiator = false, friendlyName = "decline",
+        get = { connect4SessionRegistry.get(it) },
+        decline = { connect4SessionRegistry.decline(it) },
+        sseEventName = "connect4.removed",
+    )
+
+    @PostMapping("/{guildId}/connect4/{sessionId}/cancel")
+    @ResponseBody
+    fun c4Cancel(
+        @PathVariable guildId: Long, @PathVariable sessionId: Long, @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<PvpActionResponse> = boardCloseOffer(
+        guildId, sessionId, user, isInitiator = true, friendlyName = "cancel",
+        get = { connect4SessionRegistry.get(it) },
+        decline = { connect4SessionRegistry.decline(it) },
+        sseEventName = "connect4.removed",
+    )
+
+    @PostMapping("/{guildId}/connect4/{sessionId}/move")
+    @ResponseBody
+    fun c4Move(
+        @PathVariable guildId: Long,
+        @PathVariable sessionId: Long,
+        @RequestBody request: BoardMoveRequest,
+        @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<PvpActionResponse> {
+        val discordId = user.discordIdOrNull()
+            ?: return ResponseEntity.status(401).body(PvpActionResponse(false, error = "Not signed in."))
+        val session = connect4SessionRegistry.get(sessionId)
+            ?: return ResponseEntity.status(410).body(PvpActionResponse(false, error = "Match already ended."))
+        if (session.guildId != guildId) {
+            return ResponseEntity.badRequest().body(PvpActionResponse(false, error = "Wrong guild for this match."))
+        }
+        if (discordId != session.initiatorDiscordId && discordId != session.opponentDiscordId) {
+            return ResponseEntity.status(403).body(PvpActionResponse(false, error = "You aren't in this match."))
+        }
+        val column = request.move
+            ?: return ResponseEntity.badRequest().body(PvpActionResponse(false, error = "Missing column."))
+        if (column < 0 || column > 6) {
+            return ResponseEntity.badRequest().body(PvpActionResponse(false, error = "Column must be 0–6."))
+        }
+        val result = connect4SessionRegistry.applyMove(sessionId, discordId, column) { s -> resolveC4OnMoveTimeout(s) }
+            ?: return ResponseEntity.status(409).body(PvpActionResponse(false, error = "Not your turn."))
+        return handleC4Result(guildId, sessionId, session, result)
+    }
+
+    @PostMapping("/{guildId}/connect4/{sessionId}/forfeit")
+    @ResponseBody
+    fun c4Forfeit(
+        @PathVariable guildId: Long, @PathVariable sessionId: Long, @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<PvpActionResponse> = boardForfeit(
+        guildId, sessionId, user,
+        get = { connect4SessionRegistry.get(it) },
+        forfeit = { connect4SessionRegistry.forfeit(it) },
+        resolveWithWinner = { init, opp, stake, winner ->
+            connect4Service.resolveMatch(init, opp, guildId, stake, winner)
+        },
+        sseEventName = "connect4.resolved",
+    )
+
+    private fun handleC4Result(
+        guildId: Long,
+        sessionId: Long,
+        session: Connect4SessionRegistry.Session,
+        result: Connect4Engine.MoveResult,
+    ): ResponseEntity<PvpActionResponse> {
+        return when (result) {
+            is Connect4Engine.MoveResult.Continued -> {
+                val view = pvpWebService.connect4SessionView(sessionId, session.initiatorDiscordId)
+                pvpSseService.fanOutToBoth(
+                    guildId, session.initiatorDiscordId, session.opponentDiscordId, "connect4.moved",
+                    mapOf("sessionId" to sessionId, "view" to (view ?: emptyMap<String, Any>())),
+                )
+                ResponseEntity.ok(PvpActionResponse(ok = true, sessionId = sessionId))
+            }
+            is Connect4Engine.MoveResult.Win -> {
+                val consumed = connect4SessionRegistry.consumeForResolution(sessionId) ?: session
+                val winnerDiscordId = consumed.currentActorDiscordIdForWinner(result.winner)
+                val outcome = connect4Service.resolveMatch(
+                    consumed.initiatorDiscordId, consumed.opponentDiscordId, guildId, consumed.stake, winnerDiscordId,
+                )
+                val resolution = translateBoardOutcome(outcome)
+                pvpSseService.fanOutToBoth(
+                    guildId, consumed.initiatorDiscordId, consumed.opponentDiscordId, "connect4.resolved",
+                    mapOf("sessionId" to sessionId, "outcome" to (resolution as Any? ?: emptyMap<String, Any>())),
+                )
+                ResponseEntity.ok(PvpActionResponse(ok = true, sessionId = sessionId, outcome = resolution))
+            }
+            is Connect4Engine.MoveResult.Draw -> {
+                val consumed = connect4SessionRegistry.consumeForResolution(sessionId) ?: session
+                val outcome = connect4Service.resolveMatch(
+                    consumed.initiatorDiscordId, consumed.opponentDiscordId, guildId, consumed.stake, null,
+                )
+                val resolution = translateBoardOutcome(outcome)
+                pvpSseService.fanOutToBoth(
+                    guildId, consumed.initiatorDiscordId, consumed.opponentDiscordId, "connect4.resolved",
+                    mapOf("sessionId" to sessionId, "outcome" to (resolution as Any? ?: emptyMap<String, Any>())),
+                )
+                ResponseEntity.ok(PvpActionResponse(ok = true, sessionId = sessionId, outcome = resolution))
+            }
+            Connect4Engine.MoveResult.InvalidColumn ->
+                ResponseEntity.badRequest().body(PvpActionResponse(false, error = "Column must be 0–6."))
+            Connect4Engine.MoveResult.ColumnFull ->
+                ResponseEntity.badRequest().body(PvpActionResponse(false, error = "That column is full."))
+        }
+    }
+
+    private fun Connect4SessionRegistry.Session.currentActorDiscordIdForWinner(winner: Connect4Engine.Mark): Long =
+        when (winner) {
+            Connect4Engine.Mark.RED -> initiatorDiscordId
+            Connect4Engine.Mark.YELLOW -> opponentDiscordId
+        }
+
+    private fun resolveC4OnMoveTimeout(session: Connect4SessionRegistry.Session) {
+        val opponentDiscordId = if (session.currentActorDiscordId() == session.initiatorDiscordId)
+            session.opponentDiscordId else session.initiatorDiscordId
+        val outcome = connect4Service.resolveMatch(
+            session.initiatorDiscordId, session.opponentDiscordId, session.guildId, session.stake, opponentDiscordId,
+        )
+        val resolution = translateBoardOutcome(outcome)
+        pvpSseService.fanOutToBoth(
+            session.guildId, session.initiatorDiscordId, session.opponentDiscordId, "connect4.resolved",
+            mapOf(
+                "sessionId" to session.id, "reason" to "move_timeout",
+                "outcome" to (resolution as Any? ?: emptyMap<String, Any>()),
+            ),
+        )
+    }
+
+    // ─── Shared board-game helpers ────────────────────────────────────
+    //
+    // TTT and C4 share the same Challenge / Accept / Decline / Cancel /
+    // Forfeit shapes — only the registry and service types differ. The
+    // helpers below collapse the 5x duplication those endpoints would
+    // otherwise carry, parameterised on per-game lambdas. The /move
+    // endpoint stays per-game because the parameter shape (cell vs
+    // column) and the engine MoveResult sealed types diverge.
+
+    private inline fun <S : database.boardgame.TurnBasedBoardSessionRegistry.Session> boardChallenge(
+        guildId: Long,
+        request: ChallengeRequest,
+        user: OAuth2User,
+        gameLabel: String,
+        start: (Long) -> PvpWagerService.StartOutcome,
+        register: (Long, Long, Long) -> S,
+        sseEventName: String,
+    ): ResponseEntity<PvpActionResponse> = WebGuildAccess.requireMemberForJson(
+        user, guildId, economyWebService,
+        errorBuilder = { status ->
+            ResponseEntity.status(status).body(
+                PvpActionResponse(false, error = if (status == 401) "Not signed in." else "You are not a member of that server.")
+            )
+        }
+    ) { discordId ->
+        val opponentDiscordId = request.opponentDiscordId.toLongOrNull()
+            ?: return@requireMemberForJson ResponseEntity.badRequest().body(PvpActionResponse(false, error = "Pick an opponent."))
+        if (opponentDiscordId == discordId) {
+            return@requireMemberForJson ResponseEntity.badRequest().body(PvpActionResponse(false, error = "You can't challenge yourself."))
+        }
+        if (!economyWebService.isMember(opponentDiscordId, guildId)) {
+            return@requireMemberForJson ResponseEntity.badRequest().body(PvpActionResponse(false, error = "Pick someone from this server."))
+        }
+        pvpWebService.ensureOpponent(opponentDiscordId, guildId)
+        val started = start(discordId)
+        if (started !is PvpWagerService.StartOutcome.Ok) {
+            return@requireMemberForJson ResponseEntity.badRequest().body(PvpActionResponse(false, error = pvpStartErrorMessage(started, gameLabel)))
+        }
+        val session = register(discordId, opponentDiscordId, request.stake)
+        pvpSseService.fanOutToUser(
+            guildId, opponentDiscordId, sseEventName,
+            mapOf("sessionId" to session.id),
+        )
+        ResponseEntity.ok(PvpActionResponse(ok = true, sessionId = session.id, stake = request.stake))
+    }
+
+    private inline fun <S : database.boardgame.TurnBasedBoardSessionRegistry.Session> boardAccept(
+        guildId: Long,
+        sessionId: Long,
+        user: OAuth2User,
+        get: (Long) -> S?,
+        accept: (Long) -> S?,
+        debit: (Long, Long, Long) -> PvpWagerService.AcceptOutcome,
+        forfeitOnDebitFail: (Long) -> S?,
+        sseAcceptedEvent: String,
+        sseRemovedEvent: String,
+    ): ResponseEntity<PvpActionResponse> {
+        val discordId = user.discordIdOrNull()
+            ?: return ResponseEntity.status(401).body(PvpActionResponse(false, error = "Not signed in."))
+        val session = get(sessionId)
+            ?: return ResponseEntity.status(410).body(PvpActionResponse(false, error = "This offer already resolved or expired."))
+        if (session.guildId != guildId) {
+            return ResponseEntity.badRequest().body(PvpActionResponse(false, error = "Wrong guild for this offer."))
+        }
+        if (session.opponentDiscordId != discordId) {
+            return ResponseEntity.status(403).body(PvpActionResponse(false, error = "This isn't your offer."))
+        }
+        accept(sessionId)
+            ?: return ResponseEntity.status(410).body(PvpActionResponse(false, error = "This offer already resolved or expired."))
+        val outcome = debit(session.initiatorDiscordId, session.opponentDiscordId, session.stake)
+        if (outcome !is PvpWagerService.AcceptOutcome.Ok) {
+            forfeitOnDebitFail(sessionId)
+            pvpSseService.fanOutToBoth(
+                guildId, session.initiatorDiscordId, session.opponentDiscordId, sseRemovedEvent,
+                mapOf("sessionId" to sessionId, "reason" to "balance_changed"),
+            )
+            return ResponseEntity.badRequest().body(PvpActionResponse(false, error = acceptErrorMessage(outcome)))
+        }
+        pvpSseService.fanOutToBoth(
+            guildId, session.initiatorDiscordId, session.opponentDiscordId, sseAcceptedEvent,
+            mapOf("sessionId" to sessionId, "state" to "LIVE", "stake" to session.stake),
+        )
+        return ResponseEntity.ok(PvpActionResponse(ok = true, sessionId = sessionId, stake = session.stake))
+    }
+
+    private inline fun <S : database.boardgame.TurnBasedBoardSessionRegistry.Session> boardCloseOffer(
+        guildId: Long,
+        sessionId: Long,
+        user: OAuth2User,
+        isInitiator: Boolean,
+        friendlyName: String,
+        get: (Long) -> S?,
+        decline: (Long) -> S?,
+        sseEventName: String,
+    ): ResponseEntity<PvpActionResponse> {
+        val discordId = user.discordIdOrNull()
+            ?: return ResponseEntity.status(401).body(PvpActionResponse(false, error = "Not signed in."))
+        val session = get(sessionId)
+            ?: return ResponseEntity.status(410).body(PvpActionResponse(false, error = "This offer already resolved or expired."))
+        if (session.guildId != guildId) {
+            return ResponseEntity.badRequest().body(PvpActionResponse(false, error = "Wrong guild for this offer."))
+        }
+        val expectedActor = if (isInitiator) session.initiatorDiscordId else session.opponentDiscordId
+        if (discordId != expectedActor) {
+            return ResponseEntity.status(403).body(PvpActionResponse(false, error = "This isn't your offer to $friendlyName."))
+        }
+        decline(sessionId)
+            ?: return ResponseEntity.status(410).body(PvpActionResponse(false, error = "This offer already resolved or expired."))
+        val otherDiscordId = if (isInitiator) session.opponentDiscordId else session.initiatorDiscordId
+        pvpSseService.fanOutToUser(
+            guildId, otherDiscordId, sseEventName,
+            mapOf("sessionId" to sessionId, "reason" to friendlyName),
+        )
+        return ResponseEntity.ok(PvpActionResponse(ok = true, sessionId = sessionId))
+    }
+
+    private inline fun <S : database.boardgame.TurnBasedBoardSessionRegistry.Session> boardForfeit(
+        guildId: Long,
+        sessionId: Long,
+        user: OAuth2User,
+        get: (Long) -> S?,
+        forfeit: (Long) -> S?,
+        resolveWithWinner: (Long, Long, Long, Long?) -> TurnBasedBoardWagerService.ResolveOutcome,
+        sseEventName: String,
+    ): ResponseEntity<PvpActionResponse> {
+        val discordId = user.discordIdOrNull()
+            ?: return ResponseEntity.status(401).body(PvpActionResponse(false, error = "Not signed in."))
+        val session = get(sessionId)
+            ?: return ResponseEntity.status(410).body(PvpActionResponse(false, error = "Match already ended."))
+        if (session.guildId != guildId) {
+            return ResponseEntity.badRequest().body(PvpActionResponse(false, error = "Wrong guild for this match."))
+        }
+        if (discordId != session.initiatorDiscordId && discordId != session.opponentDiscordId) {
+            return ResponseEntity.status(403).body(PvpActionResponse(false, error = "You aren't in this match."))
+        }
+        if (session.state != database.boardgame.TurnBasedBoardSessionRegistry.Session.State.LIVE) {
+            return ResponseEntity.badRequest().body(PvpActionResponse(false, error = "Match isn't live."))
+        }
+        val consumed = forfeit(sessionId)
+            ?: return ResponseEntity.status(410).body(PvpActionResponse(false, error = "Match already ended."))
+        val winnerDiscordId = if (discordId == consumed.initiatorDiscordId)
+            consumed.opponentDiscordId else consumed.initiatorDiscordId
+        val outcome = resolveWithWinner(consumed.initiatorDiscordId, consumed.opponentDiscordId, consumed.stake, winnerDiscordId)
+        val resolution = translateBoardOutcome(outcome)
+        pvpSseService.fanOutToBoth(
+            guildId, consumed.initiatorDiscordId, consumed.opponentDiscordId, sseEventName,
+            mapOf("sessionId" to sessionId, "reason" to "forfeit", "outcome" to (resolution as Any? ?: emptyMap<String, Any>())),
+        )
+        return ResponseEntity.ok(PvpActionResponse(ok = true, sessionId = sessionId, outcome = resolution))
+    }
+
     private fun pvpStartErrorMessage(outcome: PvpWagerService.StartOutcome, gameLabel: String): String = when (outcome) {
         is PvpWagerService.StartOutcome.InvalidStake -> "Stake must be between ${outcome.min} and ${outcome.max} credits."
         is PvpWagerService.StartOutcome.InvalidOpponent -> "You can't challenge yourself at $gameLabel."
@@ -733,6 +1320,10 @@ data class PvpActionResponse(
  *  [PvpWebService.parseRpsChoice] — case-insensitive, fails the
  *  request on an unknown value. */
 data class RpsPickRequest(val choice: String = "")
+
+/** TTT cell index (0–8, row-major) or C4 column index (0–6). One DTO
+ *  for both because the validation is per-game on the controller side. */
+data class BoardMoveRequest(val move: Int? = null)
 
 data class DuelActionResponse(
     val ok: Boolean,

--- a/web/src/main/kotlin/web/service/PvpWebService.kt
+++ b/web/src/main/kotlin/web/service/PvpWebService.kt
@@ -1,18 +1,22 @@
 package web.service
 
+import common.connect4.Connect4Engine
 import common.rps.RpsEngine
+import common.tictactoe.TicTacToeEngine
+import database.connect4.Connect4SessionRegistry
 import database.duel.PendingDuelRegistry
 import database.duel.RecentDuelResolutions
 import database.dto.UserDto
 import database.rps.RpsSessionRegistry
 import database.service.UserService
+import database.tictactoe.TicTacToeSessionRegistry
 import org.springframework.stereotype.Service
 
 /**
  * Read-only projection helpers around the in-memory PvP session
  * registries for the web UI, plus a lazy-create for the opponent's
  * [UserDto] row. Each game gets prefixed methods (`duel*`, `rps*`,
- * later `ticTacToe*` / `connect4*`) so the parallel projections don't
+ * `ticTacToe*`, `connect4*`) so the parallel projections don't
  * collide. Shared shape lives in [PvpParticipant] / [PvpParticipantPair]
  * so the six repeated identity fields aren't restated per game.
  */
@@ -20,6 +24,8 @@ import org.springframework.stereotype.Service
 class PvpWebService(
     private val pendingDuelRegistry: PendingDuelRegistry,
     private val rpsSessionRegistry: RpsSessionRegistry,
+    private val ticTacToeSessionRegistry: TicTacToeSessionRegistry,
+    private val connect4SessionRegistry: Connect4SessionRegistry,
     private val userService: UserService,
     private val memberLookup: MemberLookupHelper,
     private val recentDuelResolutions: RecentDuelResolutions,
@@ -314,8 +320,209 @@ class PvpWebService(
                     initiatorChoice = null,
                     opponentChoice = null,
                 )
+
+            /** TTT + C4 share [TurnBasedBoardWagerService.ResolveOutcome.Win];
+             *  the same factory translates both. RPS keeps its own because
+             *  it carries the two choices in the win-outcome. */
+            fun boardWin(o: database.boardgame.TurnBasedBoardWagerService.ResolveOutcome.Win): PvpResolutionOutcome =
+                PvpResolutionOutcome(
+                    verdict = "WIN",
+                    winnerDiscordId = o.winnerDiscordId.toString(),
+                    loserDiscordId = o.loserDiscordId.toString(),
+                    stake = o.stake, pot = o.pot,
+                    winnerNewBalance = o.winnerNewBalance,
+                    loserNewBalance = o.loserNewBalance,
+                    initiatorNewBalance = null, opponentNewBalance = null,
+                    lossTribute = o.lossTribute,
+                    initiatorChoice = null, opponentChoice = null,
+                )
+
+            fun boardDraw(o: database.boardgame.TurnBasedBoardWagerService.ResolveOutcome.Draw): PvpResolutionOutcome =
+                PvpResolutionOutcome(
+                    verdict = "DRAW",
+                    winnerDiscordId = null, loserDiscordId = null,
+                    stake = o.stake, pot = 0L,
+                    winnerNewBalance = null, loserNewBalance = null,
+                    initiatorNewBalance = o.initiatorNewBalance,
+                    opponentNewBalance = o.opponentNewBalance,
+                    lossTribute = null,
+                    initiatorChoice = null, opponentChoice = null,
+                )
         }
     }
+
+    // ─── TicTacToe ────────────────────────────────────────────────────
+
+    data class TicTacToePendingView(
+        val sessionId: Long,
+        val participants: PvpParticipantPair,
+    )
+
+    /**
+     * Tic-Tac-Toe session view. `cells` is the row-major 9-element
+     * board: "X", "O", or `null` per cell. `myMark` is "X" for the
+     * initiator, "O" for the opponent — and `null` if the viewer
+     * somehow isn't a participant (defensive; the controller filters).
+     */
+    data class TicTacToeSessionView(
+        val sessionId: Long,
+        val participants: PvpParticipantPair,
+        val state: String,
+        val cells: List<String?>,
+        val currentActorDiscordId: String?,
+        val myMark: String?,
+        val myTurn: Boolean,
+        val winningLine: List<Int>?,
+        val winner: String?,
+        val moveExpiresAtEpochSeconds: Long?,
+    )
+
+    fun ticTacToePendingForOpponent(discordId: Long, guildId: Long): List<TicTacToePendingView> =
+        ticTacToeSessionRegistry.pendingForOpponent(discordId, guildId).map { projectTicTacToePending(it) }
+
+    fun ticTacToePendingForInitiator(discordId: Long, guildId: Long): List<TicTacToePendingView> =
+        ticTacToeSessionRegistry.pendingForInitiator(discordId, guildId).map { projectTicTacToePending(it) }
+
+    fun ticTacToeActiveFor(viewerDiscordId: Long, guildId: Long): List<TicTacToeSessionView> =
+        ticTacToeSessionRegistry.liveFor(viewerDiscordId, guildId).map { projectTicTacToeSession(it, viewerDiscordId) }
+
+    fun ticTacToeSessionView(sessionId: Long, viewerDiscordId: Long): TicTacToeSessionView? {
+        val session = ticTacToeSessionRegistry.get(sessionId) ?: return null
+        if (viewerDiscordId != session.initiatorDiscordId && viewerDiscordId != session.opponentDiscordId) return null
+        return projectTicTacToeSession(session, viewerDiscordId)
+    }
+
+    private fun projectTicTacToePending(session: TicTacToeSessionRegistry.Session): TicTacToePendingView =
+        TicTacToePendingView(
+            sessionId = session.id,
+            participants = pair(
+                guildId = session.guildId,
+                initiatorDiscordId = session.initiatorDiscordId,
+                opponentDiscordId = session.opponentDiscordId,
+                stake = session.stake,
+                createdAtEpochSeconds = session.createdAt.epochSecond,
+            ),
+        )
+
+    private fun projectTicTacToeSession(
+        session: TicTacToeSessionRegistry.Session,
+        viewerDiscordId: Long,
+    ): TicTacToeSessionView {
+        val moveTtlSeconds = ticTacToeSessionRegistry.moveTtl.seconds
+        val moveExpires = if (session.state == database.boardgame.TurnBasedBoardSessionRegistry.Session.State.LIVE) {
+            session.createdAt.epochSecond + (moveTtlSeconds * (session.moveNumber + 1))
+        } else null
+        val myMark = session.markFor(viewerDiscordId)
+        return TicTacToeSessionView(
+            sessionId = session.id,
+            participants = pair(
+                guildId = session.guildId,
+                initiatorDiscordId = session.initiatorDiscordId,
+                opponentDiscordId = session.opponentDiscordId,
+                stake = session.stake,
+                createdAtEpochSeconds = session.createdAt.epochSecond,
+            ),
+            state = session.state.name,
+            cells = session.board.cells.map { it?.name },
+            currentActorDiscordId = if (session.state == database.boardgame.TurnBasedBoardSessionRegistry.Session.State.LIVE)
+                session.currentActorDiscordId().toString() else null,
+            myMark = myMark?.name,
+            myTurn = session.state == database.boardgame.TurnBasedBoardSessionRegistry.Session.State.LIVE &&
+                myMark != null && myMark == session.currentTurn,
+            winningLine = session.winningLine,
+            winner = session.winner?.name,
+            moveExpiresAtEpochSeconds = moveExpires,
+        )
+    }
+
+    // ─── Connect 4 ────────────────────────────────────────────────────
+
+    data class Connect4PendingView(
+        val sessionId: Long,
+        val participants: PvpParticipantPair,
+    )
+
+    /** Same shape as [TicTacToeSessionView] but with C4-specific marks
+     *  ("RED"/"YELLOW") and `lastDroppedRow` / `lastDroppedCol` for
+     *  cell-flash highlighting after the most recent drop. */
+    data class Connect4SessionView(
+        val sessionId: Long,
+        val participants: PvpParticipantPair,
+        val state: String,
+        val cells: List<String?>,
+        val currentActorDiscordId: String?,
+        val myMark: String?,
+        val myTurn: Boolean,
+        val winningLine: List<Int>?,
+        val winner: String?,
+        val lastDroppedRow: Int?,
+        val lastDroppedCol: Int?,
+        val moveExpiresAtEpochSeconds: Long?,
+    )
+
+    fun connect4PendingForOpponent(discordId: Long, guildId: Long): List<Connect4PendingView> =
+        connect4SessionRegistry.pendingForOpponent(discordId, guildId).map { projectConnect4Pending(it) }
+
+    fun connect4PendingForInitiator(discordId: Long, guildId: Long): List<Connect4PendingView> =
+        connect4SessionRegistry.pendingForInitiator(discordId, guildId).map { projectConnect4Pending(it) }
+
+    fun connect4ActiveFor(viewerDiscordId: Long, guildId: Long): List<Connect4SessionView> =
+        connect4SessionRegistry.liveFor(viewerDiscordId, guildId).map { projectConnect4Session(it, viewerDiscordId) }
+
+    fun connect4SessionView(sessionId: Long, viewerDiscordId: Long): Connect4SessionView? {
+        val session = connect4SessionRegistry.get(sessionId) ?: return null
+        if (viewerDiscordId != session.initiatorDiscordId && viewerDiscordId != session.opponentDiscordId) return null
+        return projectConnect4Session(session, viewerDiscordId)
+    }
+
+    private fun projectConnect4Pending(session: Connect4SessionRegistry.Session): Connect4PendingView =
+        Connect4PendingView(
+            sessionId = session.id,
+            participants = pair(
+                guildId = session.guildId,
+                initiatorDiscordId = session.initiatorDiscordId,
+                opponentDiscordId = session.opponentDiscordId,
+                stake = session.stake,
+                createdAtEpochSeconds = session.createdAt.epochSecond,
+            ),
+        )
+
+    private fun projectConnect4Session(
+        session: Connect4SessionRegistry.Session,
+        viewerDiscordId: Long,
+    ): Connect4SessionView {
+        val moveTtlSeconds = connect4SessionRegistry.moveTtl.seconds
+        val moveExpires = if (session.state == database.boardgame.TurnBasedBoardSessionRegistry.Session.State.LIVE) {
+            session.createdAt.epochSecond + (moveTtlSeconds * (session.moveNumber + 1))
+        } else null
+        val myMark = session.markFor(viewerDiscordId)
+        return Connect4SessionView(
+            sessionId = session.id,
+            participants = pair(
+                guildId = session.guildId,
+                initiatorDiscordId = session.initiatorDiscordId,
+                opponentDiscordId = session.opponentDiscordId,
+                stake = session.stake,
+                createdAtEpochSeconds = session.createdAt.epochSecond,
+            ),
+            state = session.state.name,
+            cells = session.board.cells.map { it?.name },
+            currentActorDiscordId = if (session.state == database.boardgame.TurnBasedBoardSessionRegistry.Session.State.LIVE)
+                session.currentActorDiscordId().toString() else null,
+            myMark = myMark?.name,
+            myTurn = session.state == database.boardgame.TurnBasedBoardSessionRegistry.Session.State.LIVE &&
+                myMark != null && myMark == session.currentTurn,
+            winningLine = session.winningLine,
+            winner = session.winner?.name,
+            lastDroppedRow = session.lastDroppedRow,
+            lastDroppedCol = session.lastDroppedCol,
+            moveExpiresAtEpochSeconds = moveExpires,
+        )
+    }
+
+    /** Translate "tictactoe" or "connect4" string body field to cell/column int. */
+    fun parseCellIndex(raw: Int?, max: Int): Int? =
+        if (raw != null && raw in 0 until max) raw else null
 
     /** Parse a string from the web request body into the engine enum. */
     fun parseRpsChoice(raw: String?): RpsEngine.Choice? = when (raw?.uppercase()) {

--- a/web/src/test/kotlin/web/controller/PvpControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/PvpControllerTest.kt
@@ -1,12 +1,16 @@
 package web.controller
 
+import database.connect4.Connect4SessionRegistry
 import database.duel.PendingDuelRegistry
 import database.rps.RpsSessionRegistry
+import database.service.Connect4Service
 import database.service.DuelService
 import database.service.DuelService.AcceptOutcome
 import database.service.DuelService.StartOutcome
 import database.service.RpsService
+import database.service.TicTacToeService
 import database.service.UserService
+import database.tictactoe.TicTacToeSessionRegistry
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -34,6 +38,10 @@ class PvpControllerTest {
     private lateinit var duelService: DuelService
     private lateinit var rpsService: RpsService
     private lateinit var rpsSessionRegistry: RpsSessionRegistry
+    private lateinit var ticTacToeService: TicTacToeService
+    private lateinit var ticTacToeSessionRegistry: TicTacToeSessionRegistry
+    private lateinit var connect4Service: Connect4Service
+    private lateinit var connect4SessionRegistry: Connect4SessionRegistry
     private lateinit var pvpWebService: PvpWebService
     private lateinit var pvpSseService: PvpSseService
     private lateinit var pendingDuelRegistry: PendingDuelRegistry
@@ -51,6 +59,10 @@ class PvpControllerTest {
         duelService = mockk(relaxed = true)
         rpsService = mockk(relaxed = true)
         rpsSessionRegistry = mockk(relaxed = true)
+        ticTacToeService = mockk(relaxed = true)
+        ticTacToeSessionRegistry = mockk(relaxed = true)
+        connect4Service = mockk(relaxed = true)
+        connect4SessionRegistry = mockk(relaxed = true)
         pvpWebService = mockk(relaxed = true)
         pvpSseService = mockk(relaxed = true)
         pendingDuelRegistry = mockk(relaxed = true)
@@ -67,7 +79,10 @@ class PvpControllerTest {
         every { economyWebService.isMember(discordId, guildId) } returns true
         every { economyWebService.isMember(opponentId, guildId) } returns true
         controller = PvpController(
-            duelService, rpsService, rpsSessionRegistry, pvpWebService, pvpSseService, pendingDuelRegistry,
+            duelService, rpsService, rpsSessionRegistry,
+            ticTacToeService, ticTacToeSessionRegistry,
+            connect4Service, connect4SessionRegistry,
+            pvpWebService, pvpSseService, pendingDuelRegistry,
             economyWebService, userService, jda, eventPublisher, stakeBounds,
             memberLookup
         )
@@ -382,5 +397,35 @@ class PvpControllerTest {
         assertEquals(true, response.body?.waitingForOpponent)
         verify { pvpSseService.fanOutToUser(guildId, opponentId, "rps.picked", any()) }
         verify(exactly = 0) { rpsSessionRegistry.consumeForResolution(any()) }
+    }
+
+    // ─── TTT + C4 self-challenge rejection ────────────────────────────
+    //
+    // The challenge / accept / decline / cancel / forfeit shapes are
+    // shared via the `boardChallenge` / `boardAccept` / `boardCloseOffer`
+    // / `boardForfeit` private helpers — exercised by the RPS tests
+    // above. These two tests just confirm the per-game wiring picks up
+    // the rejection before calling the service.
+
+    @Test
+    fun `tttChallenge rejects self-challenge before touching the service`() {
+        val response = controller.tttChallenge(
+            guildId,
+            ChallengeRequest(opponentDiscordId = discordId.toString(), stake = 10L),
+            user,
+        )
+        assertEquals(400, response.statusCode.value())
+        verify(exactly = 0) { ticTacToeService.startMatch(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `c4Challenge rejects self-challenge before touching the service`() {
+        val response = controller.c4Challenge(
+            guildId,
+            ChallengeRequest(opponentDiscordId = discordId.toString(), stake = 10L),
+            user,
+        )
+        assertEquals(400, response.statusCode.value())
+        verify(exactly = 0) { connect4Service.startMatch(any(), any(), any(), any()) }
     }
 }

--- a/web/src/test/kotlin/web/service/PvpWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/PvpWebServiceTest.kt
@@ -22,6 +22,8 @@ class PvpWebServiceTest {
 
     private lateinit var pendingDuelRegistry: PendingDuelRegistry
     private lateinit var rpsSessionRegistry: RpsSessionRegistry
+    private lateinit var ticTacToeSessionRegistry: database.tictactoe.TicTacToeSessionRegistry
+    private lateinit var connect4SessionRegistry: database.connect4.Connect4SessionRegistry
     private lateinit var userService: UserService
     private lateinit var memberLookup: MemberLookupHelper
     private lateinit var recentDuelResolutions: RecentDuelResolutions
@@ -31,6 +33,8 @@ class PvpWebServiceTest {
     fun setup() {
         pendingDuelRegistry = mockk(relaxed = true)
         rpsSessionRegistry = mockk(relaxed = true)
+        ticTacToeSessionRegistry = mockk(relaxed = true)
+        connect4SessionRegistry = mockk(relaxed = true)
         userService = mockk(relaxed = true)
         memberLookup = mockk {
             every { resolveAll(any(), any()) } returns emptyMap()
@@ -39,7 +43,7 @@ class PvpWebServiceTest {
         recentDuelResolutions = mockk {
             every { consumeForInitiator(any(), any()) } returns emptyList()
         }
-        service = PvpWebService(pendingDuelRegistry, rpsSessionRegistry, userService, memberLookup, recentDuelResolutions)
+        service = PvpWebService(pendingDuelRegistry, rpsSessionRegistry, ticTacToeSessionRegistry, connect4SessionRegistry, userService, memberLookup, recentDuelResolutions)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Mirrors PR #568's RPS backend shape for the two turn-based PvP games (TicTacToe + Connect 4). Both tabs still show "coming soon" on the page — frontend (HTML / JS / CSS) lands in the follow-up alongside the home counter bump.

### Backend endpoints
- `POST /pvp/{guildId}/{tictactoe|connect4}/{challenge,accept,decline,cancel,move,forfeit}` — call into the existing `TicTacToeService` / `Connect4Service` + their session registries, so achievements / XP / `*ResolvedEvent` emission fire identically to the Discord button path.
- `GET /pvp/{guildId}/{tictactoe|connect4}/{pending,outgoing,active,{sessionId}}` — one-shot initial-state fetches for the JS layer.
- `/move` takes `{move: Int}` (TTT cell `0–8`, C4 column `0–6`) → `registry.applyMove()`. On `Continued`, broadcasts `*.moved` SSE with the view snapshot. On `Win/Draw`, consumes for resolution + `service.resolveMatch(winnerDiscordId?)` + fans out `*.resolved`.

### DRY pass on PvpController
Five new private helpers — `boardChallenge`, `boardAccept`, `boardCloseOffer` (decline + cancel), `boardForfeit`, `translateBoardOutcome`. The four CRUD-shaped endpoints per game collapse to one-line lambdas pointing at these. `/move` stays per-game because the parameter validation (cell vs column) and `MoveResult` sealed types diverge — abstracting them would buy nothing and obscure the per-game quirks.

Other DRY wins:
- Listing methods (`pendingForOpponent`, `pendingForInitiator`, `liveFor`) moved from `RpsSessionRegistry` up into `TurnBasedBoardSessionRegistry` base class so both TTT and C4 inherit them.
- `PvpResolutionOutcome.Companion.boardWin` / `boardDraw` factories shared by TTT and C4 (both speak `TurnBasedBoardWagerService.ResolveOutcome`).
- `StakeBounds.ticTacToe` / `.connect4` added next to the existing `rps` / `duel` entries.

### View models
- `TicTacToePendingView` / `TicTacToeSessionView`
- `Connect4PendingView` / `Connect4SessionView` (adds `lastDroppedRow` / `lastDroppedCol` for eventual cell-flash highlight)
- Both reuse `PvpParticipantPair` — no field-list repetition.

### Known gaps (unchanged from RPS backend)
Cross-surface SSE: Discord-originated mutations still don't trigger web SSE events. Web users see their own moves in real-time but their opponent's via the next initial-fetch.

## Test plan

- [x] `./gradlew :web:test :database:test` — green; the existing `PvpControllerTest` + `PvpWebServiceTest` pass after constructor injection of the new registries; two new self-challenge rejection tests confirm the per-game wiring picks up validation before service calls.
- [ ] After frontend lands and is deployed: smoke-test TTT and C4 end-to-end (challenge web ↔ accept Discord, alternating moves both directions, board sync within ~100ms via SSE).

## Out of scope (next PR)

- TTT + C4 frontends (`pvp.html` panels, `pvp.js` board renderers, `pvp.css` grid styles)
- Home page counter bump (`GameCatalog`: add Duel as PVP, drop `total` PvP-exclusion filter, hero → "19 GAMES", new "PvP games" numbers tile)

https://claude.ai/code/session_01Gu12R3U1kygmu5c7qCPmYF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu12R3U1kygmu5c7qCPmYF)_