### PR TITLE
refactor+test+build: BoundedSessionCache, Kover wiring, activity-tracking coverage

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -44,4 +44,29 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           TOKEN: ${{ secrets.TOKEN }}
-        run: ./gradlew build
+        run: ./gradlew build koverXmlReport koverHtmlReport
+      - name: Print Kover line coverage
+        # Informational only — no threshold gate. Parses the aggregate
+        # report's LINE counter (covered / (covered + missed) * 100).
+        run: |
+          report=build/reports/kover/report.xml
+          if [ ! -f "$report" ]; then echo "Kover report not found at $report"; exit 0; fi
+          python3 - <<'PY'
+          import xml.etree.ElementTree as ET
+          root = ET.parse('build/reports/kover/report.xml').getroot()
+          for c in root.findall('counter'):
+              if c.get('type') == 'LINE':
+                  covered = int(c.get('covered', 0))
+                  missed = int(c.get('missed', 0))
+                  total = covered + missed
+                  pct = (covered * 100.0 / total) if total else 0.0
+                  print(f"Line coverage: {pct:.2f}% ({covered}/{total})")
+                  break
+          PY
+      - name: Upload Kover HTML report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: kover-html-report
+          path: build/reports/kover/html
+          if-no-files-found: ignore

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,11 @@ buildscript {
 plugins {
     id 'io.spring.dependency-management' version "$springDependencyManagementVersion"
     id 'com.autonomousapps.dependency-analysis' version '3.6.1'
+    // Kotlin-native line/branch coverage. Aggregates across every
+    // subproject (see the kover { } block + dependencies at the
+    // bottom of this file). Non-blocking — CI prints the % but does
+    // not gate merges. Run `./gradlew koverHtmlReport` locally.
+    id 'org.jetbrains.kotlinx.kover' version '0.9.1'
 }
 
 apply plugin: 'kotlin'
@@ -65,6 +70,9 @@ allprojects {
 
 subprojects {
     apply plugin: 'io.spring.dependency-management'
+    // Every module is Kotlin — applying Kover here gives per-module
+    // raw coverage data that the root aggregates into one report.
+    apply plugin: 'org.jetbrains.kotlinx.kover'
 
     configurations {
         configureEach {
@@ -116,4 +124,17 @@ repositories {
 
 kotlin {
     jvmToolchain(21)
+}
+
+// Aggregate coverage across every Kotlin subproject into one report.
+// `./gradlew koverHtmlReport` produces build/reports/kover/html/index.html;
+// `./gradlew koverXmlReport` produces build/reports/kover/report.xml that
+// CI greps for the line-coverage %.
+dependencies {
+    kover project(':common')
+    kover project(':core-api')
+    kover project(':database')
+    kover project(':discord-bot')
+    kover project(':web')
+    kover project(':application')
 }

--- a/database/src/main/kotlin/database/boardgame/TurnBasedBoardSessionRegistry.kt
+++ b/database/src/main/kotlin/database/boardgame/TurnBasedBoardSessionRegistry.kt
@@ -1,8 +1,7 @@
 package database.boardgame
 
-import com.github.benmanes.caffeine.cache.Cache
-import com.github.benmanes.caffeine.cache.Caffeine
 import database.configuration.RegistryScheduler
+import database.pvp.BoundedSessionCache
 import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
@@ -96,16 +95,12 @@ abstract class TurnBasedBoardSessionRegistry<TSession : TurnBasedBoardSessionReg
     ): TSession
 
     /**
-     * Caffeine cache + `asMap()` view. Every read/write below uses
-     * [sessions] (the ConcurrentMap view) for atomic primitives;
-     * [cache] is kept only so the `expireAfterWrite` / `maximumSize`
-     * configuration stays in scope and the GC root chain is explicit.
+     * Bounded + TTL'd `ConcurrentMap` view over a Caffeine cache. See
+     * [BoundedSessionCache] for the rationale; this registry uses the
+     * atomic-primitive surface (`put` / `remove` / `values`) directly.
      */
-    private val cache: Cache<Long, TSession> = Caffeine.newBuilder()
-        .expireAfterWrite(maxLifetime)
-        .maximumSize(maximumSessions)
-        .build()
-    private val sessions: ConcurrentMap<Long, TSession> = cache.asMap()
+    private val sessions: ConcurrentMap<Long, TSession> =
+        BoundedSessionCache.build(maxLifetime, maximumSessions)
     private val seq = AtomicLong()
 
     /** Per-session pending shot-clock task. Keyed by sessionId. */

--- a/database/src/main/kotlin/database/pvp/BoundedSessionCache.kt
+++ b/database/src/main/kotlin/database/pvp/BoundedSessionCache.kt
@@ -1,0 +1,29 @@
+package database.pvp
+
+import com.github.benmanes.caffeine.cache.Caffeine
+import java.time.Duration
+import java.util.concurrent.ConcurrentMap
+
+/**
+ * Shared factory for the bounded-and-TTL'd Caffeine map convention used
+ * by the PvP session registries. Every registry that holds short-lived
+ * in-memory state for in-flight matches wants the same two protections
+ * against runaway memory: a hard upper bound on entries
+ * ([maxEntries]) so a flood can't OOM the heap, and a backstop TTL
+ * ([maxLifetime]) so a scheduled-task drop can't leak entries past
+ * their useful life.
+ *
+ * Returns the `asMap()` view so call sites can keep using the familiar
+ * [ConcurrentMap] primitives (atomic put/remove, values iteration). The
+ * underlying Caffeine cache stays GC-alive via the returned map's back-
+ * reference — no need for the caller to retain the cache handle
+ * separately.
+ */
+object BoundedSessionCache {
+    fun <K : Any, V : Any> build(maxLifetime: Duration, maxEntries: Long): ConcurrentMap<K, V> =
+        Caffeine.newBuilder()
+            .expireAfterWrite(maxLifetime)
+            .maximumSize(maxEntries)
+            .build<K, V>()
+            .asMap()
+}

--- a/database/src/main/kotlin/database/rps/RpsSessionRegistry.kt
+++ b/database/src/main/kotlin/database/rps/RpsSessionRegistry.kt
@@ -1,9 +1,8 @@
 package database.rps
 
-import com.github.benmanes.caffeine.cache.Cache
-import com.github.benmanes.caffeine.cache.Caffeine
 import common.rps.RpsEngine
 import database.configuration.RegistryScheduler
+import database.pvp.BoundedSessionCache
 import org.springframework.stereotype.Component
 import java.time.Duration
 import java.time.Instant
@@ -66,16 +65,12 @@ class RpsSessionRegistry(
     }
 
     /**
-     * Caffeine cache + `asMap()` view. Every read/write below uses
-     * [sessions] (the ConcurrentMap view) for atomic primitives;
-     * [cache] is kept only so the `expireAfterWrite` / `maximumSize`
-     * configuration stays in scope and the GC root chain is explicit.
+     * Bounded + TTL'd `ConcurrentMap` view over a Caffeine cache. See
+     * [BoundedSessionCache] for the rationale; this registry uses the
+     * atomic-primitive surface (`put` / `remove` / `values`) directly.
      */
-    private val cache: Cache<Long, Session> = Caffeine.newBuilder()
-        .expireAfterWrite(maxLifetime)
-        .maximumSize(maximumSessions)
-        .build()
-    private val sessions: ConcurrentMap<Long, Session> = cache.asMap()
+    private val sessions: ConcurrentMap<Long, Session> =
+        BoundedSessionCache.build(maxLifetime, maximumSessions)
     private val seq = AtomicLong()
 
     /**

--- a/database/src/test/kotlin/database/persistence/impl/DefaultActivityMonthlyRollupPersistenceTest.kt
+++ b/database/src/test/kotlin/database/persistence/impl/DefaultActivityMonthlyRollupPersistenceTest.kt
@@ -1,0 +1,170 @@
+package database.persistence.impl
+
+import database.dto.ActivityMonthlyRollupDto
+import database.dto.ActivityMonthlyRollupId
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import io.mockk.verifyOrder
+import jakarta.persistence.EntityManager
+import jakarta.persistence.Query
+import jakarta.persistence.TypedQuery
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class DefaultActivityMonthlyRollupPersistenceTest {
+
+    private lateinit var em: EntityManager
+    private lateinit var persistence: DefaultActivityMonthlyRollupPersistence
+
+    private val guildId = 1L
+    private val discordId = 42L
+    private val monthStart: LocalDate = LocalDate.of(2026, 5, 1)
+    private val activityName = "voice"
+
+    @BeforeEach
+    fun setUp() {
+        em = mockk(relaxed = true)
+        persistence = DefaultActivityMonthlyRollupPersistence().apply {
+            // Inject the mocked EntityManager into the lateinit field
+            // populated by @PersistenceContext in production.
+            DefaultActivityMonthlyRollupPersistence::class.java
+                .getDeclaredField("entityManager")
+                .apply { isAccessible = true }
+                .set(this, em)
+        }
+    }
+
+    @Test
+    fun `addSeconds persists a fresh row when the composite key isn't present`() {
+        every { em.find(ActivityMonthlyRollupDto::class.java, any()) } returns null
+
+        val saved = persistence.addSeconds(discordId, guildId, monthStart, activityName, delta = 60L)
+
+        assertEquals(discordId, saved.discordId)
+        assertEquals(guildId, saved.guildId)
+        assertEquals(monthStart, saved.monthStart)
+        assertEquals(activityName, saved.activityName)
+        assertEquals(60L, saved.seconds)
+        verifyOrder {
+            em.find(ActivityMonthlyRollupDto::class.java, any())
+            em.persist(saved)
+            em.flush()
+        }
+        verify(exactly = 0) { em.merge(any<ActivityMonthlyRollupDto>()) }
+    }
+
+    @Test
+    fun `addSeconds accumulates onto the existing row when the composite key matches`() {
+        val existing = ActivityMonthlyRollupDto(discordId, guildId, monthStart, activityName, seconds = 100L)
+        every { em.find(ActivityMonthlyRollupDto::class.java, any()) } returns existing
+
+        val result = persistence.addSeconds(discordId, guildId, monthStart, activityName, delta = 60L)
+
+        assertSame(existing, result)
+        assertEquals(160L, result.seconds)
+        verifyOrder {
+            em.find(ActivityMonthlyRollupDto::class.java, any())
+            em.merge(existing)
+            em.flush()
+        }
+        verify(exactly = 0) { em.persist(any<ActivityMonthlyRollupDto>()) }
+    }
+
+    @Test
+    fun `addSeconds builds the composite id from all four key fields`() {
+        val idSlot = slot<Any>()
+        every { em.find(ActivityMonthlyRollupDto::class.java, capture(idSlot)) } returns null
+
+        persistence.addSeconds(discordId, guildId, monthStart, activityName, delta = 5L)
+
+        val id = idSlot.captured as ActivityMonthlyRollupId
+        assertEquals(discordId, id.discordId)
+        assertEquals(guildId, id.guildId)
+        assertEquals(monthStart, id.monthStart)
+        assertEquals(activityName, id.activityName)
+    }
+
+    @Test
+    fun `forGuildMonth runs the named query with the two parameters and returns its rows`() {
+        val rows = listOf(ActivityMonthlyRollupDto(discordId, guildId, monthStart, "voice", 100))
+        val q = mockNamedQuery("ActivityMonthlyRollupDto.forGuildMonth", rows)
+
+        val result = persistence.forGuildMonth(guildId, monthStart)
+
+        assertSame(rows, result)
+        verify {
+            q.setParameter("guildId", guildId)
+            q.setParameter("monthStart", monthStart)
+        }
+    }
+
+    @Test
+    fun `forUser runs the named query with discordId and guildId and returns its rows`() {
+        val rows = listOf(ActivityMonthlyRollupDto(discordId, guildId, monthStart, "voice", 100))
+        val q = mockNamedQuery("ActivityMonthlyRollupDto.forUser", rows)
+
+        assertSame(rows, persistence.forUser(guildId, discordId))
+        verify {
+            q.setParameter("guildId", guildId)
+            q.setParameter("discordId", discordId)
+        }
+    }
+
+    @Test
+    fun `forUserMonth binds all three keys and returns the rows`() {
+        val rows = listOf(ActivityMonthlyRollupDto(discordId, guildId, monthStart, "voice", 100))
+        val q = mockNamedQuery("ActivityMonthlyRollupDto.forUserMonth", rows)
+
+        assertSame(rows, persistence.forUserMonth(guildId, discordId, monthStart))
+        verify {
+            q.setParameter("guildId", guildId)
+            q.setParameter("discordId", discordId)
+            q.setParameter("monthStart", monthStart)
+        }
+    }
+
+    @Test
+    fun `forGuildSince binds guildId and since and returns the rows`() {
+        val since = LocalDate.of(2025, 6, 1)
+        val rows = listOf(ActivityMonthlyRollupDto(discordId, guildId, monthStart, "voice", 100))
+        val q = mockNamedQuery("ActivityMonthlyRollupDto.forGuildSince", rows)
+
+        assertSame(rows, persistence.forGuildSince(guildId, since))
+        verify {
+            q.setParameter("guildId", guildId)
+            q.setParameter("since", since)
+        }
+    }
+
+    @Test
+    fun `deleteBefore executes the named delete query with the cutoff and returns the row count`() {
+        val cutoff = LocalDate.of(2025, 1, 1)
+        val q = mockk<Query>(relaxed = true)
+        every { em.createNamedQuery("ActivityMonthlyRollupDto.deleteBefore") } returns q
+        every { q.setParameter("cutoff", cutoff) } returns q
+        every { q.executeUpdate() } returns 7
+
+        assertEquals(7, persistence.deleteBefore(cutoff))
+        verify { q.setParameter("cutoff", cutoff) }
+        verify { q.executeUpdate() }
+    }
+
+    private fun mockNamedQuery(
+        name: String,
+        rows: List<ActivityMonthlyRollupDto>,
+    ): TypedQuery<ActivityMonthlyRollupDto> {
+        val q = mockk<TypedQuery<ActivityMonthlyRollupDto>>(relaxed = true)
+        every {
+            em.createNamedQuery(name, ActivityMonthlyRollupDto::class.java)
+        } returns q
+        every { q.resultList } returns rows
+        return q
+    }
+}

--- a/database/src/test/kotlin/database/persistence/impl/DefaultActivitySessionPersistenceTest.kt
+++ b/database/src/test/kotlin/database/persistence/impl/DefaultActivitySessionPersistenceTest.kt
@@ -1,0 +1,138 @@
+package database.persistence.impl
+
+import database.dto.ActivitySessionDto
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifyOrder
+import jakarta.persistence.EntityManager
+import jakarta.persistence.Query
+import jakarta.persistence.TypedQuery
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class DefaultActivitySessionPersistenceTest {
+
+    private lateinit var em: EntityManager
+    private lateinit var persistence: DefaultActivitySessionPersistence
+
+    private val guildId = 1L
+    private val discordId = 42L
+
+    @BeforeEach
+    fun setUp() {
+        em = mockk(relaxed = true)
+        persistence = DefaultActivitySessionPersistence().apply {
+            DefaultActivitySessionPersistence::class.java
+                .getDeclaredField("entityManager")
+                .apply { isAccessible = true }
+                .set(this, em)
+        }
+    }
+
+    private fun sampleSession(
+        id: Long? = null,
+        endedAt: Instant? = null,
+    ) = ActivitySessionDto(
+        id = id,
+        discordId = discordId,
+        guildId = guildId,
+        activityName = "voice",
+        startedAt = Instant.parse("2026-05-23T12:00:00Z"),
+        endedAt = endedAt,
+    )
+
+    @Test
+    fun `openSession persists then flushes then returns the same row`() {
+        val session = sampleSession()
+
+        val saved = persistence.openSession(session)
+
+        assertSame(session, saved)
+        verifyOrder {
+            em.persist(session)
+            em.flush()
+        }
+        verify(exactly = 0) { em.merge(any<ActivitySessionDto>()) }
+    }
+
+    @Test
+    fun `closeSession merges then flushes then returns the same row`() {
+        val session = sampleSession(id = 99L, endedAt = Instant.parse("2026-05-23T13:00:00Z"))
+
+        val closed = persistence.closeSession(session)
+
+        assertSame(session, closed)
+        verifyOrder {
+            em.merge(session)
+            em.flush()
+        }
+        verify(exactly = 0) { em.persist(any<ActivitySessionDto>()) }
+    }
+
+    @Test
+    fun `findOpen returns the first row of the named query result list`() {
+        val session = sampleSession(id = 99L)
+        val q = mockNamedQuery("ActivitySessionDto.findOpen", listOf(session))
+
+        assertSame(session, persistence.findOpen(discordId, guildId))
+        verify {
+            q.setParameter("discordId", discordId)
+            q.setParameter("guildId", guildId)
+        }
+    }
+
+    @Test
+    fun `findOpen returns null when the named query returns empty`() {
+        mockNamedQuery("ActivitySessionDto.findOpen", emptyList())
+        assertNull(persistence.findOpen(discordId, guildId))
+    }
+
+    @Test
+    fun `findAllOpen returns the named query result list with no parameters bound`() {
+        val rows = listOf(sampleSession(id = 1L), sampleSession(id = 2L))
+        val q = mockNamedQuery("ActivitySessionDto.findAllOpen", rows)
+
+        assertSame(rows, persistence.findAllOpen())
+        verify(exactly = 0) { q.setParameter(any<String>(), any<Any>()) }
+    }
+
+    @Test
+    fun `findClosedBefore binds the cutoff and returns the rows`() {
+        val cutoff = Instant.parse("2026-05-01T00:00:00Z")
+        val rows = listOf(sampleSession(id = 1L, endedAt = Instant.parse("2026-04-30T12:00:00Z")))
+        val q = mockNamedQuery("ActivitySessionDto.findClosedBefore", rows)
+
+        assertSame(rows, persistence.findClosedBefore(cutoff))
+        verify { q.setParameter("cutoff", cutoff) }
+    }
+
+    @Test
+    fun `deleteClosedBefore executes the named delete query with the cutoff`() {
+        val cutoff = Instant.parse("2026-05-01T00:00:00Z")
+        val q = mockk<Query>(relaxed = true)
+        every { em.createNamedQuery("ActivitySessionDto.deleteClosedBefore") } returns q
+        every { q.setParameter("cutoff", cutoff) } returns q
+        every { q.executeUpdate() } returns 4
+
+        assertEquals(4, persistence.deleteClosedBefore(cutoff))
+        verify { q.setParameter("cutoff", cutoff) }
+        verify { q.executeUpdate() }
+    }
+
+    private fun mockNamedQuery(
+        name: String,
+        rows: List<ActivitySessionDto>,
+    ): TypedQuery<ActivitySessionDto> {
+        val q = mockk<TypedQuery<ActivitySessionDto>>(relaxed = true)
+        every {
+            em.createNamedQuery(name, ActivitySessionDto::class.java)
+        } returns q
+        every { q.resultList } returns rows
+        return q
+    }
+}

--- a/database/src/test/kotlin/database/service/impl/DefaultActivityMonthlyRollupServiceTest.kt
+++ b/database/src/test/kotlin/database/service/impl/DefaultActivityMonthlyRollupServiceTest.kt
@@ -1,0 +1,106 @@
+package database.service.impl
+
+import database.dto.ActivityMonthlyRollupDto
+import database.persistence.ActivityMonthlyRollupPersistence
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class DefaultActivityMonthlyRollupServiceTest {
+
+    private lateinit var persistence: ActivityMonthlyRollupPersistence
+    private lateinit var service: DefaultActivityMonthlyRollupService
+
+    private val guildId = 1L
+    private val discordId = 42L
+    private val monthStart: LocalDate = LocalDate.of(2026, 5, 1)
+    private val activityName = "voice"
+
+    @BeforeEach
+    fun setUp() {
+        persistence = mockk(relaxed = false)
+        service = DefaultActivityMonthlyRollupService(persistence)
+    }
+
+    @Test
+    fun `addSeconds delegates with all arguments and returns the persisted row`() {
+        val row = ActivityMonthlyRollupDto(discordId, guildId, monthStart, activityName, seconds = 60)
+        every { persistence.addSeconds(discordId, guildId, monthStart, activityName, 60) } returns row
+
+        val result = service.addSeconds(discordId, guildId, monthStart, activityName, 60)
+
+        assertSame(row, result)
+        verify(exactly = 1) { persistence.addSeconds(discordId, guildId, monthStart, activityName, 60) }
+    }
+
+    @Test
+    fun `forGuildMonth delegates and returns the persistence list`() {
+        val rows = listOf(
+            ActivityMonthlyRollupDto(discordId, guildId, monthStart, "voice", 100),
+            ActivityMonthlyRollupDto(discordId, guildId, monthStart, "messages", 50),
+        )
+        every { persistence.forGuildMonth(guildId, monthStart) } returns rows
+
+        assertEquals(rows, service.forGuildMonth(guildId, monthStart))
+        verify(exactly = 1) { persistence.forGuildMonth(guildId, monthStart) }
+    }
+
+    @Test
+    fun `forUser delegates and returns the persistence list`() {
+        val rows = listOf(ActivityMonthlyRollupDto(discordId, guildId, monthStart, "voice", 100))
+        every { persistence.forUser(guildId, discordId) } returns rows
+
+        assertEquals(rows, service.forUser(guildId, discordId))
+        verify(exactly = 1) { persistence.forUser(guildId, discordId) }
+    }
+
+    @Test
+    fun `forUserMonth delegates with all three keys and returns the list`() {
+        val rows = listOf(ActivityMonthlyRollupDto(discordId, guildId, monthStart, "voice", 100))
+        every { persistence.forUserMonth(guildId, discordId, monthStart) } returns rows
+
+        assertEquals(rows, service.forUserMonth(guildId, discordId, monthStart))
+        verify(exactly = 1) { persistence.forUserMonth(guildId, discordId, monthStart) }
+    }
+
+    @Test
+    fun `forGuildSince delegates and returns the list (cache annotation is Spring proxy behavior)`() {
+        // The @Cacheable annotation only fires through a Spring proxy; the
+        // direct unit call here exercises the method body, which is pure
+        // delegation. Cache hits/misses are framework behavior tested
+        // separately by Spring's own machinery.
+        val since = LocalDate.of(2025, 6, 1)
+        val rows = listOf(ActivityMonthlyRollupDto(discordId, guildId, monthStart, "voice", 100))
+        every { persistence.forGuildSince(guildId, since) } returns rows
+
+        assertEquals(rows, service.forGuildSince(guildId, since))
+        verify(exactly = 1) { persistence.forGuildSince(guildId, since) }
+    }
+
+    @Test
+    fun `deleteBefore delegates the cutoff and returns the affected-row count`() {
+        val cutoff = LocalDate.of(2025, 1, 1)
+        every { persistence.deleteBefore(cutoff) } returns 7
+
+        assertEquals(7, service.deleteBefore(cutoff))
+        verify(exactly = 1) { persistence.deleteBefore(cutoff) }
+    }
+
+    @Test
+    fun `empty results pass through unchanged for read methods`() {
+        every { persistence.forGuildMonth(guildId, monthStart) } returns emptyList()
+        every { persistence.forUser(guildId, discordId) } returns emptyList()
+        every { persistence.forUserMonth(guildId, discordId, monthStart) } returns emptyList()
+        every { persistence.forGuildSince(guildId, monthStart) } returns emptyList()
+
+        assertEquals(emptyList<ActivityMonthlyRollupDto>(), service.forGuildMonth(guildId, monthStart))
+        assertEquals(emptyList<ActivityMonthlyRollupDto>(), service.forUser(guildId, discordId))
+        assertEquals(emptyList<ActivityMonthlyRollupDto>(), service.forUserMonth(guildId, discordId, monthStart))
+        assertEquals(emptyList<ActivityMonthlyRollupDto>(), service.forGuildSince(guildId, monthStart))
+    }
+}

--- a/database/src/test/kotlin/database/service/impl/DefaultActivitySessionServiceTest.kt
+++ b/database/src/test/kotlin/database/service/impl/DefaultActivitySessionServiceTest.kt
@@ -1,0 +1,104 @@
+package database.service.impl
+
+import database.dto.ActivitySessionDto
+import database.persistence.ActivitySessionPersistence
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class DefaultActivitySessionServiceTest {
+
+    private lateinit var persistence: ActivitySessionPersistence
+    private lateinit var service: DefaultActivitySessionService
+
+    private val guildId = 1L
+    private val discordId = 42L
+
+    @BeforeEach
+    fun setUp() {
+        persistence = mockk(relaxed = false)
+        service = DefaultActivitySessionService(persistence)
+    }
+
+    private fun sampleSession(
+        id: Long? = null,
+        endedAt: Instant? = null,
+    ) = ActivitySessionDto(
+        id = id,
+        discordId = discordId,
+        guildId = guildId,
+        activityName = "voice",
+        startedAt = Instant.parse("2026-05-23T12:00:00Z"),
+        endedAt = endedAt,
+    )
+
+    @Test
+    fun `openSession delegates and returns the stored row`() {
+        val incoming = sampleSession()
+        val stored = sampleSession(id = 99L)
+        every { persistence.openSession(incoming) } returns stored
+
+        assertSame(stored, service.openSession(incoming))
+        verify(exactly = 1) { persistence.openSession(incoming) }
+    }
+
+    @Test
+    fun `closeSession delegates the same row reference and returns the merged row`() {
+        val session = sampleSession(id = 99L, endedAt = Instant.parse("2026-05-23T13:00:00Z"))
+        every { persistence.closeSession(session) } returns session
+
+        assertSame(session, service.closeSession(session))
+        verify(exactly = 1) { persistence.closeSession(session) }
+    }
+
+    @Test
+    fun `findOpen returns the persistence result and passes both keys through`() {
+        val session = sampleSession(id = 99L)
+        every { persistence.findOpen(discordId, guildId) } returns session
+
+        assertSame(session, service.findOpen(discordId, guildId))
+        verify(exactly = 1) { persistence.findOpen(discordId, guildId) }
+    }
+
+    @Test
+    fun `findOpen returns null when no open session exists`() {
+        every { persistence.findOpen(discordId, guildId) } returns null
+
+        assertNull(service.findOpen(discordId, guildId))
+        verify(exactly = 1) { persistence.findOpen(discordId, guildId) }
+    }
+
+    @Test
+    fun `findAllOpen returns the persistence list`() {
+        val rows = listOf(sampleSession(id = 1L), sampleSession(id = 2L))
+        every { persistence.findAllOpen() } returns rows
+
+        assertEquals(rows, service.findAllOpen())
+        verify(exactly = 1) { persistence.findAllOpen() }
+    }
+
+    @Test
+    fun `findClosedBefore passes the cutoff through and returns the persistence list`() {
+        val cutoff = Instant.parse("2026-05-01T00:00:00Z")
+        val rows = listOf(sampleSession(id = 1L, endedAt = Instant.parse("2026-04-30T12:00:00Z")))
+        every { persistence.findClosedBefore(cutoff) } returns rows
+
+        assertEquals(rows, service.findClosedBefore(cutoff))
+        verify(exactly = 1) { persistence.findClosedBefore(cutoff) }
+    }
+
+    @Test
+    fun `deleteClosedBefore passes the cutoff and returns the affected-row count`() {
+        val cutoff = Instant.parse("2026-05-01T00:00:00Z")
+        every { persistence.deleteClosedBefore(cutoff) } returns 12
+
+        assertEquals(12, service.deleteClosedBefore(cutoff))
+        verify(exactly = 1) { persistence.deleteClosedBefore(cutoff) }
+    }
+}


### PR DESCRIPTION
## Summary

First wave of the test-coverage + DRY/SOLID refactor pass scoped out [in the planning session](https://claude.ai/code/session_017zsUNUN5DRMTWA5ZZgJ2mM). Three logically independent commits chosen as the safest, highest-leverage foundation before the bigger PvP consolidation work:

1. **`refactor(pvp): extract BoundedSessionCache shared factory`** — Lifts the duplicated Caffeine `expireAfterWrite().maximumSize().build().asMap()` block out of `TurnBasedBoardSessionRegistry` and `RpsSessionRegistry` into a single `database.pvp.BoundedSessionCache.build(...)` factory. Pure refactor; no behavior change. Sets the convention for future registries (`PendingDuelRegistry`, `RecentDuelResolutions`, etc.) to land on.

2. **`build(coverage): wire Kover aggregate report + print line % in CI`** — Adds Kotlinx Kover 0.9.1 at the root with an aggregate dependency on every subproject. `./gradlew koverHtmlReport` produces one merged report; CI prints `Line coverage: X% (covered/total)` after every build by parsing the LINE counter from the XML report, and uploads the HTML report as a workflow artifact. **Intentionally non-blocking** — no threshold gate while the team gets familiar with the baseline.

   Baseline (non-application modules, measured locally without Docker): **75.78% (22,437 / 29,608 lines)**. The application module's integration tests need Testcontainers/Docker so they were excluded from the local measurement.

3. **`test(activity): cover four untested Default* impls in activity-tracking path`** — Adds tests for `DefaultActivityMonthlyRollupService`, `DefaultActivitySessionService`, `DefaultActivityMonthlyRollupPersistence`, and `DefaultActivitySessionPersistence`. These four classes back the moderation-dashboard Activity tab + the retention job but had **zero** direct tests. Service tests use MockK on the persistence interface; persistence tests follow the existing `PersistenceHelpersTest` convention (MockK on `EntityManager` + `TypedQuery`) and verify the right NamedQuery is invoked with the right parameter bindings.

## Bigger refactor work that's still queued

The planning session designed 10 PRs total; this branch lands 3. Next up (each independently mergeable when the team is ready):

- **`PvpSessionRegistry<TSession>` base** — pull the cache + PENDING→LIVE + indexers out of `TurnBasedBoardSessionRegistry` so `RpsSessionRegistry` can be re-parented onto it (~120 lines deleted).
- **`SimultaneousPvpEndpointSupport`** — mirror the existing `boardChallenge`/`boardAccept`/`boardCloseOffer`/`boardForfeit` helpers in `PvpController` for the RPS section that still inlines its own copies (~200 lines deleted from `PvpController`).
- **`ModerationController` split** — separate the 825-line controller into `ModerationPagesController` (GET) and `ModerationMutationsController` (POST/DELETE), same `@RequestMapping("/moderation")` base.
- **`GameSpec` sealed hierarchy + parameterized `PvpCommand` / `PvpButton`** — collapses three near-duplicate per-game command/button/embeds triplets into one driven by `RpsSpec` / `TicTacToeSpec` / `Connect4Spec` beans. Bulk of the dedup payoff (~1,000 lines).

## Test plan

- [x] `:database:test` green locally (compiled clean; all four new test classes pass)
- [x] `:common:test :core-api:test :database:test :discord-bot:test :web:test` green locally
- [x] `./gradlew :database:koverXmlReport` generates `build/reports/kover/report.xml` with a `LINE` counter
- [x] Root `./gradlew koverXmlReport` (excluding `:application:test` due to sandbox Docker absence) generates `/build/reports/kover/report.xml` aggregating all five non-application modules; baseline 75.78%
- [x] CI's Python XML-parser one-liner extracts the % correctly against the generated report
- [ ] CI green on `ubuntu-latest` (which has Docker, so the integration tests excluded locally will run)
- [ ] Verify Kover HTML report uploads as a workflow artifact and the `Print Kover line coverage` step prints `Line coverage: X% (covered/total)` on the CI log

https://claude.ai/code/session_017zsUNUN5DRMTWA5ZZgJ2mM


---
_Generated by [Claude Code](https://claude.ai/code/session_017zsUNUN5DRMTWA5ZZgJ2mM)_