### PR TITLE
Surface lottery bonus tickets and milestone jackpot draws in embed buy

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/modal/modals/LotteryBuyModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/modal/modals/LotteryBuyModal.kt
@@ -23,11 +23,23 @@ class LotteryBuyModal(
         }
 
         when (val r = jackpotLotteryService.buyTickets(guildId, userId, count)) {
-            is BuyOutcome.Ok -> event.hook.sendMessage(
-                "Bought **$count** ticket(s). You now hold **${r.ticketCount}** tickets " +
-                    "(spent ${r.totalSpent} credits total). Prize pool: **${r.newPool}** credits. " +
-                    "Your balance: **${r.newBalance}** credits."
-            ).setEphemeral(true).queue()
+            is BuyOutcome.Ok -> event.hook.sendMessage(buildString {
+                append("Bought **$count** ticket(s). ")
+                if (r.bonusAwarded > 0) {
+                    append("🎁 Plus **${r.bonusAwarded}** bonus ticket(s)! ")
+                }
+                append(
+                    "You now hold **${r.ticketCount}** tickets " +
+                        "(spent ${r.totalSpent} credits total). Prize pool: **${r.newPool}** credits. " +
+                        "Your balance: **${r.newBalance}** credits."
+                )
+                r.milestoneBonuses.forEach { m ->
+                    append(
+                        "\n🚀 Milestone reached at **${m.threshold}** tickets sold → " +
+                            "**+${m.creditsAdded}** credits drawn into the prize pool!"
+                    )
+                }
+            }).setEphemeral(true).queue()
 
             BuyOutcome.NoOpenLottery ->
                 event.hook.sendMessage("No lottery is open right now.").setEphemeral(true).queue()

--- a/discord-bot/src/main/kotlin/bot/toby/modal/modals/LotteryBuyModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/modal/modals/LotteryBuyModal.kt
@@ -25,8 +25,8 @@ class LotteryBuyModal(
         when (val r = jackpotLotteryService.buyTickets(guildId, userId, count)) {
             is BuyOutcome.Ok -> event.hook.sendMessage(buildString {
                 append("Bought **$count** ticket(s). ")
-                if (r.bonusAwarded > 0) {
-                    append("🎁 Plus **${r.bonusAwarded}** bonus ticket(s)! ")
+                if (r.bonusTicketsGranted > 0) {
+                    append("🎁 Plus **${r.bonusTicketsGranted}** bonus ticket(s) from bulk-buy! ")
                 }
                 append(
                     "You now hold **${r.ticketCount}** tickets " +

--- a/discord-bot/src/test/kotlin/bot/toby/modal/modals/LotteryBuyModalTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/modal/modals/LotteryBuyModalTest.kt
@@ -90,6 +90,58 @@ class LotteryBuyModalTest {
     }
 
     @Test
+    fun `surfaces bonus tickets awarded on a bulk buy`() {
+        val mapping = mockk<ModalMapping> { every { asString } returns "5" }
+        every { event.getValue("count") } returns mapping
+        every { jackpotLotteryService.buyTickets(100L, 42L, 5) } returns BuyOutcome.Ok(
+            ticketCount = 10, totalSpent = 250L, newBalance = 750L, newPool = 2_000L,
+            bonusAwarded = 2,
+        )
+
+        modal.handle(ctx, 0)
+
+        val msg = messageSlot.captured
+        assertTrue(msg.contains("bonus"), "expected message to mention bonus tickets: $msg")
+        assertTrue(msg.contains("2"), "expected message to mention the bonus count: $msg")
+    }
+
+    @Test
+    fun `omits bonus mention when no bonus was awarded`() {
+        val mapping = mockk<ModalMapping> { every { asString } returns "1" }
+        every { event.getValue("count") } returns mapping
+        every { jackpotLotteryService.buyTickets(100L, 42L, 1) } returns BuyOutcome.Ok(
+            ticketCount = 1, totalSpent = 50L, newBalance = 950L, newPool = 1_000L,
+            bonusAwarded = 0,
+        )
+
+        modal.handle(ctx, 0)
+
+        assertTrue(!messageSlot.captured.contains("bonus"), "did not expect a bonus mention: ${messageSlot.captured}")
+    }
+
+    @Test
+    fun `surfaces milestone jackpot draws triggered by the purchase`() {
+        val mapping = mockk<ModalMapping> { every { asString } returns "5" }
+        every { event.getValue("count") } returns mapping
+        every { jackpotLotteryService.buyTickets(100L, 42L, 5) } returns BuyOutcome.Ok(
+            ticketCount = 10, totalSpent = 250L, newBalance = 750L, newPool = 2_000L,
+            milestoneBonuses = listOf(
+                BuyOutcome.MilestoneBonus(threshold = 50L, creditsAdded = 500L),
+                BuyOutcome.MilestoneBonus(threshold = 100L, creditsAdded = 750L),
+            ),
+        )
+
+        modal.handle(ctx, 0)
+
+        val msg = messageSlot.captured
+        assertTrue(msg.contains("Milestone"), "expected message to mention milestone: $msg")
+        assertTrue(msg.contains("50"), "expected first milestone threshold: $msg")
+        assertTrue(msg.contains("500"), "expected first milestone credits: $msg")
+        assertTrue(msg.contains("100"), "expected second milestone threshold: $msg")
+        assertTrue(msg.contains("750"), "expected second milestone credits: $msg")
+    }
+
+    @Test
     fun `replies with error on NoOpenLottery`() {
         val mapping = mockk<ModalMapping> { every { asString } returns "1" }
         every { event.getValue("count") } returns mapping

--- a/discord-bot/src/test/kotlin/bot/toby/modal/modals/LotteryBuyModalTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/modal/modals/LotteryBuyModalTest.kt
@@ -126,8 +126,8 @@ class LotteryBuyModalTest {
         every { jackpotLotteryService.buyTickets(100L, 42L, 5) } returns BuyOutcome.Ok(
             ticketCount = 10, totalSpent = 250L, newBalance = 750L, newPool = 2_000L,
             milestoneBonuses = listOf(
-                BuyOutcome.MilestoneBonus(threshold = 50L, creditsAdded = 500L),
-                BuyOutcome.MilestoneBonus(threshold = 100L, creditsAdded = 750L),
+                JackpotLotteryService.MilestoneBonus(threshold = 50L, creditsAdded = 500L),
+                JackpotLotteryService.MilestoneBonus(threshold = 100L, creditsAdded = 750L),
             ),
         )
 

--- a/discord-bot/src/test/kotlin/bot/toby/modal/modals/LotteryBuyModalTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/modal/modals/LotteryBuyModalTest.kt
@@ -95,7 +95,7 @@ class LotteryBuyModalTest {
         every { event.getValue("count") } returns mapping
         every { jackpotLotteryService.buyTickets(100L, 42L, 5) } returns BuyOutcome.Ok(
             ticketCount = 10, totalSpent = 250L, newBalance = 750L, newPool = 2_000L,
-            bonusAwarded = 2,
+            bonusTicketsGranted = 2L,
         )
 
         modal.handle(ctx, 0)
@@ -111,7 +111,7 @@ class LotteryBuyModalTest {
         every { event.getValue("count") } returns mapping
         every { jackpotLotteryService.buyTickets(100L, 42L, 1) } returns BuyOutcome.Ok(
             ticketCount = 1, totalSpent = 50L, newBalance = 950L, newPool = 1_000L,
-            bonusAwarded = 0,
+            bonusTicketsGranted = 0L,
         )
 
         modal.handle(ctx, 0)


### PR DESCRIPTION
## Problem

When buying lottery tickets through the Discord **embed button**, the user had **no concept of the bonus tickets awarded or the extra jackpot drawn in**. The confirmation message only reported base tickets, spend, prize pool, and balance.

`BuyOutcome.Ok` already carries this information:
- `bonusTicketsGranted` — bulk-buy bonus tickets earned on this purchase
- `milestoneBonuses` — pool-growth milestone draws that pulled credits from the jackpot into the prize pool

…but `LotteryBuyModal` silently dropped both. The web UI (`lottery.js`) already surfaces them, so the embed path was inconsistent with the rest of the product.

## Fix

`LotteryBuyModal` now mirrors the web wording:
- 🎁 appends a bonus-ticket note when `bonusTicketsGranted > 0`
- 🚀 appends one line per fired milestone, showing the threshold crossed and the credits drawn into the prize pool

No-bonus / no-milestone purchases read exactly as before, so the common case is unchanged.

## Tests

`LotteryBuyModalTest` gains coverage for:
- bonus tickets surfaced on a bulk buy
- bonus mention omitted when none awarded
- milestone jackpot draws reported (threshold + credits, multiple milestones)

The full `LotteryBuyModalTest` suite passes locally (`./gradlew :discord-bot:test`).

https://claude.ai/code/session_014iSgLrR3yyZS3QHQ2BZvhm

---
_Generated by [Claude Code](https://claude.ai/code/session_014iSgLrR3yyZS3QHQ2BZvhm)_