### PR TITLE
Extend the daily streak: PNG card badge, reset countdown, milestones

### DIFF
--- a/web/src/main/kotlin/web/profile/ProfileCardData.kt
+++ b/web/src/main/kotlin/web/profile/ProfileCardData.kt
@@ -29,6 +29,15 @@ data class ProfileCardData(
      * Capped at 3 by the aggregator; the renderer trusts the cap.
      */
     val recentAchievements: List<AchievementSnapshot>,
+    /**
+     * Current daily-login streak length. The renderer draws the flame
+     * badge only when this is positive *and* [streakActive] is true — a
+     * lapsed streak's stale count would otherwise mislead on a static,
+     * shareable card.
+     */
+    val streakDays: Int = 0,
+    /** Whether the streak is still alive (claimed today or yesterday, UTC). */
+    val streakActive: Boolean = false,
 ) {
     data class TitleSnapshot(
         val label: String,

--- a/web/src/main/kotlin/web/profile/ProfileCardRenderer.kt
+++ b/web/src/main/kotlin/web/profile/ProfileCardRenderer.kt
@@ -65,6 +65,7 @@ class ProfileCardRenderer {
             drawBackground(g)
             val tier = tierFor(data.level)
             drawAvatar(g, data.avatarUrl)
+            drawStreakBadge(g, data)
             drawHeader(g, data, tier)
             drawProgressBar(g, data, tier)
             drawBalanceAndTitle(g, data)
@@ -117,6 +118,34 @@ class ProfileCardRenderer {
         g.drawOval(AVATAR_X, AVATAR_Y, AVATAR_SIZE, AVATAR_SIZE)
         // Mark unused to keep the linter quiet without changing semantics.
         @Suppress("UNUSED_VARIABLE") val unused = cx + cy
+    }
+
+    /**
+     * Flame streak badge, centred under the avatar in the otherwise-empty
+     * left column. Drawn only for a live streak — a lapsed streak's stale
+     * count would mislead on a shareable card (the aggregator gates
+     * [ProfileCardData.streakActive] on a today/yesterday last-claim).
+     */
+    private fun drawStreakBadge(g: Graphics2D, data: ProfileCardData) {
+        if (data.streakDays <= 0 || !data.streakActive) return
+        val text = "🔥 ${data.streakDays}-day streak"
+        g.font = boldFont.deriveFont(15f)
+        val fm = g.fontMetrics
+        val padX = 14
+        val padY = 7
+        val w = fm.stringWidth(text) + padX * 2
+        val h = fm.height + padY
+        val cx = AVATAR_X + AVATAR_SIZE / 2
+        val x = cx - w / 2
+        val y = AVATAR_Y + AVATAR_SIZE + 16
+        g.paint = GradientPaint(
+            x.toFloat(), y.toFloat(), STREAK_FROM,
+            (x + w).toFloat(), (y + h).toFloat(), STREAK_TO
+        )
+        g.fill(RoundRectangle2D.Float(x.toFloat(), y.toFloat(), w.toFloat(), h.toFloat(), 16f, 16f))
+        // Dark text reads clearly on the bright orange pill.
+        g.color = Color(0x1A, 0x1A, 0x2E)
+        g.drawString(text, x + padX, y + h - padY)
     }
 
     private fun drawHeader(g: Graphics2D, data: ProfileCardData, tier: Tier) {
@@ -324,5 +353,10 @@ class ProfileCardRenderer {
 
         private val BG_TOP = Color(0x2B, 0x2D, 0x31)
         private val BG_BOTTOM = Color(0x1E, 0x1F, 0x22)
+
+        // Flame-streak pill gradient — mirrors the web card's
+        // `--streak-from` / `--streak-to` in profile.css.
+        private val STREAK_FROM = Color(0xFF, 0x6A, 0x3D)
+        private val STREAK_TO = Color(0xFF, 0xB1, 0x3D)
     }
 }

--- a/web/src/main/kotlin/web/service/ProfileCardAggregator.kt
+++ b/web/src/main/kotlin/web/service/ProfileCardAggregator.kt
@@ -3,11 +3,15 @@ package web.service
 import common.leveling.LevelCurve
 import database.service.guild.AchievementService
 import database.service.guild.TitleService
+import database.service.social.LoginStreakService
 import database.service.user.UserService
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Member
 import org.springframework.stereotype.Service
 import web.profile.ProfileCardData
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
 
 /**
  * Builds the [ProfileCardData] snapshot consumed by both surfaces that
@@ -42,6 +46,7 @@ class ProfileCardAggregator(
     private val userService: UserService,
     private val titleService: TitleService,
     private val achievementService: AchievementService,
+    private val loginStreakService: LoginStreakService,
 ) {
     fun build(guild: Guild, member: Member): ProfileCardData {
         val discordId = member.idLong
@@ -68,6 +73,16 @@ class ProfileCardAggregator(
                 )
             }
 
+        // Day boundaries match DefaultLoginStreakService (UTC). The streak is
+        // "active" only when the last claim was today or yesterday; an older
+        // last-claim leaves a stale count that the next claim resets, so the
+        // card treats it as inactive and hides the badge.
+        val streakRow = loginStreakService.get(discordId, guildId)
+        val today = LocalDate.ofInstant(Instant.now(), ZoneOffset.UTC)
+        val lastClaim = streakRow?.lastClaimDate
+        val streakActive = lastClaim != null &&
+            (lastClaim == today || lastClaim == today.minusDays(1))
+
         return ProfileCardData(
             avatarUrl = member.effectiveAvatarUrl,
             displayName = member.effectiveName,
@@ -79,6 +94,8 @@ class ProfileCardAggregator(
             socialCredit = user?.socialCredit ?: 0L,
             equippedTitle = equippedTitle,
             recentAchievements = recent,
+            streakDays = streakRow?.currentStreak ?: 0,
+            streakActive = streakActive,
         )
     }
 

--- a/web/src/main/resources/static/css/profile.css
+++ b/web/src/main/resources/static/css/profile.css
@@ -544,6 +544,12 @@
     box-shadow: 0 0 10px var(--streak-glow);
 }
 
+.profile-streak-milestone {
+    font-size: 0.8rem;
+    margin: 0;
+    font-variant-numeric: tabular-nums;
+}
+
 .profile-streak-meta {
     font-size: 0.85rem;
     margin: 0;
@@ -562,6 +568,18 @@
 .profile-streak-card.is-lapsed .profile-streak-alert {
     color: var(--text-muted);
     font-weight: 400;
+}
+.profile-streak-countdown {
+    display: inline-block;
+    margin-left: 6px;
+    padding: 1px 8px;
+    border-radius: 999px;
+    background: var(--warn-soft);
+    color: var(--warn);
+    font-size: 0.78rem;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
 }
 
 .profile-streak-preview {
@@ -622,8 +640,20 @@
     50%      { transform: scale(1.12) rotate(-3deg); }
 }
 
+/* One-shot celebration when a claim sets a new personal best. */
+.profile-streak-flame.is-celebrating {
+    animation: streak-celebrate 0.9s var(--ease-out);
+}
+@keyframes streak-celebrate {
+    0%   { transform: scale(1); box-shadow: 0 0 0 0 var(--streak-glow); }
+    30%  { transform: scale(1.28) rotate(-6deg); box-shadow: 0 0 26px 8px var(--streak-glow); }
+    60%  { transform: scale(0.94) rotate(3deg); }
+    100% { transform: scale(1); box-shadow: 0 6px 22px var(--streak-glow); }
+}
+
 @media (prefers-reduced-motion: reduce) {
     .profile-streak-card.is-lit .profile-streak-flame-icon { animation: none; }
+    .profile-streak-flame.is-celebrating { animation: none; }
 }
 
 @media (max-width: 480px) {

--- a/web/src/main/resources/static/js/profile.js
+++ b/web/src/main/resources/static/js/profile.js
@@ -39,9 +39,63 @@
         if (!isNaN(n)) total.textContent = String(n + 1);
     }
 
+    // "N days to your next 7-day milestone" — mirrors the Thymeleaf
+    // calculation so the line stays correct after an in-place claim.
+    function updateMilestone(card, currentStreak) {
+        const el = card.querySelector('.profile-streak-milestone');
+        if (!el) return;
+        if (currentStreak <= 0) { el.hidden = true; return; }
+        const cycleDay = ((currentStreak - 1) % 7) + 1;
+        const left = 7 - cycleDay;
+        el.textContent = left === 0
+            ? '🎉 7-day milestone reached!'
+            : left + (left === 1 ? ' day' : ' days') + ' to your next milestone';
+        el.hidden = false;
+    }
+
+    // One-shot flame flourish on a new personal best.
+    function celebrate(card) {
+        const flame = card.querySelector('.profile-streak-flame');
+        if (!flame) return;
+        flame.classList.remove('is-celebrating');
+        // Force reflow so the animation re-triggers if best is beaten again.
+        void flame.offsetWidth;
+        flame.classList.add('is-celebrating');
+    }
+
+    // Live "Resets in 6h 12m" countdown for an at-risk streak — the streak
+    // breaks at the next UTC midnight (matching DefaultLoginStreakService),
+    // so turn the warning into real urgency. Returns the interval id.
+    function startCountdown(card) {
+        const el = card.querySelector('.profile-streak-countdown');
+        if (!el) return null;
+        function tick() {
+            const now = new Date();
+            const nextMidnight = Date.UTC(
+                now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1, 0, 0, 0, 0
+            );
+            const ms = nextMidnight - now.getTime();
+            if (ms <= 0) { el.textContent = 'Resets at midnight UTC'; return; }
+            const mins = Math.floor(ms / 60000);
+            const h = Math.floor(mins / 60);
+            const m = mins % 60;
+            el.textContent = h > 0
+                ? 'Resets in ' + h + 'h ' + m + 'm'
+                : (m > 0 ? 'Resets in ' + m + 'm' : 'Resets in <1m');
+            el.hidden = false;
+        }
+        tick();
+        return window.setInterval(tick, 30000);
+    }
+
     document.addEventListener('DOMContentLoaded', function () {
         const card = document.querySelector('.profile-streak-card');
         if (!card) return;
+
+        let countdownId = null;
+        if (card.getAttribute('data-status') === 'AT_RISK') {
+            countdownId = startCountdown(card);
+        }
 
         const guildId = card.getAttribute('data-guild-id');
         const button = card.querySelector('.profile-streak-claim');
@@ -67,20 +121,25 @@
                         nums[1].textContent = String(resp.longestStreak);
                     }
                     updateWeek(card, resp.currentStreak);
+                    updateMilestone(card, resp.currentStreak);
                     card.classList.add('is-lit');
                     card.classList.remove('is-lapsed');
                     card.setAttribute('data-streak', String(resp.currentStreak));
                     card.setAttribute('data-claimed-today', 'true');
+                    card.setAttribute('data-status', 'CLAIMED');
                     button.textContent = '✓ Claimed today';
 
                     // The "at risk", "lapsed" and next-reward preview lines
                     // describe the pre-claim state — drop them now it's claimed.
+                    // The reset countdown goes with them.
+                    if (countdownId) { window.clearInterval(countdownId); countdownId = null; }
                     card.querySelectorAll('.profile-streak-alert, .profile-streak-preview')
                         .forEach(function (n) { n.remove(); });
 
                     if (!alreadyClaimed) {
                         bumpTotal(card);
                         showReward(card, resp);
+                        if (resp.newBest) celebrate(card);
                     }
                 })
                 .catch(function () {

--- a/web/src/main/resources/templates/profile.html
+++ b/web/src/main/resources/templates/profile.html
@@ -89,7 +89,8 @@
                  th:classappend="${(profile.streak.streakActive ? ' is-lit' : '') + (profile.streak.status == 'LAPSED' ? ' is-lapsed' : '')}"
                  th:attr="data-guild-id=${profile.guildId},
                           data-claimed-today=${profile.streak.claimedToday},
-                          data-streak=${profile.streak.currentStreak}">
+                          data-streak=${profile.streak.currentStreak},
+                          data-status=${profile.streak.status}">
             <h2>Daily streak</h2>
             <div class="profile-streak-hero">
                 <div class="profile-streak-flame" aria-hidden="true">
@@ -118,10 +119,20 @@
                     <span class="profile-streak-day-dot" th:text="${i == 7} ? '★' : ''"></span>
                 </li>
             </ol>
+            <p class="muted profile-streak-milestone"
+               th:if="${profile.streak.streakActive and profile.streak.currentStreak > 0}"
+               th:with="daysToMilestone=${7 - ((profile.streak.currentStreak - 1) % 7 + 1)}"
+               th:text="${daysToMilestone == 0
+                           ? '🎉 7-day milestone reached!'
+                           : (daysToMilestone + (daysToMilestone == 1 ? ' day' : ' days') + ' to your next milestone')}">
+                3 days to your next milestone
+            </p>
             <p class="profile-streak-meta profile-streak-alert"
-               th:if="${profile.streak.status == 'AT_RISK'}"
-               th:text="'⚠ Claim today to keep your ' + ${profile.streak.currentStreak} + '-day streak alive!'">
-                ⚠ Claim today to keep your streak alive!
+               th:if="${profile.streak.status == 'AT_RISK'}">
+                <span th:text="'⚠ Claim today to keep your ' + ${profile.streak.currentStreak} + '-day streak alive!'">
+                    ⚠ Claim today to keep your streak alive!
+                </span>
+                <span class="profile-streak-countdown" hidden></span>
             </p>
             <p class="profile-streak-meta profile-streak-alert"
                th:if="${profile.streak.status == 'LAPSED'}"

--- a/web/src/test/kotlin/web/profile/ProfileCardRendererTest.kt
+++ b/web/src/test/kotlin/web/profile/ProfileCardRendererTest.kt
@@ -91,6 +91,24 @@ class ProfileCardRendererTest {
     }
 
     @Test
+    fun `renders with an active streak badge`() {
+        val png = renderer.renderPng(sample(streakDays = 12, streakActive = true))
+        assertPngShape(png, 900, 400)
+    }
+
+    @Test
+    fun `renders with an inactive (lapsed) streak — badge suppressed`() {
+        val png = renderer.renderPng(sample(streakDays = 30, streakActive = false))
+        assertPngShape(png, 900, 400)
+    }
+
+    @Test
+    fun `renders with a large multi-digit streak without overflowing`() {
+        val png = renderer.renderPng(sample(streakDays = 365, streakActive = true))
+        assertPngShape(png, 900, 400)
+    }
+
+    @Test
     fun `renders gracefully when the avatar URL is unreachable`() {
         // The renderer catches ImageIO / network errors and substitutes a
         // grey disc. Asserts that the substitution path produces a valid
@@ -111,6 +129,8 @@ class ProfileCardRendererTest {
             ProfileCardData.AchievementSnapshot("🔥", "5-day streak", Instant.now()),
             ProfileCardData.AchievementSnapshot("🏆", "Big winner", Instant.now()),
         ),
+        streakDays: Int = 7,
+        streakActive: Boolean = true,
     ) = ProfileCardData(
         avatarUrl = avatarUrl,
         displayName = displayName,
@@ -122,6 +142,8 @@ class ProfileCardRendererTest {
         socialCredit = 8_400,
         equippedTitle = equippedTitle,
         recentAchievements = recentAchievements,
+        streakDays = streakDays,
+        streakActive = streakActive,
     )
 
     private fun assertPngShape(png: ByteArray, expectedWidth: Int, expectedHeight: Int) {

--- a/web/src/test/kotlin/web/service/ProfileCardAggregatorTest.kt
+++ b/web/src/test/kotlin/web/service/ProfileCardAggregatorTest.kt
@@ -2,19 +2,25 @@ package web.service
 
 import database.dto.guild.AchievementDto
 import database.dto.guild.TitleDto
+import database.dto.social.LoginStreakDto
 import database.dto.user.UserDto
 import database.service.guild.AchievementService
 import database.service.guild.TitleService
+import database.service.social.LoginStreakService
 import database.service.user.UserService
 import io.mockk.every
 import io.mockk.mockk
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Member
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
 
 /**
  * Unit tests for [ProfileCardAggregator]. The aggregator combines
@@ -36,6 +42,7 @@ class ProfileCardAggregatorTest {
     private lateinit var userService: UserService
     private lateinit var titleService: TitleService
     private lateinit var achievementService: AchievementService
+    private lateinit var loginStreakService: LoginStreakService
     private lateinit var guild: Guild
     private lateinit var member: Member
     private lateinit var aggregator: ProfileCardAggregator
@@ -45,7 +52,9 @@ class ProfileCardAggregatorTest {
         userService = mockk(relaxed = true)
         titleService = mockk(relaxed = true)
         achievementService = mockk(relaxed = true)
-        aggregator = ProfileCardAggregator(userService, titleService, achievementService)
+        loginStreakService = mockk(relaxed = true)
+        every { loginStreakService.get(discordId, guildId) } returns null
+        aggregator = ProfileCardAggregator(userService, titleService, achievementService, loginStreakService)
 
         guild = mockk(relaxed = true)
         member = mockk(relaxed = true)
@@ -135,6 +144,48 @@ class ProfileCardAggregatorTest {
         assertEquals(2, data.level)
         assertEquals(255L, data.totalXp)
         assertEquals(0L, data.xpIntoLevel)
+    }
+
+    @Test
+    fun `build marks the streak active when the last claim was today or yesterday`() {
+        every { userService.getUserById(discordId, guildId) } returns userDto()
+        every { achievementService.listFor(discordId, guildId) } returns emptyList()
+        val today = LocalDate.ofInstant(Instant.now(), ZoneOffset.UTC)
+        every { loginStreakService.get(discordId, guildId) } returns LoginStreakDto(
+            discordId = discordId, guildId = guildId,
+            currentStreak = 6, longestStreak = 9, lastClaimDate = today, totalClaims = 20L
+        )
+
+        val data = aggregator.build(guild, member)
+        assertEquals(6, data.streakDays)
+        assertTrue(data.streakActive)
+    }
+
+    @Test
+    fun `build marks the streak inactive when the last claim has lapsed`() {
+        every { userService.getUserById(discordId, guildId) } returns userDto()
+        every { achievementService.listFor(discordId, guildId) } returns emptyList()
+        val staleDate = LocalDate.ofInstant(Instant.now(), ZoneOffset.UTC).minusDays(3)
+        every { loginStreakService.get(discordId, guildId) } returns LoginStreakDto(
+            discordId = discordId, guildId = guildId,
+            currentStreak = 9, longestStreak = 9, lastClaimDate = staleDate, totalClaims = 30L
+        )
+
+        val data = aggregator.build(guild, member)
+        // The stale count is still forwarded, but the renderer hides it.
+        assertEquals(9, data.streakDays)
+        assertFalse(data.streakActive)
+    }
+
+    @Test
+    fun `build yields no streak when the user has never claimed`() {
+        every { userService.getUserById(discordId, guildId) } returns userDto()
+        every { achievementService.listFor(discordId, guildId) } returns emptyList()
+        every { loginStreakService.get(discordId, guildId) } returns null
+
+        val data = aggregator.build(guild, member)
+        assertEquals(0, data.streakDays)
+        assertFalse(data.streakActive)
     }
 
     // ---- helpers ----

--- a/web/src/test/kotlin/web/static/ProfileStreakCardTemplateTest.kt
+++ b/web/src/test/kotlin/web/static/ProfileStreakCardTemplateTest.kt
@@ -119,6 +119,43 @@ class ProfileStreakCardTemplateTest {
     }
 
     @Test
+    fun `card exposes status and the milestone + reset-countdown affordances`() {
+        assertTrue(
+            html.contains("data-status="),
+            "the card must expose `data-status` so profile.js can drive the at-risk " +
+                "reset countdown without re-deriving the state.",
+        )
+        assertTrue(
+            html.contains("class=\"profile-streak-countdown\""),
+            "the AT_RISK alert must include a `.profile-streak-countdown` slot for the " +
+                "live 'Resets in Xh Ym' timer.",
+        )
+        assertTrue(
+            html.contains("class=\"muted profile-streak-milestone\"") &&
+                html.contains("daysToMilestone"),
+            "the card must render the `.profile-streak-milestone` line so the 7-day " +
+                "tracker reads as a goal, not just decoration.",
+        )
+    }
+
+    @Test
+    fun `claim JS drives the countdown, milestone, and new-best celebration`() {
+        val js = resource("static/js/profile.js")
+        assertTrue(
+            js.contains("startCountdown") && js.contains("AT_RISK"),
+            "profile.js must start the reset countdown for an at-risk streak.",
+        )
+        assertTrue(
+            js.contains("updateMilestone"),
+            "profile.js must refresh the milestone line after an in-place claim.",
+        )
+        assertTrue(
+            js.contains("celebrate") && js.contains("is-celebrating"),
+            "profile.js must trigger the flame celebration when resp.newBest is set.",
+        )
+    }
+
+    @Test
     fun `profile css styles the streak card so it is not plain`() {
         // The bug this redesign fixed: the markup existed but no CSS did,
         // so the card rendered unstyled. Pin that the styling is present.
@@ -131,6 +168,9 @@ class ProfileStreakCardTemplateTest {
             ".profile-streak-reward-pill",
             ".profile-streak-claimed-reward",
             ".profile-streak-card.is-lapsed",
+            ".profile-streak-milestone",
+            ".profile-streak-countdown",
+            ".profile-streak-flame.is-celebrating",
         ).forEach { selector ->
             assertTrue(
                 css.contains(selector),


### PR DESCRIPTION
## Why

Further improvements to the daily streak feature, following the redesign (#606) and richer-data pass (#607). The biggest gap: the streak was **web-only** — the shareable `/profile` PNG card (used in Discord) didn't show it at all.

## What changed

### 1. Streak on the shareable PNG card
`ProfileCardAggregator` now reads the login streak, and `ProfileCardRenderer` draws a flame **"🔥 N-day streak"** pill centred under the avatar. It's drawn **only for a live streak** (last claim today/yesterday, UTC) so a lapsed, stale count never ships on a static shareable card. This surfaces the streak in Discord, where the PNG is actually used.

### 2. Reset countdown (frontend-only)
The `AT_RISK` alert on the web card gains a live **"Resets in 6h 12m"** timer counting down to the next UTC midnight — when the streak actually breaks (matching `DefaultLoginStreakService`). Turns the warning into real urgency; cleared once claimed.

### 3. Milestone framing + celebration (frontend-only)
- The 7-day tracker gains an **"N days to your next milestone"** line, derived from the streak.
- A **new personal best** triggers a one-shot flame celebration animation.
- Both honour `prefers-reduced-motion`.

## Notes

- The PNG badge gates on `streakActive` (today/yesterday last claim), computed UTC to match the existing streak logic.
- The reset countdown reads the new `data-status` attribute rather than re-deriving state in JS.
- The renderer's emoji render as the font's fallback glyph — this is pre-existing across the whole card (credits 💰, title ⭐, achievement icons), and the new badge is consistent with it.

## Tests

- `ProfileCardAggregatorTest` — active / lapsed / never-claimed streak mapping.
- `ProfileCardRendererTest` — badge path for active, lapsed (suppressed), and multi-digit streaks; all assert a valid 900×400 PNG.
- `ProfileStreakCardTemplateTest` — pins the `data-status` attribute, the countdown + milestone markup, the driving JS (`startCountdown` / `updateMilestone` / `celebrate`), and the new CSS.
- Full `:web:test` and `:database:test` suites pass; `:discord-bot` `ProfileCommandTest` passes; `node --check` on `profile.js` passes.

https://claude.ai/code/session_01YLJSVJWsPD727aQXB5FvPM

---
_Generated by [Claude Code](https://claude.ai/code/session_01YLJSVJWsPD727aQXB5FvPM)_