### PR TITLE
fix(tobycoin): /buy committed then threw UnknownFormatConversionException

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/TobyCoinCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/TobyCoinCommand.kt
@@ -211,9 +211,13 @@ class TobyCoinCommand @Autowired constructor(
                 val sign = if (isBuy) "+" else "−"
                 " ($gross gross $sign ${outcome.fee} fee, 1%)"
             } else ""
-            ("$verb **${outcome.amount} TOBY** for ${outcome.transactedCredits} credits$breakdown. " +
-                    "New price: %.2f. You now hold ${outcome.newCoins} TOBY and ${outcome.newCredits} credits.")
-                .format(outcome.newPrice)
+            // Format the price up front so the message stays plain
+            // interpolation. Running String.format on the composed
+            // sentence used to choke on the literal `%)` inside `breakdown`
+            // (UnknownFormatConversionException: Conversion = ')').
+            val newPrice = "%.2f".format(outcome.newPrice)
+            "$verb **${outcome.amount} TOBY** for ${outcome.transactedCredits} credits$breakdown. " +
+                "New price: $newPrice. You now hold ${outcome.newCoins} TOBY and ${outcome.newCredits} credits."
         }
         is TradeOutcome.InsufficientCredits ->
             "You need ${outcome.needed} credits for this trade (price + 1% fee) but only have ${outcome.have}."

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/TobyCoinCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/TobyCoinCommandTest.kt
@@ -3,6 +3,7 @@ package bot.toby.command.commands.economy
 import bot.toby.command.CommandTest
 import bot.toby.command.CommandTest.Companion.event
 import bot.toby.command.CommandTest.Companion.guild
+import bot.toby.command.CommandTest.Companion.interactionHook
 import bot.toby.command.DefaultCommandContext
 import bot.toby.economy.TobyCoinChartRenderer
 import database.dto.TobyCoinMarketDto
@@ -14,9 +15,11 @@ import database.service.TobyCoinMarketService
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import net.dv8tion.jda.api.interactions.commands.OptionMapping
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Instant
@@ -107,6 +110,40 @@ internal class TobyCoinCommandTest : CommandTest {
 
         verify(exactly = 0) { tradeService.buy(any(), any(), any()) }
         verify(exactly = 0) { tradeService.sell(any(), any(), any()) }
+    }
+
+    /**
+     * Regression guard for the format-string crash that committed the
+     * trade to the DB but threw on the way to building the reply:
+     * UnknownFormatConversionException because the composed message
+     * contained literal `%)` (from the "1%)" breakdown text) before
+     * being passed to String.format.
+     */
+    @Test
+    fun `buy outcome with fee renders without throwing`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.subcommandName } returns "buy"
+        every { event.getOption("amount") } returns intOpt(5L)
+        every { tradeService.buy(discordId, guildId, 5L) } returns TradeOutcome.Ok(
+            amount = 5L,
+            transactedCredits = 1010L,
+            newCoins = 5L,
+            newCredits = 8990L,
+            newPrice = 100.20,
+            fee = 10L,
+        )
+        val sent = slot<String>()
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        verify(exactly = 1) { tradeService.buy(discordId, guildId, 5L) }
+        // Capture from the existing common-mock stub so we can assert
+        // the composed message reaches the hook intact.
+        verify(exactly = 1) { event.hook.sendMessage(capture(sent)) }
+        // Both the fee breakdown (with the literal "1%)") and the
+        // formatted price land in the same message, intact.
+        assertTrue(sent.captured.contains("fee, 1%)")) { "missing fee breakdown: '${sent.captured}'" }
+        assertTrue(sent.captured.contains("New price: 100.20")) { "missing formatted price: '${sent.captured}'" }
     }
 
     @Test


### PR DESCRIPTION
## Summary

After #596 landed, `/tobycoin buy` started showing the "Something went wrong running that command" message — but the buy transaction was still landing in the DB (coins added, credit deducted, price moved). That looked like data corruption but wasn't: the writes succeed, then the reply builder throws, and the new listener safety-net surfaces the generic error.

Real exception from the production logs (`tobybotlogs1779691184979.txt`):

```
java.util.UnknownFormatConversionException: Conversion = ')'
  at java.lang.String.format(String.java:4379)
  at bot.toby.command.commands.economy.TobyCoinCommand.describe(TobyCoinCommand.kt:215)
  at bot.toby.command.commands.economy.TobyCoinCommand.handleBuy(TobyCoinCommand.kt:145)
```

### Root cause

`describe()` mixed Kotlin string interpolation with `String.format` on the same composed message. The `breakdown` segment (rendered only when `fee > 0`) ends with the literal `"1%)"`. After Kotlin interpolation, the resulting string contains both an intended `%.2f` placeholder **and** a stray `%)`. Java's `Formatter` scans the whole string for `%`-conversions and chokes on `%)`. The `@Transactional buy()` had already committed by the time `describe()` ran, so the writes landed and the user got the safety-net error.

This bug is **pre-existing** — #596 just made it visible. Before the exception-safety-net was added, the coroutine `launch {}` silently swallowed the throw and the spinner just hung forever (which is exactly the "stuck thinking" symptom that prompted #596 in the first place).

### Fix

Format the one numeric value up front, then build the sentence with pure Kotlin interpolation. No more mixing the two paradigms.

```kotlin
val newPrice = "%.2f".format(outcome.newPrice)
"$verb **${outcome.amount} TOBY** for ${outcome.transactedCredits} credits$breakdown. " +
    "New price: $newPrice. You now hold ${outcome.newCoins} TOBY and ${outcome.newCredits} credits."
```

The pre-existing buy/sell tests didn't catch this because they all used the default `fee = 0L`, so the `breakdown` branch never ran. Added a regression-guard test with `fee = 10L` that asserts both `"fee, 1%)"` and `"New price: 100.20"` land in the composed message intact.

## Test plan
- [x] `./gradlew :discord-bot:test` — 1091 tests, 0 failures
- [x] New `buy outcome with fee renders without throwing` test exercises the previously-crashing path
- [ ] Manual: `/tobycoin buy 1` on the test server → success embed appears, no safety-net error, DB write lands once

https://claude.ai/code/session_01VYgD9FVr89DvwgaBo7Fp3k

---
_Generated by [Claude Code](https://claude.ai/code/session_01VYgD9FVr89DvwgaBo7Fp3k)_