### PR TITLE
feat(navbar): split Casino + PvP, deep-link PvP games, promote Commands

### DIFF
--- a/web/src/main/kotlin/web/controller/PvpController.kt
+++ b/web/src/main/kotlin/web/controller/PvpController.kt
@@ -78,6 +78,7 @@ class PvpController(
         @RegisteredOAuth2AuthorizedClient("discord") client: OAuth2AuthorizedClient,
         @AuthenticationPrincipal user: OAuth2User,
         @RequestParam(required = false, defaultValue = "false") pick: Boolean,
+        @RequestParam(required = false) game: String?,
         request: HttpServletRequest,
         model: Model,
     ): String {
@@ -86,23 +87,43 @@ class PvpController(
             economyWebService.getGuildsWhereUserCanView(client.accessToken.tokenValue, discordId)
         } else emptyList()
 
+        val tab = sanitizeTabSlug(game)
+        val tabQuery = if (tab != null) "?tab=$tab" else ""
+
         val defaultGuildId = DefaultGuildCookie.read(request)
         GuildPickerSupport.resolveRedirect(
             guildIds = guilds.mapNotNull { it.id.toLongOrNull() },
             cookieGuildId = defaultGuildId,
             pick = pick,
-        ) { "/pvp/$it" }?.let { return it }
+        ) { "/pvp/$it$tabQuery" }?.let { return it }
 
         model.addAttribute("guilds", guilds)
         model.addAttribute("username", user.displayName())
         model.addAttribute("defaultGuildId", defaultGuildId)
+        // Per-guild card links carry `?tab=<slug>` so picking a guild from the
+        // navbar's PvP dropdown still deep-links to the right tab after the
+        // round-trip through this picker page.
+        model.addAttribute("tabQuery", tabQuery)
         return "pvp-guilds"
+    }
+
+    /** Whitelist accepted PvP tab slugs so a navbar-driven `?game=` query
+     *  param can drive the in-page tab strip without opening a fuzzing
+     *  vector. Anything outside the four valid slugs is dropped silently. */
+    private fun sanitizeTabSlug(raw: String?): String? = when (raw?.lowercase()) {
+        "duel", "rps", "tictactoe", "connect4" -> raw.lowercase()
+        else -> null
     }
 
     @GetMapping("/{guildId}")
     fun page(
         @PathVariable guildId: Long,
         @AuthenticationPrincipal user: OAuth2User,
+        // Both `?tab=` (the canonical query, used by guildList's redirect)
+        // and `?game=` (the navbar entry shape) drive the initial tab.
+        // Tab wins if both are present.
+        @RequestParam(required = false) tab: String?,
+        @RequestParam(required = false) game: String?,
         model: Model,
         ra: RedirectAttributes,
     ): String = WebGuildAccess.requireMemberForPage(
@@ -146,6 +167,10 @@ class PvpController(
         model.addAttribute("currentUserId", discordId.toString())
         model.addAttribute("currentUserName", me?.name ?: memberLookup.fallbackName(discordId))
         model.addAttribute("currentUserAvatarUrl", me?.avatarUrl)
+        // `?tab=` (post-redirect canonical) wins over `?game=` (navbar shape)
+        // when both arrive together. Either way, pvp.js reads
+        // `data-initial-tab` and flips to the matching tab on load.
+        model.addAttribute("initialTab", sanitizeTabSlug(tab) ?: sanitizeTabSlug(game) ?: "")
         model.addAttribute("username", user.displayName())
         "pvp"
     }

--- a/web/src/main/resources/static/js/pvp.js
+++ b/web/src/main/resources/static/js/pvp.js
@@ -209,6 +209,16 @@
         t.addEventListener('click', function () { activateTab(t.dataset.pvpTab); });
     });
 
+    // Deep-link from the navbar: PvpController.page surfaces `?tab=` /
+    // `?game=` via `data-initial-tab` on <main>. If it matches a real
+    // tab, flip to it before SSE / fetches kick off. Whitelist matches
+    // the controller-side sanitize set; an unknown / empty slug is a
+    // no-op and the default Duel tab stays active.
+    const initialTab = main.dataset.initialTab;
+    if (initialTab && ['duel', 'rps', 'tictactoe', 'connect4'].indexOf(initialTab) !== -1) {
+        activateTab(initialTab);
+    }
+
     const balanceEl = document.getElementById('duel-balance');
     const challengeForm = document.getElementById('duel-challenge');
     const pendingList = document.getElementById('duel-pending-list');

--- a/web/src/main/resources/templates/fragments/navbar.html
+++ b/web/src/main/resources/templates/fragments/navbar.html
@@ -81,16 +81,17 @@
             <a class="nav-item" href="/profile/guilds"><span class="nav-item-icon" aria-hidden="true">&#128100;</span><span>Profile</span></a>
             <a class="nav-item" href="/leaderboards"><span class="nav-item-icon" aria-hidden="true">&#127942;</span><span>Leaderboards</span></a>
             <a th:if="${username != null}" class="nav-item" href="/preferences/notifications"><span class="nav-item-icon" aria-hidden="true">&#128276;</span><span>Notifications</span></a>
+            <a class="nav-item" href="/commands/wiki"><span class="nav-item-icon" aria-hidden="true">&#128218;</span><span>Commands</span></a>
         </div>
 
         <div class="nav-section">
-            <div class="nav-section-eyebrow">Games</div>
+            <div class="nav-section-eyebrow">Casino</div>
             <div class="nav-dropdown">
                 <button type="button"
                         class="nav-dropdown-toggle"
                         aria-haspopup="true"
                         aria-expanded="false"
-                        onclick="toggleDropdown(this)"><span class="nav-item-icon" aria-hidden="true">&#127922;</span><span class="nav-dropdown-label">Play</span><span class="nav-dropdown-caret" aria-hidden="true">&#9662;</span></button>
+                        onclick="toggleDropdown(this)"><span class="nav-item-icon" aria-hidden="true">&#127922;</span><span class="nav-dropdown-label">Casino</span><span class="nav-dropdown-caret" aria-hidden="true">&#9662;</span></button>
                 <div class="nav-dropdown-menu" role="menu">
                     <a href="/casino/guilds?game=slots" role="menuitem">&#127920; Slots</a>
                     <a href="/casino/guilds?game=coinflip" role="menuitem">&#129689; Coinflip</a>
@@ -113,6 +114,23 @@
         </div>
 
         <div class="nav-section">
+            <div class="nav-section-eyebrow">PvP</div>
+            <div class="nav-dropdown">
+                <button type="button"
+                        class="nav-dropdown-toggle"
+                        aria-haspopup="true"
+                        aria-expanded="false"
+                        onclick="toggleDropdown(this)"><span class="nav-item-icon" aria-hidden="true">&#9876;&#65039;</span><span class="nav-dropdown-label">PvP</span><span class="nav-dropdown-caret" aria-hidden="true">&#9662;</span></button>
+                <div class="nav-dropdown-menu" role="menu">
+                    <a href="/pvp/guilds?game=duel" role="menuitem">&#9876;&#65039; Duel</a>
+                    <a href="/pvp/guilds?game=rps" role="menuitem">&#9994; Rock-Paper-Scissors</a>
+                    <a href="/pvp/guilds?game=tictactoe" role="menuitem">&#11093; Tic-Tac-Toe</a>
+                    <a href="/pvp/guilds?game=connect4" role="menuitem">&#128308; Connect 4</a>
+                </div>
+            </div>
+        </div>
+
+        <div class="nav-section">
             <div class="nav-section-eyebrow">Economy</div>
             <div class="nav-dropdown">
                 <button type="button"
@@ -123,8 +141,7 @@
                 <div class="nav-dropdown-menu" role="menu">
                     <a href="/economy/guilds" role="menuitem">Market</a>
                     <a href="/titles/guilds" role="menuitem">Titles</a>
-                    <a href="/tip/guilds" role="menuitem">&#128184; Tip</a>
-                    <a href="/pvp/guilds" role="menuitem">&#9876;&#65039; PvP</a>
+                    <a href="/tip/guilds" role="menuitem">Tip</a>
                 </div>
             </div>
         </div>
@@ -157,7 +174,6 @@
                 <div class="nav-dropdown-menu" role="menu">
                     <a href="/utils" role="menuitem">Utils</a>
                     <a href="/dnd" role="menuitem">D&amp;D lookups</a>
-                    <a href="/commands/wiki" role="menuitem">Commands</a>
                 </div>
             </div>
         </div>

--- a/web/src/main/resources/templates/pvp-guilds.html
+++ b/web/src/main/resources/templates/pvp-guilds.html
@@ -6,7 +6,7 @@
         emoji='⚔️',
         headingTitle='PvP',
         description='Challenge another user head-to-head — duel, rock-paper-scissors, tic-tac-toe, or connect 4. Winner takes the pot (minus a small jackpot tribute).',
-        actionHref='/pvp/{id}',
+        actionHref='/pvp/{id}__${tabQuery}__',
         actionLabel='⚔️ Play',
         pickerPath='/pvp/guilds',
         emptyEmoji='⚔️',

--- a/web/src/main/resources/templates/pvp.html
+++ b/web/src/main/resources/templates/pvp.html
@@ -12,7 +12,8 @@
                data-ttl-seconds=${ttlSeconds},
                data-user-id=${currentUserId},
                data-user-name=${currentUserName},
-               data-user-avatar=${currentUserAvatarUrl}">
+               data-user-avatar=${currentUserAvatarUrl},
+               data-initial-tab=${initialTab}">
 
     <div class="duel-header">
         <a class="back-link" th:href="@{/pvp/guilds(pick=true)}">&larr; All servers</a>

--- a/web/src/test/js/navbar.test.js
+++ b/web/src/test/js/navbar.test.js
@@ -132,11 +132,11 @@ describe('navbar fragment', () => {
         );
     });
 
-    test('groups links into labelled sections (Main / Games / Economy / Social / Tools / Moderation)', () => {
+    test('groups links into labelled sections (Main / Casino / PvP / Economy / Social / Tools / Moderation)', () => {
         // Each .nav-section block carries a .nav-section-eyebrow with the
         // section name; on desktop those eyebrows are display:none, on
         // mobile they group the items inside the drawer.
-        const expected = ['Main', 'Games', 'Economy', 'Social', 'Tools', 'Moderation'];
+        const expected = ['Main', 'Casino', 'PvP', 'Economy', 'Social', 'Tools', 'Moderation'];
         for (const label of expected) {
             const re = new RegExp(
                 `<div[^>]*class="[^"]*\\bnav-section-eyebrow\\b[^"]*"[^>]*>\\s*${label}\\s*</div>`


### PR DESCRIPTION
## Summary

PvP was nested under "Economy" in the navbar — bad fit, PvP has no market mechanics. The home page's numbers strip already treats Casino + PvP as peer categories ("15 Casino games" / "4 PvP games"); the navbar now mirrors that. Plus the broader correctness pass the user asked for.

### Navbar changes
- **New top-level "PvP" section** between Casino and Economy with a dropdown listing all four PvP games — Duel, Rock-Paper-Scissors, Tic-Tac-Toe, Connect 4 — each with the same emoji as the in-page tab strip.
- **Renamed Casino section**: eyebrow `Games` → `Casino`, dropdown button `Play` → `Casino`. Fixes the only eyebrow/button mismatch in the navbar; matches the home page numbers-strip label.
- **Removed PvP from the Economy dropdown**. Economy now reads Market / Titles / Tip (no PvP). Also dropped the stray 💸 emoji on Tip for within-dropdown consistency (Market and Titles are text-only).
- **Promoted "Commands" to the Main section** as a direct link. It's the bot's "what can it do?" page — universally useful for first-time visitors — and didn't belong buried alongside Utils + D&D lookups in the Tools dropdown. Tools shrinks to Utils + D&D.

### Deep-linking (`?game=<slug>` actually works)
Without this, all four PvP entries would land on the Duel tab (the default). Pieces:
- `PvpController.guildList` and `.page` accept an optional `?game=<slug>` (and `?tab=` on `page`) query param. Whitelisted to `duel | rps | tictactoe | connect4`; anything else is silently dropped to avoid a fuzzing vector.
- `guildList` propagates the slug into the picker-redirect target as `?tab=<slug>` AND surfaces it as a `tabQuery` model attribute so per-guild card links carry it through the picker round-trip (via Thymeleaf `__${tabQuery}__` preprocessing on the fragment's `actionHref`).
- `page` exposes it as `data-initial-tab` on `<main>`.
- `pvp.js` reads `data-initial-tab` on init and calls the existing `activateTab(slug)` if it matches a real tab. No-op otherwise. Default Duel stays active when no slug present.

### Updated tests
- `navbar.test.js` — expected section list now reads `Main / Casino / PvP / Economy / Social / Tools / Moderation`.

## Test plan

- [x] `./gradlew :web:test` — green.
- [x] `npx jest` from `web/` — green (623 tests).
- [ ] Open `/`, hover each navbar dropdown:
  - **Casino** → casino minigames + Poker/Blackjack/Lottery (no PvP).
  - **PvP** → Duel / RPS / Tic-Tac-Toe / Connect 4.
  - **Economy** → Market / Titles / Tip (no PvP).
  - **Main** has the new **Commands** entry.
  - **Tools** has only Utils + D&D.
- [ ] Click each PvP entry while anchored to a guild → confirm the corresponding tab is active on load (`/pvp/{guildId}?tab=rps` opens RPS, etc.).
- [ ] Without an anchor → picker page renders, per-guild card "Play" buttons carry `?tab=<slug>` so click-through still deep-links.
- [ ] Fuzz `/pvp/guilds?game=bogus` → query dropped silently, lands on Duel default.
- [ ] Mobile drawer (≤ 600px) → confirm section eyebrows render correctly above their dropdowns.

https://claude.ai/code/session_01Gu12R3U1kygmu5c7qCPmYF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu12R3U1kygmu5c7qCPmYF)_