### PR TITLE
Include bonus tickets in the lottery embed held-ticket total

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/modal/modals/LotteryBuyModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/modal/modals/LotteryBuyModal.kt
@@ -29,7 +29,12 @@ class LotteryBuyModal(
                     append("🎁 Plus **${r.bonusTicketsGranted}** bonus ticket(s) from bulk-buy! ")
                 }
                 append(
-                    "You now hold **${r.ticketCount}** tickets " +
+                    if (r.totalBonusTickets > 0) {
+                        "You now hold **${r.ticketCount + r.totalBonusTickets}** tickets " +
+                            "(**${r.ticketCount}** paid + **${r.totalBonusTickets}** bonus) "
+                    } else {
+                        "You now hold **${r.ticketCount}** tickets "
+                    } +
                         "(spent ${r.totalSpent} credits total). Prize pool: **${r.newPool}** credits. " +
                         "Your balance: **${r.newBalance}** credits."
                 )

--- a/discord-bot/src/test/kotlin/bot/toby/modal/modals/LotteryBuyModalTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/modal/modals/LotteryBuyModalTest.kt
@@ -106,6 +106,42 @@ class LotteryBuyModalTest {
     }
 
     @Test
+    fun `held total includes bonus tickets with a paid plus bonus breakdown`() {
+        // Mirrors the reported scenario: bought 25 paid, holds 10 bonus too,
+        // so the "you now hold" total must read 35, not the paid 25.
+        val mapping = mockk<ModalMapping> { every { asString } returns "25" }
+        every { event.getValue("count") } returns mapping
+        every { jackpotLotteryService.buyTickets(100L, 42L, 25) } returns BuyOutcome.Ok(
+            ticketCount = 25, totalSpent = 1_250L, newBalance = 8_750L, newPool = 5_000L,
+            bonusTicketsGranted = 10L, totalBonusTickets = 10L,
+        )
+
+        modal.handle(ctx, 0)
+
+        val msg = messageSlot.captured
+        assertTrue(msg.contains("hold **35** tickets"), "expected combined held total of 35: $msg")
+        assertTrue(msg.contains("**25** paid"), "expected paid breakdown: $msg")
+        assertTrue(msg.contains("**10** bonus"), "expected bonus breakdown: $msg")
+    }
+
+    @Test
+    fun `held total has no breakdown when the user holds no bonus tickets`() {
+        val mapping = mockk<ModalMapping> { every { asString } returns "3" }
+        every { event.getValue("count") } returns mapping
+        every { jackpotLotteryService.buyTickets(100L, 42L, 3) } returns BuyOutcome.Ok(
+            ticketCount = 3, totalSpent = 150L, newBalance = 850L, newPool = 1_000L,
+            totalBonusTickets = 0L,
+        )
+
+        modal.handle(ctx, 0)
+
+        val msg = messageSlot.captured
+        assertTrue(msg.contains("hold **3** tickets"), "expected plain held total of 3: $msg")
+        assertTrue(!msg.contains("paid +"), "did not expect a paid/bonus breakdown: $msg")
+        assertTrue(!msg.contains("bonus"), "did not expect a bonus mention: $msg")
+    }
+
+    @Test
     fun `omits bonus mention when no bonus was awarded`() {
         val mapping = mockk<ModalMapping> { every { asString } returns "1" }
         every { event.getValue("count") } returns mapping


### PR DESCRIPTION
## Problem

Follow-up to #603. The embed buy confirmation now announces bonus tickets, but the **held total ignores them**. From the reported screenshot:

> Bought **25** ticket(s). 🎁 Plus **10** bonus ticket(s) from bulk-buy! You now hold **25** tickets…

The "you now hold 25 tickets" line used only `ticketCount` (the paid count), so the 10 bonus tickets it just announced weren't reflected in the total — confusing, since the user clearly holds 35.

## Fix

When the buyer holds any bonus tickets, render the combined total with a `paid + bonus` breakdown, mirroring the web UI:

> You now hold **35** tickets (**25** paid + **10** bonus)…

The plain "You now hold **N** tickets" wording is kept when there are no bonus tickets, so the common case is unchanged.

## Tests

`LotteryBuyModalTest` gains:
- combined held total of 35 with a `25 paid + 10 bonus` breakdown (the reported scenario)
- no-bonus case stays a plain held total with no breakdown

Full `LotteryBuyModalTest` suite passes locally (`./gradlew :discord-bot:test`).

https://claude.ai/code/session_014iSgLrR3yyZS3QHQ2BZvhm

---
_Generated by [Claude Code](https://claude.ai/code/session_014iSgLrR3yyZS3QHQ2BZvhm)_