### PR TITLE
fix(leaderboard): monthly board posts last-month snapshot, not current standings

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/scheduling/MonthlyLeaderboardJob.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/scheduling/MonthlyLeaderboardJob.kt
@@ -78,7 +78,16 @@ class MonthlyLeaderboardJob @Autowired constructor(
             .map { dto ->
                 val current = dto.socialCredit ?: 0L
                 val baseline = priorSnapshots[dto.discordId]?.socialCredit
-                val rawDelta = if (baseline == null) current else current - baseline
+                // No prior-month snapshot means we have no starting point to
+                // measure last month's change against, so treat the delta as 0
+                // rather than counting the user's entire current balance as
+                // "earned last month". Counting the full balance ranks everyone
+                // by their lifetime total and turns the board into a current-
+                // standings list instead of a last-month snapshot. This mirrors
+                // ModerationWebService / LeaderboardWebService, which use the
+                // same 0L fallback; the thisMonthStart snapshot written below
+                // seeds the baseline so the next month's delta is correct.
+                val rawDelta = if (baseline == null) 0L else current - baseline
                 val ubi = ubiByUser[dto.discordId] ?: 0L
                 val creditsDelta = (rawDelta - ubi).coerceAtLeast(0L)
                 MonthlyRow(

--- a/discord-bot/src/test/kotlin/bot/toby/scheduling/MonthlyLeaderboardJobTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/scheduling/MonthlyLeaderboardJobTest.kt
@@ -197,8 +197,10 @@ class MonthlyLeaderboardJobTest {
         member(2L, "FratLayton")
         member(3L, "Alice")
         // FratLayton's prior snapshot was 1880 → delta = -1880, no voice → should be filtered out.
+        // Alice started the month at 0 → delta = 100 → positive activity, should appear.
         every { snapshotService.listForGuildDate(guildId, any()) } returns listOf(
-            MonthlyCreditSnapshotDto(discordId = 2L, guildId = guildId, socialCredit = 1880L)
+            MonthlyCreditSnapshotDto(discordId = 2L, guildId = guildId, socialCredit = 1880L),
+            MonthlyCreditSnapshotDto(discordId = 3L, guildId = guildId, socialCredit = 0L)
         )
         every { voiceSessionService.sumCountedSecondsInRangeByUser(guildId, any(), any()) } returns emptyMap()
         every { configService.getConfigByName(any(), guildId.toString()) } returns null
@@ -235,6 +237,38 @@ class MonthlyLeaderboardJobTest {
 
         val description = embedSlot.captured.description ?: ""
         assertTrue(description.startsWith("No activity recorded"), "Expected no-activity message, got: $description")
+    }
+
+    @Test
+    fun `postMonthlyLeaderboard does not count full balance as earnings when no prior snapshot exists`() {
+        // Regression: with no prior-month snapshot, the board must NOT treat a
+        // user's entire current balance as "earned last month" — doing so ranks
+        // everyone by their lifetime total and turns the board into a current-
+        // standings list instead of a last-month snapshot. A missing baseline
+        // means 0 last-month credits (matches the web leaderboards), so a user
+        // with credits but no baseline and no voice is filtered out entirely.
+        val alice = UserDto(discordId = 1L, guildId = guildId).apply { socialCredit = 5000L }
+        every { userService.listGuildUsers(guildId) } returns listOf(alice)
+        member(1L, "Alice")
+        every { snapshotService.listForGuildDate(guildId, any()) } returns emptyList()
+        every { voiceSessionService.sumCountedSecondsInRangeByUser(guildId, any(), any()) } returns emptyMap()
+        every { configService.getConfigByName(any(), guildId.toString()) } returns null
+        val embedSlot = slot<MessageEmbed>()
+        val createAction = mockk<MessageCreateAction>(relaxed = true)
+        every { channel.sendMessageEmbeds(capture(embedSlot)) } returns createAction
+
+        job.postMonthlyLeaderboard()
+
+        verify(exactly = 1) { channel.sendMessageEmbeds(any<MessageEmbed>()) }
+        val description = embedSlot.captured.description ?: ""
+        assertTrue(
+            description.startsWith("No activity recorded"),
+            "Expected no-activity message (baseline absent → 0 delta), got: $description"
+        )
+        assertFalse(
+            description.contains("5000"),
+            "Lifetime balance must not be reported as last-month earnings, got: $description"
+        )
     }
 
     @Test


### PR DESCRIPTION
## Problem

The monthly social-credit board posted on the 1st was showing what looked like **current standings** rather than a snapshot of **last month's** activity.

## Root cause

`MonthlyLeaderboardJob`, `ModerationWebService`, and `LeaderboardWebService` all compute the same "credits earned this period" value, but the Discord job disagreed on one line when a user has **no prior-month snapshot**:

| Location | Missing-baseline behaviour |
|---|---|
| `ModerationWebService.kt:276` | `if (baseline == null) 0L else current - baseline` |
| `LeaderboardWebService` | `0L` baseline (lazy-seeds, same model) |
| `MonthlyLeaderboardJob.kt:81` (before) | `if (baseline == null) current else current - baseline` ⚠️ |

The job was the outlier. With no prior-month baseline, it counted the user's **entire current social-credit balance** as "earned last month." That happens for every user on a freshly deployed feature, a new guild, or any month before snapshots have accumulated — so the board ended up ranked by lifetime totals, reading as a current-standings list instead of a last-month snapshot.

## Fix

Align the job with the two web services: a missing baseline means there is no starting point to measure last month against, so the delta is `0L`. The `thisMonthStart` snapshot the job already writes at the end of each run seeds the baseline, so the **next** month's delta is computed correctly — the same lazy-baseline model the web leaderboards rely on.

## Tests

- Updated the bots/inactive-users test to give Alice a real prior-month baseline (`0` → delta `100`), so the "active user appears" case still holds under the corrected fallback.
- Added a regression test: a user with a 5000 balance but **no** prior snapshot and no voice time is **not** surfaced, and their lifetime balance is never reported as last-month earnings.

`./gradlew :discord-bot:test --tests "bot.toby.scheduling.MonthlyLeaderboardJobTest"` → BUILD SUCCESSFUL.

https://claude.ai/code/session_0147sjoCMjw7dtk8JBP5zvDv

---
_Generated by [Claude Code](https://claude.ai/code/session_0147sjoCMjw7dtk8JBP5zvDv)_