### PR TITLE
Update D&D category blurb to remove tabletop-sessions copy

### DIFF
--- a/web/src/main/kotlin/web/controller/CommandWikiController.kt
+++ b/web/src/main/kotlin/web/controller/CommandWikiController.kt
@@ -67,7 +67,7 @@ class CommandWikiController(
         CategoryMeta("music", "Music", "🎵",
             "Play, queue, and control music in your server's voice channels.") { it.musicCommands },
         CategoryMeta("dnd", "D&D", "🎲",
-            "Roll dice, look up spells, and run tabletop sessions.") { it.dndCommands },
+            "Roll dice and look up D&D 5e content.") { it.dndCommands },
         CategoryMeta("moderation", "Moderation", "🛡️",
             "Ban, kick, mute, purge, and manage server permissions.") { it.moderationCommands },
         CategoryMeta("games", "Games", "🎮",


### PR DESCRIPTION
## Summary

- The D&D category blurb on the commands wiki page still read "Roll dice, look up spells, and run tabletop sessions." but the tabletop-session features (`/campaign`, `/initiative`, `/character`, etc.) were removed when DnD Beyond shipped their official Discord bot.
- Replace the blurb with copy that matches what the category actually contains today (`/roll` and `/dnd` SRD lookups): "Roll dice and look up D&D 5e content."

## Test plan

- [ ] Load the commands wiki page in the running web app and confirm the D&D category header shows the new blurb.
- [ ] `./gradlew :web:build` succeeds (string-literal change, no behavior affected).

https://claude.ai/code/session_01Wy8MMcjrZ68NT7jtPUaKRv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wy8MMcjrZ68NT7jtPUaKRv)_