### PR TITLE
feat(scheduling): per-guild configurable UTC hour for daily cron jobs

### DIFF
--- a/application/src/test/kotlin/integration/database/UserNotificationPrefServiceIntegrationTest.kt
+++ b/application/src/test/kotlin/integration/database/UserNotificationPrefServiceIntegrationTest.kt
@@ -165,7 +165,7 @@ class UserNotificationPrefServiceIntegrationTest {
     }
 
     @Test
-    fun `prefs are scoped per-guild — setting in one guild doesn't bleed to another`() {
+    fun `prefs are scoped per-guild - setting in one guild doesn't bleed to another`() {
         service.setPref(discordId, guildId, NotificationChannelKind.STREAK_REMINDER, Surface.DM, optIn = true)
 
         // Same user, different guild: still on the default.

--- a/common/src/test/kotlin/common/casino/baccarat/BaccaratTest.kt
+++ b/common/src/test/kotlin/common/casino/baccarat/BaccaratTest.kt
@@ -48,7 +48,7 @@ class BaccaratTest {
     // --- naturals ---
 
     @Test
-    fun `player natural eight stops the deal — neither side draws a third card`() {
+    fun `player natural eight stops the deal - neither side draws a third card`() {
         val deck = mockDeck(
             c(Rank.FIVE), c(Rank.THREE), // player → 8 natural
             c(Rank.TWO), c(Rank.FOUR),   // banker → 6
@@ -66,7 +66,7 @@ class BaccaratTest {
     }
 
     @Test
-    fun `banker natural nine stops the deal — player does not draw even on zero`() {
+    fun `banker natural nine stops the deal - player does not draw even on zero`() {
         val deck = mockDeck(
             c(Rank.FIVE), c(Rank.FIVE), // player → 0 (would otherwise draw)
             c(Rank.FOUR), c(Rank.FIVE), // banker → 9, natural

--- a/common/src/test/kotlin/common/casino/horseracing/HorseRacingTest.kt
+++ b/common/src/test/kotlin/common/casino/horseracing/HorseRacingTest.kt
@@ -187,7 +187,7 @@ class HorseRacingTest {
     }
 
     @Test
-    fun `payout ordering — favourites pay less than longshots across every bet type`() {
+    fun `payout ordering - favourites pay less than longshots across every bet type`() {
         // H1 favourite must pay strictly less than H6 longshot on every
         // bet type; the whole point of the field is to widen the payout
         // tail.

--- a/common/src/test/kotlin/common/casino/keno/KenoTest.kt
+++ b/common/src/test/kotlin/common/casino/keno/KenoTest.kt
@@ -170,7 +170,7 @@ class KenoTest {
     }
 
     @Test
-    fun `RTP smoke — 50k random hands stay in the published band`() {
+    fun `RTP smoke - 50k random hands stay in the published band`() {
         val rng = Random(2026)
         val stake = 1_000L
         val n = 50_000

--- a/common/src/test/kotlin/common/pvp/connect4/Connect4EngineTest.kt
+++ b/common/src/test/kotlin/common/pvp/connect4/Connect4EngineTest.kt
@@ -178,7 +178,7 @@ class Connect4EngineTest {
     }
 
     @Test
-    fun `engine doesn't enforce turn order — caller is responsible`() {
+    fun `engine doesn't enforce turn order - caller is responsible`() {
         // Two RED moves in a row are accepted; the engine is intentionally
         // stateless about whose turn it is.
         val first = Connect4Engine.applyMove(Connect4Engine.empty(), 0, R) as Connect4Engine.MoveResult.Continued

--- a/common/src/test/kotlin/common/pvp/tictactoe/TicTacToeEngineTest.kt
+++ b/common/src/test/kotlin/common/pvp/tictactoe/TicTacToeEngineTest.kt
@@ -108,7 +108,7 @@ class TicTacToeEngineTest {
     }
 
     @Test
-    fun `engine doesn't enforce turn order — caller is responsible`() {
+    fun `engine doesn't enforce turn order - caller is responsible`() {
         // Two X moves in a row are accepted; the engine is intentionally
         // stateless about whose turn it is.
         val first = TicTacToeEngine.applyMove(TicTacToeEngine.empty(), 0, X)

--- a/database/src/main/kotlin/database/dto/guild/ConfigDto.kt
+++ b/database/src/main/kotlin/database/dto/guild/ConfigDto.kt
@@ -34,6 +34,11 @@ class ConfigDto(
         MOVE("DEFAULT_MOVE_CHANNEL"),
         DELETE_DELAY("DELETE_MESSAGE_DELAY"),
         LEADERBOARD_CHANNEL("LEADERBOARD_CHANNEL"),
+        // Per-guild UTC hour (0-23) at which MonthlyLeaderboardJob posts the
+        // monthly leaderboard on the 1st of the month. Defaults to 12 (noon
+        // UTC) when unset or invalid. The job runs hourly on the 1st and only
+        // acts on a guild when the current UTC hour matches this value.
+        MONTHLY_LEADERBOARD_HOUR("MONTHLY_LEADERBOARD_HOUR"),
         ACTIVITY_TRACKING("ACTIVITY_TRACKING"),
         ACTIVITY_TRACKING_NOTIFIED("ACTIVITY_TRACKING_NOTIFIED"),
         // Whole-number percentage (0-50) of every lost casino stake that
@@ -128,6 +133,13 @@ class ConfigDto(
         // has reached. Default 5. Set to 0 to disable the leveling perk
         // for UBI entirely.
         UBI_PER_LEVEL_BONUS("UBI_PER_LEVEL_BONUS"),
+
+        // Per-guild UTC hour (0-23) at which UniversalBasicIncomeJob grants
+        // the daily UBI. Defaults to 0 (midnight UTC) when unset or invalid.
+        // The job runs hourly and only grants for a guild when the current
+        // UTC hour matches; the per-user ubi_daily ledger (keyed by UTC date)
+        // keeps it once-per-day regardless of hour.
+        UBI_DAILY_HOUR("UBI_DAILY_HOUR"),
 
         // Optional Discord text-channel id where level-up announcements
         // post. When unset (default), announcements post in the channel
@@ -267,6 +279,14 @@ class ConfigDto(
         // ticket sale routes back to the jackpot.
         LOTTERY_DAILY_ENABLED("LOTTERY_DAILY_ENABLED"),
 
+        // Per-guild UTC hour (0-23) at which LotteryDailyJob rolls the daily
+        // cycle (closes the previous draw, opens a fresh one). Defaults to 0
+        // (midnight UTC) when unset or invalid. The job runs hourly and only
+        // rolls for a guild when the current UTC hour matches; the per-guild
+        // lottery_daily ledger (keyed by UTC date) keeps it once-per-day. A
+        // later hour simply delays the daily open/close to that hour.
+        LOTTERY_DAILY_HOUR("LOTTERY_DAILY_HOUR"),
+
         // Whole-number credits charged per match-numbers ticket. Default
         // 50. Range 1-1_000_000. Tickets debit `count × ticket_price`
         // from the buyer at submission time.
@@ -376,6 +396,13 @@ class ConfigDto(
         STREAK_BASE_REWARD_CREDIT("STREAK_BASE_REWARD_CREDIT"),
         STREAK_PER_DAY_BONUS_CREDIT("STREAK_PER_DAY_BONUS_CREDIT"),
         STREAK_MAX_REWARD_CREDIT("STREAK_MAX_REWARD_CREDIT"),
+
+        // Per-guild UTC hour (0-23) at which StreakReminderJob DMs/pushes the
+        // "don't lose your streak" nudge to at-risk users. Defaults to 18
+        // (18:00 UTC) when unset or invalid. The job runs hourly and only
+        // reminds a guild when the current UTC hour matches. Streaks still
+        // reset at midnight UTC, so values above ~22 leave little time to act.
+        STREAK_REMINDER_HOUR("STREAK_REMINDER_HOUR"),
 
         // Optional Discord text-channel id where achievement-unlock
         // shoutouts post in addition to the unlocker's DM. When unset,

--- a/database/src/test/kotlin/database/achievement/AchievementSeederTest.kt
+++ b/database/src/test/kotlin/database/achievement/AchievementSeederTest.kt
@@ -43,7 +43,7 @@ class AchievementSeederTest {
     }
 
     @Test
-    fun `seed is idempotent — running twice does not create duplicate rows`() {
+    fun `seed is idempotent - running twice does not create duplicate rows`() {
         val seeder = AchievementSeeder(persistence, specs = listOf(baseSpec))
 
         seeder.seed()

--- a/database/src/test/kotlin/database/service/AchievementServiceTest.kt
+++ b/database/src/test/kotlin/database/service/AchievementServiceTest.kt
@@ -74,7 +74,7 @@ class AchievementServiceTest {
     }
 
     @Test
-    fun `unlock is idempotent — second call no-ops and does not double-award`() {
+    fun `unlock is idempotent - second call no-ops and does not double-award`() {
         persistence.save(AchievementDto(code = "test_b", name = "B", description = "d", category = "c", xpReward = 10, creditReward = 0))
 
         service.unlock(discordId, guildId, "test_b")
@@ -196,7 +196,7 @@ class AchievementServiceTest {
     }
 
     @Test
-    fun `setProgress is a no-op once unlocked — streak-broke does not retract`() {
+    fun `setProgress is a no-op once unlocked - streak-broke does not retract`() {
         persistence.save(
             AchievementDto(code = "sp_idem", name = "I", description = "d", category = "c", xpReward = 10, threshold = 3)
         )

--- a/database/src/test/kotlin/database/service/BaccaratServiceTest.kt
+++ b/database/src/test/kotlin/database/service/BaccaratServiceTest.kt
@@ -132,7 +132,7 @@ class BaccaratServiceTest {
     }
 
     @Test
-    fun `tied game pushes a Player side bet — stake is refunded`() {
+    fun `tied game pushes a Player side bet - stake is refunded`() {
         val user = userWithBalance(500L)
         every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
         every { baccarat.play(Baccarat.Side.PLAYER, any()) } returns handResult(

--- a/database/src/test/kotlin/database/service/BlackjackServiceTest.kt
+++ b/database/src/test/kotlin/database/service/BlackjackServiceTest.kt
@@ -226,7 +226,7 @@ class BlackjackServiceTest {
     }
 
     @Test
-    fun `dealSolo Dealt and applySoloAction HIT echo the post-deal wallet — never re-debit per HIT`() {
+    fun `dealSolo Dealt and applySoloAction HIT echo the post-deal wallet - never re-debit per HIT`() {
         // Regression for the UI bug "blackjack is taking the stake cost per
         // interaction (e.g. hit)". The wallet is debited once at deal time;
         // each subsequent HIT/STAND is a no-op on the wallet. The Dealt /
@@ -499,7 +499,7 @@ class BlackjackServiceTest {
     }
 
     @Test
-    fun `multi hand with all winners refunds stakes only — no losers means no bonus`() {
+    fun `multi hand with all winners refunds stakes only - no losers means no bonus`() {
         // Two-seat table where both players win against the dealer. With
         // no losers contributing to the pot, each winner just gets their
         // stake back; nothing rakes to the jackpot.

--- a/database/src/test/kotlin/database/service/HighlowServiceTest.kt
+++ b/database/src/test/kotlin/database/service/HighlowServiceTest.kt
@@ -148,7 +148,7 @@ class HighlowServiceTest {
     }
 
     @Test
-    fun `win never rolls the jackpot — HIGHLOW carries the global eligibility carve-out`() {
+    fun `win never rolls the jackpot - HIGHLOW carries the global eligibility carve-out`() {
         // Even with a forced-hit RNG and a non-empty pool, a HighLow win
         // must surface jackpotPayout=0 and never touch the pool.
         // `JackpotGame.HIGHLOW.eligibleForJackpot = false` short-circuits

--- a/database/src/test/kotlin/database/service/HorseRacingServiceTest.kt
+++ b/database/src/test/kotlin/database/service/HorseRacingServiceTest.kt
@@ -153,7 +153,7 @@ class HorseRacingServiceTest {
     }
 
     @Test
-    fun `win never rolls the jackpot — HORSE_RACING carries the global eligibility carve-out`() {
+    fun `win never rolls the jackpot - HORSE_RACING carries the global eligibility carve-out`() {
         // Mirrors HighlowServiceTest's parity check. Even with a
         // forced-hit jackpot mock and a non-empty pool, a Horse Racing
         // win must surface jackpotPayout=0 and never touch the pool —

--- a/discord-bot/src/main/kotlin/bot/toby/scheduling/GuildHourGate.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/scheduling/GuildHourGate.kt
@@ -1,0 +1,33 @@
+package bot.toby.scheduling
+
+import database.dto.guild.ConfigDto
+import database.service.guild.ConfigService
+import org.springframework.stereotype.Component
+
+/**
+ * Shared per-guild scheduling gate for the daily cron jobs.
+ *
+ * Each wall-clock job runs hourly and asks this gate which UTC hour (0-23)
+ * a guild has configured for that job, falling back to the job's historical
+ * fixed hour when the config is unset or invalid. The job then acts on the
+ * guild only when the current UTC hour equals [configuredHour].
+ *
+ * Kept deliberately tiny and clock-free: the caller owns its injected
+ * [java.time.Clock] (already tested) and passes the current hour in, so this
+ * is a pure config reader. Config reads are cache-backed in [ConfigService].
+ */
+@Component
+class GuildHourGate(private val configService: ConfigService) {
+
+    /**
+     * The per-guild UTC run-hour (0-23) for [key], or [defaultHour] when the
+     * value is missing, non-numeric, or out of range.
+     */
+    fun configuredHour(
+        guildId: Long,
+        key: ConfigDto.Configurations,
+        defaultHour: Int,
+    ): Int = configService.getConfigByName(key.configValue, guildId.toString())
+        ?.value?.trim()?.toIntOrNull()?.takeIf { it in 0..23 }
+        ?: defaultHour
+}

--- a/discord-bot/src/main/kotlin/bot/toby/scheduling/LotteryDailyJob.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/scheduling/LotteryDailyJob.kt
@@ -6,6 +6,7 @@ import database.service.guild.ConfigService
 import database.service.lottery.JackpotLotteryService
 import database.service.lottery.LotteryDailyService
 import database.service.lottery.LotteryHelper
+import database.dto.guild.ConfigDto
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.Guild
 import org.springframework.beans.factory.annotation.Autowired
@@ -15,9 +16,12 @@ import org.springframework.stereotype.Component
 import java.time.Clock
 import java.time.LocalDate
 import java.time.ZoneOffset
+import java.time.ZonedDateTime
 
 /**
- * Daily lottery auto-draw. Runs at 00:00 UTC.
+ * Daily lottery auto-draw. Runs hourly; for each guild it rolls the daily
+ * cycle when the current UTC hour matches that guild's `LOTTERY_DAILY_HOUR`
+ * config (default [DEFAULT_LOTTERY_HOUR] = 00:00 UTC).
  *
  * For each guild with `LOTTERY_DAILY_ENABLED=true`, dispatches on
  * `LOTTERY_DAILY_MODE`:
@@ -33,8 +37,9 @@ import java.time.ZoneOffset
  * announce channel.
  *
  * Idempotent via composite-key ledger ([LotteryDailyService]) — a
- * mid-cron restart skips guilds whose ledger already records today.
- * Per-guild error isolation via `runCatching`. Prod-profile only.
+ * mid-cron restart (or a second tick within the matching hour) skips
+ * guilds whose ledger already records today. Per-guild error isolation
+ * via `runCatching`. Prod-profile only.
  */
 @Component
 @Profile("prod")
@@ -44,20 +49,28 @@ class LotteryDailyJob @Autowired constructor(
     private val lotteryDailyService: LotteryDailyService,
     private val jackpotLotteryService: JackpotLotteryService,
     private val lotteryAnnouncer: LotteryAnnouncer,
+    private val hourGate: GuildHourGate,
     private val clock: Clock = Clock.systemUTC(),
 ) {
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
 
-    @Scheduled(cron = "0 0 0 * * *", zone = "UTC")
+    @Scheduled(cron = "0 0 * * * *", zone = "UTC")
     fun runDaily() {
-        val today = LocalDate.now(clock.withZone(ZoneOffset.UTC))
-        logger.info { "Running daily lottery job for $today" }
+        val now = ZonedDateTime.now(clock.withZone(ZoneOffset.UTC))
+        val today = now.toLocalDate()
+        logger.info { "Running daily lottery job for $today (hour=${now.hour})" }
 
         jda.guildCache.forEach { guild ->
-            runCatching { rollGuild(guild, today) }
-                .onFailure {
-                    logger.error("Daily lottery roll failed for guild ${guild.idLong}: ${it.message}")
-                }
+            runCatching {
+                val targetHour = hourGate.configuredHour(
+                    guild.idLong,
+                    ConfigDto.Configurations.LOTTERY_DAILY_HOUR,
+                    DEFAULT_LOTTERY_HOUR,
+                )
+                if (now.hour == targetHour) rollGuild(guild, today)
+            }.onFailure {
+                logger.error("Daily lottery roll failed for guild ${guild.idLong}: ${it.message}")
+            }
         }
     }
 
@@ -270,5 +283,8 @@ class LotteryDailyJob @Autowired constructor(
     companion object {
         /** A day. The daily draw opens for 24h and closes at the next tick. */
         private const val DURATION_HOURS: Long = 24L
+
+        /** Fallback UTC hour when LOTTERY_DAILY_HOUR is unset or invalid. */
+        const val DEFAULT_LOTTERY_HOUR: Int = 0
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/scheduling/MonthlyLeaderboardJob.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/scheduling/MonthlyLeaderboardJob.kt
@@ -18,8 +18,10 @@ import org.springframework.context.annotation.Profile
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import java.awt.Color
+import java.time.Clock
 import java.time.LocalDate
 import java.time.ZoneOffset
+import java.time.ZonedDateTime
 
 @Component
 @Profile("prod")
@@ -29,23 +31,44 @@ class MonthlyLeaderboardJob @Autowired constructor(
     private val voiceSessionService: VoiceSessionService,
     private val snapshotService: MonthlyCreditSnapshotService,
     private val configService: ConfigService,
-    private val ubiDailyService: UbiDailyService
+    private val ubiDailyService: UbiDailyService,
+    private val hourGate: GuildHourGate,
+    private val clock: Clock = Clock.systemUTC()
 ) {
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
 
     companion object {
         const val TOP_N = 10
+
+        /** Fallback UTC hour when MONTHLY_LEADERBOARD_HOUR is unset or invalid. */
+        const val DEFAULT_LEADERBOARD_HOUR: Int = 12
     }
 
-    @Scheduled(cron = "0 0 12 1 * *", zone = "UTC")
+    /**
+     * Runs hourly on the 1st of the month; for each guild it posts when the
+     * current UTC hour matches that guild's `MONTHLY_LEADERBOARD_HOUR` config
+     * (default [DEFAULT_LEADERBOARD_HOUR] = 12:00 UTC). Spring's cron scheduler
+     * doesn't replay missed ticks, so this fires at most once per month per
+     * guild — the same guarantee as the original single-cron schedule.
+     */
+    @Scheduled(cron = "0 0 * 1 * *", zone = "UTC")
     fun postMonthlyLeaderboard() {
-        val today = LocalDate.now(ZoneOffset.UTC).withDayOfMonth(1)
+        val now = ZonedDateTime.now(clock.withZone(ZoneOffset.UTC))
+        val today = now.toLocalDate().withDayOfMonth(1)
         val previousMonthStart = today.minusMonths(1)
-        logger.info { "Running monthly leaderboard job for month starting $previousMonthStart" }
+        logger.info {
+            "Running monthly leaderboard job for month starting $previousMonthStart (hour=${now.hour})"
+        }
 
         jda.guildCache.forEach { guild ->
-            runCatching { postForGuild(guild, today, previousMonthStart) }
-                .onFailure { logger.error("Monthly leaderboard failed for guild ${guild.idLong}: ${it.message}") }
+            runCatching {
+                val targetHour = hourGate.configuredHour(
+                    guild.idLong,
+                    ConfigDto.Configurations.MONTHLY_LEADERBOARD_HOUR,
+                    DEFAULT_LEADERBOARD_HOUR,
+                )
+                if (now.hour == targetHour) postForGuild(guild, today, previousMonthStart)
+            }.onFailure { logger.error("Monthly leaderboard failed for guild ${guild.idLong}: ${it.message}") }
         }
     }
 

--- a/discord-bot/src/main/kotlin/bot/toby/scheduling/StreakReminderJob.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/scheduling/StreakReminderJob.kt
@@ -4,6 +4,7 @@ import bot.toby.notify.NotificationRouter
 import common.logging.DiscordLogger
 import common.notification.NotificationChannelKind
 import common.notification.PushPayload
+import database.dto.guild.ConfigDto
 import database.service.social.LoginStreakService
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.JDA
@@ -17,14 +18,19 @@ import java.awt.Color
 import java.time.Clock
 import java.time.LocalDate
 import java.time.ZoneOffset
+import java.time.ZonedDateTime
 
 /**
- * 18:00 UTC nudge for users with an active streak who haven't claimed
- * today. The streak resets at midnight UTC (the daily reset jobs run at
- * `0 0 0 * * *`), so firing six hours ahead leaves a usable window to
- * claim — the previous 23:00 slot landed one hour before the reset, in
- * the middle of the night for most timezones, and was effectively too
- * late to act on. Routed through [NotificationRouter], which checks
+ * Streak-reminder nudge for users with an active streak who haven't claimed
+ * today. Runs hourly and, for each guild, fires only when the current UTC
+ * hour matches that guild's [ConfigDto.Configurations.STREAK_REMINDER_HOUR]
+ * (default [DEFAULT_REMINDER_HOUR] = 18:00 UTC). The streak resets at
+ * midnight UTC (the daily reset jobs run at `0 0 0 * * *`), so the default
+ * fires six hours ahead — leaving a usable window to claim — and admins can
+ * shift it per server via the web moderation page. Values close to midnight
+ * leave little time to act.
+ *
+ * Routed through [NotificationRouter], which checks
  * [NotificationChannelKind.STREAK_REMINDER] opt-in — that kind defaults
  * to off, so existing servers stay quiet; users explicitly opt in via
  * `/notify set STREAK_REMINDER on` or the web preferences page.
@@ -39,21 +45,29 @@ class StreakReminderJob @Autowired constructor(
     private val jda: JDA,
     private val loginStreakService: LoginStreakService,
     private val notificationRouter: NotificationRouter,
+    private val hourGate: GuildHourGate,
     private val clock: Clock = Clock.systemUTC(),
     @Value("\${app.base-url:}") private val webBaseUrl: String = "",
 ) {
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
 
-    @Scheduled(cron = "0 0 18 * * *", zone = "UTC")
+    @Scheduled(cron = "0 0 * * * *", zone = "UTC")
     fun runHourly() {
-        val today = LocalDate.now(clock.withZone(ZoneOffset.UTC))
-        logger.info { "Running streak-reminder job for $today" }
+        val now = ZonedDateTime.now(clock.withZone(ZoneOffset.UTC))
+        val today = now.toLocalDate()
+        logger.info { "Running streak-reminder job for $today (hour=${now.hour})" }
 
         jda.guildCache.forEach { guild ->
-            runCatching { remindForGuild(guild.idLong, today) }
-                .onFailure {
-                    logger.error("Streak reminder failed for guild ${guild.idLong}: ${it.message}")
-                }
+            runCatching {
+                val targetHour = hourGate.configuredHour(
+                    guild.idLong,
+                    ConfigDto.Configurations.STREAK_REMINDER_HOUR,
+                    DEFAULT_REMINDER_HOUR,
+                )
+                if (now.hour == targetHour) remindForGuild(guild.idLong, today)
+            }.onFailure {
+                logger.error("Streak reminder failed for guild ${guild.idLong}: ${it.message}")
+            }
         }
     }
 
@@ -95,5 +109,10 @@ class StreakReminderJob @Autowired constructor(
             dispatched++
         }
         logger.info { "Streak reminder for guild $guildId: at-risk=${due.size} (opt-in checked per user)" }
+    }
+
+    companion object {
+        // Fallback UTC hour when STREAK_REMINDER_HOUR is unset or invalid.
+        const val DEFAULT_REMINDER_HOUR: Int = 18
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/scheduling/StreakReminderJob.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/scheduling/StreakReminderJob.kt
@@ -19,8 +19,12 @@ import java.time.LocalDate
 import java.time.ZoneOffset
 
 /**
- * 23:00 UTC nudge for users with an active streak who haven't claimed
- * today. Routed through [NotificationRouter], which checks
+ * 18:00 UTC nudge for users with an active streak who haven't claimed
+ * today. The streak resets at midnight UTC (the daily reset jobs run at
+ * `0 0 0 * * *`), so firing six hours ahead leaves a usable window to
+ * claim — the previous 23:00 slot landed one hour before the reset, in
+ * the middle of the night for most timezones, and was effectively too
+ * late to act on. Routed through [NotificationRouter], which checks
  * [NotificationChannelKind.STREAK_REMINDER] opt-in — that kind defaults
  * to off, so existing servers stay quiet; users explicitly opt in via
  * `/notify set STREAK_REMINDER on` or the web preferences page.
@@ -40,7 +44,7 @@ class StreakReminderJob @Autowired constructor(
 ) {
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
 
-    @Scheduled(cron = "0 0 23 * * *", zone = "UTC")
+    @Scheduled(cron = "0 0 18 * * *", zone = "UTC")
     fun runHourly() {
         val today = LocalDate.now(clock.withZone(ZoneOffset.UTC))
         logger.info { "Running streak-reminder job for $today" }

--- a/discord-bot/src/main/kotlin/bot/toby/scheduling/UniversalBasicIncomeJob.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/scheduling/UniversalBasicIncomeJob.kt
@@ -17,13 +17,16 @@ import org.springframework.stereotype.Component
 import java.time.Clock
 import java.time.LocalDate
 import java.time.ZoneOffset
+import java.time.ZonedDateTime
 
 /**
- * Daily Universal Basic Income grant. At 00:00 UTC, every guild with a
- * positive `UBI_DAILY_AMOUNT` config grants that many credits to every
- * known user, bypassing the daily cap. The `ubi_daily` ledger makes
- * retries idempotent — if the bot restarts mid-run or the job fires
- * twice in a day, only one grant per (user, guild, date) lands.
+ * Daily Universal Basic Income grant. Runs hourly; for each guild with a
+ * positive `UBI_DAILY_AMOUNT` config, grants that many credits to every
+ * known user (bypassing the daily cap) when the current UTC hour matches the
+ * guild's `UBI_DAILY_HOUR` config (default [DEFAULT_UBI_HOUR] = 00:00 UTC).
+ * The `ubi_daily` ledger makes retries idempotent — if the bot restarts
+ * mid-run or the job fires twice in the matching hour, only one grant per
+ * (user, guild, UTC date) lands.
  */
 @Component
 @Profile("prod")
@@ -33,18 +36,26 @@ class UniversalBasicIncomeJob @Autowired constructor(
     private val configService: ConfigService,
     private val ubiDailyService: UbiDailyService,
     private val awardService: SocialCreditAwardService,
+    private val hourGate: GuildHourGate,
     private val clock: Clock = Clock.systemUTC()
 ) {
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
 
-    @Scheduled(cron = "0 0 0 * * *", zone = "UTC")
+    @Scheduled(cron = "0 0 * * * *", zone = "UTC")
     fun runDaily() {
-        val today = LocalDate.now(clock.withZone(ZoneOffset.UTC))
-        logger.info { "Running UBI job for $today" }
+        val now = ZonedDateTime.now(clock.withZone(ZoneOffset.UTC))
+        val today = now.toLocalDate()
+        logger.info { "Running UBI job for $today (hour=${now.hour})" }
 
         jda.guildCache.forEach { guild ->
-            runCatching { grantForGuild(guild, today) }
-                .onFailure { logger.error("UBI grant failed for guild ${guild.idLong}: ${it.message}") }
+            runCatching {
+                val targetHour = hourGate.configuredHour(
+                    guild.idLong,
+                    ConfigDto.Configurations.UBI_DAILY_HOUR,
+                    DEFAULT_UBI_HOUR,
+                )
+                if (now.hour == targetHour) grantForGuild(guild, today)
+            }.onFailure { logger.error("UBI grant failed for guild ${guild.idLong}: ${it.message}") }
         }
     }
 
@@ -117,5 +128,8 @@ class UniversalBasicIncomeJob @Autowired constructor(
     companion object {
         // Fallback when UBI_PER_LEVEL_BONUS is unset or unparseable.
         const val DEFAULT_UBI_PER_LEVEL_BONUS: Long = 5L
+
+        // Fallback UTC hour when UBI_DAILY_HOUR is unset or invalid.
+        const val DEFAULT_UBI_HOUR: Int = 0
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/misc/MemeButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/misc/MemeButtonTest.kt
@@ -66,7 +66,7 @@ internal class MemeButtonTest {
     }
 
     @Test
-    fun `user without meme permission is silently ignored — no fetch fired`() {
+    fun `user without meme permission is silently ignored - no fetch fired`() {
         every { dto.memePermission } returns false
         every { event.componentId } returns "meme:reroll:memes:day:5"
 

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/misc/AchievementsCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/misc/AchievementsCommandTest.kt
@@ -224,7 +224,7 @@ class AchievementsCommandTest {
     }
 
     @Test
-    fun `level_5 with threshold 5 and progress 3 renders accurate progress — regression for the wiring bug`() {
+    fun `level_5 with threshold 5 and progress 3 renders accurate progress - regression for the wiring bug`() {
         every { achievementService.listFor(any(), any()) } returns listOf(
             mkView(
                 code = "level_5", category = "level", name = "Getting Started",
@@ -244,7 +244,7 @@ class AchievementsCommandTest {
     // ---------- sorting within a category ----------
 
     @Test
-    fun `entries are sorted within a category — unlocked first newest-first then locked highest-progress-first`() {
+    fun `entries are sorted within a category - unlocked first newest-first then locked highest-progress-first`() {
         val older = Instant.parse("2024-01-01T00:00:00Z")
         val newer = Instant.parse("2024-06-01T00:00:00Z")
         every { achievementService.listFor(any(), any()) } returns listOf(

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/moderation/AntiAutoclickEmbedsTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/moderation/AntiAutoclickEmbedsTest.kt
@@ -72,7 +72,7 @@ internal class AntiAutoclickEmbedsTest {
     }
 
     @Test
-    fun `activeEmbed Started field stays relative — the active embed is being live-edited`() {
+    fun `activeEmbed Started field stays relative - the active embed is being live-edited`() {
         val embed = AntiAutoclickEmbeds.activeEmbed(
             discordId = discordId,
             gameKey = gameKey,

--- a/discord-bot/src/test/kotlin/bot/toby/lavaplayer/TrackSchedulerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/lavaplayer/TrackSchedulerTest.kt
@@ -499,7 +499,7 @@ class TrackSchedulerTest {
     }
 
     @Test
-    fun `intro-resume runs before loop branch — looping intro does not repeat`() {
+    fun `intro-resume runs before loop branch - looping intro does not repeat`() {
         scheduler.isLooping = true
         val current = mockTrack("Current")
         val clone = mockTrack("Clone")

--- a/discord-bot/src/test/kotlin/bot/toby/leveling/LevelUpListenerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/leveling/LevelUpListenerTest.kt
@@ -166,7 +166,7 @@ class LevelUpListenerTest {
     }
 
     @Test
-    fun `onLevelUp also pushes the leveller — regression guard for forgotten push surface`() {
+    fun `onLevelUp also pushes the leveller - regression guard for forgotten push surface`() {
         // LEVEL_UP supports DM + CHANNEL + PUSH. Dispatch enforcement
         // requires all three; pin that the push surface fires.
         guildOnly()

--- a/discord-bot/src/test/kotlin/bot/toby/modal/modals/setconfig/SetConfigStakesModalTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/modal/modals/setconfig/SetConfigStakesModalTest.kt
@@ -87,7 +87,7 @@ class SetConfigStakesModalTest {
     }
 
     @Test
-    fun `duel modal has no bot-edge field — fills only MIN and MAX`() {
+    fun `duel modal has no bot-edge field - fills only MIN and MAX`() {
         every { event.modalId } returns SetConfigStakesModal.customIdFor(SetConfigStakesModal.Game.DUEL)
         stub(SetConfigStakesModal.FIELD_MIN_STAKE, "10")
         stub(SetConfigStakesModal.FIELD_MAX_STAKE, "1000")

--- a/discord-bot/src/test/kotlin/bot/toby/notify/NotificationRouterDispatchTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/notify/NotificationRouterDispatchTest.kt
@@ -136,7 +136,7 @@ class NotificationRouterDispatchTest {
     // ---------- enforcement: missing surfaces fail fast ----------
 
     @Test
-    fun `dispatch throws when a supported surface has no builder — the regression guard`() {
+    fun `dispatch throws when a supported surface has no builder - the regression guard`() {
         // ACHIEVEMENT_UNLOCK supports DM + CHANNEL + PUSH. Forgetting push
         // is exactly the bug that shipped achievement push broken.
         val err = assertThrows(IllegalStateException::class.java) {
@@ -284,7 +284,7 @@ class NotificationRouterDispatchTest {
     }
 
     @Test
-    fun `Surface enum stays exhaustive — dispatch's when expression covers every entry`() {
+    fun `Surface enum stays exhaustive - dispatch's when expression covers every entry`() {
         // If a fourth surface is added, dispatch's when{} won't compile.
         // This test pins today's set so the missing-surfaces detection
         // logic in dispatch is exhaustive by construction.
@@ -366,7 +366,7 @@ class NotificationRouterDispatchTest {
     }
 
     @Test
-    fun `multi-recipient dispatch enforces every supported surface — forgetting push for a many-winners cycle fails fast`() {
+    fun `multi-recipient dispatch enforces every supported surface - forgetting push for a many-winners cycle fails fast`() {
         // LOTTERY_DRAW_WITH_MY_TICKET supports CHANNEL + PUSH. Wiring
         // only channel ships the broadcast but silently drops every
         // opted-in winner's personal notification — exactly the bug
@@ -383,7 +383,7 @@ class NotificationRouterDispatchTest {
     }
 
     @Test
-    fun `multi-recipient dispatch handles an empty recipient list — channel broadcast still fires, push is a no-op`() {
+    fun `multi-recipient dispatch handles an empty recipient list - channel broadcast still fires, push is a no-op`() {
         // No winners (e.g. lottery cycle with NoTickets). The channel
         // post still announces the open draw; push fan-out is zero.
         router.dispatch(

--- a/discord-bot/src/test/kotlin/bot/toby/notify/WebDuelOfferNotifierTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/notify/WebDuelOfferNotifierTest.kt
@@ -139,7 +139,7 @@ class WebDuelOfferNotifierTest {
     }
 
     @Test
-    fun `on also pushes the opponent — regression guard for forgotten push surface`() {
+    fun `on also pushes the opponent - regression guard for forgotten push surface`() {
         notifier.on(event())
         verify(exactly = 1) {
             router.sendPush(opponentId, guildId, NotificationChannelKind.DUEL_OFFER, any())

--- a/discord-bot/src/test/kotlin/bot/toby/notify/WebPushAdapterTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/notify/WebPushAdapterTest.kt
@@ -96,7 +96,7 @@ class WebPushAdapterTest {
     }
 
     @Test
-    fun `5xx response neither marks nor prunes — will retry later`() {
+    fun `5xx response neither marks nor prunes - will retry later`() {
         every { subscriptions.listForUser(discordId) } returns listOf(sub("https://flake"))
         transport.statusFor = { 503 }
 

--- a/discord-bot/src/test/kotlin/bot/toby/notify/WebTipNotifierTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/notify/WebTipNotifierTest.kt
@@ -121,7 +121,7 @@ class WebTipNotifierTest {
     }
 
     @Test
-    fun `on also pushes the recipient — regression guard for forgotten push surface`() {
+    fun `on also pushes the recipient - regression guard for forgotten push surface`() {
         // TIP_RECEIVED supports CHANNEL + PUSH. Dispatch enforcement now
         // requires both; this pins that the push surface fires alongside
         // the channel post for opted-in recipients.

--- a/discord-bot/src/test/kotlin/bot/toby/scheduling/GuildHourGateTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/scheduling/GuildHourGateTest.kt
@@ -1,0 +1,70 @@
+package bot.toby.scheduling
+
+import database.dto.guild.ConfigDto
+import database.service.guild.ConfigService
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Coverage for [GuildHourGate.configuredHour]: returns the stored per-guild
+ * UTC hour when valid, and falls back to the supplied default when the value
+ * is absent, non-numeric, or out of the 0-23 range.
+ */
+class GuildHourGateTest {
+
+    private val configService: ConfigService = mockk(relaxed = true)
+    private val gate = GuildHourGate(configService)
+
+    private val guildId = 100L
+    private val key = ConfigDto.Configurations.STREAK_REMINDER_HOUR
+
+    private fun stub(value: String?) {
+        every {
+            configService.getConfigByName(key.configValue, guildId.toString())
+        } returns value?.let { ConfigDto(name = key.configValue, value = it, guildId = guildId.toString()) }
+    }
+
+    @Test
+    fun `returns the default when no config is set`() {
+        stub(null)
+        assertEquals(18, gate.configuredHour(guildId, key, 18))
+    }
+
+    @Test
+    fun `returns the configured hour when valid`() {
+        stub("20")
+        assertEquals(20, gate.configuredHour(guildId, key, 18))
+    }
+
+    @Test
+    fun `accepts the range boundaries 0 and 23`() {
+        stub("0")
+        assertEquals(0, gate.configuredHour(guildId, key, 18))
+        stub("23")
+        assertEquals(23, gate.configuredHour(guildId, key, 18))
+    }
+
+    @Test
+    fun `falls back to default when the value is out of range`() {
+        stub("24")
+        assertEquals(18, gate.configuredHour(guildId, key, 18))
+        stub("-1")
+        assertEquals(18, gate.configuredHour(guildId, key, 18))
+    }
+
+    @Test
+    fun `falls back to default when the value is non-numeric or blank`() {
+        stub("wibble")
+        assertEquals(18, gate.configuredHour(guildId, key, 18))
+        stub("  ")
+        assertEquals(18, gate.configuredHour(guildId, key, 18))
+    }
+
+    @Test
+    fun `trims surrounding whitespace before parsing`() {
+        stub("  9  ")
+        assertEquals(9, gate.configuredHour(guildId, key, 18))
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryDailyJobTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryDailyJobTest.kt
@@ -29,11 +29,13 @@ class LotteryDailyJobTest {
     private lateinit var lotteryDailyService: LotteryDailyService
     private lateinit var jackpotLotteryService: JackpotLotteryService
     private lateinit var lotteryAnnouncer: LotteryAnnouncer
+    private lateinit var hourGate: GuildHourGate
     private lateinit var guild: Guild
     private lateinit var job: LotteryDailyJob
 
     private val guildId = 100L
     private val today: LocalDate = LocalDate.of(2026, 5, 1)
+    // Midnight UTC == the default LOTTERY_DAILY_HOUR (0), so the hour gate fires.
     private val clock: Clock = Clock.fixed(today.atStartOfDay().toInstant(ZoneOffset.UTC), ZoneOffset.UTC)
 
     @BeforeEach
@@ -43,6 +45,8 @@ class LotteryDailyJobTest {
         lotteryDailyService = mockk(relaxed = true)
         jackpotLotteryService = mockk(relaxed = true)
         lotteryAnnouncer = mockk(relaxed = true)
+        // Relaxed configService → getConfigByName null → gate uses default hour 0.
+        hourGate = GuildHourGate(configService)
         guild = mockk(relaxed = true)
 
         val cache: SnowflakeCacheView<Guild> = mockk(relaxed = true)
@@ -53,7 +57,16 @@ class LotteryDailyJobTest {
 
         job = LotteryDailyJob(
             jda, configService, lotteryDailyService, jackpotLotteryService,
-            lotteryAnnouncer, clock,
+            lotteryAnnouncer, hourGate, clock,
+        )
+    }
+
+    /** Build a job whose clock is fixed at [hour] UTC on [today]. */
+    private fun jobAtHour(hour: Int): LotteryDailyJob {
+        val c = Clock.fixed(today.atTime(hour, 0).toInstant(ZoneOffset.UTC), ZoneOffset.UTC)
+        return LotteryDailyJob(
+            jda, configService, lotteryDailyService, jackpotLotteryService,
+            lotteryAnnouncer, hourGate, c,
         )
     }
 
@@ -92,6 +105,20 @@ class LotteryDailyJobTest {
 
         verify(exactly = 0) { jackpotLotteryService.openMatchLottery(any(), any(), any(), any()) }
         verify(exactly = 0) { jackpotLotteryService.drawMatchLottery(any()) }
+        verify(exactly = 0) { lotteryDailyService.markRan(any(), any()) }
+    }
+
+    @Test
+    fun `runDaily skips a guild when the current UTC hour is not its lottery hour`() {
+        stubEnabled(true)
+        every { lotteryDailyService.alreadyRan(guildId, today) } returns false
+
+        // Default lottery hour is 0; running the hourly tick at 09:00 UTC
+        // should gate the guild out before any roll work.
+        jobAtHour(9).runDaily()
+
+        verify(exactly = 0) { lotteryDailyService.alreadyRan(any(), any()) }
+        verify(exactly = 0) { jackpotLotteryService.openMatchLottery(any(), any(), any(), any()) }
         verify(exactly = 0) { lotteryDailyService.markRan(any(), any()) }
     }
 
@@ -365,7 +392,7 @@ class LotteryDailyJobTest {
     }
 
     @Test
-    fun `runDaily handles WEIGHTED BelowMinBuyers — cancels, refunds, announces, marks ran`() {
+    fun `runDaily handles WEIGHTED BelowMinBuyers - cancels, refunds, announces, marks ran`() {
         stubEnabled(true)
         stubMode("WEIGHTED")
         every { lotteryDailyService.alreadyRan(guildId, today) } returns false

--- a/discord-bot/src/test/kotlin/bot/toby/scheduling/MonthlyLeaderboardJobTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/scheduling/MonthlyLeaderboardJobTest.kt
@@ -26,6 +26,9 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.LocalDate
+import java.time.ZoneOffset
 
 class MonthlyLeaderboardJobTest {
 
@@ -35,11 +38,20 @@ class MonthlyLeaderboardJobTest {
     private lateinit var snapshotService: MonthlyCreditSnapshotService
     private lateinit var configService: ConfigService
     private lateinit var ubiDailyService: UbiDailyService
+    private lateinit var hourGate: GuildHourGate
     private lateinit var guild: Guild
     private lateinit var channel: TextChannel
     private lateinit var job: MonthlyLeaderboardJob
 
     private val guildId = 100L
+
+    // Keep the real calendar date (so the existing LocalDate.now(UTC)-based
+    // stubs stay correct) but fix the hour to 12:00 UTC — the default
+    // MONTHLY_LEADERBOARD_HOUR — so the per-guild hour gate fires.
+    private val clock: Clock = Clock.fixed(
+        LocalDate.now(ZoneOffset.UTC).atTime(12, 0).toInstant(ZoneOffset.UTC),
+        ZoneOffset.UTC,
+    )
 
     @BeforeEach
     fun setup() {
@@ -49,6 +61,8 @@ class MonthlyLeaderboardJobTest {
         snapshotService = mockk(relaxed = true)
         configService = mockk(relaxed = true)
         ubiDailyService = mockk(relaxed = true)
+        // Relaxed configService → getConfigByName null → gate uses default hour 12.
+        hourGate = GuildHourGate(configService)
         guild = mockk(relaxed = true)
         channel = mockk(relaxed = true)
 
@@ -64,7 +78,20 @@ class MonthlyLeaderboardJobTest {
         every { channel.sendMessageEmbeds(any<MessageEmbed>()) } returns createAction
 
         job = MonthlyLeaderboardJob(
-            jda, userService, voiceSessionService, snapshotService, configService, ubiDailyService
+            jda, userService, voiceSessionService, snapshotService, configService,
+            ubiDailyService, hourGate, clock,
+        )
+    }
+
+    /** Build a job whose clock is fixed at [hour] UTC on the current date. */
+    private fun jobAtHour(hour: Int): MonthlyLeaderboardJob {
+        val c = Clock.fixed(
+            LocalDate.now(ZoneOffset.UTC).atTime(hour, 0).toInstant(ZoneOffset.UTC),
+            ZoneOffset.UTC,
+        )
+        return MonthlyLeaderboardJob(
+            jda, userService, voiceSessionService, snapshotService, configService,
+            ubiDailyService, hourGate, c,
         )
     }
 
@@ -76,6 +103,17 @@ class MonthlyLeaderboardJobTest {
         every { m.effectiveName } returns name
         every { guild.getMemberById(id) } returns m
         return m
+    }
+
+    @Test
+    fun `postMonthlyLeaderboard skips a guild when the current UTC hour is not its hour`() {
+        // Default leaderboard hour is 12; running the hourly tick at 09:00 UTC
+        // should gate the guild out before any user/snapshot lookup.
+        jobAtHour(9).postMonthlyLeaderboard()
+
+        verify(exactly = 0) { userService.listGuildUsers(any()) }
+        verify(exactly = 0) { channel.sendMessageEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 0) { snapshotService.upsert(any()) }
     }
 
     @Test

--- a/discord-bot/src/test/kotlin/bot/toby/scheduling/StreakReminderJobTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/scheduling/StreakReminderJobTest.kt
@@ -123,8 +123,8 @@ class StreakReminderJobTest {
     }
 
     @Test
-    fun `runHourly uses today's UTC date — not the wall-clock local date`() {
-        // Cron is `0 0 23 * * *` in UTC. Job picks UTC date via the
+    fun `runHourly uses today's UTC date - not the wall-clock local date`() {
+        // Cron is `0 0 18 * * *` in UTC. Job picks UTC date via the
         // injected clock. Verify the LoginStreakService query receives
         // the fixed UTC date from the clock.
         every {
@@ -139,7 +139,7 @@ class StreakReminderJobTest {
     }
 
     @Test
-    fun `runHourly isolates per-guild failures — one throwing guild doesn't kill the loop`() {
+    fun `runHourly isolates per-guild failures - one throwing guild doesn't kill the loop`() {
         every {
             loginStreakService.findActiveStreaksDueForReminder(100L, today)
         } throws RuntimeException("DB hiccup")
@@ -193,7 +193,7 @@ class StreakReminderJobTest {
     }
 
     @Test
-    fun `runHourly also pushes every at-risk user — regression guard for forgotten push surface`() {
+    fun `runHourly also pushes every at-risk user - regression guard for forgotten push surface`() {
         // STREAK_REMINDER supports DM + PUSH. Before dispatch enforcement,
         // the job DM'd at-risk users but never pushed — opted-in browsers
         // got nothing. Dispatch now requires both, and this test pins

--- a/discord-bot/src/test/kotlin/bot/toby/scheduling/StreakReminderJobTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/scheduling/StreakReminderJobTest.kt
@@ -3,6 +3,7 @@ package bot.toby.scheduling
 import bot.toby.notify.NotificationRouter
 import common.notification.PushAdapter
 import common.notification.NotificationChannelKind
+import database.dto.guild.ConfigDto
 import database.dto.social.LoginStreakDto
 import database.service.guild.ConfigService
 import database.service.social.LoginStreakService
@@ -39,26 +40,32 @@ import java.time.ZoneOffset
 class StreakReminderJobTest {
 
     private val today: LocalDate = LocalDate.of(2026, 5, 1)
+    // Fixed at the default streak-reminder hour (18:00 UTC) so the per-guild
+    // hour gate fires for guilds that have no STREAK_REMINDER_HOUR override.
     private val clock: Clock = Clock.fixed(
-        today.atStartOfDay().toInstant(ZoneOffset.UTC),
+        today.atTime(18, 0).toInstant(ZoneOffset.UTC),
         ZoneOffset.UTC
     )
 
     private lateinit var jda: JDA
     private lateinit var loginStreakService: LoginStreakService
     private lateinit var notificationRouter: NotificationRouter
-    private lateinit var job: StreakReminderJob
+    private lateinit var configService: ConfigService
+    private lateinit var hourGate: GuildHourGate
 
     @BeforeEach
     fun setup() {
         jda = mockk(relaxed = true)
         loginStreakService = mockk(relaxed = true)
+        // Relaxed ConfigService returns null for getConfigByName, so the gate
+        // falls back to the default hour (18) unless a test stubs an override.
+        configService = mockk(relaxed = true)
+        hourGate = GuildHourGate(configService)
         // Spy on a real router so `dispatch` runs its missing-surface
         // enforcement and forwards to spied primitives we can verify.
         val prefService = mockk<UserNotificationPrefService>(relaxed = true) {
             every { isOptedIn(any(), any(), any(), any()) } returns true
         }
-        val configService = mockk<ConfigService>(relaxed = true)
         val pushAdapter = mockk<PushAdapter>(relaxed = true)
         notificationRouter = spyk(
             NotificationRouter(jda, prefService, configService, pushAdapter)
@@ -71,7 +78,11 @@ class StreakReminderJobTest {
     }
 
     /** Build the job with a JDA cache containing the supplied guild ids. */
-    private fun buildJob(vararg guildIds: Long): StreakReminderJob {
+    private fun buildJob(vararg guildIds: Long): StreakReminderJob =
+        buildJobWithClock(clock, *guildIds)
+
+    /** As [buildJob] but with an explicit clock, for hour-gate cases. */
+    private fun buildJobWithClock(clock: Clock, vararg guildIds: Long): StreakReminderJob {
         // Rename loop var so it doesn't shadow Guild.id when we stub it.
         val guilds = guildIds.map { gid ->
             val g = mockk<Guild>(relaxed = true)
@@ -82,7 +93,7 @@ class StreakReminderJobTest {
         val cache: SnowflakeCacheView<Guild> = mockk(relaxed = true)
         every { jda.guildCache } returns cache
         every { cache.iterator() } returns guilds.toMutableList().iterator()
-        return StreakReminderJob(jda, loginStreakService, notificationRouter, clock)
+        return StreakReminderJob(jda, loginStreakService, notificationRouter, hourGate, clock)
     }
 
     @Test
@@ -248,6 +259,66 @@ class StreakReminderJobTest {
         }
         verify(exactly = 1) {
             notificationRouter.sendDm(6L, 200L, NotificationChannelKind.STREAK_REMINDER, any())
+        }
+    }
+
+    @Test
+    fun `runHourly skips a guild when the current UTC hour is not its reminder hour`() {
+        // No config override → default reminder hour is 18. Run the hourly
+        // tick at 10:00 UTC: the gate should skip the guild entirely, so the
+        // at-risk query never runs and nothing is dispatched.
+        val offHourClock = Clock.fixed(
+            today.atTime(10, 0).toInstant(ZoneOffset.UTC),
+            ZoneOffset.UTC
+        )
+
+        buildJobWithClock(offHourClock, 100L).runHourly()
+
+        verify(exactly = 0) {
+            loginStreakService.findActiveStreaksDueForReminder(any(), any())
+        }
+        verify(exactly = 0) {
+            notificationRouter.sendDm(any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `runHourly honours a per-guild STREAK_REMINDER_HOUR override`() {
+        // Guild 100 overrides its reminder hour to 20:00 UTC.
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.STREAK_REMINDER_HOUR.configValue,
+                "100"
+            )
+        } returns ConfigDto(
+            name = ConfigDto.Configurations.STREAK_REMINDER_HOUR.configValue,
+            value = "20",
+            guildId = "100",
+        )
+        every {
+            loginStreakService.findActiveStreaksDueForReminder(100L, today)
+        } returns listOf(
+            LoginStreakDto(
+                discordId = 1L, guildId = 100L,
+                currentStreak = 5, longestStreak = 5,
+                lastClaimDate = today.minusDays(1), totalClaims = 5L,
+            )
+        )
+
+        // At the default 18:00 tick the override (20) does not match → skip.
+        buildJob(100L).runHourly()
+        verify(exactly = 0) {
+            notificationRouter.sendDm(any(), any(), any(), any())
+        }
+
+        // At the 20:00 tick the override matches → dispatch.
+        val twentyClock = Clock.fixed(
+            today.atTime(20, 0).toInstant(ZoneOffset.UTC),
+            ZoneOffset.UTC
+        )
+        buildJobWithClock(twentyClock, 100L).runHourly()
+        verify(exactly = 1) {
+            notificationRouter.sendDm(1L, 100L, NotificationChannelKind.STREAK_REMINDER, any())
         }
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/scheduling/TobyCoinPriceTickJobAutoTradeTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/scheduling/TobyCoinPriceTickJobAutoTradeTest.kt
@@ -197,7 +197,7 @@ class TobyCoinPriceTickJobAutoTradeTest {
     }
 
     @Test
-    fun `trade service throws — trigger still disabled`() {
+    fun `trade service throws - trigger still disabled`() {
         val marketService: TobyCoinMarketService = mockk(relaxed = true)
         val triggerService: UserPriceTriggerService = mockk(relaxed = true)
         val tradeService: EconomyTradeService = mockk(relaxed = true)

--- a/discord-bot/src/test/kotlin/bot/toby/scheduling/UniversalBasicIncomeJobTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/scheduling/UniversalBasicIncomeJobTest.kt
@@ -29,11 +29,13 @@ class UniversalBasicIncomeJobTest {
     private lateinit var configService: ConfigService
     private lateinit var ubiDailyService: UbiDailyService
     private lateinit var awardService: SocialCreditAwardService
+    private lateinit var hourGate: GuildHourGate
     private lateinit var guild: Guild
     private lateinit var job: UniversalBasicIncomeJob
 
     private val guildId = 100L
     private val today: LocalDate = LocalDate.of(2026, 5, 1)
+    // Midnight UTC == the default UBI_DAILY_HOUR (0), so the hour gate fires.
     private val clock: Clock = Clock.fixed(today.atStartOfDay().toInstant(ZoneOffset.UTC), ZoneOffset.UTC)
 
     @BeforeEach
@@ -43,6 +45,8 @@ class UniversalBasicIncomeJobTest {
         configService = mockk(relaxed = true)
         ubiDailyService = mockk(relaxed = true)
         awardService = mockk(relaxed = true)
+        // Relaxed configService → getConfigByName null → gate uses default hour 0.
+        hourGate = GuildHourGate(configService)
         guild = mockk(relaxed = true)
 
         val cache: SnowflakeCacheView<Guild> = mockk(relaxed = true)
@@ -51,7 +55,13 @@ class UniversalBasicIncomeJobTest {
         every { guild.idLong } returns guildId
         every { guild.id } returns guildId.toString()
 
-        job = UniversalBasicIncomeJob(jda, userService, configService, ubiDailyService, awardService, clock)
+        job = UniversalBasicIncomeJob(jda, userService, configService, ubiDailyService, awardService, hourGate, clock)
+    }
+
+    /** Build a job whose clock is fixed at [hour] UTC on [today]. */
+    private fun jobAtHour(hour: Int): UniversalBasicIncomeJob {
+        val c = Clock.fixed(today.atTime(hour, 0).toInstant(ZoneOffset.UTC), ZoneOffset.UTC)
+        return UniversalBasicIncomeJob(jda, userService, configService, ubiDailyService, awardService, hourGate, c)
     }
 
     private fun stubUbiAmount(value: String?) {
@@ -144,6 +154,16 @@ class UniversalBasicIncomeJobTest {
         job.runDaily()
 
         verify(exactly = 0) { ubiDailyService.upsert(any()) }
+    }
+
+    @Test
+    fun `runDaily skips a guild when the current UTC hour is not its UBI hour`() {
+        // Default UBI hour is 0; running the hourly tick at 09:00 UTC should
+        // gate the guild out before any config or user lookup.
+        jobAtHour(9).runDaily()
+
+        verify(exactly = 0) { userService.listGuildUsers(any()) }
+        verify(exactly = 0) { awardService.award(any(), any(), any(), any(), any(), any()) }
     }
 
     @Test

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -1198,6 +1198,18 @@ class ModerationWebService(
                 if (n < 0L) return "Value must be zero or positive."
                 n.toString()
             }
+            // Per-guild UTC hour (0-23) at which each daily cron job runs.
+            // The job runs hourly and only acts on the guild when the current
+            // UTC hour matches. Streaks/economy still reset at midnight UTC.
+            ConfigDto.Configurations.STREAK_REMINDER_HOUR,
+            ConfigDto.Configurations.UBI_DAILY_HOUR,
+            ConfigDto.Configurations.LOTTERY_DAILY_HOUR,
+            ConfigDto.Configurations.MONTHLY_LEADERBOARD_HOUR -> {
+                val n = rawValue.trim().toIntOrNull()
+                    ?: return "Value must be a whole number (0-23)."
+                if (n !in 0..23) return "Hour must be between 0 and 23 (UTC)."
+                n.toString()
+            }
             ConfigDto.Configurations.INSTALL_MODE,
             ConfigDto.Configurations.INSTALLED_AT ->
                 return "Install-wizard sentinel — managed by /install in Discord."

--- a/web/src/main/resources/templates/moderation/leveling.html
+++ b/web/src/main/resources/templates/moderation/leveling.html
@@ -298,6 +298,21 @@
                                th:disabled="${!isOwner}">
                         <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                     </div>
+                    <div class="config-row" data-key="STREAK_REMINDER_HOUR">
+                        <label>
+                            Streak reminder hour (UTC)
+                            <span class="config-hint">
+                                UTC hour (0&ndash;23) to DM/push the "don't lose your streak"
+                                nudge to opted-in users. Default 18. Streaks reset at midnight
+                                UTC, so values above ~22 leave little time to act.
+                            </span>
+                        </label>
+                        <input type="number" min="0" max="23"
+                               th:value="${overview.config['STREAK_REMINDER_HOUR']}"
+                               placeholder="18"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
                     <div class="config-row" data-key="ACHIEVEMENT_ANNOUNCE_CHANNEL">
                         <label>
                             Achievement shoutout channel

--- a/web/src/main/resources/templates/moderation/lottery.html
+++ b/web/src/main/resources/templates/moderation/lottery.html
@@ -50,6 +50,21 @@
                         </select>
                         <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                     </div>
+                    <div class="config-row" data-key="LOTTERY_DAILY_HOUR">
+                        <label>
+                            Daily draw hour (UTC)
+                            <span class="config-hint">
+                                UTC hour (0&ndash;23) the daily cycle rolls (closes the prior
+                                draw, opens a fresh one). Default 0 (midnight UTC). A later hour
+                                simply delays the daily open/close to that hour.
+                            </span>
+                        </label>
+                        <input type="number" min="0" max="23"
+                               th:value="${overview.config['LOTTERY_DAILY_HOUR']}"
+                               placeholder="0"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
                     <div class="config-row" data-key="LOTTERY_DAILY_MODE">
                         <label>
                             Game mode

--- a/web/src/main/resources/templates/moderation/settings.html
+++ b/web/src/main/resources/templates/moderation/settings.html
@@ -144,6 +144,20 @@
                                     disabled=${!isOwner})}"></div>
                             <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                         </div>
+                        <div class="config-row" data-key="MONTHLY_LEADERBOARD_HOUR">
+                            <label>
+                                Monthly leaderboard hour (UTC)
+                                <span class="config-hint">
+                                    UTC hour (0&ndash;23) to post the leaderboard on the 1st of
+                                    each month. Default 12 (noon UTC).
+                                </span>
+                            </label>
+                            <input type="number" min="0" max="23"
+                                   th:value="${overview.config['MONTHLY_LEADERBOARD_HOUR']}"
+                                   placeholder="12"
+                                   th:disabled="${!isOwner}">
+                            <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                        </div>
                         <div class="config-create-channel">
                             <div class="config-create-channel-text">
                                 <strong>Create a read-only leaderboard channel</strong>
@@ -195,6 +209,20 @@
                             </label>
                             <input type="number" min="0" max="1000"
                                    th:value="${overview.config['UBI_DAILY_AMOUNT']}"
+                                   placeholder="0"
+                                   th:disabled="${!isOwner}">
+                            <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                        </div>
+                        <div class="config-row" data-key="UBI_DAILY_HOUR">
+                            <label>
+                                UBI grant hour (UTC)
+                                <span class="config-hint">
+                                    UTC hour (0&ndash;23) the daily UBI is granted. Default 0
+                                    (midnight UTC). Still once per UTC day regardless of hour.
+                                </span>
+                            </label>
+                            <input type="number" min="0" max="23"
+                                   th:value="${overview.config['UBI_DAILY_HOUR']}"
                                    placeholder="0"
                                    th:disabled="${!isOwner}">
                             <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>

--- a/web/src/test/kotlin/web/controller/BaccaratControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/BaccaratControllerTest.kt
@@ -155,7 +155,7 @@ class BaccaratControllerTest {
     }
 
     @Test
-    fun `tied game pushes Player side bet — push=true and stake refunded`() {
+    fun `tied game pushes Player side bet - push=true and stake refunded`() {
         every {
             baccaratService.play(discordId, guildId, 100L, Baccarat.Side.PLAYER, false)
         } returns PlayOutcome.Push(

--- a/web/src/test/kotlin/web/controller/CasinoControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/CasinoControllerTest.kt
@@ -132,7 +132,7 @@ internal class CasinoControllerTest {
     }
 
     @Test
-    fun `does not redirect when game param is missing — picker is the index page`() {
+    fun `does not redirect when game param is missing - picker is the index page`() {
         setGuilds(777L)
 
         val result = controller.guildList(client, user, game = null, pick = false, request = request, model = model)

--- a/web/src/test/kotlin/web/profile/ProfileCardRendererTest.kt
+++ b/web/src/test/kotlin/web/profile/ProfileCardRendererTest.kt
@@ -97,7 +97,7 @@ class ProfileCardRendererTest {
     }
 
     @Test
-    fun `renders with an inactive (lapsed) streak — badge suppressed`() {
+    fun `renders with an inactive (lapsed) streak - badge suppressed`() {
         val png = renderer.renderPng(sample(streakDays = 30, streakActive = false))
         assertPngShape(png, 900, 400)
     }

--- a/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
@@ -281,6 +281,28 @@ class ModerationWebServiceTest {
     }
 
     @Test
+    fun `updateConfig accepts per-guild cron HOUR keys in 0 to 23 and rejects others`() {
+        mockMember(ownerId, isOwner = true)
+        val keys = listOf(
+            ConfigDto.Configurations.STREAK_REMINDER_HOUR,
+            ConfigDto.Configurations.UBI_DAILY_HOUR,
+            ConfigDto.Configurations.LOTTERY_DAILY_HOUR,
+            ConfigDto.Configurations.MONTHLY_LEADERBOARD_HOUR,
+        )
+        for (key in keys) {
+            assertNull(service.updateConfig(ownerId, guildId, key, "0"), "expected $key to accept 0")
+            assertNull(service.updateConfig(ownerId, guildId, key, "12"), "expected $key to accept 12")
+            assertNull(service.updateConfig(ownerId, guildId, key, "23"), "expected $key to accept 23")
+            verify { configService.upsertConfig(key.configValue, "0", guildId.toString()) }
+            verify { configService.upsertConfig(key.configValue, "23", guildId.toString()) }
+
+            assertNotNull(service.updateConfig(ownerId, guildId, key, "-1"), "expected $key to reject -1")
+            assertNotNull(service.updateConfig(ownerId, guildId, key, "24"), "expected $key to reject 24")
+            assertNotNull(service.updateConfig(ownerId, guildId, key, "wibble"), "expected $key to reject wibble")
+        }
+    }
+
+    @Test
     fun `updateConfig accepts POKER chip-amount keys when value is a positive long`() {
         mockMember(ownerId, isOwner = true)
         val keys = listOf(

--- a/web/src/test/kotlin/web/util/DefaultGuildRedirectTest.kt
+++ b/web/src/test/kotlin/web/util/DefaultGuildRedirectTest.kt
@@ -20,7 +20,7 @@ internal class DefaultGuildRedirectTest {
     }
 
     @Test
-    fun `empty guild list returns null (no mutual guilds — empty hero will render)`() {
+    fun `empty guild list returns null (no mutual guilds - empty hero will render)`() {
         assertNull(DefaultGuildRedirect.pick(emptyList(), cookieGuildId = 1L, pick = false))
         assertNull(DefaultGuildRedirect.pick(emptyList(), cookieGuildId = null, pick = false))
     }


### PR DESCRIPTION
## Background

This started as a fix for the streak reminder firing at 23:00 UTC — one hour before the midnight-UTC streak reset, too late to be actionable. That fix (move to 18:00 UTC) is included, but the real ask was broader: **make every daily cron job's run-hour configurable per Discord server**, since one global UTC hour can't suit guilds with different audiences/timezones.

## What changed

Each wall-clock cron job now runs **hourly** and, for each guild, does its work only when the current UTC hour equals that guild's configured hour — falling back to the job's historical fixed hour when unset. A small shared **`GuildHourGate`** reads the per-guild hour config (cache-backed). The streak/economy day boundary stays at **midnight UTC** (admins pick the hour in UTC; no per-guild timezone math, no DST).

| Job | New config key | Default hour (UTC) |
|-----|----------------|--------------------|
| `StreakReminderJob` | `STREAK_REMINDER_HOUR` | 18 |
| `UniversalBasicIncomeJob` | `UBI_DAILY_HOUR` | 0 |
| `LotteryDailyJob` | `LOTTERY_DAILY_HOUR` | 0 |
| `MonthlyLeaderboardJob` | `MONTHLY_LEADERBOARD_HOUR` | 12 |

Defaults reproduce today's behaviour exactly, so existing guilds are unaffected until an admin changes a value.

### Idempotency / safety
- **UBI** and **daily lottery** are already idempotent via UTC-date-keyed ledgers (`ubi_daily`, `lottery_daily`), so hourly execution is safe.
- **Monthly leaderboard** has no ledger, but Spring's cron scheduler doesn't replay missed ticks, so hourly-on-the-1st + hour-gate still fires at most once per month per guild — the same guarantee as the original single-cron schedule. (A snapshot-based guard was considered and dropped: the web leaderboard/moderation pages lazily seed current-month snapshots, so a snapshot's presence doesn't reliably mean "already posted".)
- The two `fixedDelay` interval jobs (lottery refresh, coin-price tick) are not wall-clock jobs and are **out of scope**.

### Web moderation UI
- `updateConfig` validates the four `*_HOUR` keys as integers in `0..23`.
- One editable row per key in the matching settings section (streak → leveling, UBI + leaderboard → settings, lottery → lottery). `overview.config` auto-exposes every enum key, so no overview wiring was needed; the existing `ModerationTemplateRowsTest` guard confirms each new key has a UI surface.

### Repo-wide hygiene
Replaced the em dashes in **all** test method names (35 names across 28 files) with ASCII hyphens. Test names become HTML report filenames, and an em dash crashes Gradle's report writer under a non-UTF-8 default locale (`Malformed input or input contains unmappable characters`).

## Testing

`./gradlew :common:test :database:test :discord-bot:test :web:test` — **BUILD SUCCESSFUL**. New/updated coverage: `GuildHourGateTest`, off-hour-skip + per-guild-override cases in each job test, and a `*_HOUR` validation case in `ModerationWebServiceTest`.

(`:application:test` is not run here — it needs a Docker/Testcontainers Postgres that isn't available in this environment; unaffected by this change.)

https://claude.ai/code/session_01WZRWNgyfT2L89VGbbHU12y