### PR TITLE
refactor(pvp): extract shared button-handler helpers (decline + access checks)

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/Connect4Button.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/Connect4Button.kt
@@ -60,32 +60,21 @@ class Connect4Button @Autowired constructor(
         event: ButtonInteractionEvent,
         requestingUserDto: UserDto,
         parsed: Connect4Embeds.ParsedButtonId,
-    ) {
-        if (requestingUserDto.discordId != parsed.payload) {
-            event.hook.sendMessage(
-                "This isn't your challenge to decline — wait for <@${parsed.payload}> to respond."
-            ).setEphemeral(true).queue()
-            return
-        }
-        val session = connect4SessionRegistry.decline(parsed.sessionId) ?: run {
-            PvpButtonHelpers.ephemeralAlreadyResolved(event); return
-        }
-        event.message.editMessageEmbeds(
-            Connect4Embeds.pendingDeclineEmbed(session.initiatorDiscordId, session.opponentDiscordId)
-        ).setComponents(emptyList<MessageTopLevelComponent>()).queue()
-    }
+    ) = PvpButtonHelpers.handleDecline(
+        event = event,
+        requestingUserDto = requestingUserDto,
+        scopedDiscordId = parsed.payload,
+        sessionId = parsed.sessionId,
+        decline = connect4SessionRegistry::decline,
+        pendingDeclineEmbed = Connect4Embeds::pendingDeclineEmbed,
+    )
 
     private fun handleAccept(
         event: ButtonInteractionEvent,
         requestingUserDto: UserDto,
         parsed: Connect4Embeds.ParsedButtonId,
     ) {
-        if (requestingUserDto.discordId != parsed.payload) {
-            event.hook.sendMessage(
-                "This isn't your challenge to accept — wait for <@${parsed.payload}> to respond."
-            ).setEphemeral(true).queue()
-            return
-        }
+        if (!PvpButtonHelpers.requireScopedActor(event, requestingUserDto, parsed.payload, "accept")) return
         val session = connect4SessionRegistry.accept(parsed.sessionId) { expired ->
             // Move-clock timeout: current actor never dropped. Treat
             // as forfeit by them — opponent wins by walkover.
@@ -120,14 +109,11 @@ class Connect4Button @Autowired constructor(
         val live = connect4SessionRegistry.get(parsed.sessionId) ?: run {
             PvpButtonHelpers.ephemeralAlreadyResolved(event); return
         }
-        if (requestingUserDto.discordId != live.initiatorDiscordId &&
-            requestingUserDto.discordId != live.opponentDiscordId
-        ) {
-            event.hook.sendMessage(
-                "This isn't your match — only <@${live.initiatorDiscordId}> and <@${live.opponentDiscordId}> can play."
-            ).setEphemeral(true).queue()
-            return
-        }
+        if (!PvpButtonHelpers.requireMatchParticipant(
+                event, requestingUserDto, live.initiatorDiscordId, live.opponentDiscordId,
+                notParticipantMessage = "This isn't your match — only <@${live.initiatorDiscordId}> and <@${live.opponentDiscordId}> can play.",
+            )
+        ) return
         val result = connect4SessionRegistry.applyMove(parsed.sessionId, requestingUserDto.discordId, column) { expired ->
             resolveTimeout(event, expired)
         }
@@ -162,12 +148,11 @@ class Connect4Button @Autowired constructor(
         val live = connect4SessionRegistry.get(parsed.sessionId) ?: run {
             PvpButtonHelpers.ephemeralAlreadyResolved(event); return
         }
-        if (requestingUserDto.discordId != live.initiatorDiscordId &&
-            requestingUserDto.discordId != live.opponentDiscordId
-        ) {
-            event.hook.sendMessage("This isn't your match to forfeit.").setEphemeral(true).queue()
-            return
-        }
+        if (!PvpButtonHelpers.requireMatchParticipant(
+                event, requestingUserDto, live.initiatorDiscordId, live.opponentDiscordId,
+                notParticipantMessage = "This isn't your match to forfeit.",
+            )
+        ) return
         val consumed = connect4SessionRegistry.forfeit(parsed.sessionId) ?: run {
             PvpButtonHelpers.ephemeralAlreadyResolved(event); return
         }

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/PvpButtonHelpers.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/PvpButtonHelpers.kt
@@ -1,25 +1,33 @@
 package bot.toby.button.buttons
 
+import database.dto.UserDto
+import database.pvp.PvpSessionRegistry
 import database.service.PvpWagerService
+import net.dv8tion.jda.api.components.MessageTopLevelComponent
+import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
 
 /**
  * Cross-game button helpers for the PvP mini-games (`/rps`,
- * `/tictactoe`, future `/connect4`). Holds the bits that are
- * identical between the per-game `*Button.kt` handlers — the
- * "match already resolved" ephemeral reply and the
- * [PvpWagerService.AcceptOutcome] → user-facing-text mapping.
+ * `/tictactoe`, `/connect4`). Holds the bits that would otherwise
+ * duplicate verbatim across the per-game `*Button.kt` handlers — the
+ * "match already resolved" ephemeral, the access checks for
+ * scoped-actor vs match-participant routes, the full `handleDecline`
+ * body, and the [PvpWagerService.AcceptOutcome] → user-facing text
+ * mapping.
  *
  * Per-game button code (the routing switch, the move/pick handlers,
- * the win-embed rendering) stays in the per-game `*Button.kt`.
+ * the win-embed rendering, the per-game `resolveAndEdit` that knows
+ * the engine's terminal-result shape) stays in the per-game
+ * `*Button.kt`.
  */
 object PvpButtonHelpers {
 
     /**
-     * Ephemeral "this match already resolved or expired" reply, surfaced
-     * when a click lands on a session the registry no longer has —
-     * either it timed out, was forfeited, or another race already
-     * resolved it.
+     * Ephemeral "this match already resolved or expired" reply,
+     * surfaced when a click lands on a session the registry no longer
+     * has — either it timed out, was forfeited, or another race
+     * already resolved it.
      */
     fun ephemeralAlreadyResolved(event: ButtonInteractionEvent) {
         event.hook.sendMessage("This match already resolved or expired.").setEphemeral(true).queue()
@@ -36,5 +44,83 @@ object PvpButtonHelpers {
         PvpWagerService.AcceptOutcome.UnknownOpponent ->
             "We couldn't find your profile."
         is PvpWagerService.AcceptOutcome.Ok -> "" // never surfaced
+    }
+
+    /**
+     * Access check used by the PENDING-phase scoped-actor routes
+     * (accept, decline). The accept/decline buttons are scoped to the
+     * opponent's discord id — encoded in the button payload at
+     * `scopedDiscordId`. Returns true if the click came from the
+     * expected actor (so the caller proceeds); false after sending the
+     * ephemeral rejection (so the caller returns).
+     *
+     * [friendlyVerb] is interpolated into the ephemeral message —
+     * pass "accept" or "decline" to match the click action.
+     */
+    fun requireScopedActor(
+        event: ButtonInteractionEvent,
+        requestingUserDto: UserDto,
+        scopedDiscordId: Long,
+        friendlyVerb: String,
+    ): Boolean {
+        if (requestingUserDto.discordId == scopedDiscordId) return true
+        event.hook.sendMessage(
+            "This isn't your challenge to $friendlyVerb — wait for <@${scopedDiscordId}> to respond."
+        ).setEphemeral(true).queue()
+        return false
+    }
+
+    /**
+     * Access check used by the LIVE-phase action routes
+     * (pick / place / drop / forfeit). The LIVE buttons accept clicks
+     * from either participant — but not from anyone else. Returns true
+     * if the clicker is one of the two participants (so the caller
+     * proceeds); false after sending [notParticipantMessage] as an
+     * ephemeral reply.
+     *
+     * The message text varies between routes ("can play" for board
+     * games, "can pick" for RPS, "to forfeit" for the forfeit route),
+     * so the caller supplies the exact text.
+     */
+    fun requireMatchParticipant(
+        event: ButtonInteractionEvent,
+        requestingUserDto: UserDto,
+        initiatorDiscordId: Long,
+        opponentDiscordId: Long,
+        notParticipantMessage: String,
+    ): Boolean {
+        if (requestingUserDto.discordId == initiatorDiscordId ||
+            requestingUserDto.discordId == opponentDiscordId
+        ) {
+            return true
+        }
+        event.hook.sendMessage(notParticipantMessage).setEphemeral(true).queue()
+        return false
+    }
+
+    /**
+     * Full body of the `handleDecline` route — identical across the
+     * three PvP games modulo the registry / embeds references. Runs
+     * the scoped-actor check, calls [decline] to drop the pending
+     * session, then edits the original message with the
+     * decline-rendered embed and clears the buttons. If the session
+     * already expired or was resolved, an ephemeral
+     * "already-resolved" reply is sent in lieu of the embed edit.
+     */
+    fun <S : PvpSessionRegistry.Session> handleDecline(
+        event: ButtonInteractionEvent,
+        requestingUserDto: UserDto,
+        scopedDiscordId: Long,
+        sessionId: Long,
+        decline: (Long) -> S?,
+        pendingDeclineEmbed: (initiatorDiscordId: Long, opponentDiscordId: Long) -> MessageEmbed,
+    ) {
+        if (!requireScopedActor(event, requestingUserDto, scopedDiscordId, "decline")) return
+        val session = decline(sessionId) ?: run {
+            ephemeralAlreadyResolved(event); return
+        }
+        event.message.editMessageEmbeds(
+            pendingDeclineEmbed(session.initiatorDiscordId, session.opponentDiscordId)
+        ).setComponents(emptyList<MessageTopLevelComponent>()).queue()
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/RpsButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/RpsButton.kt
@@ -54,32 +54,21 @@ class RpsButton @Autowired constructor(
         event: ButtonInteractionEvent,
         requestingUserDto: UserDto,
         parsed: RpsEmbeds.ParsedButtonId,
-    ) {
-        if (requestingUserDto.discordId != parsed.scopedDiscordId) {
-            event.hook.sendMessage(
-                "This isn't your challenge to decline — wait for <@${parsed.scopedDiscordId}> to respond."
-            ).setEphemeral(true).queue()
-            return
-        }
-        val session = rpsSessionRegistry.decline(parsed.sessionId) ?: run {
-            PvpButtonHelpers.ephemeralAlreadyResolved(event); return
-        }
-        event.message.editMessageEmbeds(
-            RpsEmbeds.pendingDeclineEmbed(session.initiatorDiscordId, session.opponentDiscordId)
-        ).setComponents(emptyList<MessageTopLevelComponent>()).queue()
-    }
+    ) = PvpButtonHelpers.handleDecline(
+        event = event,
+        requestingUserDto = requestingUserDto,
+        scopedDiscordId = parsed.scopedDiscordId,
+        sessionId = parsed.sessionId,
+        decline = rpsSessionRegistry::decline,
+        pendingDeclineEmbed = RpsEmbeds::pendingDeclineEmbed,
+    )
 
     private fun handleAccept(
         event: ButtonInteractionEvent,
         requestingUserDto: UserDto,
         parsed: RpsEmbeds.ParsedButtonId,
     ) {
-        if (requestingUserDto.discordId != parsed.scopedDiscordId) {
-            event.hook.sendMessage(
-                "This isn't your challenge to accept — wait for <@${parsed.scopedDiscordId}> to respond."
-            ).setEphemeral(true).queue()
-            return
-        }
+        if (!PvpButtonHelpers.requireScopedActor(event, requestingUserDto, parsed.scopedDiscordId, "accept")) return
         // Transition PENDING → LIVE and schedule the pick-phase timeout
         // before we touch the user table. If accept() returns null the
         // session expired or was declined between the click and now.
@@ -129,14 +118,11 @@ class RpsButton @Autowired constructor(
         val live = rpsSessionRegistry.get(parsed.sessionId) ?: run {
             PvpButtonHelpers.ephemeralAlreadyResolved(event); return
         }
-        if (requestingUserDto.discordId != live.initiatorDiscordId &&
-            requestingUserDto.discordId != live.opponentDiscordId
-        ) {
-            event.hook.sendMessage(
-                "This isn't your match — only <@${live.initiatorDiscordId}> and <@${live.opponentDiscordId}> can pick."
-            ).setEphemeral(true).queue()
-            return
-        }
+        if (!PvpButtonHelpers.requireMatchParticipant(
+                event, requestingUserDto, live.initiatorDiscordId, live.opponentDiscordId,
+                notParticipantMessage = "This isn't your match — only <@${live.initiatorDiscordId}> and <@${live.opponentDiscordId}> can pick.",
+            )
+        ) return
         val updated = rpsSessionRegistry.recordPick(parsed.sessionId, requestingUserDto.discordId, choice) ?: run {
             PvpButtonHelpers.ephemeralAlreadyResolved(event); return
         }
@@ -172,14 +158,11 @@ class RpsButton @Autowired constructor(
         val live = rpsSessionRegistry.get(parsed.sessionId) ?: run {
             PvpButtonHelpers.ephemeralAlreadyResolved(event); return
         }
-        if (requestingUserDto.discordId != live.initiatorDiscordId &&
-            requestingUserDto.discordId != live.opponentDiscordId
-        ) {
-            event.hook.sendMessage(
-                "This isn't your match to forfeit."
-            ).setEphemeral(true).queue()
-            return
-        }
+        if (!PvpButtonHelpers.requireMatchParticipant(
+                event, requestingUserDto, live.initiatorDiscordId, live.opponentDiscordId,
+                notParticipantMessage = "This isn't your match to forfeit.",
+            )
+        ) return
         // Forfeit = the other player wins by walkover. Atomically remove
         // the session so the pick-timeout can't double-resolve.
         val consumed = rpsSessionRegistry.forfeit(parsed.sessionId) ?: run {

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/TicTacToeButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/TicTacToeButton.kt
@@ -60,32 +60,21 @@ class TicTacToeButton @Autowired constructor(
         event: ButtonInteractionEvent,
         requestingUserDto: UserDto,
         parsed: TicTacToeEmbeds.ParsedButtonId,
-    ) {
-        if (requestingUserDto.discordId != parsed.payload) {
-            event.hook.sendMessage(
-                "This isn't your challenge to decline — wait for <@${parsed.payload}> to respond."
-            ).setEphemeral(true).queue()
-            return
-        }
-        val session = ticTacToeSessionRegistry.decline(parsed.sessionId) ?: run {
-            PvpButtonHelpers.ephemeralAlreadyResolved(event); return
-        }
-        event.message.editMessageEmbeds(
-            TicTacToeEmbeds.pendingDeclineEmbed(session.initiatorDiscordId, session.opponentDiscordId)
-        ).setComponents(emptyList<MessageTopLevelComponent>()).queue()
-    }
+    ) = PvpButtonHelpers.handleDecline(
+        event = event,
+        requestingUserDto = requestingUserDto,
+        scopedDiscordId = parsed.payload,
+        sessionId = parsed.sessionId,
+        decline = ticTacToeSessionRegistry::decline,
+        pendingDeclineEmbed = TicTacToeEmbeds::pendingDeclineEmbed,
+    )
 
     private fun handleAccept(
         event: ButtonInteractionEvent,
         requestingUserDto: UserDto,
         parsed: TicTacToeEmbeds.ParsedButtonId,
     ) {
-        if (requestingUserDto.discordId != parsed.payload) {
-            event.hook.sendMessage(
-                "This isn't your challenge to accept — wait for <@${parsed.payload}> to respond."
-            ).setEphemeral(true).queue()
-            return
-        }
+        if (!PvpButtonHelpers.requireScopedActor(event, requestingUserDto, parsed.payload, "accept")) return
         val session = ticTacToeSessionRegistry.accept(parsed.sessionId) { expired ->
             // Move-clock timeout: current actor never placed. Treat
             // as forfeit by them — opponent wins by walkover.
@@ -120,14 +109,11 @@ class TicTacToeButton @Autowired constructor(
         val live = ticTacToeSessionRegistry.get(parsed.sessionId) ?: run {
             PvpButtonHelpers.ephemeralAlreadyResolved(event); return
         }
-        if (requestingUserDto.discordId != live.initiatorDiscordId &&
-            requestingUserDto.discordId != live.opponentDiscordId
-        ) {
-            event.hook.sendMessage(
-                "This isn't your match — only <@${live.initiatorDiscordId}> and <@${live.opponentDiscordId}> can play."
-            ).setEphemeral(true).queue()
-            return
-        }
+        if (!PvpButtonHelpers.requireMatchParticipant(
+                event, requestingUserDto, live.initiatorDiscordId, live.opponentDiscordId,
+                notParticipantMessage = "This isn't your match — only <@${live.initiatorDiscordId}> and <@${live.opponentDiscordId}> can play.",
+            )
+        ) return
         val result = ticTacToeSessionRegistry.applyMove(parsed.sessionId, requestingUserDto.discordId, cell) { expired ->
             resolveTimeout(event, expired)
         }
@@ -162,12 +148,11 @@ class TicTacToeButton @Autowired constructor(
         val live = ticTacToeSessionRegistry.get(parsed.sessionId) ?: run {
             PvpButtonHelpers.ephemeralAlreadyResolved(event); return
         }
-        if (requestingUserDto.discordId != live.initiatorDiscordId &&
-            requestingUserDto.discordId != live.opponentDiscordId
-        ) {
-            event.hook.sendMessage("This isn't your match to forfeit.").setEphemeral(true).queue()
-            return
-        }
+        if (!PvpButtonHelpers.requireMatchParticipant(
+                event, requestingUserDto, live.initiatorDiscordId, live.opponentDiscordId,
+                notParticipantMessage = "This isn't your match to forfeit.",
+            )
+        ) return
         val consumed = ticTacToeSessionRegistry.forfeit(parsed.sessionId) ?: run {
             PvpButtonHelpers.ephemeralAlreadyResolved(event); return
         }

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/PvpButtonHelpersTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/PvpButtonHelpersTest.kt
@@ -1,0 +1,294 @@
+package bot.toby.button.buttons
+
+import database.dto.UserDto
+import database.pvp.PvpSessionRegistry
+import database.service.PvpWagerService
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import net.dv8tion.jda.api.components.MessageTopLevelComponent
+import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
+import net.dv8tion.jda.api.interactions.InteractionHook
+import net.dv8tion.jda.api.requests.restaction.MessageEditAction
+import net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+/**
+ * Direct unit tests for [PvpButtonHelpers]. These cover the per-game
+ * button handlers' shared preambles + `handleDecline` body once,
+ * instead of relying on the per-game button tests
+ * (`RpsButtonTest`, `TicTacToeButtonTest`, `Connect4ButtonTest`) to
+ * catch helper regressions three times over.
+ */
+class PvpButtonHelpersTest {
+
+    private val initiatorId = 100L
+    private val opponentId = 200L
+    private val clickerId = 300L
+    private val sessionId = 7L
+    private val guildId = 99L
+
+    private lateinit var event: ButtonInteractionEvent
+    private lateinit var hook: InteractionHook
+    private lateinit var message: Message
+    private lateinit var editAction: MessageEditAction
+    private lateinit var sendAction: WebhookMessageCreateAction<Message>
+
+    @BeforeEach
+    fun setUp() {
+        event = mockk(relaxed = true)
+        hook = mockk(relaxed = true)
+        message = mockk(relaxed = true)
+        editAction = mockk(relaxed = true)
+        sendAction = mockk(relaxed = true)
+
+        every { event.hook } returns hook
+        every { event.message } returns message
+        every { message.editMessageEmbeds(any<MessageEmbed>()) } returns editAction
+        every { editAction.setComponents(any<Collection<MessageTopLevelComponent>>()) } returns editAction
+        every { editAction.queue() } just Runs
+
+        every { hook.sendMessage(any<String>()) } returns sendAction
+        every { sendAction.setEphemeral(any()) } returns sendAction
+        every { sendAction.queue() } just Runs
+    }
+
+    // ── ephemeralAlreadyResolved ───────────────────────────────────────
+
+    @Test
+    fun `ephemeralAlreadyResolved sends a fixed-text ephemeral via the interaction hook`() {
+        PvpButtonHelpers.ephemeralAlreadyResolved(event)
+
+        verify(exactly = 1) { hook.sendMessage("This match already resolved or expired.") }
+        verify(exactly = 1) { sendAction.setEphemeral(true) }
+        verify(exactly = 1) { sendAction.queue() }
+    }
+
+    // ── describeAccept ─────────────────────────────────────────────────
+
+    @Test
+    fun `describeAccept maps InitiatorInsufficient to a challenger-facing message`() {
+        val text = PvpButtonHelpers.describeAccept(
+            PvpWagerService.AcceptOutcome.InitiatorInsufficient(have = 0L, needed = 50L)
+        )
+        assertTrue(text.contains("challenger", ignoreCase = true))
+    }
+
+    @Test
+    fun `describeAccept maps OpponentInsufficient to a self-facing message with the numbers`() {
+        val text = PvpButtonHelpers.describeAccept(
+            PvpWagerService.AcceptOutcome.OpponentInsufficient(have = 10L, needed = 50L)
+        )
+        assertTrue(text.contains("10"))
+        assertTrue(text.contains("50"))
+    }
+
+    @Test
+    fun `describeAccept maps UnknownInitiator to a challenger-profile-missing message`() {
+        val text = PvpButtonHelpers.describeAccept(PvpWagerService.AcceptOutcome.UnknownInitiator)
+        assertTrue(text.contains("challenger", ignoreCase = true))
+    }
+
+    @Test
+    fun `describeAccept maps UnknownOpponent to a self-profile-missing message`() {
+        val text = PvpButtonHelpers.describeAccept(PvpWagerService.AcceptOutcome.UnknownOpponent)
+        assertTrue(text.contains("your", ignoreCase = true))
+    }
+
+    // ── requireScopedActor ─────────────────────────────────────────────
+
+    @Test
+    fun `requireScopedActor returns true and stays silent when clicker matches the scoped actor`() {
+        val result = PvpButtonHelpers.requireScopedActor(
+            event,
+            requestingUserDto = userDto(opponentId),
+            scopedDiscordId = opponentId,
+            friendlyVerb = "accept",
+        )
+
+        assertTrue(result)
+        verify(exactly = 0) { hook.sendMessage(any<String>()) }
+    }
+
+    @Test
+    fun `requireScopedActor returns false and sends an ephemeral when clicker is not the scoped actor`() {
+        val message = slot<String>()
+        every { hook.sendMessage(capture(message)) } returns sendAction
+
+        val result = PvpButtonHelpers.requireScopedActor(
+            event,
+            requestingUserDto = userDto(clickerId),
+            scopedDiscordId = opponentId,
+            friendlyVerb = "decline",
+        )
+
+        assertFalse(result)
+        verify(exactly = 1) { sendAction.setEphemeral(true) }
+        assertTrue(message.captured.contains("decline"))
+        assertTrue(message.captured.contains("<@$opponentId>"))
+    }
+
+    // ── requireMatchParticipant ────────────────────────────────────────
+
+    @Test
+    fun `requireMatchParticipant returns true when the clicker is the initiator`() {
+        val result = PvpButtonHelpers.requireMatchParticipant(
+            event,
+            requestingUserDto = userDto(initiatorId),
+            initiatorDiscordId = initiatorId,
+            opponentDiscordId = opponentId,
+            notParticipantMessage = "irrelevant",
+        )
+
+        assertTrue(result)
+        verify(exactly = 0) { hook.sendMessage(any<String>()) }
+    }
+
+    @Test
+    fun `requireMatchParticipant returns true when the clicker is the opponent`() {
+        val result = PvpButtonHelpers.requireMatchParticipant(
+            event,
+            requestingUserDto = userDto(opponentId),
+            initiatorDiscordId = initiatorId,
+            opponentDiscordId = opponentId,
+            notParticipantMessage = "irrelevant",
+        )
+
+        assertTrue(result)
+        verify(exactly = 0) { hook.sendMessage(any<String>()) }
+    }
+
+    @Test
+    fun `requireMatchParticipant returns false and sends the caller-supplied ephemeral when clicker is a non-participant`() {
+        val result = PvpButtonHelpers.requireMatchParticipant(
+            event,
+            requestingUserDto = userDto(clickerId),
+            initiatorDiscordId = initiatorId,
+            opponentDiscordId = opponentId,
+            notParticipantMessage = "This isn't your match to forfeit.",
+        )
+
+        assertFalse(result)
+        verify(exactly = 1) { hook.sendMessage("This isn't your match to forfeit.") }
+        verify(exactly = 1) { sendAction.setEphemeral(true) }
+    }
+
+    // ── handleDecline ──────────────────────────────────────────────────
+
+    @Test
+    fun `handleDecline ignores the click and sends an ephemeral when the clicker is not the scoped actor`() {
+        val registry = StubDeclineRegistry()
+        val embedBuilder = StubEmbedBuilder()
+
+        PvpButtonHelpers.handleDecline(
+            event = event,
+            requestingUserDto = userDto(clickerId),
+            scopedDiscordId = opponentId,
+            sessionId = sessionId,
+            decline = registry::decline,
+            pendingDeclineEmbed = embedBuilder::pendingDeclineEmbed,
+        )
+
+        assertEquals(0, registry.declineCalls)
+        assertEquals(0, embedBuilder.calls)
+        verify(exactly = 1) { sendAction.setEphemeral(true) }
+        verify(exactly = 0) { message.editMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `handleDecline calls decline + edits the message embed when the scoped actor declines a live offer`() {
+        val pendingEmbed = mockk<MessageEmbed>(relaxed = true)
+        val session = TestSession(sessionId, guildId, initiatorId, opponentId, stake = 50L)
+        val registry = StubDeclineRegistry(returnValue = session)
+        val embedBuilder = StubEmbedBuilder(embed = pendingEmbed)
+
+        PvpButtonHelpers.handleDecline(
+            event = event,
+            requestingUserDto = userDto(opponentId),
+            scopedDiscordId = opponentId,
+            sessionId = sessionId,
+            decline = registry::decline,
+            pendingDeclineEmbed = embedBuilder::pendingDeclineEmbed,
+        )
+
+        assertEquals(1, registry.declineCalls)
+        assertEquals(sessionId, registry.lastSessionId)
+        assertEquals(1, embedBuilder.calls)
+        assertEquals(initiatorId, embedBuilder.lastInitiatorId)
+        assertEquals(opponentId, embedBuilder.lastOpponentId)
+        verify(exactly = 1) { message.editMessageEmbeds(pendingEmbed) }
+        verify(exactly = 1) { editAction.setComponents(emptyList<MessageTopLevelComponent>()) }
+        verify(exactly = 1) { editAction.queue() }
+    }
+
+    @Test
+    fun `handleDecline surfaces the already-resolved ephemeral when the registry returns null`() {
+        val registry = StubDeclineRegistry(returnValue = null)
+        val embedBuilder = StubEmbedBuilder()
+
+        PvpButtonHelpers.handleDecline(
+            event = event,
+            requestingUserDto = userDto(opponentId),
+            scopedDiscordId = opponentId,
+            sessionId = sessionId,
+            decline = registry::decline,
+            pendingDeclineEmbed = embedBuilder::pendingDeclineEmbed,
+        )
+
+        assertEquals(1, registry.declineCalls)
+        assertEquals(0, embedBuilder.calls)
+        verify(exactly = 1) { hook.sendMessage("This match already resolved or expired.") }
+        verify(exactly = 1) { sendAction.setEphemeral(true) }
+        verify(exactly = 0) { message.editMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────
+
+    private fun userDto(discordId: Long) = UserDto(discordId = discordId, guildId = guildId)
+
+    /** Minimal session subclass used only as the [PvpSessionRegistry.Session] return type. */
+    private class TestSession(
+        id: Long, guildId: Long, initiatorDiscordId: Long, opponentDiscordId: Long, stake: Long,
+    ) : PvpSessionRegistry.Session(
+        id, guildId, initiatorDiscordId, opponentDiscordId, stake, Instant.parse("2026-05-24T00:00:00Z"),
+    )
+
+    /** Counting stub — records what `decline(sessionId)` was called with. */
+    private class StubDeclineRegistry(
+        private val returnValue: TestSession? = null,
+    ) {
+        var declineCalls: Int = 0; private set
+        var lastSessionId: Long? = null; private set
+
+        fun decline(id: Long): TestSession? {
+            declineCalls += 1
+            lastSessionId = id
+            return returnValue
+        }
+    }
+
+    /** Counting stub — records which (initiator, opponent) pair was rendered. */
+    private class StubEmbedBuilder(private val embed: MessageEmbed? = null) {
+        var calls: Int = 0; private set
+        var lastInitiatorId: Long? = null; private set
+        var lastOpponentId: Long? = null; private set
+
+        fun pendingDeclineEmbed(initiatorId: Long, opponentId: Long): MessageEmbed {
+            calls += 1
+            lastInitiatorId = initiatorId
+            lastOpponentId = opponentId
+            return embed ?: mockk(relaxed = true)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Sixth wave of the test-coverage + DRY/SOLID refactor pass (continuing from #579, #580, #581, #582, #583).

Symmetric follow-up to #583 (which extracted the slash-command challenge ceremony). The three PvP `*Button` handlers — `RpsButton`, `TicTacToeButton`, `Connect4Button` — carried verbatim copies of:

- The full `handleDecline` body (scoped-actor check → registry decline → message-edit with `pendingDeclineEmbed` + cleared components → ephemeral "already-resolved" reply on null)
- The PENDING-phase scoped-actor preamble shared by accept and decline ("This isn't your challenge to <verb> — wait for X to respond.")
- The LIVE-phase match-participant preamble shared by pick / place / drop / forfeit ("This isn't your match — only X and Y can …")

Extend `PvpButtonHelpers` with three new helpers and replace the duplicated bodies in all three button handlers.

## New helpers

```kotlin
// Full route body. Each per-game handleDecline becomes one delegation call.
fun <S : PvpSessionRegistry.Session> handleDecline(
    event, requestingUserDto, scopedDiscordId, sessionId, decline, pendingDeclineEmbed,
)

// Accept/decline preamble. Caller does `if (!… ) return`.
fun requireScopedActor(event, requestingUserDto, scopedDiscordId, friendlyVerb): Boolean

// pick/place/drop/forfeit preamble. Caller passes the exact ephemeral text
// since it differs across routes ("can play" / "can pick" / "to forfeit").
fun requireMatchParticipant(
    event, requestingUserDto, initiatorDiscordId, opponentDiscordId, notParticipantMessage,
): Boolean
```

## Wire-format detail preserved

RPS encodes the scoped discord id in `ParsedButtonId.scopedDiscordId` while TTT/C4 store it in `ParsedButtonId.payload`. The helper takes a `Long` so each caller plucks the right field. **No wire-format change** — live un-clicked Discord buttons stay routable.

## Net

- 4 files changed: **+152 / -113 = +39 lines absolute**
- The 3 button files each shed ~25 lines; the helper file grew ~90 lines
- The real win is structural: three identical decline bodies → one. Two identical access-check preambles → one each.
- Future PvP games inherit all three patterns for free.

## Test plan

- [x] `:discord-bot:test` green locally with `LANG=C.UTF-8 LC_ALL=C.UTF-8`
- [x] Existing per-game button tests (`RpsButtonTest`, `TicTacToeButtonTest`, `Connect4ButtonTest`) pass without modification — the `sendMessage(any<String>())` matchers don't pin exact ephemeral text, so the refactor preserves observable behaviour by construction
- [ ] CI green on `ubuntu-latest`
- [ ] Manual smoke: accept / decline / forfeit clicks on `/rps`, `/tictactoe`, `/connect4` from both participants + a non-participant still produce the same ephemeral / embed-edit responses

## Still queued from original plan

- **Full `GameSpec` sealed hierarchy** — the bulk consolidation that would let `RpsCommand`/`TicTacToeCommand`/`Connect4Command` (and their three button counterparts) collapse into single parameterized `PvpCommand` + `PvpButton` beans. Bigger blast radius (touches Spring component scanning + `CommandManager`/`ButtonManager` test enumerations) — worth doing as its own staged change with explicit user sign-off.

https://claude.ai/code/session_017zsUNUN5DRMTWA5ZZgJ2mM


---
_Generated by [Claude Code](https://claude.ai/code/session_017zsUNUN5DRMTWA5ZZgJ2mM)_