### PR TITLE
refactor(pvp): extract shared PvpButtonIdCodec for the three PvP embeds

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/game/Connect4Embeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/game/Connect4Embeds.kt
@@ -64,16 +64,12 @@ object Connect4Embeds {
     fun forfeitButtonId(sessionId: Long): String = encode(Action.FORFEIT, sessionId, 0L)
 
     private fun encode(action: Action, sessionId: Long, payload: Long): String =
-        listOf(BUTTON_NAME, action.name, sessionId.toString(), payload.toString())
-            .joinToString(":")
+        PvpButtonIdCodec.encode(BUTTON_NAME, action.name, sessionId, payload)
 
     fun parseButtonId(componentId: String): ParsedButtonId? {
-        val parts = componentId.split(':')
-        if (parts.size != 4 || !parts[0].equals(BUTTON_NAME, ignoreCase = true)) return null
-        val action = runCatching { Action.valueOf(parts[1]) }.getOrNull() ?: return null
-        val sessionId = parts[2].toLongOrNull() ?: return null
-        val payload = parts[3].toLongOrNull() ?: return null
-        return ParsedButtonId(action, sessionId, payload)
+        val raw = PvpButtonIdCodec.parse(componentId, BUTTON_NAME) ?: return null
+        val action = runCatching { Action.valueOf(raw.actionName) }.getOrNull() ?: return null
+        return ParsedButtonId(action, raw.sessionId, raw.payload)
     }
 
     /** Maps DROP_<n> → column index `n`; returns null for non-DROP actions. */

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/game/PvpButtonIdCodec.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/game/PvpButtonIdCodec.kt
@@ -1,0 +1,50 @@
+package bot.toby.command.commands.game
+
+/**
+ * Shared encode/parse for the colon-delimited button-id convention used
+ * by every PvP mini-game (`/rps`, `/tictactoe`, `/connect4`, future
+ * games). Format:
+ *
+ *   `<buttonName>:<actionName>:<sessionId>:<payload>`
+ *
+ *  - `buttonName`: matches [`Button.name`][bot.toby.button.Button.name]
+ *    so `DefaultButtonManager` routes by `parts[0]` to the right
+ *    handler (`"rps"`, `"tictactoe"`, `"connect4"`).
+ *  - `actionName`: the per-game `Action` enum's `name` — the per-game
+ *    embeds object owns its own enum + `Action.valueOf(...)` so this
+ *    codec stays game-agnostic.
+ *  - `sessionId`: the PvP session id allocated by the per-game
+ *    registry. Long.
+ *  - `payload`: action-dependent — discord id for ACCEPT/DECLINE,
+ *    cell/column index for PLACE/DROP, `0` for FORFEIT or for actions
+ *    where the clicker is known from the event. Long for uniformity.
+ *
+ * The button-id wire format is a public contract — un-clicked
+ * messages on Discord may sit for days before a click, so any change
+ * to the format must remain backwards-compatible. The codec is
+ * intentionally permissive on case for the prefix (matches the
+ * pre-existing per-game `equals(BUTTON_NAME, ignoreCase = true)`
+ * convention).
+ */
+object PvpButtonIdCodec {
+
+    /**
+     * Stage-1 parse result — the codec only knows the wire format, not
+     * the per-game `Action` enum. The caller does
+     * `Action.valueOf(actionName)` itself so the per-game `ParsedButtonId`
+     * stays strongly-typed against its own enum.
+     */
+    data class ParsedRaw(val actionName: String, val sessionId: Long, val payload: Long)
+
+    fun encode(buttonName: String, actionName: String, sessionId: Long, payload: Long): String =
+        listOf(buttonName, actionName, sessionId.toString(), payload.toString())
+            .joinToString(":")
+
+    fun parse(componentId: String, buttonName: String): ParsedRaw? {
+        val parts = componentId.split(':')
+        if (parts.size != 4 || !parts[0].equals(buttonName, ignoreCase = true)) return null
+        val sessionId = parts[2].toLongOrNull() ?: return null
+        val payload = parts[3].toLongOrNull() ?: return null
+        return ParsedRaw(actionName = parts[1], sessionId = sessionId, payload = payload)
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/game/RpsEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/game/RpsEmbeds.kt
@@ -65,16 +65,12 @@ object RpsEmbeds {
     fun forfeitButtonId(sessionId: Long): String = encode(Action.FORFEIT, sessionId, 0L)
 
     private fun encode(action: Action, sessionId: Long, scopedDiscordId: Long): String =
-        listOf(BUTTON_NAME, action.name, sessionId.toString(), scopedDiscordId.toString())
-            .joinToString(":")
+        PvpButtonIdCodec.encode(BUTTON_NAME, action.name, sessionId, scopedDiscordId)
 
     fun parseButtonId(componentId: String): ParsedButtonId? {
-        val parts = componentId.split(':')
-        if (parts.size != 4 || !parts[0].equals(BUTTON_NAME, ignoreCase = true)) return null
-        val action = runCatching { Action.valueOf(parts[1]) }.getOrNull() ?: return null
-        val sessionId = parts[2].toLongOrNull() ?: return null
-        val scopedDiscordId = parts[3].toLongOrNull() ?: return null
-        return ParsedButtonId(action, sessionId, scopedDiscordId)
+        val raw = PvpButtonIdCodec.parse(componentId, BUTTON_NAME) ?: return null
+        val action = runCatching { Action.valueOf(raw.actionName) }.getOrNull() ?: return null
+        return ParsedButtonId(action, raw.sessionId, raw.payload)
     }
 
     /**

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/game/TicTacToeEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/game/TicTacToeEmbeds.kt
@@ -66,16 +66,12 @@ object TicTacToeEmbeds {
     fun forfeitButtonId(sessionId: Long): String = encode(Action.FORFEIT, sessionId, 0L)
 
     private fun encode(action: Action, sessionId: Long, payload: Long): String =
-        listOf(BUTTON_NAME, action.name, sessionId.toString(), payload.toString())
-            .joinToString(":")
+        PvpButtonIdCodec.encode(BUTTON_NAME, action.name, sessionId, payload)
 
     fun parseButtonId(componentId: String): ParsedButtonId? {
-        val parts = componentId.split(':')
-        if (parts.size != 4 || !parts[0].equals(BUTTON_NAME, ignoreCase = true)) return null
-        val action = runCatching { Action.valueOf(parts[1]) }.getOrNull() ?: return null
-        val sessionId = parts[2].toLongOrNull() ?: return null
-        val payload = parts[3].toLongOrNull() ?: return null
-        return ParsedButtonId(action, sessionId, payload)
+        val raw = PvpButtonIdCodec.parse(componentId, BUTTON_NAME) ?: return null
+        val action = runCatching { Action.valueOf(raw.actionName) }.getOrNull() ?: return null
+        return ParsedButtonId(action, raw.sessionId, raw.payload)
     }
 
     /** Maps PLACE_<n> → cell index `n`; returns null for non-PLACE actions. */

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/game/PvpButtonIdCodecTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/game/PvpButtonIdCodecTest.kt
@@ -1,0 +1,69 @@
+package bot.toby.command.commands.game
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+/**
+ * Wire-format tests for [PvpButtonIdCodec]. The button-id format is a
+ * public contract — un-clicked Discord messages may sit for days before
+ * the click arrives, so any change here must keep old encodings parsing
+ * correctly.
+ */
+class PvpButtonIdCodecTest {
+
+    @Test
+    fun `encode joins parts with colons in fixed order`() {
+        val id = PvpButtonIdCodec.encode("rps", "ACCEPT", sessionId = 42L, payload = 999L)
+        assertEquals("rps:ACCEPT:42:999", id)
+    }
+
+    @Test
+    fun `parse round-trips the encode output`() {
+        val encoded = PvpButtonIdCodec.encode("tictactoe", "PLACE_3", 7L, 3L)
+        val raw = PvpButtonIdCodec.parse(encoded, "tictactoe")
+        assertEquals("PLACE_3", raw?.actionName)
+        assertEquals(7L, raw?.sessionId)
+        assertEquals(3L, raw?.payload)
+    }
+
+    @Test
+    fun `parse accepts negative payload (forfeit and zero-sentinel actions)`() {
+        val raw = PvpButtonIdCodec.parse("rps:FORFEIT:5:0", "rps")
+        assertEquals("FORFEIT", raw?.actionName)
+        assertEquals(5L, raw?.sessionId)
+        assertEquals(0L, raw?.payload)
+    }
+
+    @Test
+    fun `parse is case-insensitive on the prefix`() {
+        val raw = PvpButtonIdCodec.parse("RPS:ACCEPT:1:2", "rps")
+        assertEquals("ACCEPT", raw?.actionName)
+    }
+
+    @Test
+    fun `parse returns null when the prefix doesn't match`() {
+        assertNull(PvpButtonIdCodec.parse("connect4:DROP_0:1:0", "rps"))
+    }
+
+    @Test
+    fun `parse returns null when the segment count is wrong`() {
+        assertNull(PvpButtonIdCodec.parse("rps:ACCEPT:1", "rps"))
+        assertNull(PvpButtonIdCodec.parse("rps:ACCEPT:1:0:extra", "rps"))
+    }
+
+    @Test
+    fun `parse returns null when sessionId or payload is not numeric`() {
+        assertNull(PvpButtonIdCodec.parse("rps:ACCEPT:not-a-number:0", "rps"))
+        assertNull(PvpButtonIdCodec.parse("rps:ACCEPT:1:nope", "rps"))
+    }
+
+    @Test
+    fun `parse leaves Action validation to the caller (stage-2)`() {
+        // The codec doesn't know the per-game Action enum; an unknown
+        // actionName parses successfully here and only fails when the
+        // caller does Action.valueOf(raw.actionName).
+        val raw = PvpButtonIdCodec.parse("rps:NEVER_HEARD_OF_IT:1:0", "rps")
+        assertEquals("NEVER_HEARD_OF_IT", raw?.actionName)
+    }
+}


### PR DESCRIPTION
## Summary

Fourth wave of the test-coverage + DRY/SOLID refactor pass (continuing from #579, #580, #581).

Each of `RpsEmbeds`, `TicTacToeEmbeds`, and `Connect4Embeds` carried a line-for-line identical `encode()` and `parseButtonId()` body — same 4-segment colon-delimited wire format, same case-insensitive prefix check, same null-on-malformed contract. Only the `BUTTON_NAME` constant and the per-game `Action` enum type differed.

Lift the wire-format halves to a new shared `PvpButtonIdCodec` object. Each per-game embeds file keeps its own `Action` enum and strongly-typed `ParsedButtonId` data class; the codec methods shrink to one-line delegations:

```kotlin
private fun encode(action: Action, sessionId: Long, payload: Long): String =
    PvpButtonIdCodec.encode(BUTTON_NAME, action.name, sessionId, payload)

fun parseButtonId(componentId: String): ParsedButtonId? {
    val raw = PvpButtonIdCodec.parse(componentId, BUTTON_NAME) ?: return null
    val action = runCatching { Action.valueOf(raw.actionName) }.getOrNull() ?: return null
    return ParsedButtonId(action, raw.sessionId, raw.payload)
}
```

The codec's stage-1 `ParsedRaw(actionName, sessionId, payload)` lets the caller do its own `Action.valueOf(...)` against the per-game enum — keeps `ParsedButtonId` typed.

## Wire-format guardrails

The button-id format is a **public contract** — un-clicked Discord messages may sit for days before the user clicks, and they encode the routing string verbatim into the button payload. So:

- **No format change** — same `<buttonName>:<actionName>:<sessionId>:<payload>` shape.
- **Case-insensitive prefix preserved** — pre-existing `equals(BUTTON_NAME, ignoreCase = true)` convention kept.
- **Long payload preserved** — `0L` sentinel for FORFEIT / PICK actions still works.
- **Test coverage**: new `PvpButtonIdCodecTest` pins all of the above as a wire-format regression guard.

## Net

- **+131 / -24 lines** total (3 per-game embeds files shed ~5 lines each; the new shared codec + its test add ~165 lines).
- The real win is structural: the canonical wire-format definition now lives in one place, and future PvP games inherit it. Sets the table for the `GameSpec` consolidation (the bigger PR that's still queued).

## Test plan

- [x] `:discord-bot:test` green locally with `LANG=C.UTF-8 LC_ALL=C.UTF-8`
- [x] All other non-application module tests green
- [x] `PvpButtonIdCodecTest`: 8 tests cover round-trip, case-insensitive prefix, segment-count validation, non-numeric payload rejection, and stage-1/stage-2 separation
- [ ] CI green on `ubuntu-latest`
- [ ] Manual smoke: a button posted **before** this deploy still parses correctly after rollout (the codec format is unchanged so this should work by construction, but worth a sanity check)

## Still queued from original plan

The big consolidation — `GameSpec` sealed hierarchy + `PvpGameEmbeds` interface + parameterized `PvpCommand`/`PvpButton` + cutover that deletes the six per-game command/button files — is still ahead. That's ~1000 lines deletable but needs careful staging because it touches Spring component scanning, the `CommandManager`/`ButtonManager` test enumerations, and (potentially) the button-id wire format. This PR is a deliberate first half-step: the codec extraction unblocks anything that needs to encode button IDs against a generic spec without bringing the whole consolidation with it.

https://claude.ai/code/session_017zsUNUN5DRMTWA5ZZgJ2mM


---
_Generated by [Claude Code](https://claude.ai/code/session_017zsUNUN5DRMTWA5ZZgJ2mM)_