### PR TITLE
Surface richer daily-streak data on the profile card

### DIFF
--- a/database/src/main/kotlin/database/service/social/LoginStreakService.kt
+++ b/database/src/main/kotlin/database/service/social/LoginStreakService.kt
@@ -23,6 +23,16 @@ interface LoginStreakService {
     fun get(discordId: Long, guildId: Long): LoginStreakDto?
 
     /**
+     * Preview the XP/credit reward a claim landing the user on [streak]
+     * would grant — without claiming. Mirrors the on-claim reward maths
+     * (same config keys, same base/per-day/cap formula) so the web profile
+     * can show "claim for +X" before the user commits. [streak] is the
+     * streak value *after* the hypothetical claim (e.g. a continuing claim
+     * on a 4-day streak previews `streak = 5`).
+     */
+    fun previewReward(guildId: Long, streak: Int): RewardPreview
+
+    /**
      * Users in [guildId] with an active streak (`current_streak > 0`)
      * that haven't claimed yet on [today]. Used by `StreakReminderJob`
      * to DM the at-risk cohort just before their streak resets at
@@ -32,6 +42,11 @@ interface LoginStreakService {
         guildId: Long,
         today: java.time.LocalDate
     ): List<LoginStreakDto>
+
+    data class RewardPreview(
+        val xp: Long,
+        val credits: Long
+    )
 
     sealed class ClaimResult {
         data class Granted(

--- a/database/src/main/kotlin/database/service/social/impl/DefaultLoginStreakService.kt
+++ b/database/src/main/kotlin/database/service/social/impl/DefaultLoginStreakService.kt
@@ -130,6 +130,14 @@ class DefaultLoginStreakService(
         )
     }
 
+    override fun previewReward(guildId: Long, streak: Int): LoginStreakService.RewardPreview {
+        val effective = streak.coerceAtLeast(1)
+        return LoginStreakService.RewardPreview(
+            xp = resolveXpReward(guildId, effective),
+            credits = resolveCreditReward(guildId, effective)
+        )
+    }
+
     private fun resolveXpReward(guildId: Long, streak: Int): Long {
         val base = configLong(guildId, ConfigDto.Configurations.STREAK_BASE_REWARD_XP, DEFAULT_BASE_XP)
         val perDay = configLong(guildId, ConfigDto.Configurations.STREAK_PER_DAY_BONUS_XP, DEFAULT_PER_DAY_BONUS_XP)

--- a/database/src/test/kotlin/database/service/LoginStreakServiceTest.kt
+++ b/database/src/test/kotlin/database/service/LoginStreakServiceTest.kt
@@ -197,6 +197,28 @@ class LoginStreakServiceTest {
         assertEquals(LocalDate.ofInstant(day2, java.time.ZoneOffset.UTC), row.lastClaimDate)
     }
 
+    @Test
+    fun `previewReward mirrors the on-claim reward maths without claiming`() {
+        // Defaults: XP base 50 +5/day cap 300; credits base 25 +5/day cap 200.
+        val day1Preview = service.previewReward(guildId, 1)
+        assertEquals(50L, day1Preview.xp, "streak-1 XP preview == base")
+        assertEquals(25L, day1Preview.credits, "streak-1 credit preview == base")
+
+        val day5Preview = service.previewReward(guildId, 5)
+        assertEquals(70L, day5Preview.xp, "streak-5 XP == 50 + 4*5")
+        assertEquals(45L, day5Preview.credits, "streak-5 credits == 25 + 4*5")
+
+        // Previewing must not write anything — no row, no event, no XP.
+        assertNull(persistence.get(discordId, guildId))
+        assertTrue(eventPublisher.streakEvents.isEmpty())
+        assertEquals(0L, userService.current(discordId, guildId)?.xp)
+    }
+
+    @Test
+    fun `previewReward clamps a non-positive streak to the streak-1 reward`() {
+        assertEquals(service.previewReward(guildId, 1), service.previewReward(guildId, 0))
+    }
+
     // ---------- Fakes ----------
 
     private class InMemoryLoginStreakPersistence : LoginStreakPersistence {

--- a/web/src/main/kotlin/web/service/ProfileWebService.kt
+++ b/web/src/main/kotlin/web/service/ProfileWebService.kt
@@ -65,11 +65,33 @@ class ProfileWebService(
 
         val streakRow = loginStreakService.get(discordId, guildId)
         val today = LocalDate.ofInstant(Instant.now(), ZoneOffset.UTC)
+        val lastClaim = streakRow?.lastClaimDate
+        val currentStreak = streakRow?.currentStreak ?: 0
+        // Day boundaries match DefaultLoginStreakService (UTC). The stored
+        // currentStreak only decays on the next claim, so a row last claimed
+        // two-or-more days ago still reads its old count — LAPSED flags that
+        // the next claim resets to 1, so the UI can stop pretending it's live.
+        val status = when {
+            lastClaim == today -> StreakStatus.CLAIMED
+            lastClaim == null -> StreakStatus.NEW
+            lastClaim == today.minusDays(1) -> StreakStatus.AT_RISK
+            else -> StreakStatus.LAPSED
+        }
+        val streakActive = status == StreakStatus.CLAIMED || status == StreakStatus.AT_RISK
+        // Streak value the *next* claim would produce: +1 while the streak is
+        // alive, otherwise it resets to 1.
+        val nextStreak = if (streakActive) currentStreak + 1 else 1
+        val nextReward = loginStreakService.previewReward(guildId, nextStreak)
         val streakView = ProfileStreakView(
-            currentStreak = streakRow?.currentStreak ?: 0,
+            currentStreak = currentStreak,
             longestStreak = streakRow?.longestStreak ?: 0,
-            lastClaimDate = streakRow?.lastClaimDate?.toString(),
-            claimedToday = streakRow?.lastClaimDate == today,
+            lastClaimDate = lastClaim?.toString(),
+            claimedToday = status == StreakStatus.CLAIMED,
+            totalClaims = streakRow?.totalClaims ?: 0L,
+            status = status.name,
+            streakActive = streakActive,
+            nextRewardXp = nextReward.xp,
+            nextRewardCredits = nextReward.credits,
         )
 
         val achievementViews = achievementService.listFor(discordId, guildId)
@@ -209,11 +231,28 @@ data class ProfileView(
     val achievementCategories: List<ProfileAchievementCategory>,
 )
 
+/**
+ * Lifecycle state of a user's daily streak, derived from `lastClaimDate`
+ * relative to today (UTC). Drives the profile card's messaging and visuals:
+ *   - CLAIMED  — already claimed today; safe.
+ *   - AT_RISK  — alive (last claim was yesterday) but unclaimed today, so
+ *                it breaks at the next UTC midnight unless claimed.
+ *   - LAPSED   — last claim was 2+ days ago; the stored count is stale and
+ *                the next claim restarts at 1.
+ *   - NEW      — never claimed.
+ */
+enum class StreakStatus { CLAIMED, AT_RISK, LAPSED, NEW }
+
 data class ProfileStreakView(
     val currentStreak: Int,
     val longestStreak: Int,
     val lastClaimDate: String?,
-    val claimedToday: Boolean
+    val claimedToday: Boolean,
+    val totalClaims: Long,
+    val status: String,
+    val streakActive: Boolean,
+    val nextRewardXp: Long,
+    val nextRewardCredits: Long,
 )
 
 data class ProfileAchievementCategory(

--- a/web/src/main/resources/static/css/profile.css
+++ b/web/src/main/resources/static/css/profile.css
@@ -466,7 +466,7 @@
 .profile-streak-hero-meta {
     display: flex;
     flex-direction: column;
-    gap: 2px;
+    gap: 6px;
     min-width: 0;
 }
 .profile-streak-hero-label {
@@ -474,13 +474,32 @@
     font-weight: 600;
     color: var(--text);
 }
-.profile-streak-best {
-    font-size: 0.85rem;
-    color: var(--text-muted);
+.profile-streak-stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
 }
-.profile-streak-best strong {
+.profile-streak-stat-chip {
+    font-size: 0.78rem;
+    color: var(--text-muted);
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    padding: 2px 9px;
+}
+.profile-streak-stat-chip strong {
     color: var(--text);
     font-variant-numeric: tabular-nums;
+}
+
+/* Lapsed: the stored streak is stale, so dim the flame and number to
+   stop it reading as a live count. */
+.profile-streak-card.is-lapsed .profile-streak-flame {
+    opacity: 0.6;
+    filter: grayscale(0.5);
+}
+.profile-streak-card.is-lapsed .profile-streak-flame-count {
+    color: var(--text-muted);
 }
 
 .profile-streak-week {
@@ -535,6 +554,48 @@
     background: var(--bg);
     border: 1px solid var(--border);
     font-size: 0.8em;
+}
+.profile-streak-alert {
+    color: var(--warn);
+    font-weight: 600;
+}
+.profile-streak-card.is-lapsed .profile-streak-alert {
+    color: var(--text-muted);
+    font-weight: 400;
+}
+
+.profile-streak-preview {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin: 0;
+    font-size: 0.85rem;
+}
+.profile-streak-reward-pill {
+    display: inline-block;
+    padding: 1px 8px;
+    border-radius: 999px;
+    background: var(--accent-soft);
+    color: var(--accent-light);
+    font-weight: 600;
+    font-size: 0.8rem;
+    font-variant-numeric: tabular-nums;
+}
+
+.profile-streak-claimed-reward {
+    margin: 0;
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--buy);
+    opacity: 0;
+    transform: translateY(4px);
+}
+.profile-streak-claimed-reward.is-shown {
+    opacity: 1;
+    transform: translateY(0);
+    transition: opacity var(--dur-base) var(--ease-out),
+                transform var(--dur-base) var(--ease-out);
 }
 
 .profile-streak-claim {

--- a/web/src/main/resources/static/js/profile.js
+++ b/web/src/main/resources/static/js/profile.js
@@ -16,6 +16,29 @@
         });
     }
 
+    // Surface the reward the claim actually granted — xpGranted /
+    // creditsGranted / newBest come back on the response and were
+    // previously thrown away, leaving the user with no feedback.
+    function showReward(card, resp) {
+        const el = card.querySelector('.profile-streak-claimed-reward');
+        if (!el) return;
+        const parts = [];
+        if (resp.xpGranted > 0) parts.push('+' + resp.xpGranted + ' XP');
+        if (resp.creditsGranted > 0) parts.push('+' + resp.creditsGranted + ' credits');
+        let text = parts.length ? '🎉 Claimed ' + parts.join(' · ') : '🎉 Claimed!';
+        if (resp.newBest) text += ' · 🔥 New personal best!';
+        el.textContent = text;
+        el.hidden = false;
+        el.classList.add('is-shown');
+    }
+
+    function bumpTotal(card) {
+        const total = card.querySelector('.profile-streak-total');
+        if (!total) return;
+        const n = parseInt(total.textContent, 10);
+        if (!isNaN(n)) total.textContent = String(n + 1);
+    }
+
     document.addEventListener('DOMContentLoaded', function () {
         const card = document.querySelector('.profile-streak-card');
         if (!card) return;
@@ -37,16 +60,28 @@
                         button.textContent = originalLabel;
                         return;
                     }
+                    const alreadyClaimed = resp.status === 'already_claimed';
                     const nums = card.querySelectorAll('.profile-streak-num');
                     if (nums.length >= 2) {
                         nums[0].textContent = String(resp.currentStreak);
                         nums[1].textContent = String(resp.longestStreak);
                     }
                     updateWeek(card, resp.currentStreak);
-                    card.classList.toggle('is-lit', resp.currentStreak > 0);
+                    card.classList.add('is-lit');
+                    card.classList.remove('is-lapsed');
                     card.setAttribute('data-streak', String(resp.currentStreak));
-                    button.textContent = '✓ Claimed today';
                     card.setAttribute('data-claimed-today', 'true');
+                    button.textContent = '✓ Claimed today';
+
+                    // The "at risk", "lapsed" and next-reward preview lines
+                    // describe the pre-claim state — drop them now it's claimed.
+                    card.querySelectorAll('.profile-streak-alert, .profile-streak-preview')
+                        .forEach(function (n) { n.remove(); });
+
+                    if (!alreadyClaimed) {
+                        bumpTotal(card);
+                        showReward(card, resp);
+                    }
                 })
                 .catch(function () {
                     button.disabled = false;

--- a/web/src/main/resources/templates/profile.html
+++ b/web/src/main/resources/templates/profile.html
@@ -86,7 +86,7 @@
         </section>
 
         <section class="profile-card profile-streak-card"
-                 th:classappend="${profile.streak.currentStreak > 0} ? ' is-lit' : ''"
+                 th:classappend="${(profile.streak.streakActive ? ' is-lit' : '') + (profile.streak.status == 'LAPSED' ? ' is-lapsed' : '')}"
                  th:attr="data-guild-id=${profile.guildId},
                           data-claimed-today=${profile.streak.claimedToday},
                           data-streak=${profile.streak.currentStreak}">
@@ -99,30 +99,59 @@
                 </div>
                 <div class="profile-streak-hero-meta">
                     <span class="profile-streak-hero-label">day streak</span>
-                    <span class="profile-streak-best">
-                        Best <strong class="profile-streak-num" th:text="${profile.streak.longestStreak}">0</strong>
-                    </span>
+                    <div class="profile-streak-stats">
+                        <span class="profile-streak-stat-chip">
+                            Best <strong class="profile-streak-num" th:text="${profile.streak.longestStreak}">0</strong>
+                        </span>
+                        <span class="profile-streak-stat-chip">
+                            Claimed <strong class="profile-streak-total"
+                                            th:text="${profile.streak.totalClaims}">0</strong>
+                        </span>
+                    </div>
                 </div>
             </div>
             <ol class="profile-streak-week" aria-label="Progress through the 7-day cycle">
                 <li th:each="i : ${#numbers.sequence(1, 7)}"
                     class="profile-streak-day"
-                    th:classappend="${(i &lt;= (profile.streak.currentStreak == 0 ? 0 : ((profile.streak.currentStreak - 1) % 7) + 1) ? ' is-filled' : '') + (i == 7 ? ' is-milestone' : '')}"
+                    th:classappend="${(profile.streak.streakActive and i &lt;= (profile.streak.currentStreak == 0 ? 0 : ((profile.streak.currentStreak - 1) % 7) + 1) ? ' is-filled' : '') + (i == 7 ? ' is-milestone' : '')}"
                     th:attr="data-day=${i}">
                     <span class="profile-streak-day-dot" th:text="${i == 7} ? '★' : ''"></span>
                 </li>
             </ol>
-            <p class="muted profile-streak-meta"
-               th:if="${profile.streak.lastClaimDate != null}"
-               th:text="'Last claim: ' + ${profile.streak.lastClaimDate}">Last claim: —</p>
-            <p class="muted profile-streak-meta"
-               th:if="${viewerIsOwner and profile.streak.lastClaimDate == null}">
-                You haven't claimed yet — run <code>/daily</code> in Discord or hit the button below.
+            <p class="profile-streak-meta profile-streak-alert"
+               th:if="${profile.streak.status == 'AT_RISK'}"
+               th:text="'⚠ Claim today to keep your ' + ${profile.streak.currentStreak} + '-day streak alive!'">
+                ⚠ Claim today to keep your streak alive!
+            </p>
+            <p class="profile-streak-meta profile-streak-alert"
+               th:if="${profile.streak.status == 'LAPSED'}"
+               th:text="'Your ' + ${profile.streak.currentStreak} + '-day streak lapsed — claim to start a new one.'">
+                Your streak lapsed.
             </p>
             <p class="muted profile-streak-meta"
-               th:if="${!viewerIsOwner and profile.streak.lastClaimDate == null}">
+               th:if="${profile.streak.status == 'CLAIMED'}">
+                Claimed today — come back tomorrow to keep it going.
+            </p>
+            <p class="muted profile-streak-meta"
+               th:if="${profile.streak.status == 'NEW' and viewerIsOwner}">
+                Start your streak — run <code>/daily</code> in Discord or hit the button below.
+            </p>
+            <p class="muted profile-streak-meta"
+               th:if="${profile.streak.status == 'NEW' and !viewerIsOwner}">
                 Hasn't claimed yet.
             </p>
+            <p class="profile-streak-preview"
+               th:if="${viewerIsOwner and (profile.streak.nextRewardXp > 0 or profile.streak.nextRewardCredits > 0)}">
+                <span class="muted"
+                      th:text="${profile.streak.claimedToday} ? 'Tomorrow' : 'Claim now'">Claim now</span>
+                <span class="profile-streak-reward-pill"
+                      th:if="${profile.streak.nextRewardXp > 0}"
+                      th:text="'+' + ${profile.streak.nextRewardXp} + ' XP'">+0 XP</span>
+                <span class="profile-streak-reward-pill"
+                      th:if="${profile.streak.nextRewardCredits > 0}"
+                      th:text="'+' + ${profile.streak.nextRewardCredits} + ' credits'">+0 credits</span>
+            </p>
+            <p class="profile-streak-claimed-reward" hidden aria-live="polite"></p>
             <button th:if="${viewerIsOwner}" type="button" class="btn profile-streak-claim"
                     th:disabled="${profile.streak.claimedToday}"
                     th:text="${profile.streak.claimedToday} ? '✓ Claimed today' : 'Claim daily reward'">

--- a/web/src/test/kotlin/web/service/ProfileWebServiceEngagementTest.kt
+++ b/web/src/test/kotlin/web/service/ProfileWebServiceEngagementTest.kt
@@ -70,6 +70,8 @@ class ProfileWebServiceEngagementTest {
         every { userService.getUserById(discordId, guildId) } returns
             UserDto(discordId, guildId).apply { socialCredit = 100L; xp = 0L }
         every { titleService.listOwned(discordId) } returns emptyList()
+        every { loginStreakService.previewReward(any(), any()) } returns
+            LoginStreakService.RewardPreview(0L, 0L)
     }
 
     @Test
@@ -112,6 +114,67 @@ class ProfileWebServiceEngagementTest {
         assertEquals(0, view.streak.longestStreak)
         assertEquals(null, view.streak.lastClaimDate)
         assertFalse(view.streak.claimedToday)
+        assertEquals(0L, view.streak.totalClaims)
+        assertEquals("NEW", view.streak.status)
+        assertFalse(view.streak.streakActive)
+    }
+
+    @Test
+    fun `claimed-today streak is CLAIMED, active, and previews tomorrow's reward at streak + 1`() {
+        val today = LocalDate.ofInstant(Instant.now(), ZoneOffset.UTC)
+        every { loginStreakService.get(discordId, guildId) } returns LoginStreakDto(
+            discordId = discordId, guildId = guildId,
+            currentStreak = 5, longestStreak = 12, lastClaimDate = today, totalClaims = 30L
+        )
+        // A claimed-today user's next claim is tomorrow → streak 6.
+        every { loginStreakService.previewReward(guildId, 6) } returns
+            LoginStreakService.RewardPreview(75L, 50L)
+        every { achievementService.listFor(discordId, guildId) } returns emptyList()
+
+        val view = service.getProfile(discordId, guildId)!!
+        assertEquals("CLAIMED", view.streak.status)
+        assertTrue(view.streak.streakActive)
+        assertEquals(30L, view.streak.totalClaims)
+        assertEquals(75L, view.streak.nextRewardXp)
+        assertEquals(50L, view.streak.nextRewardCredits)
+    }
+
+    @Test
+    fun `streak last claimed yesterday is AT_RISK and previews the continuing claim`() {
+        val yesterday = LocalDate.ofInstant(Instant.now(), ZoneOffset.UTC).minusDays(1)
+        every { loginStreakService.get(discordId, guildId) } returns LoginStreakDto(
+            discordId = discordId, guildId = guildId,
+            currentStreak = 4, longestStreak = 9, lastClaimDate = yesterday, totalClaims = 11L
+        )
+        // Claiming today continues the streak → streak 5.
+        every { loginStreakService.previewReward(guildId, 5) } returns
+            LoginStreakService.RewardPreview(70L, 45L)
+        every { achievementService.listFor(discordId, guildId) } returns emptyList()
+
+        val view = service.getProfile(discordId, guildId)!!
+        assertEquals("AT_RISK", view.streak.status)
+        assertTrue(view.streak.streakActive)
+        assertEquals(70L, view.streak.nextRewardXp)
+        assertEquals(45L, view.streak.nextRewardCredits)
+    }
+
+    @Test
+    fun `streak last claimed days ago is LAPSED, inactive, and previews a reset to streak 1`() {
+        val staleDate = LocalDate.ofInstant(Instant.now(), ZoneOffset.UTC).minusDays(3)
+        every { loginStreakService.get(discordId, guildId) } returns LoginStreakDto(
+            discordId = discordId, guildId = guildId,
+            currentStreak = 9, longestStreak = 9, lastClaimDate = staleDate, totalClaims = 20L
+        )
+        // The stale count won't continue — the next claim restarts at 1.
+        every { loginStreakService.previewReward(guildId, 1) } returns
+            LoginStreakService.RewardPreview(50L, 25L)
+        every { achievementService.listFor(discordId, guildId) } returns emptyList()
+
+        val view = service.getProfile(discordId, guildId)!!
+        assertEquals("LAPSED", view.streak.status)
+        assertFalse(view.streak.streakActive)
+        assertEquals(50L, view.streak.nextRewardXp)
+        assertEquals(25L, view.streak.nextRewardCredits)
     }
 
     @Test

--- a/web/src/test/kotlin/web/static/ProfileStreakCardTemplateTest.kt
+++ b/web/src/test/kotlin/web/static/ProfileStreakCardTemplateTest.kt
@@ -83,6 +83,42 @@ class ProfileStreakCardTemplateTest {
     }
 
     @Test
+    fun `streak card surfaces lifetime claims, status nudges, and the next-reward preview`() {
+        assertTrue(
+            html.contains("class=\"profile-streak-total\""),
+            "profile.html must render the lifetime `total_claims` count " +
+                "(`.profile-streak-total`) — it is persisted but was previously unused.",
+        )
+        assertTrue(
+            html.contains("profile.streak.status == 'AT_RISK'") &&
+                html.contains("profile.streak.status == 'LAPSED'"),
+            "the card must branch on the derived streak status so it can nudge " +
+                "an at-risk streak and flag a lapsed one, instead of a flat last-claim date.",
+        )
+        assertTrue(
+            html.contains("profile.streak.nextRewardXp") &&
+                html.contains("class=\"profile-streak-reward-pill\""),
+            "the card must preview the next claim's reward (`nextRewardXp` in " +
+                "`.profile-streak-reward-pill`) so the claim is motivated, not blind.",
+        )
+    }
+
+    @Test
+    fun `claim JS surfaces the reward the API returns and is wired to the feedback slot`() {
+        val js = resource("static/js/profile.js")
+        assertTrue(
+            js.contains("xpGranted") && js.contains("creditsGranted") && js.contains("newBest"),
+            "profile.js must read xpGranted / creditsGranted / newBest off the claim " +
+                "response — they ship in the payload and were previously discarded.",
+        )
+        assertTrue(
+            html.contains("class=\"profile-streak-claimed-reward\""),
+            "profile.html must include the `.profile-streak-claimed-reward` slot the " +
+                "claim handler reveals with the earned reward.",
+        )
+    }
+
+    @Test
     fun `profile css styles the streak card so it is not plain`() {
         // The bug this redesign fixed: the markup existed but no CSS did,
         // so the card rendered unstyled. Pin that the styling is present.
@@ -91,6 +127,10 @@ class ProfileStreakCardTemplateTest {
             ".profile-streak-week",
             ".profile-streak-day",
             ".profile-streak-claim",
+            ".profile-streak-stat-chip",
+            ".profile-streak-reward-pill",
+            ".profile-streak-claimed-reward",
+            ".profile-streak-card.is-lapsed",
         ).forEach { selector ->
             assertTrue(
                 css.contains(selector),


### PR DESCRIPTION
## Why

Follow-up to the streak-card redesign (#606). The card looked good but was rendering thin data — and in one case **throwing data away**. This surfaces the streak information that already exists.

## What changed

- **Reward feedback on claim** — the `POST /daily/claim` endpoint already returns `xpGranted`, `creditsGranted`, and `newBest`, but `profile.js` discarded all of it, so claiming gave *no feedback*. It now reveals **🎉 Claimed +X XP · +Y credits** (with a **🔥 New personal best!** flourish) in a dedicated slot.
- **Lifetime claims** — maps the persisted `total_claims` onto `ProfileStreakView` and shows it as a **"Claimed N"** chip next to **"Best N"**. JS bumps it on a successful claim.
- **Streak status nudge** — derives `CLAIMED / AT_RISK / LAPSED / NEW` from `lastClaimDate` vs. today (UTC):
  - **AT_RISK** → ⚠ *"Claim today to keep your N-day streak alive!"*
  - **LAPSED** → flags that the stale stored count will reset to 1, and dims the flame so it stops reading as live.
  - The lit/dot-fill state now follows the *live* streak rather than the raw (possibly stale) DB count.
- **Next-reward preview** — new `LoginStreakService.previewReward(guildId, streak)` reuses the exact on-claim reward formula, so the card shows **"Claim now +X XP · +Y credits"** (or **"Tomorrow …"** once claimed) for the streak value the next claim would actually produce.

## Notes

- `previewReward` is read-only — it shares the private `resolveXpReward`/`resolveCreditReward` maths and writes nothing.
- The "next reward" streak value is computed correctly per state: `currentStreak + 1` while alive, `1` when lapsed/new.

## Tests

- `LoginStreakServiceTest` — `previewReward` matches the on-claim maths, clamps a non-positive streak to the day-1 reward, and performs no writes/events.
- `ProfileWebServiceEngagementTest` — status + preview mapping for `CLAIMED` / `AT_RISK` / `LAPSED` / `NEW`, including the lifetime-claims passthrough.
- `ProfileStreakCardTemplateTest` — extended pins for the lifetime-claims chip, status branching, reward preview, the claim-feedback slot, and the matching CSS.
- Full `:database:test` and `:web:test` suites pass; `node --check` on `profile.js` passes.

https://claude.ai/code/session_01YLJSVJWsPD727aQXB5FvPM

---
_Generated by [Claude Code](https://claude.ai/code/session_01YLJSVJWsPD727aQXB5FvPM)_