### PR TITLE
refactor(pvp): lift shared challenge ceremony out of the three slash commands

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/game/Connect4Command.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/game/Connect4Command.kt
@@ -1,14 +1,10 @@
 package bot.toby.command.commands.game
 
 import bot.toby.helpers.UserDtoHelper
-import core.command.Command.Companion.replyEmbedAndDelete
 import core.command.CommandContext
 import database.connect4.Connect4SessionRegistry
 import database.dto.UserDto
 import database.service.Connect4Service
-import database.service.PvpWagerService
-import net.dv8tion.jda.api.components.MessageTopLevelComponent
-import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.interactions.commands.build.OptionData
 import org.springframework.beans.factory.annotation.Autowired
@@ -28,6 +24,9 @@ import org.springframework.stereotype.Component
  * [bot.toby.button.buttons.Connect4Button], which routes through
  * [Connect4SessionRegistry] (in-memory board + turn state) and
  * [Connect4Service] (wager arithmetic).
+ *
+ * The handler body is the shared [PvpChallengeCeremony] — see that
+ * file for the per-game ceremony shape.
  */
 @Component
 class Connect4Command @Autowired constructor(
@@ -40,81 +39,28 @@ class Connect4Command @Autowired constructor(
     override val description: String =
         "Challenge another user to Connect 4. Stake is optional — leave it off for free play."
 
-    companion object {
-        private const val OPT_USER = "user"
-        private const val OPT_STAKE = "stake"
-    }
-
     override val optionData: List<OptionData> = listOf(
-        OptionData(OptionType.USER, OPT_USER, "Opponent", true),
+        OptionData(OptionType.USER, "user", "Opponent", true),
         OptionData(
             OptionType.INTEGER,
-            OPT_STAKE,
+            "stake",
             "Credits to wager each (optional; per-guild bounds; 0 = free play)",
             false,
         ).setMinValue(0L),
     )
 
-    override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
-        val event = ctx.event
-        event.deferReply().queue()
-
-        val guild = event.guild ?: run {
-            replyError(event, "This command can only be used in a server.", deleteDelay); return
-        }
-        val targetUser = event.getOption(OPT_USER)?.asUser ?: run {
-            replyError(event, "You must specify an opponent.", deleteDelay); return
-        }
-        if (targetUser.isBot) {
-            replyError(event, "You can't challenge a bot.", deleteDelay); return
-        }
-        if (targetUser.idLong == requestingUserDto.discordId) {
-            replyError(event, "You can't challenge yourself.", deleteDelay); return
-        }
-        val stake = event.getOption(OPT_STAKE)?.asLong ?: 0L
-
-        userDtoHelper.calculateUserDto(targetUser.idLong, guild.idLong)
-
-        val start = connect4Service.startMatch(
-            initiatorDiscordId = requestingUserDto.discordId,
-            opponentDiscordId = targetUser.idLong,
-            guildId = guild.idLong,
-            stake = stake,
+    override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) =
+        PvpChallengeCeremony.run(
+            ctx = ctx,
+            requestingUserDto = requestingUserDto,
+            deleteDelay = deleteDelay,
+            userDtoHelper = userDtoHelper,
+            startMatch = { init, opp, gid, stake -> connect4Service.startMatch(init, opp, gid, stake) },
+            register = { gid, init, opp, stake, cb ->
+                connect4SessionRegistry.register(gid, init, opp, stake, onPendingTimeout = cb)
+            },
+            pendingEmbed = Connect4Embeds::pendingEmbed,
+            pendingButtons = Connect4Embeds::pendingButtons,
+            pendingTimeoutEmbed = Connect4Embeds::pendingTimeoutEmbed,
         )
-        if (start !is PvpWagerService.StartOutcome.Ok) {
-            event.hook.replyEmbedAndDelete(
-                PvpEmbeds.startErrorEmbed(PvpEmbeds.describeStartOutcome(start)),
-                deleteDelay,
-            )
-            return
-        }
-
-        val initiatorId = requestingUserDto.discordId
-        val opponentId = targetUser.idLong
-        val session = connect4SessionRegistry.register(
-            guildId = guild.idLong,
-            initiatorDiscordId = initiatorId,
-            opponentDiscordId = opponentId,
-            stake = stake,
-        ) { expired ->
-            runCatching {
-                event.hook.editOriginalEmbeds(
-                    Connect4Embeds.pendingTimeoutEmbed(expired.initiatorDiscordId, expired.opponentDiscordId)
-                ).setComponents(emptyList<MessageTopLevelComponent>()).queue()
-            }
-        }
-
-        event.hook.sendMessageEmbeds(Connect4Embeds.pendingEmbed(initiatorId, opponentId, stake))
-            .addContent("<@$opponentId>")
-            .addComponents(Connect4Embeds.pendingButtons(session.id, opponentId))
-            .queue()
-    }
-
-    private fun replyError(
-        event: SlashCommandInteractionEvent,
-        message: String,
-        deleteDelay: Int,
-    ) {
-        event.hook.replyEmbedAndDelete(PvpEmbeds.startErrorEmbed(message), deleteDelay)
-    }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/game/PvpChallengeCeremony.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/game/PvpChallengeCeremony.kt
@@ -1,0 +1,108 @@
+package bot.toby.command.commands.game
+
+import bot.toby.helpers.UserDtoHelper
+import core.command.Command.Companion.replyEmbedAndDelete
+import core.command.CommandContext
+import database.dto.UserDto
+import database.pvp.PvpSessionRegistry
+import database.service.PvpWagerService
+import net.dv8tion.jda.api.components.MessageTopLevelComponent
+import net.dv8tion.jda.api.components.actionrow.ActionRow
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+
+/**
+ * Game-agnostic body for the `/<game> user: stake:` slash-command
+ * handler. The three PvP commands (`/rps`, `/tictactoe`, `/connect4`)
+ * carried verbatim copies of this ~60-line ceremony — guild / target /
+ * bot / self validation, opponent lazy-create, service.startMatch
+ * pre-flight, registry.register with a pending-timeout embed edit, and
+ * the final pending-embed send. Only the per-game service / registry /
+ * embeds objects vary.
+ *
+ * Per-game commands now reduce to: assemble the option metadata, hand
+ * the [run] call references for the three rendering helpers + the two
+ * domain actions, done. Adding a future PvP game gets the same body
+ * for free.
+ *
+ * Pre-conditions assumed by callers:
+ *  - The command has been registered with two options named "user"
+ *    (USER, required) and "stake" (INTEGER, optional, min 0). The
+ *    helper reads them by those names.
+ *  - The registry type extends [PvpSessionRegistry] so its `register`
+ *    method's `onPendingTimeout: (TSession) -> Unit` callback shape is
+ *    consistent across games.
+ */
+object PvpChallengeCeremony {
+
+    private const val OPT_USER = "user"
+    private const val OPT_STAKE = "stake"
+
+    fun <TSession : PvpSessionRegistry.Session> run(
+        ctx: CommandContext,
+        requestingUserDto: UserDto,
+        deleteDelay: Int,
+        userDtoHelper: UserDtoHelper,
+        startMatch: (initiatorDiscordId: Long, opponentDiscordId: Long, guildId: Long, stake: Long) -> PvpWagerService.StartOutcome,
+        register: (guildId: Long, initiatorDiscordId: Long, opponentDiscordId: Long, stake: Long, onPendingTimeout: (TSession) -> Unit) -> TSession,
+        pendingEmbed: (initiatorDiscordId: Long, opponentDiscordId: Long, stake: Long) -> MessageEmbed,
+        pendingButtons: (sessionId: Long, opponentDiscordId: Long) -> ActionRow,
+        pendingTimeoutEmbed: (initiatorDiscordId: Long, opponentDiscordId: Long) -> MessageEmbed,
+    ) {
+        val event = ctx.event
+        event.deferReply().queue()
+
+        val guild = event.guild ?: run {
+            replyError(event, "This command can only be used in a server.", deleteDelay); return
+        }
+        val targetUser = event.getOption(OPT_USER)?.asUser ?: run {
+            replyError(event, "You must specify an opponent.", deleteDelay); return
+        }
+        if (targetUser.isBot) {
+            replyError(event, "You can't challenge a bot.", deleteDelay); return
+        }
+        if (targetUser.idLong == requestingUserDto.discordId) {
+            replyError(event, "You can't challenge yourself.", deleteDelay); return
+        }
+        val stake = event.getOption(OPT_STAKE)?.asLong ?: 0L
+
+        // Lazy-create the opponent's user row so pre-flight balance check can read it.
+        userDtoHelper.calculateUserDto(targetUser.idLong, guild.idLong)
+
+        val start = startMatch(requestingUserDto.discordId, targetUser.idLong, guild.idLong, stake)
+        if (start !is PvpWagerService.StartOutcome.Ok) {
+            event.hook.replyEmbedAndDelete(
+                PvpEmbeds.startErrorEmbed(PvpEmbeds.describeStartOutcome(start)),
+                deleteDelay,
+            )
+            return
+        }
+
+        val initiatorId = requestingUserDto.discordId
+        val opponentId = targetUser.idLong
+        val session = register(guild.idLong, initiatorId, opponentId, stake) { expired ->
+            // Pending-phase timeout — nothing was ever debited so just
+            // edit the message in place. Best-effort: if the hook has
+            // already expired or the message is gone there's nothing
+            // useful to log.
+            runCatching {
+                event.hook.editOriginalEmbeds(
+                    pendingTimeoutEmbed(expired.initiatorDiscordId, expired.opponentDiscordId)
+                ).setComponents(emptyList<MessageTopLevelComponent>()).queue()
+            }
+        }
+
+        event.hook.sendMessageEmbeds(pendingEmbed(initiatorId, opponentId, stake))
+            .addContent("<@$opponentId>")
+            .addComponents(pendingButtons(session.id, opponentId))
+            .queue()
+    }
+
+    private fun replyError(
+        event: SlashCommandInteractionEvent,
+        message: String,
+        deleteDelay: Int,
+    ) {
+        event.hook.replyEmbedAndDelete(PvpEmbeds.startErrorEmbed(message), deleteDelay)
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/game/RpsCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/game/RpsCommand.kt
@@ -1,14 +1,10 @@
 package bot.toby.command.commands.game
 
 import bot.toby.helpers.UserDtoHelper
-import core.command.Command.Companion.replyEmbedAndDelete
 import core.command.CommandContext
 import database.dto.UserDto
 import database.rps.RpsSessionRegistry
-import database.service.PvpWagerService
 import database.service.RpsService
-import net.dv8tion.jda.api.components.MessageTopLevelComponent
-import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.interactions.commands.build.OptionData
 import org.springframework.beans.factory.annotation.Autowired
@@ -26,6 +22,9 @@ import org.springframework.stereotype.Component
  * handled by [bot.toby.button.buttons.RpsButton], which routes through
  * [RpsSessionRegistry] (in-memory session state) and [RpsService]
  * (wager arithmetic).
+ *
+ * The handler body is the shared [PvpChallengeCeremony] — see that
+ * file for the per-game ceremony shape.
  */
 @Component
 class RpsCommand @Autowired constructor(
@@ -38,87 +37,28 @@ class RpsCommand @Autowired constructor(
     override val description: String =
         "Challenge another user to Rock-Paper-Scissors. Stake is optional — leave it off for free play."
 
-    companion object {
-        private const val OPT_USER = "user"
-        private const val OPT_STAKE = "stake"
-    }
-
     override val optionData: List<OptionData> = listOf(
-        OptionData(OptionType.USER, OPT_USER, "Opponent", true),
+        OptionData(OptionType.USER, "user", "Opponent", true),
         OptionData(
             OptionType.INTEGER,
-            OPT_STAKE,
+            "stake",
             "Credits to wager each (optional; per-guild bounds; 0 = free play)",
             false,
-        )
-            .setMinValue(0L),
+        ).setMinValue(0L),
     )
 
-    override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
-        val event = ctx.event
-        event.deferReply().queue()
-
-        val guild = event.guild ?: run {
-            replyError(event, "This command can only be used in a server.", deleteDelay); return
-        }
-        val targetUser = event.getOption(OPT_USER)?.asUser ?: run {
-            replyError(event, "You must specify an opponent.", deleteDelay); return
-        }
-        if (targetUser.isBot) {
-            replyError(event, "You can't challenge a bot.", deleteDelay); return
-        }
-        if (targetUser.idLong == requestingUserDto.discordId) {
-            replyError(event, "You can't challenge yourself.", deleteDelay); return
-        }
-        val stake = event.getOption(OPT_STAKE)?.asLong ?: 0L
-
-        // Lazy-create the opponent's user row so pre-flight balance check can read it.
-        userDtoHelper.calculateUserDto(targetUser.idLong, guild.idLong)
-
-        val start = rpsService.startMatch(
-            initiatorDiscordId = requestingUserDto.discordId,
-            opponentDiscordId = targetUser.idLong,
-            guildId = guild.idLong,
-            stake = stake,
+    override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) =
+        PvpChallengeCeremony.run(
+            ctx = ctx,
+            requestingUserDto = requestingUserDto,
+            deleteDelay = deleteDelay,
+            userDtoHelper = userDtoHelper,
+            startMatch = { init, opp, gid, stake -> rpsService.startMatch(init, opp, gid, stake) },
+            register = { gid, init, opp, stake, cb ->
+                rpsSessionRegistry.register(gid, init, opp, stake, onPendingTimeout = cb)
+            },
+            pendingEmbed = RpsEmbeds::pendingEmbed,
+            pendingButtons = RpsEmbeds::pendingButtons,
+            pendingTimeoutEmbed = RpsEmbeds::pendingTimeoutEmbed,
         )
-        if (start !is PvpWagerService.StartOutcome.Ok) {
-            event.hook.replyEmbedAndDelete(
-                PvpEmbeds.startErrorEmbed(PvpEmbeds.describeStartOutcome(start)),
-                deleteDelay,
-            )
-            return
-        }
-
-        val initiatorId = requestingUserDto.discordId
-        val opponentId = targetUser.idLong
-        val session = rpsSessionRegistry.register(
-            guildId = guild.idLong,
-            initiatorDiscordId = initiatorId,
-            opponentDiscordId = opponentId,
-            stake = stake,
-        ) { expired ->
-            // Pending-phase timeout — nothing was ever debited so just
-            // edit the message in place. Best-effort: if the hook has
-            // already expired or the message is gone there's nothing
-            // useful to log.
-            runCatching {
-                event.hook.editOriginalEmbeds(
-                    RpsEmbeds.pendingTimeoutEmbed(expired.initiatorDiscordId, expired.opponentDiscordId)
-                ).setComponents(emptyList<MessageTopLevelComponent>()).queue()
-            }
-        }
-
-        event.hook.sendMessageEmbeds(RpsEmbeds.pendingEmbed(initiatorId, opponentId, stake))
-            .addContent("<@$opponentId>")
-            .addComponents(RpsEmbeds.pendingButtons(session.id, opponentId))
-            .queue()
-    }
-
-    private fun replyError(
-        event: SlashCommandInteractionEvent,
-        message: String,
-        deleteDelay: Int,
-    ) {
-        event.hook.replyEmbedAndDelete(PvpEmbeds.startErrorEmbed(message), deleteDelay)
-    }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/game/TicTacToeCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/game/TicTacToeCommand.kt
@@ -1,14 +1,10 @@
 package bot.toby.command.commands.game
 
 import bot.toby.helpers.UserDtoHelper
-import core.command.Command.Companion.replyEmbedAndDelete
 import core.command.CommandContext
 import database.dto.UserDto
-import database.service.PvpWagerService
 import database.service.TicTacToeService
 import database.tictactoe.TicTacToeSessionRegistry
-import net.dv8tion.jda.api.components.MessageTopLevelComponent
-import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.interactions.commands.build.OptionData
 import org.springframework.beans.factory.annotation.Autowired
@@ -27,6 +23,9 @@ import org.springframework.stereotype.Component
  * [bot.toby.button.buttons.TicTacToeButton], which routes through
  * [TicTacToeSessionRegistry] (in-memory board + turn state) and
  * [TicTacToeService] (wager arithmetic).
+ *
+ * The handler body is the shared [PvpChallengeCeremony] — see that
+ * file for the per-game ceremony shape.
  */
 @Component
 class TicTacToeCommand @Autowired constructor(
@@ -39,81 +38,28 @@ class TicTacToeCommand @Autowired constructor(
     override val description: String =
         "Challenge another user to Tic-Tac-Toe. Stake is optional — leave it off for free play."
 
-    companion object {
-        private const val OPT_USER = "user"
-        private const val OPT_STAKE = "stake"
-    }
-
     override val optionData: List<OptionData> = listOf(
-        OptionData(OptionType.USER, OPT_USER, "Opponent", true),
+        OptionData(OptionType.USER, "user", "Opponent", true),
         OptionData(
             OptionType.INTEGER,
-            OPT_STAKE,
+            "stake",
             "Credits to wager each (optional; per-guild bounds; 0 = free play)",
             false,
         ).setMinValue(0L),
     )
 
-    override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
-        val event = ctx.event
-        event.deferReply().queue()
-
-        val guild = event.guild ?: run {
-            replyError(event, "This command can only be used in a server.", deleteDelay); return
-        }
-        val targetUser = event.getOption(OPT_USER)?.asUser ?: run {
-            replyError(event, "You must specify an opponent.", deleteDelay); return
-        }
-        if (targetUser.isBot) {
-            replyError(event, "You can't challenge a bot.", deleteDelay); return
-        }
-        if (targetUser.idLong == requestingUserDto.discordId) {
-            replyError(event, "You can't challenge yourself.", deleteDelay); return
-        }
-        val stake = event.getOption(OPT_STAKE)?.asLong ?: 0L
-
-        userDtoHelper.calculateUserDto(targetUser.idLong, guild.idLong)
-
-        val start = ticTacToeService.startMatch(
-            initiatorDiscordId = requestingUserDto.discordId,
-            opponentDiscordId = targetUser.idLong,
-            guildId = guild.idLong,
-            stake = stake,
+    override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) =
+        PvpChallengeCeremony.run(
+            ctx = ctx,
+            requestingUserDto = requestingUserDto,
+            deleteDelay = deleteDelay,
+            userDtoHelper = userDtoHelper,
+            startMatch = { init, opp, gid, stake -> ticTacToeService.startMatch(init, opp, gid, stake) },
+            register = { gid, init, opp, stake, cb ->
+                ticTacToeSessionRegistry.register(gid, init, opp, stake, onPendingTimeout = cb)
+            },
+            pendingEmbed = TicTacToeEmbeds::pendingEmbed,
+            pendingButtons = TicTacToeEmbeds::pendingButtons,
+            pendingTimeoutEmbed = TicTacToeEmbeds::pendingTimeoutEmbed,
         )
-        if (start !is PvpWagerService.StartOutcome.Ok) {
-            event.hook.replyEmbedAndDelete(
-                PvpEmbeds.startErrorEmbed(PvpEmbeds.describeStartOutcome(start)),
-                deleteDelay,
-            )
-            return
-        }
-
-        val initiatorId = requestingUserDto.discordId
-        val opponentId = targetUser.idLong
-        val session = ticTacToeSessionRegistry.register(
-            guildId = guild.idLong,
-            initiatorDiscordId = initiatorId,
-            opponentDiscordId = opponentId,
-            stake = stake,
-        ) { expired ->
-            runCatching {
-                event.hook.editOriginalEmbeds(
-                    TicTacToeEmbeds.pendingTimeoutEmbed(expired.initiatorDiscordId, expired.opponentDiscordId)
-                ).setComponents(emptyList<MessageTopLevelComponent>()).queue()
-            }
-        }
-
-        event.hook.sendMessageEmbeds(TicTacToeEmbeds.pendingEmbed(initiatorId, opponentId, stake))
-            .addContent("<@$opponentId>")
-            .addComponents(TicTacToeEmbeds.pendingButtons(session.id, opponentId))
-            .queue()
-    }
-
-    private fun replyError(
-        event: SlashCommandInteractionEvent,
-        message: String,
-        deleteDelay: Int,
-    ) {
-        event.hook.replyEmbedAndDelete(PvpEmbeds.startErrorEmbed(message), deleteDelay)
-    }
 }


### PR DESCRIPTION
## Summary

Fifth wave of the test-coverage + DRY/SOLID refactor pass (continuing from #579, #580, #581, #582).

`RpsCommand`, `TicTacToeCommand`, and `Connect4Command` each carried a verbatim copy of a ~60-line `handle()` body — guild / target / bot / self / stake validation, opponent lazy-create, service.startMatch pre-flight + error embed, registry.register with a pending-timeout embed-edit callback, and the final pending-embed send. The only per-game bits were the service / registry / embeds references.

Lift the ceremony into `PvpChallengeCeremony.run(...)`, parameterised on the differing pieces:

```kotlin
fun <TSession : PvpSessionRegistry.Session> run(
    ctx: CommandContext,
    requestingUserDto: UserDto,
    deleteDelay: Int,
    userDtoHelper: UserDtoHelper,
    startMatch: (init, opp, gid, stake) -> PvpWagerService.StartOutcome,
    register: (gid, init, opp, stake, cb) -> TSession,
    pendingEmbed: (init, opp, stake) -> MessageEmbed,
    pendingButtons: (sessionId, opp) -> ActionRow,
    pendingTimeoutEmbed: (init, opp) -> MessageEmbed,
)
```

Generic over `TSession : PvpSessionRegistry.Session` — the new base class introduced in #580 carries its weight here. The per-game commands shrink to thin shells: name + description + option metadata + one call to `PvpChallengeCeremony.run(...)`. Adding a future PvP game inherits the ceremony body for free.

## Per-game command shape after refactor

```kotlin
override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) =
    PvpChallengeCeremony.run(
        ctx = ctx,
        requestingUserDto = requestingUserDto,
        deleteDelay = deleteDelay,
        userDtoHelper = userDtoHelper,
        startMatch = { init, opp, gid, stake -> rpsService.startMatch(init, opp, gid, stake) },
        register = { gid, init, opp, stake, cb ->
            rpsSessionRegistry.register(gid, init, opp, stake, onPendingTimeout = cb)
        },
        pendingEmbed = RpsEmbeds::pendingEmbed,
        pendingButtons = RpsEmbeds::pendingButtons,
        pendingTimeoutEmbed = RpsEmbeds::pendingTimeoutEmbed,
    )
```

## Net

- 4 files changed: **+163 / -223 = -60 lines**
- Each per-game command file: ~120 lines → ~65 lines (mostly imports + class scaffolding + option metadata)
- Same observable `handle()` behaviour — the sole existing command-level test (`Connect4CommandTest`) passes unchanged

## Test plan

- [x] `:discord-bot:test` green locally with `LANG=C.UTF-8 LC_ALL=C.UTF-8`
- [x] Pattern mirrors the successful `pvpChallenge`/`pvpAccept`/`pvpCloseOffer`/`pvpForfeit` extraction in `PvpController` from #581
- [ ] CI green on `ubuntu-latest`
- [ ] Manual smoke: `/rps`, `/tictactoe`, `/connect4` slash commands still produce the same pending-offer embed + accept/decline buttons, still survive the pending-timeout edit, still hit the `startMatch` error path correctly when the initiator's balance is too low

## Still queued from original plan

- **Symmetric extraction for the three `*Button.kt` files** (next candidate — same near-duplication shape as the commands, ~220 lines per file)
- **Full `GameSpec` sealed hierarchy** — the bulk consolidation that would let `RpsCommand`/`TicTacToeCommand`/`Connect4Command` collapse into a single parameterized `PvpCommand` bean. Bigger blast radius (touches Spring component scanning and `CommandManager` test enumerations) — worth doing as its own staged change.

https://claude.ai/code/session_017zsUNUN5DRMTWA5ZZgJ2mM


---
_Generated by [Claude Code](https://claude.ai/code/session_017zsUNUN5DRMTWA5ZZgJ2mM)_