### PR TITLE
refactor(common): lift remaining engine dirs into casino/ and pvp/ parents

### DIFF
--- a/common/src/main/kotlin/common/casino/blackjack/Blackjack.kt
+++ b/common/src/main/kotlin/common/casino/blackjack/Blackjack.kt
@@ -1,8 +1,12 @@
-package common.blackjack
+package common.casino.blackjack
 
 import common.card.Card
 import common.card.Deck
 import kotlin.random.Random
+import common.casino.blackjack.bestTotal
+import common.casino.blackjack.isBlackjack
+import common.casino.blackjack.isBust
+import common.casino.blackjack.isSoft
 
 /**
  * Pure-logic blackjack primitives. No Spring, no DB, no JDA — just the

--- a/common/src/main/kotlin/common/casino/blackjack/BlackjackHand.kt
+++ b/common/src/main/kotlin/common/casino/blackjack/BlackjackHand.kt
@@ -1,4 +1,4 @@
-package common.blackjack
+package common.casino.blackjack
 
 import common.card.Card
 import common.card.Rank

--- a/common/src/main/kotlin/common/casino/blackjack/BlackjackTable.kt
+++ b/common/src/main/kotlin/common/casino/blackjack/BlackjackTable.kt
@@ -1,8 +1,9 @@
-package common.blackjack
+package common.casino.blackjack
 
 import common.card.Card
 import common.card.Deck
 import java.time.Instant
+import common.casino.blackjack.Blackjack
 
 /**
  * Mutable state of a single blackjack table — used for both the SOLO
@@ -10,7 +11,7 @@ import java.time.Instant
  * inside a monitor on the table object (see [BlackjackTableRegistry.lockTable])
  * so concurrent button clicks serialise around the hand state.
  *
- * Like [common.poker.PokerTable], chips on each [Seat] are escrow:
+ * Like [common.casino.poker.PokerTable], chips on each [Seat] are escrow:
  * the player's `socialCredit` was debited at deal/buy-in time; nothing
  * else touches it until the hand resolves and the seat is paid out
  * (or evicted on idle).

--- a/common/src/main/kotlin/common/casino/casinoholdem/CasinoHoldem.kt
+++ b/common/src/main/kotlin/common/casino/casinoholdem/CasinoHoldem.kt
@@ -1,9 +1,10 @@
-package common.poker
+package common.casino.casinoholdem
 
 import common.card.Card
 import common.card.Deck
 import common.card.Rank
 import kotlin.random.Random
+import common.casino.poker.HandEvaluator
 
 /**
  * Pure-logic Casino Hold'em — the standard casino table variant of

--- a/common/src/main/kotlin/common/casino/casinoholdem/CasinoHoldemTable.kt
+++ b/common/src/main/kotlin/common/casino/casinoholdem/CasinoHoldemTable.kt
@@ -1,13 +1,14 @@
-package common.poker
+package common.casino.casinoholdem
 
 import common.card.Card
 import common.card.Deck
 import java.time.Instant
+import common.casino.casinoholdem.CasinoHoldem
 
 /**
  * Mutable state of a single Casino Hold'em table. One table per active
  * hand — there's no lobby phase or multi-seat support, so the layout is
- * deliberately flatter than [common.blackjack.BlackjackTable] /
+ * deliberately flatter than [common.casino.blackjack.BlackjackTable] /
  * [PokerTable].
  *
  * All mutations happen inside a monitor on the table object (see

--- a/common/src/main/kotlin/common/casino/poker/HandEvaluator.kt
+++ b/common/src/main/kotlin/common/casino/poker/HandEvaluator.kt
@@ -1,4 +1,4 @@
-package common.poker
+package common.casino.poker
 
 import common.card.Card
 import common.card.Rank

--- a/common/src/main/kotlin/common/casino/poker/PokerEngine.kt
+++ b/common/src/main/kotlin/common/casino/poker/PokerEngine.kt
@@ -1,11 +1,13 @@
-package common.poker
+package common.casino.poker
 
 import common.card.Card
 import common.card.Deck
-import common.poker.PokerTable.Phase
-import common.poker.PokerTable.SeatStatus
+import common.casino.poker.PokerTable.Phase
+import common.casino.poker.PokerTable.SeatStatus
 import java.time.Instant
 import kotlin.random.Random
+import common.casino.poker.HandEvaluator
+import common.casino.poker.PokerTable
 
 /**
  * Pure state-machine over [PokerTable]. Mutates the table in place but

--- a/common/src/main/kotlin/common/casino/poker/PokerTable.kt
+++ b/common/src/main/kotlin/common/casino/poker/PokerTable.kt
@@ -1,4 +1,4 @@
-package common.poker
+package common.casino.poker
 
 import common.card.Card
 import common.card.Deck

--- a/common/src/main/kotlin/common/events/casino/blackjack/BlackjackNaturalEvent.kt
+++ b/common/src/main/kotlin/common/events/casino/blackjack/BlackjackNaturalEvent.kt
@@ -2,7 +2,7 @@ package common.events.casino.blackjack
 
 /**
  * Fact emitted by `BlackjackService` whenever a player slot resolves to
- * [common.blackjack.Blackjack.Result.PLAYER_BLACKJACK]. That result is
+ * [common.casino.blackjack.Blackjack.Result.PLAYER_BLACKJACK]. That result is
  * only produced by `evaluate()` on a two-card hand, so it always means a
  * natural-on-the-deal win (not a 21 reached after a hit, and not a
  * split-hand 21 — both of which return PLAYER_WIN instead).

--- a/common/src/main/kotlin/common/pvp/connect4/Connect4Engine.kt
+++ b/common/src/main/kotlin/common/pvp/connect4/Connect4Engine.kt
@@ -1,4 +1,4 @@
-package common.connect4
+package common.pvp.connect4
 
 /**
  * Pure logic for 7×6 Connect 4 outcomes. No JDA / Spring / DB —

--- a/common/src/main/kotlin/common/pvp/rps/RpsEngine.kt
+++ b/common/src/main/kotlin/common/pvp/rps/RpsEngine.kt
@@ -1,4 +1,4 @@
-package common.rps
+package common.pvp.rps
 
 /**
  * Pure logic for Rock-Paper-Scissors outcomes. No JDA / Spring / DB —

--- a/common/src/main/kotlin/common/pvp/tictactoe/TicTacToeEngine.kt
+++ b/common/src/main/kotlin/common/pvp/tictactoe/TicTacToeEngine.kt
@@ -1,4 +1,4 @@
-package common.tictactoe
+package common.pvp.tictactoe
 
 /**
  * Pure logic for 3×3 Tic-Tac-Toe outcomes. No JDA / Spring / DB —

--- a/common/src/test/kotlin/common/casino/blackjack/BlackjackHandTest.kt
+++ b/common/src/test/kotlin/common/casino/blackjack/BlackjackHandTest.kt
@@ -1,4 +1,4 @@
-package common.blackjack
+package common.casino.blackjack
 
 import common.card.Card
 import common.card.Rank
@@ -7,6 +7,11 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import common.casino.blackjack.bestTotal
+import common.casino.blackjack.canSplit
+import common.casino.blackjack.isBlackjack
+import common.casino.blackjack.isBust
+import common.casino.blackjack.isSoft
 
 class BlackjackHandTest {
 

--- a/common/src/test/kotlin/common/casino/blackjack/BlackjackTest.kt
+++ b/common/src/test/kotlin/common/casino/blackjack/BlackjackTest.kt
@@ -1,4 +1,4 @@
-package common.blackjack
+package common.casino.blackjack
 
 import common.card.Card
 import common.card.Deck
@@ -9,6 +9,11 @@ import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import kotlin.random.Random
+import common.casino.blackjack.Blackjack
+import common.casino.blackjack.bestTotal
+import common.casino.blackjack.blackjackValues
+import common.casino.blackjack.isBlackjack
+import common.casino.blackjack.isBust
 
 class BlackjackTest {
 

--- a/common/src/test/kotlin/common/casino/casinoholdem/CasinoHoldemTest.kt
+++ b/common/src/test/kotlin/common/casino/casinoholdem/CasinoHoldemTest.kt
@@ -1,4 +1,4 @@
-package common.poker
+package common.casino.casinoholdem
 
 import common.card.Card
 import common.card.Deck
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import kotlin.random.Random
+import common.casino.casinoholdem.CasinoHoldem
+import common.casino.poker.HandEvaluator
 
 class CasinoHoldemTest {
 

--- a/common/src/test/kotlin/common/casino/poker/HandEvaluatorTest.kt
+++ b/common/src/test/kotlin/common/casino/poker/HandEvaluatorTest.kt
@@ -1,12 +1,13 @@
-package common.poker
+package common.casino.poker
 
 import common.card.Card
 import common.card.Rank
 import common.card.Suit
-import common.poker.HandEvaluator.Category
+import common.casino.poker.HandEvaluator.Category
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import common.casino.poker.HandEvaluator
 
 class HandEvaluatorTest {
 

--- a/common/src/test/kotlin/common/casino/poker/PokerEngineTest.kt
+++ b/common/src/test/kotlin/common/casino/poker/PokerEngineTest.kt
@@ -1,11 +1,11 @@
-package common.poker
+package common.casino.poker
 
 import common.card.Card
 import common.card.Rank
 import common.card.Suit
-import common.poker.PokerEngine.PokerAction
-import common.poker.PokerTable.Phase
-import common.poker.PokerTable.SeatStatus
+import common.casino.poker.PokerEngine.PokerAction
+import common.casino.poker.PokerTable.Phase
+import common.casino.poker.PokerTable.SeatStatus
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
@@ -13,6 +13,8 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.time.Instant
 import kotlin.random.Random
+import common.casino.poker.PokerEngine
+import common.casino.poker.PokerTable
 
 class PokerEngineTest {
 

--- a/common/src/test/kotlin/common/poker/PokerEngineSidePotTest.kt
+++ b/common/src/test/kotlin/common/poker/PokerEngineSidePotTest.kt
@@ -3,14 +3,16 @@ package common.poker
 import common.card.Card
 import common.card.Rank
 import common.card.Suit
-import common.poker.PokerTable.Phase
-import common.poker.PokerTable.SeatStatus
+import common.casino.poker.PokerTable.Phase
+import common.casino.poker.PokerTable.SeatStatus
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.time.Instant
 import kotlin.random.Random
+import common.casino.poker.PokerEngine
+import common.casino.poker.PokerTable
 
 /**
  * Multi-tier side-pot resolution. Drives [PokerEngine.resolveHand]

--- a/common/src/test/kotlin/common/pvp/connect4/Connect4EngineTest.kt
+++ b/common/src/test/kotlin/common/pvp/connect4/Connect4EngineTest.kt
@@ -1,10 +1,11 @@
-package common.connect4
+package common.pvp.connect4
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import common.pvp.connect4.Connect4Engine
 
 /**
  * Truth table for [Connect4Engine]. Pure-function unit tests — no

--- a/common/src/test/kotlin/common/pvp/rps/RpsEngineTest.kt
+++ b/common/src/test/kotlin/common/pvp/rps/RpsEngineTest.kt
@@ -1,7 +1,8 @@
-package common.rps
+package common.pvp.rps
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import common.pvp.rps.RpsEngine
 
 /**
  * Truth table for [RpsEngine.resolve]. Pure-function unit tests — no

--- a/common/src/test/kotlin/common/pvp/tictactoe/TicTacToeEngineTest.kt
+++ b/common/src/test/kotlin/common/pvp/tictactoe/TicTacToeEngineTest.kt
@@ -1,10 +1,11 @@
-package common.tictactoe
+package common.pvp.tictactoe
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import common.pvp.tictactoe.TicTacToeEngine
 
 /**
  * Truth table for [TicTacToeEngine]. Pure-function unit tests — no

--- a/database/src/main/kotlin/database/blackjack/BlackjackTableRegistry.kt
+++ b/database/src/main/kotlin/database/blackjack/BlackjackTableRegistry.kt
@@ -1,6 +1,6 @@
 package database.blackjack
 
-import common.blackjack.BlackjackTable
+import common.casino.blackjack.BlackjackTable
 import database.configuration.RegistryScheduler
 import org.springframework.stereotype.Component
 import java.time.Duration

--- a/database/src/main/kotlin/database/connect4/Connect4SessionRegistry.kt
+++ b/database/src/main/kotlin/database/connect4/Connect4SessionRegistry.kt
@@ -1,6 +1,6 @@
 package database.connect4
 
-import common.connect4.Connect4Engine
+import common.pvp.connect4.Connect4Engine
 import database.boardgame.TurnBasedBoardSessionRegistry
 import database.configuration.RegistryScheduler
 import database.pvp.PvpSessionRegistry

--- a/database/src/main/kotlin/database/poker/CasinoHoldemTableRegistry.kt
+++ b/database/src/main/kotlin/database/poker/CasinoHoldemTableRegistry.kt
@@ -1,7 +1,7 @@
 package database.poker
 
-import common.poker.CasinoHoldem
-import common.poker.CasinoHoldemTable
+import common.casino.casinoholdem.CasinoHoldem
+import common.casino.casinoholdem.CasinoHoldemTable
 import database.configuration.RegistryScheduler
 import org.springframework.stereotype.Component
 import java.time.Duration

--- a/database/src/main/kotlin/database/poker/PokerTableRegistry.kt
+++ b/database/src/main/kotlin/database/poker/PokerTableRegistry.kt
@@ -1,6 +1,6 @@
 package database.poker
 
-import common.poker.PokerTable
+import common.casino.poker.PokerTable
 import database.configuration.RegistryScheduler
 import org.springframework.stereotype.Component
 import java.time.Duration

--- a/database/src/main/kotlin/database/rps/RpsSessionRegistry.kt
+++ b/database/src/main/kotlin/database/rps/RpsSessionRegistry.kt
@@ -1,6 +1,6 @@
 package database.rps
 
-import common.rps.RpsEngine
+import common.pvp.rps.RpsEngine
 import database.configuration.RegistryScheduler
 import database.pvp.PvpSessionRegistry
 import org.springframework.stereotype.Component

--- a/database/src/main/kotlin/database/service/casino/blackjack/BlackjackService.kt
+++ b/database/src/main/kotlin/database/service/casino/blackjack/BlackjackService.kt
@@ -1,13 +1,13 @@
 package database.service.casino.blackjack
 
 import common.events.casino.blackjack.BlackjackNaturalEvent
-import common.blackjack.Blackjack
-import common.blackjack.BlackjackTable
+import common.casino.blackjack.Blackjack
+import common.casino.blackjack.BlackjackTable
 import database.blackjack.BlackjackTableRegistry
-import common.blackjack.bestTotal
-import common.blackjack.canSplit
-import common.blackjack.isBlackjack
-import common.blackjack.isBust
+import common.casino.blackjack.bestTotal
+import common.casino.blackjack.canSplit
+import common.casino.blackjack.isBlackjack
+import common.casino.blackjack.isBust
 import database.dto.casino.blackjack.BlackjackHandLogDto
 import database.dto.guild.ConfigDto
 import database.persistence.casino.blackjack.BlackjackHandLogPersistence
@@ -35,6 +35,10 @@ import database.service.casino.TopUpResult
 import database.service.guild.cfgLong
 import database.service.guild.cfgLongMax
 import database.service.user.lockUsersInAscendingOrder
+import common.casino.blackjack.bestTotal
+import common.casino.blackjack.canSplit
+import common.casino.blackjack.isBlackjack
+import common.casino.blackjack.isBust
 
 /**
  * Atomic play path for both `/blackjack solo` and `/blackjack` multi

--- a/database/src/main/kotlin/database/service/casino/casinoholdem/CasinoHoldemService.kt
+++ b/database/src/main/kotlin/database/service/casino/casinoholdem/CasinoHoldemService.kt
@@ -4,8 +4,8 @@ import common.casino.CasinoCommonFailure
 import common.events.casino.casinoholdem.CasinoHoldemWonEvent
 import database.dto.guild.ConfigDto
 import database.dto.user.UserDto
-import common.poker.CasinoHoldem
-import common.poker.CasinoHoldemTable
+import common.casino.casinoholdem.CasinoHoldem
+import common.casino.casinoholdem.CasinoHoldemTable
 import database.poker.CasinoHoldemTableRegistry
 import jakarta.annotation.PostConstruct
 import org.springframework.beans.factory.annotation.Autowired

--- a/database/src/main/kotlin/database/service/casino/poker/PokerService.kt
+++ b/database/src/main/kotlin/database/service/casino/poker/PokerService.kt
@@ -8,10 +8,10 @@ import database.dto.casino.poker.PokerHandPotDto
 import database.dto.user.UserDto
 import database.persistence.casino.poker.PokerHandLogPersistence
 import database.persistence.casino.poker.PokerHandPotPersistence
-import common.poker.HandEvaluator
-import common.poker.PokerEngine
-import common.poker.PokerEngine.PokerAction
-import common.poker.PokerTable
+import common.casino.poker.HandEvaluator
+import common.casino.poker.PokerEngine
+import common.casino.poker.PokerEngine.PokerAction
+import common.casino.poker.PokerTable
 import database.poker.PokerTableRegistry
 import jakarta.annotation.PostConstruct
 import org.springframework.beans.factory.annotation.Autowired

--- a/database/src/main/kotlin/database/service/pvp/rps/RpsService.kt
+++ b/database/src/main/kotlin/database/service/pvp/rps/RpsService.kt
@@ -1,7 +1,7 @@
 package database.service.pvp.rps
 
 import common.events.pvp.rps.RpsResolvedEvent
-import common.rps.RpsEngine
+import common.pvp.rps.RpsEngine
 import database.dto.guild.ConfigDto
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationEventPublisher

--- a/database/src/main/kotlin/database/tictactoe/TicTacToeSessionRegistry.kt
+++ b/database/src/main/kotlin/database/tictactoe/TicTacToeSessionRegistry.kt
@@ -1,6 +1,6 @@
 package database.tictactoe
 
-import common.tictactoe.TicTacToeEngine
+import common.pvp.tictactoe.TicTacToeEngine
 import database.boardgame.TurnBasedBoardSessionRegistry
 import database.configuration.RegistryScheduler
 import database.pvp.PvpSessionRegistry

--- a/database/src/test/kotlin/database/blackjack/BlackjackTableRegistryTest.kt
+++ b/database/src/test/kotlin/database/blackjack/BlackjackTableRegistryTest.kt
@@ -1,6 +1,6 @@
 package database.blackjack
 
-import common.blackjack.BlackjackTable
+import common.casino.blackjack.BlackjackTable
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNotNull

--- a/database/src/test/kotlin/database/connect4/Connect4SessionRegistryTest.kt
+++ b/database/src/test/kotlin/database/connect4/Connect4SessionRegistryTest.kt
@@ -1,6 +1,6 @@
 package database.connect4
 
-import common.connect4.Connect4Engine
+import common.pvp.connect4.Connect4Engine
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull

--- a/database/src/test/kotlin/database/poker/PokerTableRegistryShotClockTest.kt
+++ b/database/src/test/kotlin/database/poker/PokerTableRegistryShotClockTest.kt
@@ -1,6 +1,6 @@
 package database.poker
 
-import common.poker.PokerTable
+import common.casino.poker.PokerTable
 import common.testing.DeterministicScheduler
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull

--- a/database/src/test/kotlin/database/rps/RpsSessionRegistryTest.kt
+++ b/database/src/test/kotlin/database/rps/RpsSessionRegistryTest.kt
@@ -1,6 +1,6 @@
 package database.rps
 
-import common.rps.RpsEngine
+import common.pvp.rps.RpsEngine
 import database.pvp.PvpSessionRegistry
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull

--- a/database/src/test/kotlin/database/service/BlackjackServiceTest.kt
+++ b/database/src/test/kotlin/database/service/BlackjackServiceTest.kt
@@ -1,9 +1,9 @@
 package database.service
 
-import common.blackjack.Blackjack
-import common.blackjack.BlackjackTable
+import common.casino.blackjack.Blackjack
+import common.casino.blackjack.BlackjackTable
 import database.blackjack.BlackjackTableRegistry
-import common.blackjack.bestTotal
+import common.casino.blackjack.bestTotal
 import common.card.Card
 import common.card.Deck
 import common.card.Rank
@@ -28,6 +28,7 @@ import database.service.economy.JackpotHelper
 import database.service.economy.JackpotService
 import database.service.user.UserService
 import common.events.casino.blackjack.BlackjackNaturalEvent
+import common.casino.blackjack.bestTotal
 
 class BlackjackServiceTest {
 

--- a/database/src/test/kotlin/database/service/CasinoHoldemServiceTest.kt
+++ b/database/src/test/kotlin/database/service/CasinoHoldemServiceTest.kt
@@ -4,10 +4,10 @@ import common.card.Card
 import common.card.Rank
 import common.card.Suit
 import database.dto.user.UserDto
-import common.poker.CasinoHoldem
-import common.poker.CasinoHoldemTable
+import common.casino.casinoholdem.CasinoHoldem
+import common.casino.casinoholdem.CasinoHoldemTable
 import database.poker.CasinoHoldemTableRegistry
-import common.poker.HandEvaluator
+import common.casino.poker.HandEvaluator
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot

--- a/database/src/test/kotlin/database/service/PokerServiceTest.kt
+++ b/database/src/test/kotlin/database/service/PokerServiceTest.kt
@@ -6,8 +6,8 @@ import database.dto.casino.poker.PokerHandPotDto
 import database.dto.user.UserDto
 import database.persistence.casino.poker.PokerHandLogPersistence
 import database.persistence.casino.poker.PokerHandPotPersistence
-import common.poker.PokerEngine
-import common.poker.PokerTable
+import common.casino.poker.PokerEngine
+import common.casino.poker.PokerTable
 import database.poker.PokerTableRegistry
 import database.service.economy.EconomyTradeService.TradeOutcome
 import io.mockk.every

--- a/database/src/test/kotlin/database/service/RpsServiceTest.kt
+++ b/database/src/test/kotlin/database/service/RpsServiceTest.kt
@@ -1,7 +1,7 @@
 package database.service
 
 import common.events.pvp.rps.RpsResolvedEvent
-import common.rps.RpsEngine
+import common.pvp.rps.RpsEngine
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify

--- a/database/src/test/kotlin/database/tictactoe/TicTacToeSessionRegistryTest.kt
+++ b/database/src/test/kotlin/database/tictactoe/TicTacToeSessionRegistryTest.kt
@@ -1,6 +1,6 @@
 package database.tictactoe
 
-import common.tictactoe.TicTacToeEngine
+import common.pvp.tictactoe.TicTacToeEngine
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/casino/blackjack/BlackjackButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/casino/blackjack/BlackjackButton.kt
@@ -3,10 +3,10 @@ package bot.toby.button.buttons.casino.blackjack
 import bot.toby.command.commands.game.casino.blackjack.BlackjackEmbeds
 import core.button.Button
 import core.button.ButtonContext
-import common.blackjack.Blackjack
-import common.blackjack.BlackjackTable
+import common.casino.blackjack.Blackjack
+import common.casino.blackjack.BlackjackTable
 import database.blackjack.BlackjackTableRegistry
-import common.blackjack.canSplit
+import common.casino.blackjack.canSplit
 import database.dto.user.UserDto
 import database.service.casino.blackjack.BlackjackService
 import database.service.casino.blackjack.BlackjackService.MultiActionOutcome
@@ -17,6 +17,7 @@ import net.dv8tion.jda.api.components.buttons.Button as JdaButton
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
+import common.casino.blackjack.canSplit
 
 /**
  * Resolves a click on a `/blackjack` action button. The button id

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/casino/casinoholdem/CasinoHoldemButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/casino/casinoholdem/CasinoHoldemButton.kt
@@ -4,7 +4,7 @@ import bot.toby.command.commands.game.casino.casinoholdem.CasinoHoldemEmbeds
 import core.button.Button
 import core.button.ButtonContext
 import database.dto.user.UserDto
-import common.poker.CasinoHoldem
+import common.casino.casinoholdem.CasinoHoldem
 import database.poker.CasinoHoldemTableRegistry
 import database.service.casino.casinoholdem.CasinoHoldemService
 import database.service.casino.casinoholdem.CasinoHoldemService.ActionOutcome

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/casino/poker/PokerActionButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/casino/poker/PokerActionButton.kt
@@ -4,8 +4,8 @@ import bot.toby.command.commands.game.casino.poker.PokerEmbeds
 import core.button.Button
 import core.button.ButtonContext
 import database.dto.user.UserDto
-import common.poker.PokerEngine
-import common.poker.PokerTable
+import common.casino.poker.PokerEngine
+import common.casino.poker.PokerTable
 import database.poker.PokerTableRegistry
 import database.service.casino.poker.PokerService
 import database.service.casino.poker.PokerService.ActionOutcome

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/pvp/connect4/Connect4Button.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/pvp/connect4/Connect4Button.kt
@@ -2,7 +2,7 @@ package bot.toby.button.buttons.pvp.connect4
 
 import bot.toby.command.commands.game.pvp.connect4.Connect4Embeds
 import bot.toby.command.commands.game.pvp.PvpEmbeds
-import common.connect4.Connect4Engine
+import common.pvp.connect4.Connect4Engine
 import core.button.Button
 import core.button.ButtonContext
 import database.boardgame.TurnBasedBoardWagerService

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/pvp/tictactoe/TicTacToeButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/pvp/tictactoe/TicTacToeButton.kt
@@ -2,7 +2,7 @@ package bot.toby.button.buttons.pvp.tictactoe
 
 import bot.toby.command.commands.game.pvp.PvpEmbeds
 import bot.toby.command.commands.game.pvp.tictactoe.TicTacToeEmbeds
-import common.tictactoe.TicTacToeEngine
+import common.pvp.tictactoe.TicTacToeEngine
 import core.button.Button
 import core.button.ButtonContext
 import database.boardgame.TurnBasedBoardWagerService

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/game/casino/blackjack/BlackjackCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/game/casino/blackjack/BlackjackCommand.kt
@@ -3,10 +3,10 @@ package bot.toby.command.commands.game.casino.blackjack
 import core.command.Command.Companion.invokeDeleteOnMessageResponse
 import core.command.Command.Companion.replyEmbedAndDelete
 import core.command.CommandContext
-import common.blackjack.Blackjack
-import common.blackjack.BlackjackTable
+import common.casino.blackjack.Blackjack
+import common.casino.blackjack.BlackjackTable
 import database.blackjack.BlackjackTableRegistry
-import common.blackjack.canSplit
+import common.casino.blackjack.canSplit
 import database.dto.user.UserDto
 import database.service.casino.blackjack.BlackjackService
 import database.service.casino.blackjack.BlackjackService.MultiCreateOutcome
@@ -26,6 +26,7 @@ import bot.toby.command.commands.game.casino.blackjack.BlackjackEmbeds
 import bot.toby.command.commands.game.pvp.GameCommand
 import bot.toby.command.commands.game.WagerCommandEmbeds
 import bot.toby.command.commands.game.WagerCommandFailure
+import common.casino.blackjack.canSplit
 
 /**
  * `/blackjack solo|create|join|start|leave|tables|peek` — classic

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/game/casino/blackjack/BlackjackEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/game/casino/blackjack/BlackjackEmbeds.kt
@@ -1,9 +1,9 @@
 package bot.toby.command.commands.game.casino.blackjack
 
-import common.blackjack.Blackjack
-import common.blackjack.BlackjackTable
-import common.blackjack.bestTotal
-import common.blackjack.isSoft
+import common.casino.blackjack.Blackjack
+import common.casino.blackjack.BlackjackTable
+import common.casino.blackjack.bestTotal
+import common.casino.blackjack.isSoft
 import common.card.Card
 import database.dto.casino.blackjack.BlackjackHandLogDto
 import net.dv8tion.jda.api.EmbedBuilder
@@ -13,6 +13,8 @@ import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import bot.toby.command.commands.game.WagerCommandColors
 import bot.toby.command.commands.game.WagerCommandEmbeds
+import common.casino.blackjack.bestTotal
+import common.casino.blackjack.isSoft
 
 /**
  * Shared embed/component plumbing for the Discord `/blackjack` flow.

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/game/casino/casinoholdem/CasinoHoldemCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/game/casino/casinoholdem/CasinoHoldemCommand.kt
@@ -3,7 +3,7 @@ package bot.toby.command.commands.game.casino.casinoholdem
 import core.command.Command.Companion.replyEmbedAndDelete
 import core.command.CommandContext
 import database.dto.user.UserDto
-import common.poker.CasinoHoldem
+import common.casino.casinoholdem.CasinoHoldem
 import database.poker.CasinoHoldemTableRegistry
 import database.service.casino.casinoholdem.CasinoHoldemService
 import database.service.casino.casinoholdem.CasinoHoldemService.DealOutcome

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/game/casino/casinoholdem/CasinoHoldemEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/game/casino/casinoholdem/CasinoHoldemEmbeds.kt
@@ -1,8 +1,8 @@
 package bot.toby.command.commands.game.casino.casinoholdem
 
 import common.card.Card
-import common.poker.CasinoHoldem
-import common.poker.CasinoHoldemTable
+import common.casino.casinoholdem.CasinoHoldem
+import common.casino.casinoholdem.CasinoHoldemTable
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.entities.MessageEmbed
 import java.awt.Color

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/game/casino/poker/PokerCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/game/casino/poker/PokerCommand.kt
@@ -5,7 +5,7 @@ import core.command.Command.Companion.invokeDeleteOnMessageResponse
 import core.command.Command.Companion.replyEmbedAndDelete
 import core.command.CommandContext
 import database.dto.user.UserDto
-import common.poker.PokerTable
+import common.casino.poker.PokerTable
 import database.poker.PokerTableRegistry
 import database.service.casino.poker.PokerService
 import database.service.casino.poker.PokerService.BuyInOutcome
@@ -29,7 +29,7 @@ import bot.toby.command.commands.game.casino.poker.PokerEmbeds
  * `/poker create|join|start|leave|tables` — multiplayer fixed-limit
  * Texas Hold'em over the social-credit economy.
  *
- * The state machine lives in [common.poker.PokerEngine] and is driven
+ * The state machine lives in [common.casino.poker.PokerEngine] and is driven
  * by [PokerService], which keeps tables in [PokerTableRegistry] (shared
  * with the web layer) and routes 5 % of every settled pot into the
  * existing per-guild jackpot pool. Per-turn betting is handled by

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/game/casino/poker/PokerEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/game/casino/poker/PokerEmbeds.kt
@@ -2,8 +2,8 @@ package bot.toby.command.commands.game.casino.poker
 
 import database.dto.casino.poker.PokerHandLogDto
 import common.card.Card
-import common.poker.PokerTable
-import common.poker.PokerTable.Phase
+import common.casino.poker.PokerTable
+import common.casino.poker.PokerTable.Phase
 import database.service.casino.poker.PokerService
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.entities.MessageEmbed

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/game/pvp/connect4/Connect4Embeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/game/pvp/connect4/Connect4Embeds.kt
@@ -1,6 +1,6 @@
 package bot.toby.command.commands.game.pvp.connect4
 
-import common.connect4.Connect4Engine
+import common.pvp.connect4.Connect4Engine
 import database.boardgame.TurnBasedBoardWagerService
 import database.connect4.Connect4SessionRegistry
 import net.dv8tion.jda.api.EmbedBuilder

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/game/pvp/rps/RpsEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/game/pvp/rps/RpsEmbeds.kt
@@ -1,6 +1,6 @@
 package bot.toby.command.commands.game.pvp.rps
 
-import common.rps.RpsEngine
+import common.pvp.rps.RpsEngine
 import database.service.pvp.rps.RpsService
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.components.actionrow.ActionRow

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/game/pvp/tictactoe/TicTacToeEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/game/pvp/tictactoe/TicTacToeEmbeds.kt
@@ -1,6 +1,6 @@
 package bot.toby.command.commands.game.pvp.tictactoe
 
-import common.tictactoe.TicTacToeEngine
+import common.pvp.tictactoe.TicTacToeEngine
 import database.boardgame.TurnBasedBoardWagerService
 import database.tictactoe.TicTacToeSessionRegistry
 import net.dv8tion.jda.api.EmbedBuilder

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
@@ -21,6 +21,7 @@ import net.dv8tion.jda.api.interactions.commands.build.OptionData
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
+import common.casino.blackjack.Blackjack
 
 /**
  * `/setconfig <subcommand>` — guild-owner-only configuration editor.

--- a/discord-bot/src/main/kotlin/bot/toby/install/WizardSection.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/WizardSection.kt
@@ -1,6 +1,7 @@
 package bot.toby.install
 
 import bot.toby.command.commands.moderation.SetConfigCommand
+import common.casino.blackjack.Blackjack
 
 /** Synthetic category token for the General section's Quick channels modal (`InstallQuickChannelsModal`). */
 const val QUICK_CHANNELS_TOKEN = "quick_channels"

--- a/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigBlackjackRulesModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigBlackjackRulesModal.kt
@@ -4,6 +4,7 @@ import bot.toby.modal.modals.setconfig.SetConfigFieldValidator.FieldSpec
 import database.dto.guild.ConfigDto.Configurations
 import database.service.guild.ConfigService
 import org.springframework.stereotype.Component
+import common.casino.blackjack.Blackjack
 
 /**
  * `/setconfig blackjack_rules` — the hand-rules knobs admins tweak

--- a/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigBlackjackTableModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigBlackjackTableModal.kt
@@ -4,6 +4,7 @@ import bot.toby.modal.modals.setconfig.SetConfigFieldValidator.FieldSpec
 import database.dto.guild.ConfigDto.Configurations
 import database.service.guild.ConfigService
 import org.springframework.stereotype.Component
+import common.casino.blackjack.Blackjack
 
 /**
  * `/setconfig blackjack_table` — seat count + the natural-blackjack

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/casino/blackjack/BlackjackButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/casino/blackjack/BlackjackButtonTest.kt
@@ -5,8 +5,8 @@ import bot.toby.button.ButtonTest.Companion.event
 import bot.toby.button.ButtonTest.Companion.mockGuild
 import bot.toby.button.DefaultButtonContext
 import bot.toby.command.commands.game.casino.blackjack.BlackjackEmbeds
-import common.blackjack.Blackjack
-import common.blackjack.BlackjackTable
+import common.casino.blackjack.Blackjack
+import common.casino.blackjack.BlackjackTable
 import database.blackjack.BlackjackTableRegistry
 import database.dto.user.UserDto
 import database.service.casino.blackjack.BlackjackService

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/casino/poker/PokerActionButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/casino/poker/PokerActionButtonTest.kt
@@ -7,8 +7,8 @@ import bot.toby.button.ButtonTest.Companion.mockHook
 import bot.toby.button.DefaultButtonContext
 import bot.toby.command.commands.game.casino.poker.PokerEmbeds
 import database.dto.user.UserDto
-import common.poker.PokerEngine
-import common.poker.PokerTable
+import common.casino.poker.PokerEngine
+import common.casino.poker.PokerTable
 import database.poker.PokerTableRegistry
 import database.service.casino.poker.PokerService
 import database.service.casino.poker.PokerService.ActionOutcome

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/pvp/connect4/Connect4ButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/pvp/connect4/Connect4ButtonTest.kt
@@ -6,7 +6,7 @@ import bot.toby.button.ButtonTest.Companion.mockGuild
 import bot.toby.button.ButtonTest.Companion.mockHook
 import bot.toby.button.DefaultButtonContext
 import bot.toby.command.commands.game.pvp.connect4.Connect4Embeds
-import common.connect4.Connect4Engine
+import common.pvp.connect4.Connect4Engine
 import database.boardgame.TurnBasedBoardWagerService
 import database.connect4.Connect4SessionRegistry
 import database.dto.user.UserDto

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/pvp/rps/RpsButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/pvp/rps/RpsButtonTest.kt
@@ -7,7 +7,7 @@ import bot.toby.button.ButtonTest.Companion.mockHook
 import bot.toby.button.DefaultButtonContext
 import bot.toby.command.commands.game.pvp.rps.RpsEmbeds
 import database.dto.user.UserDto
-import common.rps.RpsEngine
+import common.pvp.rps.RpsEngine
 import database.rps.RpsSessionRegistry
 import database.service.pvp.PvpWagerService
 import database.service.pvp.rps.RpsService

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/pvp/tictactoe/TicTacToeButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/pvp/tictactoe/TicTacToeButtonTest.kt
@@ -6,7 +6,7 @@ import bot.toby.button.ButtonTest.Companion.mockGuild
 import bot.toby.button.ButtonTest.Companion.mockHook
 import bot.toby.button.DefaultButtonContext
 import bot.toby.command.commands.game.pvp.tictactoe.TicTacToeEmbeds
-import common.tictactoe.TicTacToeEngine
+import common.pvp.tictactoe.TicTacToeEngine
 import database.boardgame.TurnBasedBoardWagerService
 import database.dto.user.UserDto
 import database.service.pvp.PvpWagerService

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/game/casino/blackjack/BlackjackCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/game/casino/blackjack/BlackjackCommandTest.kt
@@ -5,8 +5,8 @@ import bot.toby.command.CommandTest.Companion.event
 import bot.toby.command.CommandTest.Companion.guild
 import bot.toby.command.CommandTest.Companion.webhookMessageCreateAction
 import bot.toby.command.DefaultCommandContext
-import common.blackjack.Blackjack
-import common.blackjack.BlackjackTable
+import common.casino.blackjack.Blackjack
+import common.casino.blackjack.BlackjackTable
 import database.blackjack.BlackjackTableRegistry
 import database.dto.user.UserDto
 import database.service.casino.blackjack.BlackjackService

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/game/casino/blackjack/BlackjackEmbedsTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/game/casino/blackjack/BlackjackEmbedsTest.kt
@@ -1,7 +1,7 @@
 package bot.toby.command.commands.game.casino.blackjack
 
-import common.blackjack.Blackjack
-import common.blackjack.BlackjackTable
+import common.casino.blackjack.Blackjack
+import common.casino.blackjack.BlackjackTable
 import common.card.Card
 import common.card.Rank
 import common.card.Suit

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/game/casino/poker/PokerCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/game/casino/poker/PokerCommandTest.kt
@@ -6,7 +6,7 @@ import bot.toby.command.CommandTest.Companion.guild
 import bot.toby.command.DefaultCommandContext
 import bot.toby.helpers.UserDtoHelper
 import database.dto.user.UserDto
-import common.poker.PokerTable
+import common.casino.poker.PokerTable
 import database.poker.PokerTableRegistry
 import database.service.casino.poker.PokerService
 import database.service.casino.poker.PokerService.BuyInOutcome

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/game/casino/poker/PokerEmbedsTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/game/casino/poker/PokerEmbedsTest.kt
@@ -1,7 +1,7 @@
 package bot.toby.command.commands.game.casino.poker
 
 import common.card.Card
-import common.poker.PokerTable
+import common.casino.poker.PokerTable
 import common.card.Rank
 import common.card.Suit
 import org.junit.jupiter.api.Assertions.assertEquals

--- a/web/src/main/kotlin/web/casino/StakeBounds.kt
+++ b/web/src/main/kotlin/web/casino/StakeBounds.kt
@@ -12,8 +12,8 @@ import common.casino.roulette.Roulette
 import common.casino.scratch.ScratchCard
 import common.casino.slots.SlotMachine
 import common.casino.wheeloffortune.WheelOfFortune
-import common.blackjack.Blackjack
-import common.poker.CasinoHoldem
+import common.casino.blackjack.Blackjack
+import common.casino.casinoholdem.CasinoHoldem
 import database.service.guild.ConfigService
 import database.boardgame.TurnBasedBoardWagerService
 import database.service.pvp.duel.DuelService

--- a/web/src/main/kotlin/web/catalog/GameCatalog.kt
+++ b/web/src/main/kotlin/web/catalog/GameCatalog.kt
@@ -1,5 +1,6 @@
 package web.catalog
 
+import common.casino.blackjack.Blackjack
 /**
  * Single source of truth for the games listed on the homepage. Adding,
  * removing, or renaming a game here updates every count and label

--- a/web/src/main/kotlin/web/controller/BlackjackController.kt
+++ b/web/src/main/kotlin/web/controller/BlackjackController.kt
@@ -1,7 +1,7 @@
 package web.controller
 
-import common.blackjack.Blackjack
-import common.blackjack.BlackjackTable
+import common.casino.blackjack.Blackjack
+import common.casino.blackjack.BlackjackTable
 import database.blackjack.BlackjackTableRegistry
 import database.service.casino.blackjack.BlackjackService
 import database.service.casino.blackjack.BlackjackService.MultiActionOutcome

--- a/web/src/main/kotlin/web/controller/CasinoHoldemController.kt
+++ b/web/src/main/kotlin/web/controller/CasinoHoldemController.kt
@@ -1,7 +1,7 @@
 package web.controller
 
 import common.casino.CasinoCommonFailure
-import common.poker.CasinoHoldem
+import common.casino.casinoholdem.CasinoHoldem
 import database.poker.CasinoHoldemTableRegistry
 import database.service.casino.casinoholdem.CasinoHoldemService
 import database.service.casino.casinoholdem.CasinoHoldemService.ActionOutcome

--- a/web/src/main/kotlin/web/controller/PokerController.kt
+++ b/web/src/main/kotlin/web/controller/PokerController.kt
@@ -1,7 +1,7 @@
 package web.controller
 
-import common.poker.PokerEngine
-import common.poker.PokerTable
+import common.casino.poker.PokerEngine
+import common.casino.poker.PokerTable
 import database.service.casino.poker.PokerService
 import database.service.casino.poker.PokerService.ActionOutcome
 import database.service.casino.poker.PokerService.BuyInOutcome

--- a/web/src/main/kotlin/web/controller/PvpController.kt
+++ b/web/src/main/kotlin/web/controller/PvpController.kt
@@ -1,7 +1,7 @@
 package web.controller
 
-import common.connect4.Connect4Engine
-import common.tictactoe.TicTacToeEngine
+import common.pvp.connect4.Connect4Engine
+import common.pvp.tictactoe.TicTacToeEngine
 import database.connect4.Connect4SessionRegistry
 import database.duel.PendingDuelRegistry
 import database.rps.RpsSessionRegistry

--- a/web/src/main/kotlin/web/service/BlackjackWebService.kt
+++ b/web/src/main/kotlin/web/service/BlackjackWebService.kt
@@ -1,6 +1,5 @@
 package web.service
 
-import common.blackjack.*
 import common.card.Card
 import database.blackjack.BlackjackTableRegistry
 import org.springframework.stereotype.Service

--- a/web/src/main/kotlin/web/service/BlackjackWebService.kt
+++ b/web/src/main/kotlin/web/service/BlackjackWebService.kt
@@ -4,6 +4,11 @@ import common.blackjack.*
 import common.card.Card
 import database.blackjack.BlackjackTableRegistry
 import org.springframework.stereotype.Service
+import common.casino.blackjack.Blackjack
+import common.casino.blackjack.BlackjackTable
+import common.casino.blackjack.bestTotal
+import common.casino.blackjack.canSplit
+import common.casino.blackjack.isSoft
 
 /**
  * Read-only projection of [BlackjackTable] for the web UI. Crucially,

--- a/web/src/main/kotlin/web/service/CasinoHoldemWebService.kt
+++ b/web/src/main/kotlin/web/service/CasinoHoldemWebService.kt
@@ -1,8 +1,8 @@
 package web.service
 
 import common.card.Card
-import common.poker.CasinoHoldem
-import common.poker.CasinoHoldemTable
+import common.casino.casinoholdem.CasinoHoldem
+import common.casino.casinoholdem.CasinoHoldemTable
 import database.poker.CasinoHoldemTableRegistry
 import org.springframework.stereotype.Service
 

--- a/web/src/main/kotlin/web/service/PokerWebService.kt
+++ b/web/src/main/kotlin/web/service/PokerWebService.kt
@@ -1,7 +1,7 @@
 package web.service
 
 import common.card.Card
-import common.poker.PokerTable
+import common.casino.poker.PokerTable
 import database.poker.PokerTableRegistry
 import org.springframework.stereotype.Service
 

--- a/web/src/main/kotlin/web/service/PvpWebService.kt
+++ b/web/src/main/kotlin/web/service/PvpWebService.kt
@@ -1,8 +1,8 @@
 package web.service
 
-import common.connect4.Connect4Engine
-import common.rps.RpsEngine
-import common.tictactoe.TicTacToeEngine
+import common.pvp.connect4.Connect4Engine
+import common.pvp.rps.RpsEngine
+import common.pvp.tictactoe.TicTacToeEngine
 import database.connect4.Connect4SessionRegistry
 import database.duel.PendingDuelRegistry
 import database.duel.RecentDuelResolutions

--- a/web/src/test/kotlin/web/controller/BlackjackControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/BlackjackControllerTest.kt
@@ -1,6 +1,6 @@
 package web.controller
 
-import common.blackjack.BlackjackTable
+import common.casino.blackjack.BlackjackTable
 import database.blackjack.BlackjackTableRegistry
 import database.service.casino.blackjack.BlackjackService
 import database.service.economy.JackpotGame
@@ -19,6 +19,7 @@ import web.casino.CasinoPageContext
 import web.casino.StakeBounds
 import web.service.BlackjackWebService
 import web.service.EconomyWebService
+import common.casino.blackjack.canSplit
 
 /**
  * Page-handler regression tests. The JSON endpoints (`/state`, `/deal`,

--- a/web/src/test/kotlin/web/controller/CasinoHoldemControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/CasinoHoldemControllerTest.kt
@@ -3,8 +3,8 @@ package web.controller
 import common.card.Card
 import common.card.Rank
 import common.card.Suit
-import common.poker.CasinoHoldem
-import common.poker.CasinoHoldemTable
+import common.casino.casinoholdem.CasinoHoldem
+import common.casino.casinoholdem.CasinoHoldemTable
 import database.poker.CasinoHoldemTableRegistry
 import database.service.casino.casinoholdem.CasinoHoldemService
 import database.service.casino.casinoholdem.CasinoHoldemService.ActionOutcome

--- a/web/src/test/kotlin/web/controller/PokerControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/PokerControllerTest.kt
@@ -1,7 +1,7 @@
 package web.controller
 
-import common.poker.PokerEngine
-import common.poker.PokerTable
+import common.casino.poker.PokerEngine
+import common.casino.poker.PokerTable
 import database.service.economy.JackpotService
 import database.service.casino.poker.PokerService
 import database.service.casino.poker.PokerService.ActionOutcome

--- a/web/src/test/kotlin/web/controller/PvpControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/PvpControllerTest.kt
@@ -386,10 +386,10 @@ class PvpControllerTest {
     fun `rpsPick by one side fans pick to other but does not resolve`() {
         val session = rpsSession(PvpSessionRegistry.Session.State.LIVE)
         every { rpsSessionRegistry.get(1L) } returns session
-        every { pvpWebService.parseRpsChoice("ROCK") } returns common.rps.RpsEngine.Choice.ROCK
-        every { rpsSessionRegistry.recordPick(1L, discordId, common.rps.RpsEngine.Choice.ROCK) } returns
+        every { pvpWebService.parseRpsChoice("ROCK") } returns common.pvp.rps.RpsEngine.Choice.ROCK
+        every { rpsSessionRegistry.recordPick(1L, discordId, common.pvp.rps.RpsEngine.Choice.ROCK) } returns
             rpsSession(PvpSessionRegistry.Session.State.LIVE).also {
-                it.picks[discordId] = common.rps.RpsEngine.Choice.ROCK
+                it.picks[discordId] = common.pvp.rps.RpsEngine.Choice.ROCK
             }
 
         val response = controller.rpsPick(guildId, 1L, RpsPickRequest(choice = "ROCK"), user)

--- a/web/src/test/kotlin/web/service/BlackjackWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/BlackjackWebServiceTest.kt
@@ -1,6 +1,6 @@
 package web.service
 
-import common.blackjack.BlackjackTable
+import common.casino.blackjack.BlackjackTable
 import database.blackjack.BlackjackTableRegistry
 import common.card.Card
 import common.card.Rank

--- a/web/src/test/kotlin/web/service/CasinoHoldemWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/CasinoHoldemWebServiceTest.kt
@@ -3,10 +3,10 @@ package web.service
 import common.card.Card
 import common.card.Rank
 import common.card.Suit
-import common.poker.CasinoHoldem
-import common.poker.CasinoHoldemTable
+import common.casino.casinoholdem.CasinoHoldem
+import common.casino.casinoholdem.CasinoHoldemTable
 import database.poker.CasinoHoldemTableRegistry
-import common.poker.HandEvaluator
+import common.casino.poker.HandEvaluator
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull

--- a/web/src/test/kotlin/web/service/PokerWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/PokerWebServiceTest.kt
@@ -1,8 +1,8 @@
 package web.service
 
 import common.card.Card
-import common.poker.PokerEngine
-import common.poker.PokerTable
+import common.casino.poker.PokerEngine
+import common.casino.poker.PokerTable
 import database.poker.PokerTableRegistry
 import common.card.Rank
 import common.card.Suit

--- a/web/src/test/kotlin/web/template/ModerationTemplateRowsTest.kt
+++ b/web/src/test/kotlin/web/template/ModerationTemplateRowsTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import common.casino.coinflip.Coinflip
 import common.casino.dice.Dice
+import common.casino.blackjack.Blackjack
 
 /**
  * Presence regression for the per-game config rows on the moderation


### PR DESCRIPTION
## Summary

Completes the common-module consolidation started in #592. The pre-existing top-level engine directories (`common/blackjack/`, `common/poker/`, `common/connect4/`, `common/rps/`, `common/tictactoe/`) moved under `common/casino/<game>/` and `common/pvp/<game>/` so the parallel paths now match the database service/persistence/dto layouts and the discord-bot game/button layouts.

## Moves

```
common/blackjack/{Blackjack,BlackjackHand,BlackjackTable}.kt
    → common/casino/blackjack/

common/poker/{PokerEngine,PokerTable,HandEvaluator}.kt
    → common/casino/poker/

common/poker/{CasinoHoldem,CasinoHoldemTable}.kt
    → common/casino/casinoholdem/    (Casino Hold'em is its own game,
                                       not a poker variant for org
                                       purposes — matches the service-
                                       side split)

common/connect4/Connect4Engine.kt    → common/pvp/connect4/
common/rps/RpsEngine.kt              → common/pvp/rps/
common/tictactoe/TicTacToeEngine.kt  → common/pvp/tictactoe/
```

`HandEvaluator` stays in `common/casino/poker/` (poker-specific math); `CasinoHoldem` imports it from there.

## Result

After this PR, the top-level `common/` directory shows only theme directories:

```
card/  casino/  configuration/  discord/  economy/  events/
helpers/  leveling/  logging/  notification/  pvp/
```

`economy/` now holds just `TobyCoinEngine.kt` — the only true economy engine, distinct from the casino games that misleadingly lived there before #592.

## Scale

- **85 files modified** — basename-sed for renamed FQNs + follow-up cleanup pass for top-level extension functions (`bestTotal`, `canSplit`, `isBust`, `isBlackjack` from `BlackjackHand.kt`) that the basename-only rewrite missed.
- Net diff: **+181 / -131 = +50 lines** (explicit imports replacing same-package implicits, mostly for the BlackjackHand top-level fns).

## Packaging series, fully complete

| PR | Package | Files | Status |
|---|---|---|---|
| #586 | `database/service/` | 88 | ✅ merged |
| #587 | `database/persistence/` | 77 | ✅ merged |
| #589 | `discord-bot/.../game/` | 34 | ✅ merged |
| #590 | `discord-bot/.../buttons/` | 19 | ✅ merged |
| #591 | `database/dto/` | 43 | ✅ merged |
| #592 | `common/events/` + `common/economy/` lift | 39 | ✅ merged |
| this | `common/blackjack/poker/connect4/rps/tictactoe/` lift | 15 | this PR |

Every flat package bucket in the project is now a themed tree with per-game leaf dirs inside `casino/` and `pvp/`. Parallel paths line up across modules: `common/casino/blackjack/`, `database/service/casino/blackjack/`, `database/persistence/casino/blackjack/`, `database/dto/casino/blackjack/`, `discord-bot/.../game/casino/blackjack/`, `discord-bot/.../buttons/casino/blackjack/`.

## Test plan

- [x] `./gradlew compileKotlin compileTestKotlin` — every module compiles clean
- [x] `:common:test :core-api:test :database:test :discord-bot:test :web:test` green locally under `LANG=C.UTF-8 LC_ALL=C.UTF-8`
- [ ] CI green on `ubuntu-latest`
- [ ] Spot-check: top-level `common/` shows only theme dirs (no per-game engine dirs at the root)
- [ ] Spot-check: `common/casino/blackjack/Blackjack.kt` + `common/casino/blackjack/BlackjackTest.kt` line up

https://claude.ai/code/session_017zsUNUN5DRMTWA5ZZgJ2mM


---
_Generated by [Claude Code](https://claude.ai/code/session_017zsUNUN5DRMTWA5ZZgJ2mM)_