### PR TITLE
feat(web): polyhedral dice shapes + quick-pick grid on /utils

### DIFF
--- a/web/src/main/resources/static/css/utils.css
+++ b/web/src/main/resources/static/css/utils.css
@@ -116,6 +116,14 @@
 .die-num-value-md { font-size: 1.5rem; }
 .die-num-value-sm { font-size: 1.1rem; }
 .die-num-value-xs { font-size: 0.85rem; }
+
+/* Shape-specific number positioning. The d4 triangle's centroid sits
+   ~1/6 below its bounding-box centre, so the number is nudged down and
+   the font shrunk a step since the inscribed circle is small. The d10
+   kite is mildly bottom-heavy. Diamond / pentagon / hexagon don't
+   need overrides — geometric centre matches visual centre. */
+.die.die-d4 .die-num-value { padding-top: 18%; font-size: 1.4rem; }
+.die.die-d10 .die-num-value { padding-top: 8%; }
 .dice-tray .die-more {
     padding: 4px 10px;
     border-radius: 999px;
@@ -144,6 +152,71 @@
     0%   { transform: scale(1.06); }
     100% { transform: scale(1);    }
 }
+
+/* ---- Dice quick-pick grid ---- */
+.dice-quick {
+    display: grid;
+    gap: 8px;
+    margin-bottom: var(--space-3);
+}
+.dice-quick-mod {
+    display: grid;
+    gap: 4px;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    max-width: 140px;
+}
+.dice-quick-mod input {
+    padding: 6px 10px;
+    background: var(--bg);
+    color: var(--text);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-sm);
+    font: inherit;
+}
+.dice-quick-grid {
+    display: grid;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    gap: 6px;
+}
+.dice-quick-grid button {
+    min-height: 44px;
+    padding: 6px 4px;
+    background: var(--bg);
+    color: var(--text);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-sm);
+    font: 600 0.9rem/1 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    cursor: pointer;
+    transition: border-color var(--dur-fast) var(--ease-out),
+                color var(--dur-fast) var(--ease-out),
+                box-shadow var(--dur-fast) var(--ease-out);
+}
+.dice-quick-grid button:hover,
+.dice-quick-grid button:focus-visible {
+    border-color: var(--accent);
+    color: var(--accent-light);
+    box-shadow: 0 0 0 2px var(--accent-soft);
+    outline: none;
+}
+.dice-quick-grid button:active {
+    transform: translateY(1px);
+}
+
+/* Custom-roll disclosure — keeps the form available but visually
+   subordinate to the grid. */
+.dice-custom {
+    margin-bottom: var(--space-3);
+}
+.dice-custom summary {
+    cursor: pointer;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    padding: 4px 0;
+    list-style: revert;
+}
+.dice-custom summary:hover { color: var(--text); }
+.dice-custom[open] summary { margin-bottom: var(--space-2); }
 
 /* ---- Random chooser reel ----
    The window is 132px tall (three 44px rows). The strip translates
@@ -361,4 +434,6 @@
     .ball-stage { width: 132px; height: 132px; }
     .ball-window { width: 70px; height: 40px; font-size: 0.6rem; }
     .dice-tray .die { width: 44px; height: 44px; }
+    .dice-quick-grid { gap: 4px; }
+    .dice-quick-grid button { font-size: 0.8rem; padding: 6px 2px; }
 }

--- a/web/src/main/resources/static/images/utils/d10.svg
+++ b/web/src/main/resources/static/images/utils/d10.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" role="img" aria-label="Ten-sided die">
+  <defs>
+    <linearGradient id="df-10" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ffffff"/>
+      <stop offset="100%" stop-color="#d6d8e0"/>
+    </linearGradient>
+  </defs>
+  <polygon points="50,4 90,40 75,72 50,96 25,72 10,40" fill="url(#df-10)"
+           stroke="#1a1a2e" stroke-width="2" stroke-linejoin="round"/>
+</svg>

--- a/web/src/main/resources/static/images/utils/d12.svg
+++ b/web/src/main/resources/static/images/utils/d12.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" role="img" aria-label="Twelve-sided die">
+  <defs>
+    <linearGradient id="df-12" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ffffff"/>
+      <stop offset="100%" stop-color="#d6d8e0"/>
+    </linearGradient>
+  </defs>
+  <polygon points="50,6 94,42 78,93 22,93 6,42" fill="url(#df-12)"
+           stroke="#1a1a2e" stroke-width="2" stroke-linejoin="round"/>
+</svg>

--- a/web/src/main/resources/static/images/utils/d20.svg
+++ b/web/src/main/resources/static/images/utils/d20.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" role="img" aria-label="Twenty-sided die">
+  <defs>
+    <linearGradient id="df-20" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ffffff"/>
+      <stop offset="100%" stop-color="#d6d8e0"/>
+    </linearGradient>
+  </defs>
+  <polygon points="50,6 90,28 90,72 50,94 10,72 10,28" fill="url(#df-20)"
+           stroke="#1a1a2e" stroke-width="2" stroke-linejoin="round"/>
+</svg>

--- a/web/src/main/resources/static/images/utils/d4.svg
+++ b/web/src/main/resources/static/images/utils/d4.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" role="img" aria-label="Four-sided die">
+  <defs>
+    <linearGradient id="df-4" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ffffff"/>
+      <stop offset="100%" stop-color="#d6d8e0"/>
+    </linearGradient>
+  </defs>
+  <polygon points="50,8 12,88 88,88" fill="url(#df-4)"
+           stroke="#1a1a2e" stroke-width="2" stroke-linejoin="round"/>
+</svg>

--- a/web/src/main/resources/static/images/utils/d8.svg
+++ b/web/src/main/resources/static/images/utils/d8.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" role="img" aria-label="Eight-sided die">
+  <defs>
+    <linearGradient id="df-8" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ffffff"/>
+      <stop offset="100%" stop-color="#d6d8e0"/>
+    </linearGradient>
+  </defs>
+  <polygon points="50,6 94,50 50,94 6,50" fill="url(#df-8)"
+           stroke="#1a1a2e" stroke-width="2" stroke-linejoin="round"/>
+</svg>

--- a/web/src/main/resources/static/js/utils.js
+++ b/web/src/main/resources/static/js/utils.js
@@ -36,6 +36,9 @@
 
     // --- Dice roller ---
     const MAX_VISIBLE_DICE = 24;
+    // The canonical TTRPG set. Anything outside this falls back to the
+    // rounded-square die-num.svg template (covers d2, d7, d100, etc.).
+    const STD_POLYHEDRALS = new Set([4, 8, 10, 12, 20]);
 
     function makeDie(sides, value) {
         if (sides === 6 && value >= 1 && value <= 6) {
@@ -47,13 +50,19 @@
             return img;
         }
         // Numbered die: shared SVG body with the value overlaid via CSS so
-        // we don't have to refetch & rewrite the SVG per roll.
+        // we don't have to refetch & rewrite the SVG per roll. Polyhedrals
+        // get a shape-specific SVG; other sides fall back to a rounded square.
         const wrap = document.createElement('span');
         wrap.className = 'die die-num';
         wrap.setAttribute('role', 'img');
         wrap.setAttribute('aria-label', 'Die showing ' + value);
         const face = document.createElement('img');
-        face.src = '/images/utils/die-num.svg';
+        if (STD_POLYHEDRALS.has(sides)) {
+            face.src = '/images/utils/d' + sides + '.svg';
+            wrap.classList.add('die-poly', 'die-d' + sides);
+        } else {
+            face.src = '/images/utils/die-num.svg';
+        }
         face.alt = '';
         face.decoding = 'async';
         face.className = 'die-num-face';
@@ -70,6 +79,53 @@
         return wrap;
     }
 
+    function rollAndRender(sides, count, modifier) {
+        if (!Number.isFinite(count) || count < 1 || count > 100) {
+            toast('Count must be between 1 and 100.', 'error');
+            return;
+        }
+        if (!Number.isFinite(sides) || sides < 2 || sides > 1000) {
+            toast('Sides must be between 2 and 1000.', 'error');
+            return;
+        }
+        const rolls = [];
+        let total = 0;
+        for (let i = 0; i < count; i++) {
+            const r = randInt(sides);
+            rolls.push(r);
+            total += r;
+        }
+        const grand = total + modifier;
+        const label = count + 'd' + sides + (modifier ? (modifier > 0 ? ' + ' + modifier : ' - ' + Math.abs(modifier)) : '');
+
+        const tray = stage('dice');
+        tray.innerHTML = '';
+        const visible = Math.min(rolls.length, MAX_VISIBLE_DICE);
+        for (let i = 0; i < visible; i++) {
+            const die = makeDie(sides, rolls[i]);
+            if (!reducedMotion) {
+                die.classList.add('rolling');
+                die.style.animationDelay = (i * 40) + 'ms';
+                die.addEventListener('animationend', function onEnd() {
+                    die.removeEventListener('animationend', onEnd);
+                    die.classList.remove('rolling');
+                    die.classList.add('settled');
+                }, { once: true });
+            }
+            tray.appendChild(die);
+        }
+        if (rolls.length > MAX_VISIBLE_DICE) {
+            const more = document.createElement('span');
+            more.className = 'die-more';
+            more.textContent = '+' + (rolls.length - MAX_VISIBLE_DICE) + ' more';
+            tray.appendChild(more);
+        }
+
+        output('dice').textContent =
+            label + '\nRolls: [' + rolls.join(', ') + ']\nSum: ' + total +
+            (modifier ? '\nWith modifier: ' + grand : '');
+    }
+
     const diceForm = document.querySelector('[data-form="dice"]');
     if (diceForm) {
         diceForm.addEventListener('submit', e => {
@@ -77,50 +133,20 @@
             const count = parseInt(diceForm.elements.count.value, 10);
             const sides = parseInt(diceForm.elements.sides.value, 10);
             const modifier = parseInt(diceForm.elements.modifier.value, 10) || 0;
-            if (!Number.isFinite(count) || count < 1 || count > 100) {
-                toast('Count must be between 1 and 100.', 'error');
-                return;
-            }
-            if (!Number.isFinite(sides) || sides < 2 || sides > 1000) {
-                toast('Sides must be between 2 and 1000.', 'error');
-                return;
-            }
-            const rolls = [];
-            let total = 0;
-            for (let i = 0; i < count; i++) {
-                const r = randInt(sides);
-                rolls.push(r);
-                total += r;
-            }
-            const grand = total + modifier;
-            const label = count + 'd' + sides + (modifier ? (modifier > 0 ? ' + ' + modifier : ' - ' + Math.abs(modifier)) : '');
+            rollAndRender(sides, count, modifier);
+        });
+    }
 
-            const tray = stage('dice');
-            tray.innerHTML = '';
-            const visible = Math.min(rolls.length, MAX_VISIBLE_DICE);
-            for (let i = 0; i < visible; i++) {
-                const die = makeDie(sides, rolls[i]);
-                if (!reducedMotion) {
-                    die.classList.add('rolling');
-                    die.style.animationDelay = (i * 40) + 'ms';
-                    die.addEventListener('animationend', function onEnd() {
-                        die.removeEventListener('animationend', onEnd);
-                        die.classList.remove('rolling');
-                        die.classList.add('settled');
-                    }, { once: true });
-                }
-                tray.appendChild(die);
-            }
-            if (rolls.length > MAX_VISIBLE_DICE) {
-                const more = document.createElement('span');
-                more.className = 'die-more';
-                more.textContent = '+' + (rolls.length - MAX_VISIBLE_DICE) + ' more';
-                tray.appendChild(more);
-            }
-
-            output('dice').textContent =
-                label + '\nRolls: [' + rolls.join(', ') + ']\nSum: ' + total +
-                (modifier ? '\nWith modifier: ' + grand : '');
+    const diceQuick = stage('dice-quick');
+    if (diceQuick) {
+        const modInput = diceQuick.querySelector('[name="quickModifier"]');
+        diceQuick.querySelector('.dice-quick-grid').addEventListener('click', e => {
+            const btn = e.target.closest('button[data-quick-sides]');
+            if (!btn) return;
+            const sides = parseInt(btn.dataset.quickSides, 10);
+            const count = parseInt(btn.dataset.quickCount, 10);
+            const modifier = parseInt(modInput && modInput.value, 10) || 0;
+            rollAndRender(sides, count, modifier);
         });
     }
 

--- a/web/src/main/resources/templates/utils.html
+++ b/web/src/main/resources/templates/utils.html
@@ -17,18 +17,58 @@
         <section class="util-card" data-util="dice">
             <h2>Dice roller</h2>
             <p class="muted">Equivalent to <code>/roll</code>.</p>
-            <form class="util-form" data-form="dice">
-                <label>Number of dice
-                    <input type="number" name="count" value="1" min="1" max="100" required>
+            <div class="dice-quick" data-stage="dice-quick">
+                <label class="dice-quick-mod">Modifier
+                    <input type="number" name="quickModifier" value="0" step="1">
                 </label>
-                <label>Sides
-                    <input type="number" name="sides" value="20" min="2" max="1000" required>
-                </label>
-                <label>Modifier
-                    <input type="number" name="modifier" value="0" step="1">
-                </label>
-                <button type="submit" class="btn">Roll</button>
-            </form>
+                <div class="dice-quick-grid" role="grid" aria-label="Quick roll">
+                    <button type="button" data-quick-sides="4"  data-quick-count="1">d4</button>
+                    <button type="button" data-quick-sides="4"  data-quick-count="2">2d4</button>
+                    <button type="button" data-quick-sides="4"  data-quick-count="3">3d4</button>
+                    <button type="button" data-quick-sides="4"  data-quick-count="4">4d4</button>
+                    <button type="button" data-quick-sides="4"  data-quick-count="5">5d4</button>
+                    <button type="button" data-quick-sides="6"  data-quick-count="1">d6</button>
+                    <button type="button" data-quick-sides="6"  data-quick-count="2">2d6</button>
+                    <button type="button" data-quick-sides="6"  data-quick-count="3">3d6</button>
+                    <button type="button" data-quick-sides="6"  data-quick-count="4">4d6</button>
+                    <button type="button" data-quick-sides="6"  data-quick-count="5">5d6</button>
+                    <button type="button" data-quick-sides="8"  data-quick-count="1">d8</button>
+                    <button type="button" data-quick-sides="8"  data-quick-count="2">2d8</button>
+                    <button type="button" data-quick-sides="8"  data-quick-count="3">3d8</button>
+                    <button type="button" data-quick-sides="8"  data-quick-count="4">4d8</button>
+                    <button type="button" data-quick-sides="8"  data-quick-count="5">5d8</button>
+                    <button type="button" data-quick-sides="10" data-quick-count="1">d10</button>
+                    <button type="button" data-quick-sides="10" data-quick-count="2">2d10</button>
+                    <button type="button" data-quick-sides="10" data-quick-count="3">3d10</button>
+                    <button type="button" data-quick-sides="10" data-quick-count="4">4d10</button>
+                    <button type="button" data-quick-sides="10" data-quick-count="5">5d10</button>
+                    <button type="button" data-quick-sides="12" data-quick-count="1">d12</button>
+                    <button type="button" data-quick-sides="12" data-quick-count="2">2d12</button>
+                    <button type="button" data-quick-sides="12" data-quick-count="3">3d12</button>
+                    <button type="button" data-quick-sides="12" data-quick-count="4">4d12</button>
+                    <button type="button" data-quick-sides="12" data-quick-count="5">5d12</button>
+                    <button type="button" data-quick-sides="20" data-quick-count="1">d20</button>
+                    <button type="button" data-quick-sides="20" data-quick-count="2">2d20</button>
+                    <button type="button" data-quick-sides="20" data-quick-count="3">3d20</button>
+                    <button type="button" data-quick-sides="20" data-quick-count="4">4d20</button>
+                    <button type="button" data-quick-sides="20" data-quick-count="5">5d20</button>
+                </div>
+            </div>
+            <details class="dice-custom">
+                <summary>Custom roll</summary>
+                <form class="util-form" data-form="dice">
+                    <label>Number of dice
+                        <input type="number" name="count" value="1" min="1" max="100" required>
+                    </label>
+                    <label>Sides
+                        <input type="number" name="sides" value="20" min="2" max="1000" required>
+                    </label>
+                    <label>Modifier
+                        <input type="number" name="modifier" value="0" step="1">
+                    </label>
+                    <button type="submit" class="btn">Roll</button>
+                </form>
+            </details>
             <div class="dice-tray" data-stage="dice" aria-hidden="true"></div>
             <pre class="util-output" data-output="dice" aria-live="polite"></pre>
         </section>


### PR DESCRIPTION
## Summary

Two related upgrades to the `/utils` dice card, shipped together since
they share `makeDie` / `rollAndRender`:

### 1. Polyhedral dice shapes
Every standard TTRPG die now renders as its actual silhouette instead
of falling back to a generic rounded square:

- d4 → triangle (tetrahedron face)
- d6 → unchanged (pip patterns from PR #588)
- d8 → diamond / rhombus
- d10 → kite (pentagonal trapezohedron)
- d12 → pentagon
- d20 → hexagon

Non-standard sides (d2, d7, d100, anything outside `{4, 6, 8, 10, 12,
20}`) keep the existing rounded-square fallback so weird rolls still
render cleanly.

### 2. Quick-pick grid
A 6×5 grid above the form — rows are die type, columns are how many to
roll (1–5). Single Modifier input applies to whichever cell you tap.
The previous custom form drops into a collapsed `<details>` for
off-grid rolls (`30d6+15`, weird sides, etc.). Both entry points funnel
through a single `rollAndRender(sides, count, modifier)` so validation
and animation stay in one place.

### Files
- New: `static/images/utils/{d4,d8,d10,d12,d20}.svg`
- Edited: `templates/utils.html`, `static/css/utils.css`, `static/js/utils.js`

## Test plan
- [x] `node --check static/js/utils.js`
- [x] `npx stylelint static/css/utils.css`
- [x] Playwright headless render at 1280×1100 and 380×1100:
      `1d4`/`5d4`, `1d8`, `5d10`, `5d12`, `5d20` all render with the
      expected shape and centred number; `1d100` via the Custom roll
      disclosure falls back to the rounded square as designed; mobile
      view keeps 5-column grid + 44 px touch targets
- [ ] Run the real Spring app once a reviewer has Discord/DB creds —
      `./gradlew :web:bootRun`, exercise each grid cell + a couple of
      custom rolls


---
_Generated by [Claude Code](https://claude.ai/code/session_012Cc54jqj96KhVqNToEuU1B)_