### PR TITLE
fix(leaderboard): monthly board posts a frozen midnight-boundary snapshot of last month

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/scheduling/MonthlyLeaderboardJob.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/scheduling/MonthlyLeaderboardJob.kt
@@ -42,14 +42,30 @@ class MonthlyLeaderboardJob @Autowired constructor(
 
         /** Fallback UTC hour when MONTHLY_LEADERBOARD_HOUR is unset or invalid. */
         const val DEFAULT_LEADERBOARD_HOUR: Int = 12
+
+        /**
+         * The month boundary itself. The hourly tick at this UTC hour (00:00 on
+         * the 1st) freezes each guild's authoritative end-of-last-month snapshot,
+         * so the figures reflect balances at the moment the new month starts even
+         * when a guild posts later in the day.
+         */
+        const val BOUNDARY_HOUR: Int = 0
     }
 
     /**
-     * Runs hourly on the 1st of the month; for each guild it posts when the
-     * current UTC hour matches that guild's `MONTHLY_LEADERBOARD_HOUR` config
-     * (default [DEFAULT_LEADERBOARD_HOUR] = 12:00 UTC). Spring's cron scheduler
-     * doesn't replay missed ticks, so this fires at most once per month per
-     * guild — the same guarantee as the original single-cron schedule.
+     * Runs hourly on the 1st of the month. Two things happen per guild:
+     *
+     * 1. At [BOUNDARY_HOUR] (00:00 UTC) — and, as a best-effort fallback, at the
+     *    guild's posting hour — the guild's month-boundary snapshot is frozen via
+     *    [snapshotService] `upsertIfMissing`. The midnight tick wins the race, so
+     *    the frozen value is the balance at exactly the month boundary.
+     * 2. When the current UTC hour matches the guild's `MONTHLY_LEADERBOARD_HOUR`
+     *    config (default [DEFAULT_LEADERBOARD_HOUR] = 12:00 UTC) the board is
+     *    posted, computed purely from the frozen boundary snapshots — never the
+     *    live balance.
+     *
+     * Spring's cron scheduler doesn't replay missed ticks, so the post fires at
+     * most once per month per guild.
      */
     @Scheduled(cron = "0 0 * 1 * *", zone = "UTC")
     fun postMonthlyLeaderboard() {
@@ -67,18 +83,57 @@ class MonthlyLeaderboardJob @Autowired constructor(
                     ConfigDto.Configurations.MONTHLY_LEADERBOARD_HOUR,
                     DEFAULT_LEADERBOARD_HOUR,
                 )
-                if (now.hour == targetHour) postForGuild(guild, today, previousMonthStart)
+                val isBoundary = now.hour == BOUNDARY_HOUR
+                val isPosting = now.hour == targetHour
+                if (!isBoundary && !isPosting) return@runCatching
+
+                val users = userService.listGuildUsers(guild.idLong).filterNotNull()
+                if (users.isEmpty()) {
+                    logger.info { "Skipping guild ${guild.idLong} — no tracked users." }
+                    return@runCatching
+                }
+
+                // Freeze (or reuse) the authoritative month-boundary snapshot.
+                // upsertIfMissing keeps whatever was written first — the 00:00
+                // tick — so a later posting tick reads the midnight values.
+                val boundarySnapshots = freezeMonthBoundary(guild.idLong, today, users)
+
+                if (isPosting) {
+                    postForGuild(guild, today, previousMonthStart, users, boundarySnapshots)
+                }
             }.onFailure { logger.error("Monthly leaderboard failed for guild ${guild.idLong}: ${it.message}") }
         }
     }
 
-    private fun postForGuild(guild: Guild, thisMonthStart: LocalDate, previousMonthStart: LocalDate) {
-        val users = userService.listGuildUsers(guild.idLong).filterNotNull()
-        if (users.isEmpty()) {
-            logger.info { "Skipping guild ${guild.idLong} — no tracked users." }
-            return
-        }
+    /**
+     * Snapshots each user's current balance as the month-boundary value for
+     * [boundaryDate], unless one already exists, and returns the authoritative
+     * (possibly pre-existing) snapshot per user. The live balance is only ever
+     * used to seed a missing row — once frozen, the boundary value is reused.
+     */
+    private fun freezeMonthBoundary(
+        guildId: Long,
+        boundaryDate: LocalDate,
+        users: List<database.dto.user.UserDto>
+    ): Map<Long, MonthlyCreditSnapshotDto> = users.associate { dto ->
+        dto.discordId to snapshotService.upsertIfMissing(
+            MonthlyCreditSnapshotDto(
+                discordId = dto.discordId,
+                guildId = guildId,
+                snapshotDate = boundaryDate,
+                socialCredit = dto.socialCredit ?: 0L,
+                tobyCoins = dto.tobyCoins
+            )
+        )
+    }
 
+    private fun postForGuild(
+        guild: Guild,
+        thisMonthStart: LocalDate,
+        previousMonthStart: LocalDate,
+        users: List<database.dto.user.UserDto>,
+        boundarySnapshots: Map<Long, MonthlyCreditSnapshotDto>
+    ) {
         val priorSnapshots = snapshotService.listForGuildDate(guild.idLong, previousMonthStart)
             .associateBy { it.discordId }
 
@@ -99,29 +154,31 @@ class MonthlyLeaderboardJob @Autowired constructor(
         val rows = users
             .filter { dto -> guild.getMemberById(dto.discordId)?.user?.isBot != true }
             .map { dto ->
-                val current = dto.socialCredit ?: 0L
-                val baseline = priorSnapshots[dto.discordId]?.socialCredit
+                // End-of-last-month total = the balance frozen at this month's
+                // boundary (00:00 on the 1st). Fall back to the live balance only
+                // if the boundary freeze somehow never ran for this user.
+                val endTotal = boundarySnapshots[dto.discordId]?.socialCredit ?: (dto.socialCredit ?: 0L)
+                // Start-of-last-month total = the previous month's boundary snapshot.
+                val startTotal = priorSnapshots[dto.discordId]?.socialCredit
                 // No prior-month snapshot means we have no starting point to
-                // measure last month's change against, so treat the delta as 0
-                // rather than counting the user's entire current balance as
-                // "earned last month". Counting the full balance ranks everyone
-                // by their lifetime total and turns the board into a current-
-                // standings list instead of a last-month snapshot. This mirrors
-                // ModerationWebService / LeaderboardWebService, which use the
-                // same 0L fallback; the thisMonthStart snapshot written below
-                // seeds the baseline so the next month's delta is correct.
-                val rawDelta = if (baseline == null) 0L else current - baseline
+                // measure last month's change against, so report 0 earned rather
+                // than counting the user's whole balance. Mirrors the web
+                // leaderboards; the boundary snapshot frozen above seeds the
+                // baseline so next month's earnings are correct.
                 val ubi = ubiByUser[dto.discordId] ?: 0L
-                val creditsDelta = (rawDelta - ubi).coerceAtLeast(0L)
+                val creditsEarned = if (startTotal == null) 0L
+                    else (endTotal - startTotal - ubi).coerceAtLeast(0L)
                 MonthlyRow(
                     discordId = dto.discordId,
-                    creditsDelta = creditsDelta,
+                    creditsEarned = creditsEarned,
+                    endTotal = endTotal,
                     voiceSeconds = voiceSecondsByUser[dto.discordId] ?: 0L
                 )
             }
-            .filter { it.creditsDelta > 0 || it.voiceSeconds > 0 }
+            .filter { it.creditsEarned > 0 || it.voiceSeconds > 0 }
             .sortedWith(
-                compareByDescending<MonthlyRow> { it.creditsDelta }
+                compareByDescending<MonthlyRow> { it.creditsEarned }
+                    .thenByDescending { it.endTotal }
                     .thenByDescending { it.voiceSeconds }
             ).take(TOP_N)
 
@@ -136,8 +193,6 @@ class MonthlyLeaderboardJob @Autowired constructor(
             runCatching { channel.sendMessageEmbeds(embed).queue() }
                 .onFailure { logger.error("Could not send leaderboard to ${channel.id}: ${it.message}") }
         }
-
-        writeCurrentMonthSnapshot(guild.idLong, users, thisMonthStart)
     }
 
     private fun resolveChannel(guild: Guild): TextChannel? {
@@ -167,7 +222,7 @@ class MonthlyLeaderboardJob @Autowired constructor(
             rows.mapIndexed { idx, row ->
                 val name = guild.getMemberById(row.discordId)?.effectiveName ?: "Unknown (${row.discordId})"
                 val voice = formatDuration(row.voiceSeconds)
-                "**#${idx + 1}** $name — ${row.creditsDelta} credits · $voice"
+                "**#${idx + 1}** $name — ${row.creditsEarned} credits · ${row.endTotal} total · $voice"
             }.joinToString("\n")
         }
 
@@ -175,22 +230,11 @@ class MonthlyLeaderboardJob @Autowired constructor(
             .setTitle("Monthly Social Credit Leaderboard — $monthLabel")
             .setDescription(description)
             .setColor(Color(0xFFD700))
-            .setFooter("Totals reflect credits earned (including voice-time) and counted voice time.")
-            .build()
-    }
-
-    private fun writeCurrentMonthSnapshot(guildId: Long, users: List<database.dto.user.UserDto>, snapshotDate: LocalDate) {
-        users.forEach { dto ->
-            snapshotService.upsert(
-                MonthlyCreditSnapshotDto(
-                    discordId = dto.discordId,
-                    guildId = guildId,
-                    snapshotDate = snapshotDate,
-                    socialCredit = dto.socialCredit ?: 0L,
-                    tobyCoins = dto.tobyCoins
-                )
+            .setFooter(
+                "Credits = earned last month (voice-time included, UBI excluded). " +
+                        "Total = balance at month end. Frozen at the 1st."
             )
-        }
+            .build()
     }
 
     private fun formatDuration(seconds: Long): String {
@@ -202,7 +246,8 @@ class MonthlyLeaderboardJob @Autowired constructor(
 
     private data class MonthlyRow(
         val discordId: Long,
-        val creditsDelta: Long,
+        val creditsEarned: Long,
+        val endTotal: Long,
         val voiceSeconds: Long
     )
 }

--- a/discord-bot/src/test/kotlin/bot/toby/scheduling/MonthlyLeaderboardJobTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/scheduling/MonthlyLeaderboardJobTest.kt
@@ -117,7 +117,7 @@ class MonthlyLeaderboardJobTest {
 
         verify(exactly = 0) { userService.listGuildUsers(any()) }
         verify(exactly = 0) { channel.sendMessageEmbeds(any<MessageEmbed>()) }
-        verify(exactly = 0) { snapshotService.upsert(any()) }
+        verify(exactly = 0) { snapshotService.upsertIfMissing(any()) }
     }
 
     @Test
@@ -127,7 +127,7 @@ class MonthlyLeaderboardJobTest {
         job.postMonthlyLeaderboard()
 
         verify(exactly = 0) { channel.sendMessageEmbeds(any<MessageEmbed>()) }
-        verify(exactly = 0) { snapshotService.upsert(any()) }
+        verify(exactly = 0) { snapshotService.upsertIfMissing(any()) }
     }
 
     @Test
@@ -144,7 +144,7 @@ class MonthlyLeaderboardJobTest {
         every { configService.getConfigByName(any(), guildId.toString()) } returns null
 
         val snapshots = mutableListOf<MonthlyCreditSnapshotDto>()
-        every { snapshotService.upsert(capture(snapshots)) } answers { firstArg() }
+        every { snapshotService.upsertIfMissing(capture(snapshots)) } answers { firstArg() }
 
         job.postMonthlyLeaderboard()
 
@@ -356,7 +356,7 @@ class MonthlyLeaderboardJobTest {
         every { guild.selfMember.hasPermission(channel, *anyVararg<Permission>()) } returns false
 
         val snapshots = mutableListOf<MonthlyCreditSnapshotDto>()
-        every { snapshotService.upsert(capture(snapshots)) } answers { firstArg() }
+        every { snapshotService.upsertIfMissing(capture(snapshots)) } answers { firstArg() }
 
         job.postMonthlyLeaderboard()
 

--- a/discord-bot/src/test/kotlin/bot/toby/scheduling/MonthlyLeaderboardJobTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/scheduling/MonthlyLeaderboardJobTest.kt
@@ -76,6 +76,10 @@ class MonthlyLeaderboardJobTest {
         every { guild.selfMember.hasPermission(channel, *anyVararg<Permission>()) } returns true
         val createAction = mockk<MessageCreateAction>(relaxed = true)
         every { channel.sendMessageEmbeds(any<MessageEmbed>()) } returns createAction
+        // Default: the boundary freeze echoes back the dto it was given, so the
+        // frozen end-of-month total equals the user's balance unless a test
+        // overrides upsertIfMissing to simulate a pre-existing boundary row.
+        every { snapshotService.upsertIfMissing(any()) } answers { firstArg() }
 
         job = MonthlyLeaderboardJob(
             jda, userService, voiceSessionService, snapshotService, configService,
@@ -358,5 +362,104 @@ class MonthlyLeaderboardJobTest {
 
         verify(exactly = 0) { channel.sendMessageEmbeds(any<MessageEmbed>()) }
         assertEquals(1, snapshots.size)
+    }
+
+    // ---------------------------------------------------------------------
+    // The board must post a SNAPSHOT of last month, frozen at the midnight
+    // month boundary — not a figure derived from the live balance at the
+    // (later) posting hour. The three tests below pin that contract.
+    // ---------------------------------------------------------------------
+
+    @Test
+    fun `earnings come from the frozen month-boundary snapshot, not the live balance`() {
+        val today = LocalDate.now(ZoneOffset.UTC).withDayOfMonth(1)
+        val prevMonth = today.minusMonths(1)
+        // Alice's LIVE balance has already drifted to 999 in the new month, but
+        // the authoritative end-of-last-month boundary snapshot froze her at 400.
+        val alice = UserDto(discordId = 1L, guildId = guildId).apply { socialCredit = 999L }
+        every { userService.listGuildUsers(guildId) } returns listOf(alice)
+        member(1L, "Alice")
+        every { snapshotService.listForGuildDate(guildId, prevMonth) } returns
+            listOf(MonthlyCreditSnapshotDto(discordId = 1L, guildId = guildId, snapshotDate = prevMonth, socialCredit = 100L))
+        // The boundary snapshot already exists (frozen at midnight), so the
+        // freeze is a no-op that returns the authoritative 400 — never 999.
+        every { snapshotService.upsertIfMissing(any()) } answers {
+            val dto = firstArg<MonthlyCreditSnapshotDto>()
+            if (dto.snapshotDate == today)
+                MonthlyCreditSnapshotDto(discordId = dto.discordId, guildId = guildId, snapshotDate = today, socialCredit = 400L)
+            else dto
+        }
+        every { voiceSessionService.sumCountedSecondsInRangeByUser(guildId, any(), any()) } returns emptyMap()
+        every { configService.getConfigByName(any(), guildId.toString()) } returns null
+        val embedSlot = slot<MessageEmbed>()
+        val createAction = mockk<MessageCreateAction>(relaxed = true)
+        every { channel.sendMessageEmbeds(capture(embedSlot)) } returns createAction
+
+        job.postMonthlyLeaderboard()
+
+        val description = embedSlot.captured.description ?: ""
+        // Earnings = 400 (frozen end) - 100 (frozen start) = 300, NOT 999 - 100 = 899.
+        assertTrue(description.contains("300 credits"),
+            "expected frozen-boundary earnings of 300, got: $description")
+        assertFalse(description.contains("899"),
+            "must not derive earnings from the live balance (899): $description")
+    }
+
+    @Test
+    fun `end-of-month total comes from the frozen boundary even after the balance drops`() {
+        val today = LocalDate.now(ZoneOffset.UTC).withDayOfMonth(1)
+        val prevMonth = today.minusMonths(1)
+        // Alice ended last month at 400 (frozen) but has since spent down to 50
+        // in the new month. The board is a snapshot of last month, so it must
+        // still show her 400 total and her 300 of earnings.
+        val alice = UserDto(discordId = 1L, guildId = guildId).apply { socialCredit = 50L }
+        every { userService.listGuildUsers(guildId) } returns listOf(alice)
+        member(1L, "Alice")
+        every { snapshotService.listForGuildDate(guildId, prevMonth) } returns
+            listOf(MonthlyCreditSnapshotDto(discordId = 1L, guildId = guildId, snapshotDate = prevMonth, socialCredit = 100L))
+        every { snapshotService.upsertIfMissing(any()) } answers {
+            val dto = firstArg<MonthlyCreditSnapshotDto>()
+            if (dto.snapshotDate == today)
+                MonthlyCreditSnapshotDto(discordId = dto.discordId, guildId = guildId, snapshotDate = today, socialCredit = 400L)
+            else dto
+        }
+        every { voiceSessionService.sumCountedSecondsInRangeByUser(guildId, any(), any()) } returns emptyMap()
+        every { configService.getConfigByName(any(), guildId.toString()) } returns null
+        val embedSlot = slot<MessageEmbed>()
+        val createAction = mockk<MessageCreateAction>(relaxed = true)
+        every { channel.sendMessageEmbeds(capture(embedSlot)) } returns createAction
+
+        job.postMonthlyLeaderboard()
+
+        val description = embedSlot.captured.description ?: ""
+        assertFalse(description.startsWith("No activity recorded"),
+            "live balance (50 < 100 baseline) wrongly drops Alice from the board: $description")
+        assertTrue(description.contains("400 total"),
+            "expected end-of-month total of 400 (frozen), got: $description")
+        assertTrue(description.contains("300 credits"),
+            "expected frozen-boundary earnings of 300, got: $description")
+    }
+
+    @Test
+    fun `boundary snapshot is frozen at the midnight tick even when the guild posts later`() {
+        // A guild posts at the default hour (12:00). At the 00:00 tick the job
+        // must still freeze the authoritative month-boundary snapshot for that
+        // guild (so the noon post reflects midnight) without posting yet.
+        val alice = UserDto(discordId = 1L, guildId = guildId).apply { socialCredit = 250L }
+        every { userService.listGuildUsers(guildId) } returns listOf(alice)
+        member(1L, "Alice")
+        every { snapshotService.listForGuildDate(guildId, any()) } returns emptyList()
+        every { voiceSessionService.sumCountedSecondsInRangeByUser(guildId, any(), any()) } returns emptyMap()
+        every { configService.getConfigByName(any(), guildId.toString()) } returns null
+        val today = LocalDate.now(ZoneOffset.UTC).withDayOfMonth(1)
+
+        jobAtHour(0).postMonthlyLeaderboard()
+
+        // Frozen the boundary for the user at midnight…
+        verify(atLeast = 1) {
+            snapshotService.upsertIfMissing(match { it.discordId == 1L && it.snapshotDate == today })
+        }
+        // …but did NOT post (the guild's posting hour is 12:00, not 00:00).
+        verify(exactly = 0) { channel.sendMessageEmbeds(any<MessageEmbed>()) }
     }
 }


### PR DESCRIPTION
## Problem

The monthly board didn't post a true snapshot of last month — it derived its numbers from each user's **live** social-credit balance at the (configurable, default noon) posting hour:

```
creditsDelta = liveBalance - startOfMonthSnapshot
```

So the figures tracked the **current** month, not last:
- current-month earning inflated the numbers,
- current-month **spending** could erase last month — a user who dropped below last month's starting balance went negative, got coerced to 0, and was **filtered off the board entirely**,
- there was no end-of-month **total** shown at all.

The web leaderboards are correct and were left untouched; this was the scheduled job only.

## Tests first (per request)

The first commit adds three characterisation tests that **fail against the old job**, pinning the intended contract:

| Test | Old (broken) result |
|---|---|
| earnings come from the frozen boundary, not live balance | reported `899` (live `999` − `100`) instead of `300` |
| end-of-month total survives a balance drop | live `50` − `100` < 0 → filtered out → `No activity recorded` |
| boundary is frozen at the 00:00 tick even when the guild posts later | never froze at midnight |

## Fix

The second commit makes the job post a frozen snapshot of last month:

- **Freezes** an authoritative month-boundary snapshot at the **00:00 tick** on the 1st (`upsertIfMissing`, so the midnight tick wins over any later posting tick or web lazy-baseline). Guilds posting later in the day still report the balance **as of the boundary**.
- **Computes earnings from frozen snapshots only**: `(end-of-last-month boundary) − (start-of-last-month boundary) − UBI`. The live balance is only ever used to *seed* a missing boundary row.
- **Shows both** last month's earnings **and** each member's end-of-month total: `#1 Alice — 300 credits · 400 total · 1h 20m`.
- Switches the snapshot write from `upsert` to `upsertIfMissing` so a frozen boundary value is never clobbered.

Scope is `MonthlyLeaderboardJob` + its tests; the per-guild configurable posting hour (#609) is preserved — only the *data* is now pinned to midnight.

## Verification

`./gradlew :discord-bot:test` → BUILD SUCCESSFUL (all three new tests green, existing tests updated for `upsertIfMissing`).

https://claude.ai/code/session_0147sjoCMjw7dtk8JBP5zvDv

---
_Generated by [Claude Code](https://claude.ai/code/session_0147sjoCMjw7dtk8JBP5zvDv)_