### PR TITLE
Redesign the daily streak card on the profile page

### DIFF
--- a/web/src/main/resources/static/css/profile.css
+++ b/web/src/main/resources/static/css/profile.css
@@ -394,3 +394,183 @@
 .profile-achievement-unlocked-at {
     font-variant-numeric: tabular-nums;
 }
+
+/* ----- Daily streak card ----- */
+.profile-streak-card {
+    --streak-from: #ff6a3d;
+    --streak-to: #ffb13d;
+    --streak-glow: rgba(255, 122, 61, 0.28);
+    position: relative;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+}
+.profile-streak-card.is-lit {
+    border-color: rgba(255, 122, 61, 0.35);
+    background:
+        radial-gradient(120% 80% at 100% 0%, var(--streak-glow) 0%, transparent 55%),
+        var(--bg-elevated);
+}
+
+.profile-streak-hero {
+    display: flex;
+    align-items: center;
+    gap: var(--space-4);
+}
+.profile-streak-flame {
+    position: relative;
+    flex-shrink: 0;
+    width: 72px;
+    height: 72px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background: linear-gradient(135deg, var(--border) 0%, var(--bg) 100%);
+    box-shadow:
+        0 0 0 4px var(--bg-elevated),
+        0 0 0 5px var(--border-strong);
+    transition: box-shadow var(--dur-base) var(--ease-out);
+}
+.profile-streak-card.is-lit .profile-streak-flame {
+    background: linear-gradient(135deg, var(--streak-from) 0%, var(--streak-to) 100%);
+    box-shadow:
+        0 0 0 4px var(--bg-elevated),
+        0 0 0 5px rgba(255, 122, 61, 0.45),
+        0 6px 22px var(--streak-glow);
+}
+.profile-streak-flame-icon {
+    position: absolute;
+    top: -6px;
+    right: -2px;
+    font-size: 1.35rem;
+    filter: grayscale(0.85) opacity(0.5);
+    transition: filter var(--dur-base) var(--ease-out);
+}
+.profile-streak-card.is-lit .profile-streak-flame-icon {
+    filter: none;
+    animation: streak-flicker 2.4s ease-in-out infinite;
+}
+.profile-streak-flame-count {
+    font-size: 1.7rem;
+    font-weight: 800;
+    line-height: 1;
+    color: var(--text-muted);
+    font-variant-numeric: tabular-nums;
+}
+.profile-streak-card.is-lit .profile-streak-flame-count {
+    color: #1a1a2e;
+}
+
+.profile-streak-hero-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
+.profile-streak-hero-label {
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: var(--text);
+}
+.profile-streak-best {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+.profile-streak-best strong {
+    color: var(--text);
+    font-variant-numeric: tabular-nums;
+}
+
+.profile-streak-week {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 6px;
+}
+.profile-streak-day {
+    flex: 1;
+    display: flex;
+    justify-content: center;
+}
+.profile-streak-day-dot {
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--bg);
+    border: 1px solid var(--border-strong);
+    font-size: 0.6rem;
+    line-height: 1;
+    color: var(--text-dim);
+    transition: background var(--dur-base) var(--ease-out),
+                border-color var(--dur-base) var(--ease-out),
+                box-shadow var(--dur-base) var(--ease-out);
+}
+.profile-streak-day.is-milestone .profile-streak-day-dot {
+    width: 22px;
+    height: 22px;
+    font-size: 0.7rem;
+}
+.profile-streak-day.is-filled .profile-streak-day-dot {
+    background: linear-gradient(135deg, var(--streak-from) 0%, var(--streak-to) 100%);
+    border-color: transparent;
+    color: #1a1a2e;
+    box-shadow: 0 0 10px var(--streak-glow);
+}
+
+.profile-streak-meta {
+    font-size: 0.85rem;
+    margin: 0;
+}
+.profile-streak-meta code {
+    padding: 1px 5px;
+    border-radius: 4px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    font-size: 0.8em;
+}
+
+.profile-streak-claim {
+    margin-top: auto;
+    align-self: flex-start;
+    background: linear-gradient(135deg, var(--streak-from) 0%, var(--streak-to) 100%);
+    border: 0;
+    color: #1a1a2e;
+    font-weight: 700;
+}
+.profile-streak-claim:hover:not(:disabled) {
+    filter: brightness(1.06);
+    box-shadow: 0 4px 16px var(--streak-glow);
+}
+.profile-streak-claim:disabled {
+    background: var(--border);
+    color: var(--text-muted);
+    cursor: default;
+    opacity: 1;
+}
+
+@keyframes streak-flicker {
+    0%, 100% { transform: scale(1) rotate(0deg); }
+    50%      { transform: scale(1.12) rotate(-3deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .profile-streak-card.is-lit .profile-streak-flame-icon { animation: none; }
+}
+
+@media (max-width: 480px) {
+    .profile-streak-flame {
+        width: 60px;
+        height: 60px;
+    }
+    .profile-streak-flame-count {
+        font-size: 1.45rem;
+    }
+}

--- a/web/src/main/resources/static/js/profile.js
+++ b/web/src/main/resources/static/js/profile.js
@@ -4,6 +4,18 @@
 (function () {
     'use strict';
 
+    // Fill the 7-day cycle dots based on the current streak. The cycle
+    // repeats every 7 days, so day 8 lights one dot again, etc. — mirrors
+    // the Thymeleaf-rendered initial state.
+    function updateWeek(card, currentStreak) {
+        const days = card.querySelectorAll('.profile-streak-day');
+        if (!days.length) return;
+        const filled = currentStreak <= 0 ? 0 : ((currentStreak - 1) % 7) + 1;
+        days.forEach(function (day, idx) {
+            day.classList.toggle('is-filled', idx + 1 <= filled);
+        });
+    }
+
     document.addEventListener('DOMContentLoaded', function () {
         const card = document.querySelector('.profile-streak-card');
         if (!card) return;
@@ -30,7 +42,10 @@
                         nums[0].textContent = String(resp.currentStreak);
                         nums[1].textContent = String(resp.longestStreak);
                     }
-                    button.textContent = 'Already claimed today';
+                    updateWeek(card, resp.currentStreak);
+                    card.classList.toggle('is-lit', resp.currentStreak > 0);
+                    card.setAttribute('data-streak', String(resp.currentStreak));
+                    button.textContent = '✓ Claimed today';
                     card.setAttribute('data-claimed-today', 'true');
                 })
                 .catch(function () {

--- a/web/src/main/resources/templates/profile.html
+++ b/web/src/main/resources/templates/profile.html
@@ -86,25 +86,38 @@
         </section>
 
         <section class="profile-card profile-streak-card"
+                 th:classappend="${profile.streak.currentStreak > 0} ? ' is-lit' : ''"
                  th:attr="data-guild-id=${profile.guildId},
-                          data-claimed-today=${profile.streak.claimedToday}">
+                          data-claimed-today=${profile.streak.claimedToday},
+                          data-streak=${profile.streak.currentStreak}">
             <h2>Daily streak</h2>
-            <div class="profile-streak">
-                <div class="profile-streak-stat">
-                    <span class="profile-streak-num" th:text="${profile.streak.currentStreak}">0</span>
-                    <span class="muted">Current</span>
+            <div class="profile-streak-hero">
+                <div class="profile-streak-flame" aria-hidden="true">
+                    <span class="profile-streak-flame-icon">🔥</span>
+                    <span class="profile-streak-flame-count profile-streak-num"
+                          th:text="${profile.streak.currentStreak}">0</span>
                 </div>
-                <div class="profile-streak-stat">
-                    <span class="profile-streak-num" th:text="${profile.streak.longestStreak}">0</span>
-                    <span class="muted">Best</span>
+                <div class="profile-streak-hero-meta">
+                    <span class="profile-streak-hero-label">day streak</span>
+                    <span class="profile-streak-best">
+                        Best <strong class="profile-streak-num" th:text="${profile.streak.longestStreak}">0</strong>
+                    </span>
                 </div>
             </div>
+            <ol class="profile-streak-week" aria-label="Progress through the 7-day cycle">
+                <li th:each="i : ${#numbers.sequence(1, 7)}"
+                    class="profile-streak-day"
+                    th:classappend="${(i &lt;= (profile.streak.currentStreak == 0 ? 0 : ((profile.streak.currentStreak - 1) % 7) + 1) ? ' is-filled' : '') + (i == 7 ? ' is-milestone' : '')}"
+                    th:attr="data-day=${i}">
+                    <span class="profile-streak-day-dot" th:text="${i == 7} ? '★' : ''"></span>
+                </li>
+            </ol>
             <p class="muted profile-streak-meta"
                th:if="${profile.streak.lastClaimDate != null}"
                th:text="'Last claim: ' + ${profile.streak.lastClaimDate}">Last claim: —</p>
             <p class="muted profile-streak-meta"
                th:if="${viewerIsOwner and profile.streak.lastClaimDate == null}">
-                You haven't claimed yet — `/daily` in Discord or click the button below.
+                You haven't claimed yet — run <code>/daily</code> in Discord or hit the button below.
             </p>
             <p class="muted profile-streak-meta"
                th:if="${!viewerIsOwner and profile.streak.lastClaimDate == null}">
@@ -112,8 +125,8 @@
             </p>
             <button th:if="${viewerIsOwner}" type="button" class="btn profile-streak-claim"
                     th:disabled="${profile.streak.claimedToday}"
-                    th:text="${profile.streak.claimedToday} ? 'Already claimed today' : 'Claim daily'">
-                Claim daily
+                    th:text="${profile.streak.claimedToday} ? '✓ Claimed today' : 'Claim daily reward'">
+                Claim daily reward
             </button>
         </section>
 

--- a/web/src/test/kotlin/web/static/ProfileStreakCardTemplateTest.kt
+++ b/web/src/test/kotlin/web/static/ProfileStreakCardTemplateTest.kt
@@ -1,0 +1,102 @@
+package web.static
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * Pins the redesigned "Daily streak" card on the profile page.
+ *
+ * The card originally shipped with markup that referenced CSS classes
+ * (`profile-streak`, `profile-streak-num`, `profile-streak-claim`) that
+ * had **no styling defined anywhere** — so it rendered as a bare heading,
+ * two raw numbers and an unstyled button. The redesign adds a flame hero,
+ * a 7-day cycle tracker and a gradient claim button, all backed by real
+ * CSS in `profile.css`.
+ *
+ * This guards three regressions:
+ *
+ *  1. A refactor drops the flame hero / 7-day tracker, reverting the card
+ *     to the plain two-number layout.
+ *  2. The `.profile-streak-num` hooks the claim JS depends on disappear,
+ *     silently breaking the in-place update after claiming.
+ *  3. `profile.css` loses the streak styling, leaving the markup unstyled
+ *     again (the exact "very plain" state this redesign fixed).
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ProfileStreakCardTemplateTest {
+
+    private lateinit var html: String
+    private lateinit var css: String
+
+    @BeforeAll
+    fun load() {
+        html = resource("templates/profile.html")
+        css = resource("static/css/profile.css")
+    }
+
+    private fun resource(path: String): String =
+        javaClass.classLoader.getResourceAsStream(path)
+            ?.bufferedReader()
+            ?.readText()
+            ?: error("$path is not on the classpath")
+
+    @Test
+    fun `streak card renders a flame hero with the current streak`() {
+        assertTrue(
+            html.contains("class=\"profile-streak-flame\""),
+            "profile.html must render a `.profile-streak-flame` hero so the daily " +
+                "streak reads as a focal point, not two bare numbers.",
+        )
+        assertTrue(
+            html.contains("profile-streak-flame-count profile-streak-num"),
+            "the flame count must keep the `.profile-streak-num` hook so profile.js " +
+                "can update it in place after a claim.",
+        )
+    }
+
+    @Test
+    fun `streak card renders the 7-day cycle tracker`() {
+        assertTrue(
+            html.contains("class=\"profile-streak-week\""),
+            "profile.html must render the `.profile-streak-week` 7-day tracker.",
+        )
+        assertTrue(
+            html.contains("\${#numbers.sequence(1, 7)}"),
+            "the tracker must iterate a 1..7 sequence so the dots reflect the " +
+                "7-day claim cycle rather than being hand-rolled markup.",
+        )
+    }
+
+    @Test
+    fun `claim button keeps its JS hook and gains a friendlier label`() {
+        assertTrue(
+            html.contains("class=\"btn profile-streak-claim\""),
+            "the claim button must keep the `.profile-streak-claim` class profile.js " +
+                "binds its click handler to.",
+        )
+        assertTrue(
+            html.contains("Claim daily reward"),
+            "the claim button label should read `Claim daily reward`.",
+        )
+    }
+
+    @Test
+    fun `profile css styles the streak card so it is not plain`() {
+        // The bug this redesign fixed: the markup existed but no CSS did,
+        // so the card rendered unstyled. Pin that the styling is present.
+        listOf(
+            ".profile-streak-flame",
+            ".profile-streak-week",
+            ".profile-streak-day",
+            ".profile-streak-claim",
+        ).forEach { selector ->
+            assertTrue(
+                css.contains(selector),
+                "profile.css must style `$selector` — without it the daily streak " +
+                    "card renders plain/unstyled again.",
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Why

The "Daily streak" section on the profile page was very plain. Its markup referenced CSS classes (`profile-streak`, `profile-streak-num`, `profile-streak-claim`) that **had no styling defined anywhere** in `profile.css` — so it rendered as a bare heading, two raw numbers, and an unstyled button.

## What changed

Redesigned it into a proper focal card, matching the existing `level-card` design language (gradient badge + glow):

- **Flame hero** — a gradient circular badge showing the current streak, with an animated 🔥 that only lights up once a streak is active (dim/greyscale at zero).
- **7-day cycle tracker** — a row of dots that fill as the streak progresses through each 7-day cycle, with the 7th day marked as a ★ milestone.
- **Best-streak inline stat** and a friendlier "Last claim" / first-claim hint with a `code`-styled `/daily` reference.
- **Gradient "Claim daily reward" button** with hover glow and a clear disabled `✓ Claimed today` state.

`profile.js` now refreshes the flame count, best stat, week dots, and lit state **in place** after a claim (no reload). The animation respects `prefers-reduced-motion`.

The two `.profile-streak-num` hooks the claim JS depends on are preserved, so the in-place update keeps working.

## Tests

Added `ProfileStreakCardTemplateTest` — a pin test (matching the repo's existing `HomeFeatureCardsTemplateTest` convention) guarding the flame hero, the 7-day tracker, the claim button's JS hook + label, and that `profile.css` actually styles the card — so the plain/unstyled state can't silently return.

- `./gradlew :web:test --tests "web.static.*"` ✅
- `node --check` on `profile.js` ✅

## Notes

This is purely a frontend/template change (HTML + CSS + JS) plus one test — no backend, data-contract, or reward-logic changes. The 7-day tracker is derived from the existing `currentStreak` value; it does not require new data from `ProfileStreakView`.

https://claude.ai/code/session_01YLJSVJWsPD727aQXB5FvPM

---
_Generated by [Claude Code](https://claude.ai/code/session_01YLJSVJWsPD727aQXB5FvPM)_