### PR TITLE
feat(web): polish /utils page with animated 8-ball, dice, and reel

### DIFF
--- a/web/src/main/resources/static/css/utils.css
+++ b/web/src/main/resources/static/css/utils.css
@@ -9,6 +9,8 @@
     border: 1px solid var(--border);
     border-radius: var(--radius-md);
     padding: var(--space-4);
+    display: flex;
+    flex-direction: column;
 }
 
 .util-card h2 {
@@ -61,15 +63,270 @@
     min-height: 20px;
 }
 
+/* ---- Dice tray ---- */
+.dice-tray {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    min-height: 76px;
+    padding: var(--space-3);
+    margin-bottom: var(--space-3);
+    background: radial-gradient(120% 80% at 50% 0%, rgba(88, 101, 242, 0.08) 0%, transparent 70%), var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+}
+.dice-tray:empty::before {
+    content: 'Roll to summon dice';
+    color: var(--text-dim);
+    font-size: 0.85rem;
+    font-style: italic;
+}
+.dice-tray .die {
+    width: 56px;
+    height: 56px;
+    filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.45));
+    transform-origin: center;
+    will-change: transform;
+    display: block;
+}
+.dice-tray .die.die-num {
+    position: relative;
+    display: inline-block;
+}
+.die-num-face {
+    width: 100%;
+    height: 100%;
+    display: block;
+}
+.die-num-value {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: Georgia, 'Times New Roman', serif;
+    font-weight: 700;
+    font-size: 1.9rem;
+    color: #1a1a2e;
+    line-height: 1;
+    pointer-events: none;
+}
+.die-num-value-md { font-size: 1.5rem; }
+.die-num-value-sm { font-size: 1.1rem; }
+.die-num-value-xs { font-size: 0.85rem; }
+.dice-tray .die-more {
+    padding: 4px 10px;
+    border-radius: 999px;
+    background: var(--accent-soft);
+    color: var(--accent-light);
+    font-size: 0.8rem;
+    font-weight: 600;
+    align-self: center;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    .dice-tray .die.rolling {
+        animation: die-tumble 0.55s cubic-bezier(0.3, 0.6, 0.2, 1);
+    }
+    .dice-tray .die.settled {
+        animation: die-settle 0.25s var(--ease-out);
+    }
+}
+@keyframes die-tumble {
+    0%   { transform: translateY(-12px) rotate(-180deg) scale(0.85); opacity: 0.6; }
+    35%  { transform: translateY(4px)   rotate(-40deg)  scale(1.08); opacity: 1;   }
+    65%  { transform: translateY(-2px)  rotate(20deg)   scale(0.98); }
+    100% { transform: translateY(0)     rotate(0)       scale(1);    }
+}
+@keyframes die-settle {
+    0%   { transform: scale(1.06); }
+    100% { transform: scale(1);    }
+}
+
+/* ---- Random chooser reel ----
+   The window is 132px tall (three 44px rows). The strip translates
+   upward; positioning math in utils.js targets the center row. */
+.reel {
+    position: relative;
+    margin-bottom: var(--space-3);
+    background: radial-gradient(120% 80% at 50% 0%, rgba(88, 101, 242, 0.08) 0%, transparent 70%), var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    overflow: hidden;
+}
+.reel-window {
+    position: relative;
+    height: 132px;
+    overflow: hidden;
+    mask-image: linear-gradient(to bottom, transparent 0, #000 22%, #000 78%, transparent 100%);
+    -webkit-mask-image: linear-gradient(to bottom, transparent 0, #000 22%, #000 78%, transparent 100%);
+}
+.reel-strip {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    will-change: transform;
+    transform: translateY(0);
+}
+.reel-strip:empty::before {
+    content: 'Add options and pick one';
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 132px;
+    color: var(--text-dim);
+    font-size: 0.85rem;
+    font-style: italic;
+}
+.reel-strip li {
+    height: 44px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    color: var(--text-muted);
+    font-weight: 600;
+    font-size: 1rem;
+    padding: 0 var(--space-3);
+    transition: color var(--dur-base) var(--ease-out);
+}
+.reel-strip li.is-winner {
+    color: var(--heading);
+    text-shadow: 0 0 12px rgba(88, 101, 242, 0.6);
+}
+.reel-marker {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 44px;
+    height: 44px;
+    pointer-events: none;
+    border-top: 1px solid var(--accent);
+    border-bottom: 1px solid var(--accent);
+    box-shadow: inset 0 0 24px rgba(88, 101, 242, 0.2);
+}
+
+/* ---- Magic 8-ball ---- */
+.ball-stage {
+    position: relative;
+    width: 180px;
+    height: 180px;
+    margin: 0 auto var(--space-3);
+    transform-origin: center;
+    will-change: transform;
+}
+.ball-img {
+    width: 100%;
+    height: 100%;
+    display: block;
+    filter: drop-shadow(0 8px 16px rgba(0, 0, 0, 0.5));
+}
+.ball-window {
+    position: absolute;
+    left: 50%;
+    top: 64%;
+    transform: translate(-50%, -50%);
+    width: 96px;
+    height: 54px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 0 6px;
+    color: #c8d4ff;
+    font-size: 0.72rem;
+    font-weight: 600;
+    line-height: 1.15;
+    text-shadow: 0 0 6px rgba(120, 160, 255, 0.55);
+    pointer-events: none;
+    transition: opacity var(--dur-base) var(--ease-out);
+}
+.ball-window-text {
+    opacity: 0.9;
+}
+.ball-stage.is-shaking .ball-window { opacity: 0.25; }
+.ball-stage.is-revealed .ball-window-text {
+    animation: ball-reveal var(--dur-slow) var(--ease-out) both;
+}
+.ball-btn {
+    display: block;
+    margin: 0 auto;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    .ball-stage.is-shaking {
+        animation: ball-shake 0.18s ease-in-out 4;
+    }
+}
+@keyframes ball-shake {
+    0%, 100% { transform: translate(0, 0) rotate(0); }
+    25%      { transform: translate(-4px, -2px) rotate(-5deg); }
+    50%      { transform: translate(3px, 2px)  rotate(4deg);  }
+    75%      { transform: translate(-3px, 3px) rotate(-3deg); }
+}
+@keyframes ball-reveal {
+    0%   { opacity: 0; transform: translateY(6px) scale(0.94); }
+    100% { opacity: 1; transform: translateY(0)   scale(1);    }
+}
+
+/* ---- Meme frame ---- */
+.meme-frame {
+    position: relative;
+    margin-bottom: var(--space-3);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    background: var(--bg);
+    min-height: 200px;
+    overflow: hidden;
+}
+.meme-skeleton {
+    position: absolute;
+    inset: 0;
+    background:
+        linear-gradient(90deg, transparent 0%, rgba(255, 255, 255, 0.06) 50%, transparent 100%),
+        var(--border);
+    background-size: 200% 100%, 100% 100%;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity var(--dur-fast) var(--ease-out);
+}
+.meme-frame.is-loading .meme-skeleton {
+    opacity: 1;
+}
+@media (prefers-reduced-motion: no-preference) {
+    .meme-frame.is-loading .meme-skeleton {
+        animation: meme-shimmer 1.2s linear infinite;
+    }
+}
+@keyframes meme-shimmer {
+    0%   { background-position: -100% 0, 0 0; }
+    100% { background-position: 100% 0, 0 0; }
+}
+
 .meme-output {
     display: grid;
     gap: 6px;
+    padding: var(--space-3);
+    background: transparent;
+    border: none;
+    min-height: 200px;
 }
+.meme-frame.is-loading .meme-output { opacity: 0.3; }
 
+.meme-empty {
+    align-self: center;
+    justify-self: center;
+    margin: auto;
+    font-size: 0.9rem;
+    font-style: italic;
+}
 .meme-title a {
     font-weight: 600;
     color: var(--accent);
 }
+.meme-title a:hover { color: var(--accent-light); }
 
 .meme-image {
     max-width: 100%;
@@ -77,4 +334,31 @@
     object-fit: contain;
     border-radius: var(--radius-sm);
     background: var(--border);
+    opacity: 0;
+}
+.meme-image.is-loaded {
+    animation: meme-fadein var(--dur-base) var(--ease-out) forwards;
+}
+@keyframes meme-fadein {
+    from { opacity: 0; transform: translateY(4px); }
+    to   { opacity: 1; transform: translateY(0);   }
+}
+
+.meme-reroll {
+    align-self: flex-start;
+}
+.meme-reroll[hidden] { display: none; }
+
+/* ---- Responsive ---- */
+@media (max-width: 480px) {
+    .ball-stage { width: 150px; height: 150px; }
+    .ball-window { width: 80px; height: 46px; font-size: 0.66rem; }
+    .dice-tray .die { width: 48px; height: 48px; }
+    .reel-window { height: 120px; }
+}
+
+@media (max-width: 380px) {
+    .ball-stage { width: 132px; height: 132px; }
+    .ball-window { width: 70px; height: 40px; font-size: 0.6rem; }
+    .dice-tray .die { width: 44px; height: 44px; }
 }

--- a/web/src/main/resources/static/images/utils/8ball.svg
+++ b/web/src/main/resources/static/images/utils/8ball.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" role="img" aria-label="Magic 8-ball">
+  <defs>
+    <radialGradient id="ball-body" cx="35%" cy="30%" r="80%">
+      <stop offset="0%" stop-color="#3a3a4e"/>
+      <stop offset="55%" stop-color="#15151c"/>
+      <stop offset="100%" stop-color="#050507"/>
+    </radialGradient>
+    <radialGradient id="ball-shine" cx="32%" cy="26%" r="22%">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.55)"/>
+      <stop offset="100%" stop-color="rgba(255,255,255,0)"/>
+    </radialGradient>
+    <radialGradient id="window-bg" cx="50%" cy="55%" r="65%">
+      <stop offset="0%" stop-color="#1f3a8a"/>
+      <stop offset="100%" stop-color="#0a1233"/>
+    </radialGradient>
+  </defs>
+  <circle cx="100" cy="100" r="96" fill="url(#ball-body)"/>
+  <circle cx="100" cy="100" r="96" fill="url(#ball-shine)"/>
+  <circle cx="100" cy="58" r="26" fill="#ffffff"/>
+  <text x="100" y="58" text-anchor="middle" dominant-baseline="central"
+        font-family="Georgia, 'Times New Roman', serif" font-weight="700"
+        font-size="32" fill="#111">8</text>
+  <polygon points="100,86 158,150 42,150" fill="url(#window-bg)" opacity="0.92"/>
+  <polygon points="100,86 158,150 42,150" fill="none"
+           stroke="rgba(255,255,255,0.18)" stroke-width="1.5"/>
+</svg>

--- a/web/src/main/resources/static/images/utils/d6-1.svg
+++ b/web/src/main/resources/static/images/utils/d6-1.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" role="img" aria-label="Die showing 1">
+  <defs>
+    <linearGradient id="d6f-1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ffffff"/>
+      <stop offset="100%" stop-color="#d6d8e0"/>
+    </linearGradient>
+  </defs>
+  <rect x="4" y="4" width="92" height="92" rx="18" fill="url(#d6f-1)"
+        stroke="#1a1a2e" stroke-width="2"/>
+  <circle cx="50" cy="50" r="9" fill="#1a1a2e"/>
+</svg>

--- a/web/src/main/resources/static/images/utils/d6-2.svg
+++ b/web/src/main/resources/static/images/utils/d6-2.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" role="img" aria-label="Die showing 2">
+  <defs>
+    <linearGradient id="d6f-2" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ffffff"/>
+      <stop offset="100%" stop-color="#d6d8e0"/>
+    </linearGradient>
+  </defs>
+  <rect x="4" y="4" width="92" height="92" rx="18" fill="url(#d6f-2)"
+        stroke="#1a1a2e" stroke-width="2"/>
+  <circle cx="30" cy="30" r="8" fill="#1a1a2e"/>
+  <circle cx="70" cy="70" r="8" fill="#1a1a2e"/>
+</svg>

--- a/web/src/main/resources/static/images/utils/d6-3.svg
+++ b/web/src/main/resources/static/images/utils/d6-3.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" role="img" aria-label="Die showing 3">
+  <defs>
+    <linearGradient id="d6f-3" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ffffff"/>
+      <stop offset="100%" stop-color="#d6d8e0"/>
+    </linearGradient>
+  </defs>
+  <rect x="4" y="4" width="92" height="92" rx="18" fill="url(#d6f-3)"
+        stroke="#1a1a2e" stroke-width="2"/>
+  <circle cx="28" cy="28" r="8" fill="#1a1a2e"/>
+  <circle cx="50" cy="50" r="8" fill="#1a1a2e"/>
+  <circle cx="72" cy="72" r="8" fill="#1a1a2e"/>
+</svg>

--- a/web/src/main/resources/static/images/utils/d6-4.svg
+++ b/web/src/main/resources/static/images/utils/d6-4.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" role="img" aria-label="Die showing 4">
+  <defs>
+    <linearGradient id="d6f-4" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ffffff"/>
+      <stop offset="100%" stop-color="#d6d8e0"/>
+    </linearGradient>
+  </defs>
+  <rect x="4" y="4" width="92" height="92" rx="18" fill="url(#d6f-4)"
+        stroke="#1a1a2e" stroke-width="2"/>
+  <circle cx="30" cy="30" r="8" fill="#1a1a2e"/>
+  <circle cx="70" cy="30" r="8" fill="#1a1a2e"/>
+  <circle cx="30" cy="70" r="8" fill="#1a1a2e"/>
+  <circle cx="70" cy="70" r="8" fill="#1a1a2e"/>
+</svg>

--- a/web/src/main/resources/static/images/utils/d6-5.svg
+++ b/web/src/main/resources/static/images/utils/d6-5.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" role="img" aria-label="Die showing 5">
+  <defs>
+    <linearGradient id="d6f-5" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ffffff"/>
+      <stop offset="100%" stop-color="#d6d8e0"/>
+    </linearGradient>
+  </defs>
+  <rect x="4" y="4" width="92" height="92" rx="18" fill="url(#d6f-5)"
+        stroke="#1a1a2e" stroke-width="2"/>
+  <circle cx="28" cy="28" r="8" fill="#1a1a2e"/>
+  <circle cx="72" cy="28" r="8" fill="#1a1a2e"/>
+  <circle cx="50" cy="50" r="8" fill="#1a1a2e"/>
+  <circle cx="28" cy="72" r="8" fill="#1a1a2e"/>
+  <circle cx="72" cy="72" r="8" fill="#1a1a2e"/>
+</svg>

--- a/web/src/main/resources/static/images/utils/d6-6.svg
+++ b/web/src/main/resources/static/images/utils/d6-6.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" role="img" aria-label="Die showing 6">
+  <defs>
+    <linearGradient id="d6f-6" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ffffff"/>
+      <stop offset="100%" stop-color="#d6d8e0"/>
+    </linearGradient>
+  </defs>
+  <rect x="4" y="4" width="92" height="92" rx="18" fill="url(#d6f-6)"
+        stroke="#1a1a2e" stroke-width="2"/>
+  <circle cx="30" cy="25" r="7.5" fill="#1a1a2e"/>
+  <circle cx="70" cy="25" r="7.5" fill="#1a1a2e"/>
+  <circle cx="30" cy="50" r="7.5" fill="#1a1a2e"/>
+  <circle cx="70" cy="50" r="7.5" fill="#1a1a2e"/>
+  <circle cx="30" cy="75" r="7.5" fill="#1a1a2e"/>
+  <circle cx="70" cy="75" r="7.5" fill="#1a1a2e"/>
+</svg>

--- a/web/src/main/resources/static/images/utils/die-num.svg
+++ b/web/src/main/resources/static/images/utils/die-num.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" role="img" aria-label="Numbered die">
+  <defs>
+    <linearGradient id="die-num-face" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ffffff"/>
+      <stop offset="100%" stop-color="#d6d8e0"/>
+    </linearGradient>
+  </defs>
+  <rect x="4" y="4" width="92" height="92" rx="18" fill="url(#die-num-face)"
+        stroke="#1a1a2e" stroke-width="2"/>
+</svg>

--- a/web/src/main/resources/static/js/utils.js
+++ b/web/src/main/resources/static/js/utils.js
@@ -15,6 +15,10 @@
         return document.querySelector('[data-output="' + name + '"]');
     }
 
+    function stage(name) {
+        return document.querySelector('[data-stage="' + name + '"]');
+    }
+
     function fetchJson(url) {
         return fetch(url, { credentials: 'same-origin', headers: { 'Accept': 'application/json' } })
             .then(function (r) {
@@ -28,7 +32,44 @@
         return 1 + Math.floor(Math.random() * maxInclusive);
     }
 
+    const reducedMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
     // --- Dice roller ---
+    const MAX_VISIBLE_DICE = 24;
+
+    function makeDie(sides, value) {
+        if (sides === 6 && value >= 1 && value <= 6) {
+            const img = document.createElement('img');
+            img.className = 'die';
+            img.alt = 'Die showing ' + value;
+            img.decoding = 'async';
+            img.src = '/images/utils/d6-' + value + '.svg';
+            return img;
+        }
+        // Numbered die: shared SVG body with the value overlaid via CSS so
+        // we don't have to refetch & rewrite the SVG per roll.
+        const wrap = document.createElement('span');
+        wrap.className = 'die die-num';
+        wrap.setAttribute('role', 'img');
+        wrap.setAttribute('aria-label', 'Die showing ' + value);
+        const face = document.createElement('img');
+        face.src = '/images/utils/die-num.svg';
+        face.alt = '';
+        face.decoding = 'async';
+        face.className = 'die-num-face';
+        const numEl = document.createElement('span');
+        numEl.className = 'die-num-value';
+        numEl.textContent = String(value);
+        // Shrink the digit slot for very large values so it always fits.
+        const digits = String(value).length;
+        if (digits >= 4) numEl.classList.add('die-num-value-xs');
+        else if (digits === 3) numEl.classList.add('die-num-value-sm');
+        else if (digits === 2) numEl.classList.add('die-num-value-md');
+        wrap.appendChild(face);
+        wrap.appendChild(numEl);
+        return wrap;
+    }
+
     const diceForm = document.querySelector('[data-form="dice"]');
     if (diceForm) {
         diceForm.addEventListener('submit', e => {
@@ -53,6 +94,30 @@
             }
             const grand = total + modifier;
             const label = count + 'd' + sides + (modifier ? (modifier > 0 ? ' + ' + modifier : ' - ' + Math.abs(modifier)) : '');
+
+            const tray = stage('dice');
+            tray.innerHTML = '';
+            const visible = Math.min(rolls.length, MAX_VISIBLE_DICE);
+            for (let i = 0; i < visible; i++) {
+                const die = makeDie(sides, rolls[i]);
+                if (!reducedMotion) {
+                    die.classList.add('rolling');
+                    die.style.animationDelay = (i * 40) + 'ms';
+                    die.addEventListener('animationend', function onEnd() {
+                        die.removeEventListener('animationend', onEnd);
+                        die.classList.remove('rolling');
+                        die.classList.add('settled');
+                    }, { once: true });
+                }
+                tray.appendChild(die);
+            }
+            if (rolls.length > MAX_VISIBLE_DICE) {
+                const more = document.createElement('span');
+                more.className = 'die-more';
+                more.textContent = '+' + (rolls.length - MAX_VISIBLE_DICE) + ' more';
+                tray.appendChild(more);
+            }
+
             output('dice').textContent =
                 label + '\nRolls: [' + rolls.join(', ') + ']\nSum: ' + total +
                 (modifier ? '\nWith modifier: ' + grand : '');
@@ -60,6 +125,9 @@
     }
 
     // --- Random chooser ---
+    const REEL_ROW_HEIGHT = 44;
+    const REEL_REPEATS = 8;
+
     const randomForm = document.querySelector('[data-form="random"]');
     if (randomForm) {
         randomForm.addEventListener('submit', e => {
@@ -70,7 +138,53 @@
                 toast('Provide at least one option.', 'error');
                 return;
             }
-            const pick = items[Math.floor(Math.random() * items.length)];
+            const pickIndex = Math.floor(Math.random() * items.length);
+            const pick = items[pickIndex];
+
+            const reelStage = stage('random');
+            const strip = reelStage.querySelector('.reel-strip');
+            strip.innerHTML = '';
+            strip.style.transition = 'none';
+            strip.style.transform = 'translateY(0)';
+
+            // Build a strip several rotations long so the spin has runway.
+            // Land on the LAST occurrence of the winner so users see scrolling
+            // before it settles.
+            const stripItems = [];
+            for (let r = 0; r < REEL_REPEATS; r++) {
+                for (let i = 0; i < items.length; i++) {
+                    stripItems.push(items[i]);
+                }
+            }
+            const winnerStripIndex = stripItems.length - items.length + pickIndex;
+
+            stripItems.forEach((label, idx) => {
+                const li = document.createElement('li');
+                li.textContent = label;
+                if (idx === winnerStripIndex) {
+                    li.dataset.winner = 'true';
+                }
+                strip.appendChild(li);
+            });
+
+            // Force a reflow so the next transform animates.
+            void strip.offsetHeight;
+
+            const targetY = -((winnerStripIndex - 1) * REEL_ROW_HEIGHT);
+            if (reducedMotion) {
+                strip.style.transform = 'translateY(' + targetY + 'px)';
+                const winner = strip.querySelector('[data-winner="true"]');
+                if (winner) winner.classList.add('is-winner');
+            } else {
+                strip.style.transition = 'transform 1200ms cubic-bezier(0.18, 0.7, 0.2, 1)';
+                strip.style.transform = 'translateY(' + targetY + 'px)';
+                strip.addEventListener('transitionend', function onDone() {
+                    strip.removeEventListener('transitionend', onDone);
+                    const winner = strip.querySelector('[data-winner="true"]');
+                    if (winner) winner.classList.add('is-winner');
+                }, { once: true });
+            }
+
             output('random').textContent = '> ' + pick;
         });
     }
@@ -100,63 +214,129 @@
     ];
 
     const eightballBtn = document.querySelector('[data-action="eightball"]');
-    if (eightballBtn) {
-        eightballBtn.addEventListener('click', () => {
+    const ballStage = stage('eightball');
+    if (eightballBtn && ballStage) {
+        const windowEl = ballStage.querySelector('.ball-window');
+        const textEl = ballStage.querySelector('.ball-window-text');
+
+        function revealAnswer() {
             const choice = EIGHTBALL_RESPONSES[Math.floor(Math.random() * EIGHTBALL_RESPONSES.length)];
-            output('eightball').textContent = 'MAGIC 8-BALL SAYS: ' + choice + '.';
+            textEl.textContent = choice;
+            windowEl.setAttribute('aria-label', 'Magic 8-ball window: ' + choice);
+            ballStage.classList.remove('is-revealed');
+            void ballStage.offsetWidth;
+            ballStage.classList.add('is-revealed');
+            eightballBtn.disabled = false;
+        }
+
+        eightballBtn.addEventListener('click', () => {
+            if (eightballBtn.disabled) return;
+            eightballBtn.disabled = true;
+            ballStage.classList.remove('is-revealed');
+            if (reducedMotion) {
+                revealAnswer();
+                return;
+            }
+            ballStage.classList.add('is-shaking');
+            ballStage.addEventListener('animationend', function onShake() {
+                ballStage.removeEventListener('animationend', onShake);
+                ballStage.classList.remove('is-shaking');
+                revealAnswer();
+            }, { once: true });
         });
     }
 
     // --- Meme fetcher ---
     const memeForm = document.querySelector('[data-form="meme"]');
-    if (memeForm) {
+    const memeFrame = stage('meme');
+    const memeReroll = document.querySelector('[data-action="meme-reroll"]');
+
+    function renderMeme(data) {
+        const slot = output('meme');
+        slot.innerHTML = '';
+        const title = document.createElement('div');
+        title.className = 'meme-title';
+        const link = document.createElement('a');
+        link.href = data.permalink;
+        link.target = '_blank';
+        link.rel = 'noopener';
+        link.textContent = data.title;
+        title.appendChild(link);
+        const author = document.createElement('div');
+        author.className = 'muted';
+        author.textContent = 'by u/' + data.author + ' in r/' + data.subreddit;
+        const img = document.createElement('img');
+        img.alt = data.title;
+        img.className = 'meme-image';
+        img.loading = 'lazy';
+        img.addEventListener('load', () => img.classList.add('is-loaded'), { once: true });
+        img.addEventListener('error', () => {
+            img.classList.add('is-loaded');
+            img.alt = 'Image failed to load';
+        }, { once: true });
+        img.src = data.imageUrl;
+        slot.appendChild(title);
+        slot.appendChild(author);
+        slot.appendChild(img);
+    }
+
+    function renderMemeError(msg) {
+        const slot = output('meme');
+        slot.innerHTML = '';
+        const p = document.createElement('p');
+        p.className = 'meme-empty';
+        p.textContent = msg;
+        slot.appendChild(p);
+    }
+
+    function fetchMeme(submitButton) {
+        const subreddit = memeForm.elements.subreddit.value.trim();
+        const timePeriod = memeForm.elements.timePeriod.value;
+        const limit = parseInt(memeForm.elements.limit.value, 10) || 10;
+        if (!subreddit) {
+            toast('Subreddit is required.', 'error');
+            return;
+        }
+        submitButton.disabled = true;
+        if (memeReroll) memeReroll.disabled = true;
+        memeFrame.classList.add('is-loading');
+        const params = new URLSearchParams({
+            subreddit: subreddit,
+            timePeriod: timePeriod,
+            limit: String(limit)
+        });
+        fetchJson('/utils/api/meme?' + params.toString())
+            .then(r => {
+                submitButton.disabled = false;
+                if (memeReroll) memeReroll.disabled = false;
+                memeFrame.classList.remove('is-loading');
+                if (r && r.ok && r.meme) {
+                    renderMeme(r.meme);
+                    if (memeReroll) memeReroll.hidden = false;
+                } else {
+                    const msg = (r && r.error) || 'Could not fetch meme.';
+                    renderMemeError(msg);
+                    toast(msg, 'error');
+                }
+            })
+            .catch(() => {
+                submitButton.disabled = false;
+                if (memeReroll) memeReroll.disabled = false;
+                memeFrame.classList.remove('is-loading');
+                renderMemeError('Network error.');
+                toast('Network error.', 'error');
+            });
+    }
+
+    if (memeForm && memeFrame) {
         memeForm.addEventListener('submit', e => {
             e.preventDefault();
-            const subreddit = memeForm.elements.subreddit.value.trim();
-            const timePeriod = memeForm.elements.timePeriod.value;
-            const limit = parseInt(memeForm.elements.limit.value, 10) || 10;
-            if (!subreddit) {
-                toast('Subreddit is required.', 'error');
-                return;
-            }
-            const submit = memeForm.querySelector('button[type="submit"]');
-            submit.disabled = true;
-            const params = new URLSearchParams({
-                subreddit: subreddit,
-                timePeriod: timePeriod,
-                limit: String(limit)
-            });
-            fetchJson('/utils/api/meme?' + params.toString())
-                .then(r => {
-                    submit.disabled = false;
-                    const slot = output('meme');
-                    if (r && r.ok && r.meme) {
-                        slot.innerHTML = '';
-                        const title = document.createElement('div');
-                        title.className = 'meme-title';
-                        const link = document.createElement('a');
-                        link.href = r.meme.permalink;
-                        link.target = '_blank';
-                        link.rel = 'noopener';
-                        link.textContent = r.meme.title;
-                        title.appendChild(link);
-                        const author = document.createElement('div');
-                        author.className = 'muted';
-                        author.textContent = 'by u/' + r.meme.author + ' in r/' + r.meme.subreddit;
-                        const img = document.createElement('img');
-                        img.src = r.meme.imageUrl;
-                        img.alt = r.meme.title;
-                        img.className = 'meme-image';
-                        img.loading = 'lazy';
-                        slot.appendChild(title);
-                        slot.appendChild(author);
-                        slot.appendChild(img);
-                    } else {
-                        slot.textContent = r?.error || 'Could not fetch meme.';
-                        toast(r?.error || 'Could not fetch meme.', 'error');
-                    }
-                })
-                .catch(() => { submit.disabled = false; toast('Network error.', 'error'); });
+            fetchMeme(memeForm.querySelector('button[type="submit"]'));
         });
+        if (memeReroll) {
+            memeReroll.addEventListener('click', () => {
+                fetchMeme(memeForm.querySelector('button[type="submit"]'));
+            });
+        }
     }
 })();

--- a/web/src/main/resources/templates/utils.html
+++ b/web/src/main/resources/templates/utils.html
@@ -29,6 +29,7 @@
                 </label>
                 <button type="submit" class="btn">Roll</button>
             </form>
+            <div class="dice-tray" data-stage="dice" aria-hidden="true"></div>
             <pre class="util-output" data-output="dice" aria-live="polite"></pre>
         </section>
 
@@ -41,14 +42,25 @@
                 </label>
                 <button type="submit" class="btn">Pick one</button>
             </form>
+            <div class="reel" data-stage="random" aria-hidden="true">
+                <div class="reel-window">
+                    <ul class="reel-strip"></ul>
+                </div>
+                <div class="reel-marker" aria-hidden="true"></div>
+            </div>
             <pre class="util-output" data-output="random" aria-live="polite"></pre>
         </section>
 
         <section class="util-card" data-util="eightball">
             <h2>Magic 8-ball</h2>
             <p class="muted">Equivalent to <code>/8ball</code>.</p>
-            <button type="button" class="btn" data-action="eightball">Ask the ball</button>
-            <pre class="util-output" data-output="eightball" aria-live="polite"></pre>
+            <div class="ball-stage" data-stage="eightball">
+                <img class="ball-img" src="/images/utils/8ball.svg" alt="" aria-hidden="true">
+                <div class="ball-window" data-output="eightball" aria-live="polite">
+                    <span class="ball-window-text">Ask a question…</span>
+                </div>
+            </div>
+            <button type="button" class="btn ball-btn" data-action="eightball">Shake the ball</button>
         </section>
 
         <section class="util-card" data-util="meme">
@@ -71,7 +83,13 @@
                 </label>
                 <button type="submit" class="btn">Fetch meme</button>
             </form>
-            <div class="util-output meme-output" data-output="meme" aria-live="polite"></div>
+            <div class="meme-frame" data-stage="meme">
+                <div class="meme-skeleton" aria-hidden="true"></div>
+                <div class="util-output meme-output" data-output="meme" aria-live="polite">
+                    <p class="meme-empty muted">No meme yet — pick a subreddit and hit fetch.</p>
+                </div>
+            </div>
+            <button type="button" class="btn btn-secondary meme-reroll" data-action="meme-reroll" hidden>Re-roll</button>
         </section>
     </div>
 </main>


### PR DESCRIPTION
## Summary

The `/utils` page used to be plain forms with a `<pre>` printing the
answer in monospace text. Every utility now mirrors the thing it does:

- **Magic 8-ball** — a real ball that shakes for ~700 ms, then fades the
  answer into the triangular window.
- **Dice roller** — classic pip-faced d6s (six static SVGs) for 6-sided
  rolls; rounded numbered die for everything else. Dice tumble in,
  staggered, and settle. >24 dice collapse to "+N more" while the text
  output still lists every roll.
- **Random chooser** — slot-machine reel that scrolls past the options
  and lands on the winner, highlighted in the accent glow.
- **Reddit meme** — shimmer skeleton during fetch, image fades in once
  loaded, optional "Re-roll" button so you don't have to re-type the
  subreddit.

Backend untouched — same `/utils/api/meme` endpoint, same client RNG,
same `EIGHTBALL_RESPONSES` list. All animations respect
`prefers-reduced-motion`.

### Files
- New: `static/images/utils/{8ball.svg, d6-1..6.svg, die-num.svg}`
- Edited: `templates/utils.html`, `static/css/utils.css`, `static/js/utils.js`

## Test plan
- [x] `node --check` on the rewritten `utils.js`
- [x] `npx stylelint static/css/utils.css` — clean
- [x] `npx jest` — all 623 existing tests still pass
- [x] jsdom smoke test: dice / random / 8-ball handlers all dispatch
      without errors and produce the expected DOM output
- [x] Playwright visual render at 1280×900 and 380×800: pristine state,
      6d6 pips, 30d6 with "+more" pill, 1d20 numbered die, random reel
      landing on winner, 8-ball revealing answer
- [ ] Boot the real Spring app once a reviewer has a clone with
      Discord/DB creds — `./gradlew :web:bootRun`, hit `/utils`, exercise
      each card

---
_Generated by [Claude Code](https://claude.ai/code/session_012Cc54jqj96KhVqNToEuU1B)_