### PR TITLE
fix(pvp): resolve winner names, drop ghost thinking, share resolution overlay

### DIFF
--- a/application/src/main/resources/log4j2.xml
+++ b/application/src/main/resources/log4j2.xml
@@ -1,7 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN">
+<Configuration status="WARN" packages="web.configuration">
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
+            <!--
+              Drop log events whose throwable chain is a "Broken pipe"
+              IOException. These come from SSE heartbeats landing on
+              connections Heroku's router closed at its 55s idle
+              timeout — KeyedSseRegistry handles the failure, the log
+              noise is just Tomcat's wrapper surfacing the IOException.
+            -->
+            <BrokenPipeLogFilter/>
             <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg %n"/>
         </Console>
     </Appenders>

--- a/core-api/src/main/kotlin/core/button/Button.kt
+++ b/core-api/src/main/kotlin/core/button/Button.kt
@@ -9,5 +9,17 @@ interface Button : Loggable, Named {
     val description: String
     val defersReply: Boolean get() = true
 
+    /**
+     * Buttons that update their source message (board games, paginators)
+     * should ack via `deferEdit()` instead of `deferReply(true)`. This
+     * produces no "thinking" indicator and lets the handler use
+     * `event.message.editMessage*()` / `event.hook.editOriginal*()`
+     * without leaving a dangling deferred reply.
+     *
+     * When this is true, `defersReply` is ignored and the channel-typing
+     * indicator is also suppressed.
+     */
+    val defersEdit: Boolean get() = false
+
     fun handle(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int)
 }

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/pvp/connect4/Connect4Button.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/pvp/connect4/Connect4Button.kt
@@ -37,6 +37,10 @@ class Connect4Button @Autowired constructor(
     override val name: String get() = Connect4Embeds.BUTTON_NAME
     override val description: String get() = "Routes /connect4 accept/decline + drop + forfeit clicks."
 
+    // Every action edits the original board message — ack with deferEdit
+    // so the per-move click doesn't show a hanging "thinking" indicator.
+    override val defersEdit: Boolean = true
+
     override fun handle(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
         val event = ctx.event
         val parsed = Connect4Embeds.parseButtonId(event.componentId) ?: run {
@@ -195,7 +199,10 @@ class Connect4Button @Autowired constructor(
             winnerDiscordId = winnerDiscordId,
         )
         val embed: MessageEmbed = when (outcome) {
-            is TurnBasedBoardWagerService.ResolveOutcome.Win -> Connect4Embeds.winEmbed(session, outcome, forfeit)
+            is TurnBasedBoardWagerService.ResolveOutcome.Win -> Connect4Embeds.winEmbed(
+                session, outcome, forfeit,
+                winnerName = PvpEmbeds.winnerDisplayName(event.jda, session.guildId, outcome.winnerDiscordId),
+            )
             is TurnBasedBoardWagerService.ResolveOutcome.Draw -> Connect4Embeds.drawEmbed(session, outcome)
             TurnBasedBoardWagerService.ResolveOutcome.Unknown -> PvpEmbeds.acceptErrorEmbed(
                 "Couldn't resolve the match — both players' profiles must exist."

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/pvp/duel/DuelButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/pvp/duel/DuelButton.kt
@@ -31,6 +31,10 @@ class DuelButton @Autowired constructor(
     override val name: String get() = DuelEmbeds.BUTTON_NAME
     override val description: String get() = "Resolves a /duel offer in the opponent's chosen direction."
 
+    // Duel button edits the source offer message — ack with deferEdit so no
+    // "Toby is thinking…" indicator hangs while we resolve the offer.
+    override val defersEdit: Boolean = true
+
     override fun handle(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
         val event = ctx.event
         val parsed = DuelEmbeds.parseButtonId(event.componentId) ?: run {

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/pvp/rps/RpsButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/pvp/rps/RpsButton.kt
@@ -35,6 +35,10 @@ class RpsButton @Autowired constructor(
     override val name: String get() = RpsEmbeds.BUTTON_NAME
     override val description: String get() = "Routes /rps accept/decline + pick + forfeit clicks."
 
+    // Every action edits the original board message — ack with deferEdit
+    // so the per-move click doesn't show a hanging "thinking" indicator.
+    override val defersEdit: Boolean = true
+
     override fun handle(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
         val event = ctx.event
         val parsed = RpsEmbeds.parseButtonId(event.componentId) ?: run {
@@ -185,7 +189,10 @@ class RpsButton @Autowired constructor(
             opponentChoice = session.picks[session.opponentDiscordId],
         )
         val embed: MessageEmbed = when (outcome) {
-            is RpsService.ResolveOutcome.Win -> RpsEmbeds.winEmbed(outcome)
+            is RpsService.ResolveOutcome.Win -> RpsEmbeds.winEmbed(
+                outcome,
+                winnerName = PvpEmbeds.winnerDisplayName(event.jda, session.guildId, outcome.winnerDiscordId),
+            )
             is RpsService.ResolveOutcome.Draw -> RpsEmbeds.drawEmbed(
                 outcome, session.initiatorDiscordId, session.opponentDiscordId,
             )

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/pvp/tictactoe/TicTacToeButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/pvp/tictactoe/TicTacToeButton.kt
@@ -37,6 +37,10 @@ class TicTacToeButton @Autowired constructor(
     override val name: String get() = TicTacToeEmbeds.BUTTON_NAME
     override val description: String get() = "Routes /tictactoe accept/decline + place + forfeit clicks."
 
+    // Every action edits the original board message — ack with deferEdit
+    // so the per-move click doesn't show a hanging "thinking" indicator.
+    override val defersEdit: Boolean = true
+
     override fun handle(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
         val event = ctx.event
         val parsed = TicTacToeEmbeds.parseButtonId(event.componentId) ?: run {
@@ -195,7 +199,10 @@ class TicTacToeButton @Autowired constructor(
             winnerDiscordId = winnerDiscordId,
         )
         val embed: MessageEmbed = when (outcome) {
-            is TurnBasedBoardWagerService.ResolveOutcome.Win -> TicTacToeEmbeds.winEmbed(session, outcome, forfeit)
+            is TurnBasedBoardWagerService.ResolveOutcome.Win -> TicTacToeEmbeds.winEmbed(
+                session, outcome, forfeit,
+                winnerName = PvpEmbeds.winnerDisplayName(event.jda, session.guildId, outcome.winnerDiscordId),
+            )
             is TurnBasedBoardWagerService.ResolveOutcome.Draw -> TicTacToeEmbeds.drawEmbed(session, outcome)
             TurnBasedBoardWagerService.ResolveOutcome.Unknown -> PvpEmbeds.acceptErrorEmbed(
                 "Couldn't resolve the match — both players' profiles must exist."

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/game/pvp/PvpEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/game/pvp/PvpEmbeds.kt
@@ -2,6 +2,7 @@ package bot.toby.command.commands.game.pvp
 
 import database.service.pvp.PvpWagerService
 import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.components.actionrow.ActionRow
 import net.dv8tion.jda.api.components.buttons.Button
 import net.dv8tion.jda.api.entities.MessageEmbed
@@ -73,6 +74,19 @@ object PvpEmbeds {
         Button.success(acceptButtonId, "Accept"),
         Button.danger(declineButtonId, "Decline"),
     )
+
+    /**
+     * Resolve a Discord id into a display-friendly name for use in embed
+     * titles. JDA's mention syntax (`<@id>`) only renders to a name when
+     * the receiving client has the user cached, so for titles (which
+     * Discord shows in embed metadata, not the description body) we
+     * prefer the resolved name. Falls back to `Player NNNN` matching the
+     * web `MemberLookupHelper.fallbackName` shape.
+     */
+    fun winnerDisplayName(jda: JDA, guildId: Long, winnerId: Long): String =
+        jda.getGuildById(guildId)?.getMemberById(winnerId)?.effectiveName
+            ?: runCatching { jda.retrieveUserById(winnerId).complete()?.effectiveName }.getOrNull()
+            ?: "Player ${winnerId.toString().takeLast(4)}"
 
     /** Per-game text rendering of a [PvpWagerService.StartOutcome] rejection. */
     fun describeStartOutcome(outcome: PvpWagerService.StartOutcome): String = when (outcome) {

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/game/pvp/connect4/Connect4Embeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/game/pvp/connect4/Connect4Embeds.kt
@@ -132,15 +132,16 @@ object Connect4Embeds {
         session: Connect4SessionRegistry.Session,
         outcome: TurnBasedBoardWagerService.ResolveOutcome.Win,
         forfeit: Boolean,
+        winnerName: String,
     ): MessageEmbed {
         val winnerMark = session.markFor(outcome.winnerDiscordId)
         val verb = if (forfeit) "wins by forfeit" else "wins"
         val markLabel = winnerMark?.let { " (${prettyMark(it)})" } ?: ""
         val board = renderBoard(session.board, winningLine = session.winningLine)
         return EmbedBuilder()
-            .setTitle("🏆 Connect 4 — <@${outcome.winnerDiscordId}>$markLabel $verb!")
+            .setTitle("🏆 Connect 4 — $winnerName$markLabel $verb!")
             .setDescription(
-                board +
+                "<@${outcome.winnerDiscordId}>\n" + board +
                     if (outcome.pot > 0) {
                         "\n\nPot: **${outcome.pot}** credits → " +
                             "winner takes **${outcome.pot - outcome.lossTribute}** " +

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/game/pvp/rps/RpsEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/game/pvp/rps/RpsEmbeds.kt
@@ -119,8 +119,8 @@ object RpsEmbeds {
         .setColor(0x5B8DEF)
         .build()
 
-    fun winEmbed(outcome: RpsService.ResolveOutcome.Win): MessageEmbed = EmbedBuilder()
-        .setTitle("🏆 Rock-Paper-Scissors — <@${outcome.winnerDiscordId}> wins!")
+    fun winEmbed(outcome: RpsService.ResolveOutcome.Win, winnerName: String): MessageEmbed = EmbedBuilder()
+        .setTitle("🏆 Rock-Paper-Scissors — $winnerName wins!")
         .setDescription(
             "<@${outcome.winnerDiscordId}> picked **${prettyChoice(outcome.winnerChoice)}**" +
                 ", <@${outcome.loserDiscordId}> picked **${prettyChoice(outcome.loserChoice)}**." +

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/game/pvp/tictactoe/TicTacToeEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/game/pvp/tictactoe/TicTacToeEmbeds.kt
@@ -138,15 +138,16 @@ object TicTacToeEmbeds {
         session: TicTacToeSessionRegistry.Session,
         outcome: TurnBasedBoardWagerService.ResolveOutcome.Win,
         forfeit: Boolean,
+        winnerName: String,
     ): MessageEmbed {
         val winnerMark = session.markFor(outcome.winnerDiscordId)
         val verb = if (forfeit) "wins by forfeit" else "wins"
         val markLabel = winnerMark?.let { " (${prettyMark(it)})" } ?: ""
         val board = renderBoard(session.board, winningLine = session.winningLine)
         return EmbedBuilder()
-            .setTitle("🏆 Tic-Tac-Toe — <@${outcome.winnerDiscordId}>$markLabel $verb!")
+            .setTitle("🏆 Tic-Tac-Toe — $winnerName$markLabel $verb!")
             .setDescription(
-                board +
+                "<@${outcome.winnerDiscordId}>\n" + board +
                     if (outcome.pot > 0) {
                         "\n\nPot: **${outcome.pot}** credits → " +
                             "winner takes **${outcome.pot - outcome.lossTribute}** " +

--- a/discord-bot/src/main/kotlin/bot/toby/managers/DefaultButtonManager.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/managers/DefaultButtonManager.kt
@@ -31,10 +31,11 @@ class DefaultButtonManager @Autowired constructor(
 
         val btn = getButton(event.componentId.lowercase()) ?: return
 
-        if (btn.defersReply) {
-            event.deferReply(true).queue()
+        when {
+            btn.defersEdit -> event.deferEdit().queue()
+            btn.defersReply -> event.deferReply(true).queue()
         }
-        event.channel.sendTyping().queue()
+        if (!btn.defersEdit) event.channel.sendTyping().queue()
         val ctx = DefaultButtonContext(event)
         btn.handle(ctx, requestingUserDto, deleteDelay)
     }

--- a/web/src/main/kotlin/web/configuration/BrokenPipeLogFilter.kt
+++ b/web/src/main/kotlin/web/configuration/BrokenPipeLogFilter.kt
@@ -1,0 +1,54 @@
+package web.configuration
+
+import org.apache.logging.log4j.Level
+import org.apache.logging.log4j.Marker
+import org.apache.logging.log4j.core.Filter
+import org.apache.logging.log4j.core.LogEvent
+import org.apache.logging.log4j.core.Logger
+import org.apache.logging.log4j.core.config.Node
+import org.apache.logging.log4j.core.config.plugins.Plugin
+import org.apache.logging.log4j.core.config.plugins.PluginFactory
+import org.apache.logging.log4j.core.filter.AbstractFilter
+import org.apache.logging.log4j.message.Message
+
+/**
+ * Log4j2 filter that drops log events whose throwable chain contains a
+ * `Broken pipe` IOException. These come from SSE heartbeats landing on
+ * connections Heroku's router has already torn down at its 55-second
+ * idle timeout — [web.service.sse.KeyedSseRegistry.broadcast] catches
+ * the failure and evicts the dead emitter, but Tomcat's
+ * `ContainerBase.[Tomcat].[localhost].[/].[dispatcherServlet]` logger
+ * surfaces the IOException at ERROR before our catch runs.
+ *
+ * Wired into the root appender via `log4j2.xml` as
+ * `<BrokenPipeLogFilter/>`.
+ */
+@Plugin(name = "BrokenPipeLogFilter", category = Node.CATEGORY, elementType = Filter.ELEMENT_TYPE, printObject = true)
+class BrokenPipeLogFilter private constructor() : AbstractFilter(Filter.Result.DENY, Filter.Result.NEUTRAL) {
+
+    override fun filter(event: LogEvent): Filter.Result = decide(event.thrown)
+
+    override fun filter(logger: Logger?, level: Level?, marker: Marker?, msg: Message?, t: Throwable?): Filter.Result =
+        decide(t)
+
+    override fun filter(logger: Logger?, level: Level?, marker: Marker?, msg: Any?, t: Throwable?): Filter.Result =
+        decide(t)
+
+    override fun filter(logger: Logger?, level: Level?, marker: Marker?, msg: String?, vararg params: Any?): Filter.Result =
+        Filter.Result.NEUTRAL
+
+    private fun decide(throwable: Throwable?): Filter.Result {
+        var current = throwable
+        while (current != null) {
+            if (current.message?.contains("Broken pipe", ignoreCase = true) == true) return Filter.Result.DENY
+            current = current.cause
+        }
+        return Filter.Result.NEUTRAL
+    }
+
+    companion object {
+        @JvmStatic
+        @PluginFactory
+        fun createFilter(): BrokenPipeLogFilter = BrokenPipeLogFilter()
+    }
+}

--- a/web/src/main/kotlin/web/controller/PvpController.kt
+++ b/web/src/main/kotlin/web/controller/PvpController.kt
@@ -45,9 +45,11 @@ import web.util.displayName
  * Discord command uses and the same in-memory [PendingDuelRegistry]
  * so a duel offered in Discord can be accepted via the web inbox and
  * vice versa. Rock-paper-scissors plays end-to-end on the web via
- * `/pvp/{guildId}/rps/...`; tic-tac-toe and connect 4 tabs render in
- * the unified page but are placeholders until their controller
- * endpoints land in a follow-up PR.
+ * `/pvp/{guildId}/rps/...`, tic-tac-toe via `/pvp/{guildId}/tictactoe/...`,
+ * and connect 4 via `/pvp/{guildId}/connect4/...`.
+ *
+ * Deep-links from the Discord side accept `?opponentDiscordId=&stake=`
+ * to pre-fill every game's challenge form — see [page].
  *
  * Old `/duel/...` URLs are kept alive via [DuelRedirectController]
  * which 301/308s every former route into the new `/pvp/...` space.
@@ -123,6 +125,11 @@ class PvpController(
         // Tab wins if both are present.
         @RequestParam(required = false) tab: String?,
         @RequestParam(required = false) game: String?,
+        // Deep-link pre-fill from Discord-side notifications: surfaces
+        // the opponent + stake the user just challenged so every game's
+        // form lands ready to send instead of forcing a re-pick.
+        @RequestParam(required = false) opponentDiscordId: String?,
+        @RequestParam(required = false) stake: Long?,
         model: Model,
         ra: RedirectAttributes,
     ): String = WebGuildAccess.requireMemberForPage(
@@ -170,6 +177,16 @@ class PvpController(
         // when both arrive together. Either way, pvp.js reads
         // `data-initial-tab` and flips to the matching tab on load.
         model.addAttribute("initialTab", sanitizeTabSlug(tab) ?: sanitizeTabSlug(game) ?: "")
+        // Pre-fill every game's opponent picker + stake input from the
+        // deep-link query params. We only honour the opponent id if it's
+        // actually a member of this guild (so a stale link can't pre-fill
+        // a non-member id that would just bounce on /challenge).
+        val preselectedOpponentId = opponentDiscordId
+            ?.toLongOrNull()
+            ?.takeIf { it != discordId && economyWebService.isMember(it, guildId) }
+            ?.toString()
+        model.addAttribute("preselectedOpponentId", preselectedOpponentId)
+        model.addAttribute("preselectedStake", stake?.takeIf { it >= 0 })
         model.addAttribute("username", user.displayName())
         "pvp"
     }

--- a/web/src/main/resources/static/js/pvp.js
+++ b/web/src/main/resources/static/js/pvp.js
@@ -1097,7 +1097,13 @@
     // re-broadcast each named SSE event as a DOM CustomEvent so multiple
     // panels (initRpsPanel + the two initBoardGamePanel calls) can each
     // attach listeners without needing direct EventSource access.
-    let sharedStreamOpened = false;
+    //
+    // Declared with `var` (not `let`) so the hoisted binding is
+    // `undefined` instead of in the temporal dead zone — `ensureSharedStream`
+    // is reached via `initBoardGamePanel` *before* this line is evaluated
+    // and a TDZ ReferenceError here would abort the entire IIFE (and with
+    // it every form submit handler the page needs).
+    var sharedStreamOpened = false;
     function ensureSharedStream() {
         if (sharedStreamOpened) return;
         sharedStreamOpened = true;

--- a/web/src/main/resources/static/js/pvp.js
+++ b/web/src/main/resources/static/js/pvp.js
@@ -1,14 +1,13 @@
 // /pvp — unified PvP page. Tab strip switches between Duel, RPS,
-// TicTacToe, Connect 4 (the last three are placeholders until their
-// controller endpoints land). Duel: challenge form posts to
-// /pvp/{guildId}/duel/challenge; the inbox panel polls
-// /pvp/{guildId}/duel/pending every 5 seconds and posts to /accept or
-// /decline via the shared CSRF-aware fetch wrapper.
+// TicTacToe, Connect 4 — all four are SSE-driven and share the same
+// result-overlay animation (`playPvpResolution`). The duel-shaped
+// pending/outgoing/accept-decline flow drives all four; per-game
+// boards live in `initRpsPanel` and `initBoardGamePanel`.
 //
-// UMD-style export: `playDuelResolution`, `makeFigure`, and `formatExpiry`
-// are pulled out for unit testing (see casino-jackpot-wheel.js for the
-// same pattern). Page-init code only runs when a real `document` with
-// the pvp page DOM is present.
+// UMD-style export: `playDuelResolution`, `playPvpResolution`,
+// `makeFigure`, and `formatExpiry` are pulled out for unit testing
+// (see casino-jackpot-wheel.js for the same pattern). Page-init code
+// only runs when a real `document` with the pvp page DOM is present.
 (function (root) {
     'use strict';
 
@@ -52,7 +51,33 @@
             : 'expires in ' + minutes + 'm';
     }
 
-    function playDuelResolution(row, resp, opts) {
+    // Per-flair flash glyph and aria-label for the result overlay. Duel
+    // is the original art (gunfire bang); the other PvP games reuse the
+    // same arena chrome with a game-appropriate icon so RPS/TTT/C4
+    // outcomes land with the same weight.
+    const FLAIR = {
+        duel: { flash: '💥', label: 'Duel result' },
+        rps: { flash: '✊', label: 'Rock-Paper-Scissors result' },
+        tictactoe: { flash: '❌', label: 'Tic-Tac-Toe result' },
+        connect4: { flash: '🔴', label: 'Connect 4 result' },
+    };
+
+    /**
+     * Render a head-to-head result as a full-screen overlay with both
+     * participants' avatars + names, a winner/loser highlight, and a
+     * credits pill on WIN outcomes. Used by every PvP game's resolution
+     * path (duel, rps, tictactoe, connect4). Draw / refund outcomes
+     * skip the flash + pill and show a refund line instead.
+     *
+     * `spec` shape:
+     *   - initiator: { discordId, name, avatarUrl }
+     *   - opponent:  { discordId, name, avatarUrl }
+     *   - winnerDiscordId: string | null  (null on DRAW / REFUND)
+     *   - verdict: 'WIN' | 'DRAW' | 'REFUND'
+     *   - pot, lossTribute (numeric; ignored on non-WIN)
+     *   - flair: 'duel' | 'rps' | 'tictactoe' | 'connect4'
+     */
+    function playPvpResolution(spec, opts) {
         opts = opts || {};
         const doc = opts.doc || (root && root.document);
         const win = opts.window || root;
@@ -60,54 +85,72 @@
         const autoDismissMs = opts.autoDismissMs == null ? 6000 : opts.autoDismissMs;
         const fadeOutMs = opts.fadeOutMs == null ? 200 : opts.fadeOutMs;
 
-        const initiatorName = row.dataset.initiatorName || 'Challenger';
-        const initiatorAvatar = row.dataset.initiatorAvatar || null;
-        const opponentName = row.dataset.opponentName || 'You';
-        const opponentAvatar = row.dataset.opponentAvatar || null;
-        const winnerId = resp.winnerDiscordId;
-        const initiatorWon = winnerId === row.dataset.initiatorDiscordId;
-        const winnerName = initiatorWon ? initiatorName : opponentName;
+        const flair = FLAIR[spec.flair] || FLAIR.duel;
+        const verdict = spec.verdict || (spec.winnerDiscordId ? 'WIN' : 'DRAW');
+        const isWin = verdict === 'WIN';
+
+        const initiator = spec.initiator || {};
+        const opponent = spec.opponent || {};
+        const initiatorName = initiator.name || 'Challenger';
+        const opponentName = opponent.name || 'Opponent';
+        const initiatorWon = isWin && String(spec.winnerDiscordId) === String(initiator.discordId);
+        const winnerName = !isWin
+            ? null
+            : (initiatorWon ? initiatorName : opponentName);
 
         const reduceMotion = !!(win && win.matchMedia &&
             win.matchMedia('(prefers-reduced-motion: reduce)').matches);
 
         const overlay = doc.createElement('div');
-        overlay.className = 'duel-resolution-overlay';
+        // Keep the `duel-*` class names — the existing CSS already
+        // styles the overlay chrome; we add a per-game modifier for
+        // flair-specific colour tweaks (e.g. `is-rps`).
+        overlay.className = 'duel-resolution-overlay is-' + (spec.flair || 'duel');
         if (reduceMotion) overlay.classList.add('is-reduced');
+        if (!isWin) overlay.classList.add('is-draw');
         overlay.setAttribute('role', 'dialog');
-        overlay.setAttribute('aria-label', 'Duel result');
+        overlay.setAttribute('aria-label', flair.label);
 
         const arena = doc.createElement('div');
         arena.className = 'duel-arena';
 
-        const left = makeFigure(initiatorName, initiatorAvatar, 'left', doc);
-        const right = makeFigure(opponentName, opponentAvatar, 'right', doc);
-        if (initiatorWon) left.classList.add('is-winner'); else left.classList.add('is-loser');
-        if (initiatorWon) right.classList.add('is-loser'); else right.classList.add('is-winner');
+        const left = makeFigure(initiatorName, initiator.avatarUrl, 'left', doc);
+        const right = makeFigure(opponentName, opponent.avatarUrl, 'right', doc);
+        if (isWin) {
+            if (initiatorWon) { left.classList.add('is-winner'); right.classList.add('is-loser'); }
+            else              { right.classList.add('is-winner'); left.classList.add('is-loser'); }
+        }
 
         const flash = doc.createElement('div');
         flash.className = 'duel-flash';
-        // Position the bang near the winner's muzzle, not centred between
-        // the two figures — CSS reads `from-left` / `from-right` and
-        // sets a translateX offset toward that side.
         flash.classList.add(initiatorWon ? 'from-left' : 'from-right');
-        flash.textContent = '💥';
+        flash.textContent = flair.flash;
+        if (!isWin) flash.style.opacity = '0'; // no flash on draws
 
         arena.appendChild(left);
         arena.appendChild(flash);
         arena.appendChild(right);
         overlay.appendChild(arena);
 
-        const pill = doc.createElement('div');
-        pill.className = 'duel-credits-pill';
-        pill.textContent = '+' + resp.pot + ' credits';
-        if (initiatorWon) pill.classList.add('flies-left'); else pill.classList.add('flies-right');
-        overlay.appendChild(pill);
+        if (isWin) {
+            const pill = doc.createElement('div');
+            pill.className = 'duel-credits-pill';
+            pill.textContent = '+' + (spec.pot || 0) + ' credits';
+            pill.classList.add(initiatorWon ? 'flies-left' : 'flies-right');
+            overlay.appendChild(pill);
+        }
 
         const resultLine = doc.createElement('div');
         resultLine.className = 'duel-result-line';
-        resultLine.textContent = 'Winner: ' + winnerName + ' took ' + resp.pot +
-            ' credits (' + resp.lossTribute + ' to jackpot)';
+        if (isWin) {
+            const tribute = spec.lossTribute || 0;
+            resultLine.textContent = 'Winner: ' + winnerName + ' took ' + (spec.pot || 0) +
+                ' credits' + (tribute ? ' (' + tribute + ' to jackpot)' : '');
+        } else if (verdict === 'DRAW') {
+            resultLine.textContent = 'Draw — stakes refunded.';
+        } else {
+            resultLine.textContent = 'Refund — no winner.';
+        }
         overlay.appendChild(resultLine);
 
         const hint = doc.createElement('div');
@@ -123,7 +166,6 @@
             clearTimeout(autoDismiss);
             doc.removeEventListener('keydown', onKey);
             overlay.classList.add('is-dismissing');
-            // Brief fade-out so it doesn't pop off.
             setTimeout(function () {
                 if (overlay.parentNode) overlay.parentNode.removeChild(overlay);
                 onDismiss();
@@ -136,6 +178,29 @@
 
         doc.body.appendChild(overlay);
         return { overlay: overlay, dismiss: dismiss };
+    }
+
+    // Back-compat wrapper used by the duel `/accept` flow and the duel
+    // preview button. Translates the legacy `(row, resp, opts)` shape
+    // into the general `playPvpResolution(spec, opts)`.
+    function playDuelResolution(row, resp, opts) {
+        return playPvpResolution({
+            initiator: {
+                discordId: row.dataset.initiatorDiscordId,
+                name: row.dataset.initiatorName || 'Challenger',
+                avatarUrl: row.dataset.initiatorAvatar || null,
+            },
+            opponent: {
+                discordId: row.dataset.opponentDiscordId,
+                name: row.dataset.opponentName || 'You',
+                avatarUrl: row.dataset.opponentAvatar || null,
+            },
+            winnerDiscordId: resp.winnerDiscordId,
+            verdict: 'WIN',
+            pot: resp.pot,
+            lossTribute: resp.lossTribute,
+            flair: 'duel',
+        }, opts);
     }
 
     // Build the same offscreen-row + fake-resp shape the live accept
@@ -171,6 +236,7 @@
 
     const api = {
         playDuelResolution: playDuelResolution,
+        playPvpResolution: playPvpResolution,
         makeFigure: makeFigure,
         formatExpiry: formatExpiry,
         playFromResolution: playFromResolution,
@@ -190,9 +256,9 @@
     if (!guildId) return;
     const ttlSeconds = parseInt(main.dataset.ttlSeconds, 10) || 0;
 
-    // Tab strip — Duel + three placeholder tabs (RPS/TTT/C4 land in a
-    // follow-up PR). One panel visible at a time; chips drive `hidden`
-    // on the panels and `aria-selected` on the tabs.
+    // Tab strip — Duel / RPS / TicTacToe / Connect 4. One panel visible
+    // at a time; chips drive `hidden` on the panels and `aria-selected`
+    // on the tabs.
     const tabs = Array.prototype.slice.call(document.querySelectorAll('.pvp-tab'));
     const panels = Array.prototype.slice.call(document.querySelectorAll('.pvp-panel'));
     function activateTab(slug) {
@@ -749,20 +815,7 @@
         }
 
         function renderResolution(boardEl, outcome) {
-            boardEl.innerHTML = '';
-            const verdict = document.createElement('h3');
-            verdict.className = 'pvp-board-verdict';
-            const winnerName = outcome.winnerDiscordId === activeSnapshot.participants.initiator.discordId
-                ? activeSnapshot.participants.initiator.name
-                : (activeSnapshot.participants.opponent && activeSnapshot.participants.opponent.name) || 'Opponent';
-            if (outcome.verdict === 'WIN') {
-                verdict.textContent = winnerName + ' wins — pot ' + outcome.pot;
-            } else if (outcome.verdict === 'DRAW') {
-                verdict.textContent = 'Draw — both picked ' + (outcome.initiatorChoice || '?').toLowerCase();
-            } else {
-                verdict.textContent = 'Refund — neither picked';
-            }
-            boardEl.appendChild(verdict);
+            playOutcomeOverlay(outcome, activeSnapshot, 'rps');
         }
 
         // ── Mutations ──
@@ -1015,22 +1068,7 @@
         }
 
         function renderBoardOutcome(boardEl, outcome, snapshot) {
-            boardEl.innerHTML = '';
-            const verdict = document.createElement('h3');
-            verdict.className = 'pvp-board-verdict';
-            if (outcome.verdict === 'WIN') {
-                const initiator = snapshot && snapshot.participants && snapshot.participants.initiator;
-                const opponent = snapshot && snapshot.participants && snapshot.participants.opponent;
-                const winnerName = (initiator && outcome.winnerDiscordId === initiator.discordId)
-                    ? initiator.name
-                    : (opponent && opponent.name) || 'Opponent';
-                verdict.textContent = winnerName + ' wins — pot ' + outcome.pot;
-            } else if (outcome.verdict === 'DRAW') {
-                verdict.textContent = 'Draw — stakes refunded';
-            } else {
-                verdict.textContent = 'Refund';
-            }
-            boardEl.appendChild(verdict);
+            playOutcomeOverlay(outcome, snapshot, slug);
         }
 
         form.addEventListener('submit', function (e) {
@@ -1078,6 +1116,32 @@
                     document.dispatchEvent(new CustomEvent('pvp.sse.' + name, { detail: detail }));
                 });
             });
+    }
+
+    // Translate a per-game `outcome` + session-view `snapshot` into the
+    // shared `playPvpResolution` overlay. Pulls initiator / opponent
+    // identity from the active session snapshot (already carries names
+    // and avatars from `PvpWebService.PvpParticipant`).
+    function playOutcomeOverlay(outcome, snapshot, flair) {
+        if (!outcome || !snapshot || !snapshot.participants) return;
+        const participants = snapshot.participants;
+        playPvpResolution({
+            initiator: {
+                discordId: participants.initiator && participants.initiator.discordId,
+                name: participants.initiator && participants.initiator.name,
+                avatarUrl: participants.initiator && participants.initiator.avatarUrl,
+            },
+            opponent: {
+                discordId: participants.opponent && participants.opponent.discordId,
+                name: participants.opponent && participants.opponent.name,
+                avatarUrl: participants.opponent && participants.opponent.avatarUrl,
+            },
+            winnerDiscordId: outcome.winnerDiscordId,
+            verdict: outcome.verdict || (outcome.winnerDiscordId ? 'WIN' : 'DRAW'),
+            pot: outcome.pot,
+            lossTribute: outcome.lossTribute,
+            flair: flair,
+        });
     }
 
     function renderTicTacToeBoard(boardEl, view, ctx) {

--- a/web/src/main/resources/templates/pvp.html
+++ b/web/src/main/resources/templates/pvp.html
@@ -44,13 +44,14 @@
     <section id="pvp-panel-duel" class="pvp-panel" role="tabpanel" aria-labelledby="pvp-tab-duel">
         <section class="duel-card">
             <h2>Challenge someone</h2>
-            <form id="duel-challenge" autocomplete="off">
+            <form id="duel-challenge" autocomplete="off"
+                  onsubmit="event.preventDefault();return false;">
                 <label for="duel-opponent">Opponent</label>
                 <div th:replace="~{fragments/userPicker :: userPicker(
                         name='opponentDiscordId',
                         id='duel-opponent',
                         members=${members},
-                        selectedId=null,
+                        selectedId=${preselectedOpponentId},
                         placeholder='Pick an opponent…',
                         emptyLabel=null,
                         required=true,
@@ -62,7 +63,9 @@
 
                 <label for="duel-stake">Stake (credits)</label>
                 <input id="duel-stake" name="stake" type="number"
-                       th:attr="min=${minStake}, max=${maxStake}" th:value="${minStake}" step="1" required>
+                       th:attr="min=${minStake}, max=${maxStake}"
+                       th:value="${preselectedStake != null ? preselectedStake : minStake}"
+                       step="1" required>
 
                 <div class="duel-form-actions">
                     <button type="submit" id="duel-send" class="btn-primary">Send challenge</button>
@@ -136,13 +139,14 @@
              th:attr="data-min-stake=${rpsMinStake}, data-max-stake=${rpsMaxStake}" hidden>
         <section class="pvp-card">
             <h2>✊ Challenge someone</h2>
-            <form id="rps-challenge" autocomplete="off">
+            <form id="rps-challenge" autocomplete="off"
+                  onsubmit="event.preventDefault();return false;">
                 <label for="rps-opponent">Opponent</label>
                 <div th:replace="~{fragments/userPicker :: userPicker(
                         name='opponentDiscordId',
                         id='rps-opponent',
                         members=${members},
-                        selectedId=null,
+                        selectedId=${preselectedOpponentId},
                         placeholder='Pick an opponent…',
                         emptyLabel=null,
                         required=true,
@@ -151,7 +155,9 @@
 
                 <label for="rps-stake">Stake (credits)</label>
                 <input id="rps-stake" name="stake" type="number"
-                       th:attr="min=${rpsMinStake}, max=${rpsMaxStake}" th:value="${rpsMinStake}" step="1" required>
+                       th:attr="min=${rpsMinStake}, max=${rpsMaxStake}"
+                       th:value="${preselectedStake != null ? preselectedStake : rpsMinStake}"
+                       step="1" required>
 
                 <div class="pvp-form-actions">
                     <button type="submit" id="rps-send" class="btn-primary">Send challenge</button>
@@ -183,13 +189,14 @@
              th:attr="data-min-stake=${tttMinStake}, data-max-stake=${tttMaxStake}" hidden>
         <section class="pvp-card">
             <h2>⭕ Challenge someone</h2>
-            <form id="tictactoe-challenge" autocomplete="off">
+            <form id="tictactoe-challenge" autocomplete="off"
+                  onsubmit="event.preventDefault();return false;">
                 <label for="tictactoe-opponent">Opponent</label>
                 <div th:replace="~{fragments/userPicker :: userPicker(
                         name='opponentDiscordId',
                         id='tictactoe-opponent',
                         members=${members},
-                        selectedId=null,
+                        selectedId=${preselectedOpponentId},
                         placeholder='Pick an opponent…',
                         emptyLabel=null,
                         required=true,
@@ -198,7 +205,9 @@
 
                 <label for="tictactoe-stake">Stake (credits)</label>
                 <input id="tictactoe-stake" name="stake" type="number"
-                       th:attr="min=${tttMinStake}, max=${tttMaxStake}" th:value="${tttMinStake}" step="1" required>
+                       th:attr="min=${tttMinStake}, max=${tttMaxStake}"
+                       th:value="${preselectedStake != null ? preselectedStake : tttMinStake}"
+                       step="1" required>
 
                 <div class="pvp-form-actions">
                     <button type="submit" id="tictactoe-send" class="btn-primary">Send challenge</button>
@@ -230,13 +239,14 @@
              th:attr="data-min-stake=${c4MinStake}, data-max-stake=${c4MaxStake}" hidden>
         <section class="pvp-card">
             <h2>🔴 Challenge someone</h2>
-            <form id="connect4-challenge" autocomplete="off">
+            <form id="connect4-challenge" autocomplete="off"
+                  onsubmit="event.preventDefault();return false;">
                 <label for="connect4-opponent">Opponent</label>
                 <div th:replace="~{fragments/userPicker :: userPicker(
                         name='opponentDiscordId',
                         id='connect4-opponent',
                         members=${members},
-                        selectedId=null,
+                        selectedId=${preselectedOpponentId},
                         placeholder='Pick an opponent…',
                         emptyLabel=null,
                         required=true,
@@ -245,7 +255,9 @@
 
                 <label for="connect4-stake">Stake (credits)</label>
                 <input id="connect4-stake" name="stake" type="number"
-                       th:attr="min=${c4MinStake}, max=${c4MaxStake}" th:value="${c4MinStake}" step="1" required>
+                       th:attr="min=${c4MinStake}, max=${c4MaxStake}"
+                       th:value="${preselectedStake != null ? preselectedStake : c4MinStake}"
+                       step="1" required>
 
                 <div class="pvp-form-actions">
                     <button type="submit" id="connect4-send" class="btn-primary">Send challenge</button>

--- a/web/src/test/js/duel-resolution.test.js
+++ b/web/src/test/js/duel-resolution.test.js
@@ -398,3 +398,73 @@ describe('playFromResolution', () => {
     });
 });
 
+describe('page-init regression: full DOM bootstrap', () => {
+    // Regression for a TDZ bug where `sharedStreamOpened` was declared
+    // with `let` *after* `initBoardGamePanel` invoked `ensureSharedStream`.
+    // The temporal dead zone aborted the IIFE on real pages, so the
+    // challenge forms never got their submit handlers attached — the
+    // page silently fell back to a native GET form submit and no game
+    // state ever started. We re-evaluate the IIFE in the live jsdom
+    // window after staging the four PvP panels and assert it completes
+    // without throwing *and* wires the challenge forms.
+
+    const fs = require('fs');
+    const path = require('path');
+    const pvpSource = fs.readFileSync(
+        path.resolve(__dirname, '../../main/resources/static/js/pvp.js'),
+        'utf8',
+    );
+
+    function setupPvpDom() {
+        document.body.innerHTML = `
+            <main id="main" data-guild-id="1" data-ttl-seconds="60"></main>
+            <div class="pvp-tabs">
+                <button class="pvp-tab is-active" data-pvp-tab="duel"></button>
+                <button class="pvp-tab" data-pvp-tab="rps"></button>
+                <button class="pvp-tab" data-pvp-tab="tictactoe"></button>
+                <button class="pvp-tab" data-pvp-tab="connect4"></button>
+            </div>
+            ${['duel', 'rps', 'tictactoe', 'connect4'].map(function (slug) {
+                return '<section class="pvp-panel" id="pvp-panel-' + slug + '" hidden>' +
+                    '<form id="' + slug + '-challenge"><select id="' + slug + '-opponent"></select>' +
+                    '<input id="' + slug + '-stake" type="number" value="1"></form>' +
+                    '<section id="' + slug + '-active-section" hidden>' +
+                        '<div id="' + slug + '-active"></div>' +
+                    '</section>' +
+                    '<div id="' + slug + '-pending-list"></div>' +
+                    '<div id="' + slug + '-outgoing-list"></div>' +
+                '</section>';
+            }).join('')}
+        `;
+        // Stub EventSource so ensureSharedStream / ensureStream don't try
+        // to open a real connection in the jsdom env.
+        window.EventSource = function () { this.addEventListener = function () {}; };
+    }
+
+    test('IIFE completes when every PvP panel is present (regression: no TDZ on sharedStreamOpened)', () => {
+        setupPvpDom();
+        expect(() => {
+            // Re-evaluate the IIFE against the live document. The
+            // module-level `require` at the top of the test file also
+            // ran the IIFE, but against an empty body — the page-init
+            // exits early without #main and never reaches the bug.
+            (new Function('window', 'document', pvpSource))(window, document);
+        }).not.toThrow();
+    });
+
+    test('submit handlers are wired so the form does not fall back to native GET submit', () => {
+        setupPvpDom();
+        (new Function('window', 'document', pvpSource))(window, document);
+        // Each form must have a JS submit handler that calls preventDefault.
+        // If the IIFE crashed mid-bootstrap (as it did with the TDZ bug),
+        // the `submit` event would propagate to the form's default action
+        // and the browser would GET-navigate the page away.
+        ['rps', 'tictactoe', 'connect4'].forEach(function (slug) {
+            const form = document.getElementById(slug + '-challenge');
+            expect(form).not.toBeNull();
+            const evt = new Event('submit', { cancelable: true, bubbles: true });
+            form.dispatchEvent(evt);
+            expect(evt.defaultPrevented).toBe(true);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

PvP polish across Discord and the web, addressing four reported issues:

- **TicTacToe / Connect 4 / RPS win embeds tagged the winner as a raw `<@id>` mention** when the Discord client couldn't resolve the user. The title now uses a JDA-resolved display name (with a `Player NNNN` fallback) while the description keeps the mention so the winner still gets pinged.
- **`/connect4` (and `/tictactoe`, `/rps`) button clicks left a ghost "Toby is thinking…" on every move.** Added a `defersEdit` flag on the `Button` interface that routes board-editing buttons through `event.deferEdit()` instead of `event.deferReply(true)`, and suppresses the channel-typing prod that produced the second indicator. Connect4 / TicTacToe / RPS / Duel buttons opt in.
- **Web RPS didn't announce the result, and TTT / C4 only printed a verdict line.** Generalized the duel resolution overlay into a shared `playPvpResolution` and wired RPS / TTT / C4 to use it (avatars, winner highlight, credits pill on WIN, draw/refund variants).
- **The TicTacToe / Connect 4 / RPS tabs ignored Discord deep-link query params.** `/pvp/{guildId}?opponentDiscordId=&stake=` now pre-fills every game's opponent picker and stake input.

Additional polish bundled in the same pass:

- Belt-and-braces `onsubmit="event.preventDefault();return false;"` on the four PvP challenge forms so a JS-init failure can't fall back to a native form submit and navigate away from the page.
- Log4j2 `BrokenPipeLogFilter` quietens the Tomcat servlet-wrapper ERROR log Heroku raises when its 55-second router idle timeout closes an SSE connection mid-heartbeat. `KeyedSseRegistry` already evicts the dead emitter — the noise was just the wrapper surfacing the IOException before our catch ran.

## Test plan

- [x] `:discord-bot:test` — 1558 tests pass
- [x] `:web:test` — 1101 tests pass
- [x] `npx jest` (Jest JS suite) — 623 tests pass, existing `duel-resolution.test.js` coverage holds
- [ ] In a test guild: `/connect4 user:@friend stake:0`, accept, drop a column — no thinking indicator; board updates in place. Same for `/tictactoe` and `/rps`.
- [ ] Force a win on each Discord game; embed title shows the resolved display name, body still pings the winner.
- [ ] On `/pvp/{guildId}` web: send a TTT or C4 challenge from one account, accept on a second account; the duel-style overlay fires with both avatars on win. Repeat with a draw to confirm the refund variant.
- [ ] Deep-link `/pvp/{guildId}?opponentDiscordId=<X>&stake=10` to a TTT / C4 / RPS tab; opponent picker pre-selected, stake input pre-filled.

https://claude.ai/code/session_01N945YhZDq9cca7UA2Yygtc

---
_Generated by [Claude Code](https://claude.ai/code/session_01N945YhZDq9cca7UA2Yygtc)_