### PR TITLE
Add MTG cube tooling: as-fan calculator and randomised pack generator

### DIFF
--- a/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
@@ -30,6 +30,7 @@ import bot.toby.command.commands.game.casino.wheeloffortune.WheelOfFortuneComman
 import bot.toby.command.commands.fetch.MemeCommand
 import bot.toby.command.commands.misc.*
 import bot.toby.command.commands.moderation.*
+import bot.toby.command.commands.mtg.CubeCommand
 import bot.toby.command.commands.music.channel.JoinCommand
 import bot.toby.command.commands.music.channel.LeaveCommand
 import bot.toby.command.commands.music.intro.DeleteIntroCommand
@@ -173,6 +174,7 @@ class CommandManagerTest {
             RpsCommand::class.java,
             TicTacToeCommand::class.java,
             Connect4Command::class.java,
+            CubeCommand::class.java,
         )
 
         Assertions.assertTrue(availableCommands.containsAll(commandManager.allCommands.map { it.javaClass }.toList()))

--- a/common/src/main/kotlin/common/mtg/AsFan.kt
+++ b/common/src/main/kotlin/common/mtg/AsFan.kt
@@ -1,0 +1,51 @@
+package common.mtg
+
+/**
+ * "As-fan" — the expected number of cards of a given characteristic a
+ * player opens in a single booster pack. Straight from the cube-design
+ * doc:
+ *
+ *   as-fan = (cards of that type ÷ cube size) × pack size
+ *
+ * Example: 60 removal spells in a 540-card cube with 15-card packs →
+ * (60 / 540) × 15 ≈ 1.67 removal spells per pack.
+ *
+ * Pure maths so the Discord command, the web tool, and the pack
+ * generator all agree on the number.
+ */
+object AsFan {
+
+    /**
+     * Core formula. [typeCount] cards of some characteristic in a
+     * [cubeSize]-card cube, opened [packSize] at a time.
+     *
+     * @throws IllegalArgumentException if the inputs can't describe a real
+     *   cube (non-positive cube/pack size, negative or oversized type count).
+     */
+    fun value(typeCount: Int, cubeSize: Int, packSize: Int): Double {
+        require(cubeSize > 0) { "Cube size must be positive (was $cubeSize)" }
+        require(packSize > 0) { "Pack size must be positive (was $packSize)" }
+        require(typeCount >= 0) { "Type count can't be negative (was $typeCount)" }
+        require(typeCount <= cubeSize) {
+            "Type count ($typeCount) can't exceed cube size ($cubeSize)"
+        }
+        return typeCount.toDouble() / cubeSize.toDouble() * packSize.toDouble()
+    }
+
+    /** Count of cards in each [CardCategory] present in the pool. */
+    fun categoryCounts(cards: List<CubeCard>): Map<CardCategory, Int> =
+        cards.groupingBy { it.category }.eachCount()
+
+    /**
+     * As-fan per [CardCategory] across the whole pool — i.e. how many
+     * White cards, Lands, etc. a player expects to open per pack. Only
+     * categories actually present in the pool appear in the result.
+     */
+    fun distribution(cards: List<CubeCard>, packSize: Int): Map<CardCategory, Double> {
+        if (cards.isEmpty()) return emptyMap()
+        val cubeSize = cards.size
+        return categoryCounts(cards).mapValues { (_, count) ->
+            value(count, cubeSize, packSize)
+        }
+    }
+}

--- a/common/src/main/kotlin/common/mtg/CubeCard.kt
+++ b/common/src/main/kotlin/common/mtg/CubeCard.kt
@@ -1,0 +1,59 @@
+package common.mtg
+
+/**
+ * The "as-fan" buckets the doc cares about: one per colour, plus
+ * multicolour, colourless, and land. These are the characteristics a
+ * cube designer balances a pack around so every colour drafts and every
+ * archetype has enough fixing.
+ */
+enum class CardCategory(val displayName: String) {
+    WHITE("White"),
+    BLUE("Blue"),
+    BLACK("Black"),
+    RED("Red"),
+    GREEN("Green"),
+    MULTICOLOR("Multicolor"),
+    COLORLESS("Colorless"),
+    LAND("Land");
+
+    companion object {
+        private val BY_COLOR: Map<MtgColor, CardCategory> = mapOf(
+            MtgColor.WHITE to WHITE,
+            MtgColor.BLUE to BLUE,
+            MtgColor.BLACK to BLACK,
+            MtgColor.RED to RED,
+            MtgColor.GREEN to GREEN,
+        )
+
+        /** The single-colour bucket for a mono-coloured card. */
+        fun ofColor(color: MtgColor): CardCategory = BY_COLOR.getValue(color)
+    }
+}
+
+/**
+ * A card in a cube pool. Deliberately minimal — only what the cube tools
+ * need to randomise packs and compute as-fan. Built from Scryfall data
+ * (see the bot's `ScryfallCubeFetcher` / web's `CubeWebService`) but has
+ * no dependency on any HTTP client, so it stays a `common` value type.
+ *
+ * Land classification keys off [isLand] rather than [colors] because a
+ * land is bucketed as a land regardless of any colour identity it has
+ * (e.g. a dual land that taps for two colours is still "a land" for
+ * as-fan purposes — it's fixing, not a spell of those colours).
+ */
+data class CubeCard(
+    val name: String,
+    val colors: Set<MtgColor> = emptySet(),
+    val isLand: Boolean = false,
+    val typeLine: String = "",
+    val manaValue: Double = 0.0,
+) {
+    /** Which as-fan bucket this card falls into. Lands first, then by colour count. */
+    val category: CardCategory
+        get() = when {
+            isLand -> CardCategory.LAND
+            colors.isEmpty() -> CardCategory.COLORLESS
+            colors.size >= 2 -> CardCategory.MULTICOLOR
+            else -> CardCategory.ofColor(colors.first())
+        }
+}

--- a/common/src/main/kotlin/common/mtg/MtgColor.kt
+++ b/common/src/main/kotlin/common/mtg/MtgColor.kt
@@ -1,0 +1,31 @@
+package common.mtg
+
+/**
+ * The five colours of Magic: The Gathering's colour pie. Pure data — no
+ * Spring, no JDA — so the cube tooling ([AsFan], [PackGenerator],
+ * [DraftEngine]) can live in `common` and be unit-tested in isolation.
+ *
+ * [symbol] is the single-letter mana code Scryfall (and the wider game)
+ * uses in a card's `color_identity` / `colors` arrays — W, U, B, R, G.
+ */
+enum class MtgColor(val symbol: Char, val displayName: String) {
+    WHITE('W', "White"),
+    BLUE('U', "Blue"),
+    BLACK('B', "Black"),
+    RED('R', "Red"),
+    GREEN('G', "Green");
+
+    companion object {
+        /** Maps a mana symbol (case-insensitive) to its colour, or null. */
+        fun fromSymbol(symbol: Char): MtgColor? =
+            entries.firstOrNull { it.symbol == symbol.uppercaseChar() }
+
+        /**
+         * Parses a Scryfall-style colour array (`["W", "U"]`) into a set,
+         * silently dropping anything that isn't a recognised symbol so a
+         * stray value in the API payload can't blow up cube generation.
+         */
+        fun parse(symbols: Iterable<String>): Set<MtgColor> =
+            symbols.mapNotNull { it.trim().firstOrNull()?.let(::fromSymbol) }.toSet()
+    }
+}

--- a/common/src/main/kotlin/common/mtg/PackGenerator.kt
+++ b/common/src/main/kotlin/common/mtg/PackGenerator.kt
@@ -1,0 +1,79 @@
+package common.mtg
+
+import kotlin.random.Random
+
+/**
+ * Step 2–3 of the cube-prep tool from the doc: take a card pool, pull a
+ * random subset, and deal it into evenly-sized booster packs while
+ * keeping the as-fan distribution (colours / colourless / lands) as level
+ * across packs as possible.
+ *
+ * The "balanced" deal groups the selected cards into contiguous
+ * [CardCategory] blocks and round-robins them into packs, so each
+ * category's cards land on consecutive packs and every pack ends up
+ * within one card of every other for each category — near the cube's
+ * overall as-fan, with no pack all-red or land-flooded by luck of the
+ * shuffle. The "unbalanced" deal is a plain shuffle-and-split, kept for
+ * callers that want raw randomness.
+ */
+class PackGenerator(private val random: Random = Random.Default) {
+
+    data class Packs(
+        val packs: List<List<CubeCard>>,
+        val packSize: Int,
+    ) {
+        val packCount: Int get() = packs.size
+
+        /** Every dealt card, flattened — the realised cube subset. */
+        val cards: List<CubeCard> get() = packs.flatten()
+    }
+
+    sealed interface Result {
+        data class Success(val value: Packs) : Result
+        data class Failure(val reason: String) : Result
+    }
+
+    /**
+     * Deals [packCount] packs of [packSize] cards drawn from [pool].
+     *
+     * @param balanced when true, spreads each [CardCategory] as evenly as
+     *   possible across the packs; when false, deals a plain shuffle.
+     */
+    fun generate(
+        pool: List<CubeCard>,
+        packCount: Int,
+        packSize: Int,
+        balanced: Boolean = true,
+    ): Result {
+        if (packCount <= 0) return Result.Failure("Pack count must be at least 1 (was $packCount).")
+        if (packSize <= 0) return Result.Failure("Pack size must be at least 1 (was $packSize).")
+        val needed = packCount * packSize
+        if (pool.size < needed) {
+            return Result.Failure(
+                "Not enough cards: need $needed ($packCount × $packSize) but the pool only has ${pool.size}."
+            )
+        }
+
+        // Randomly select the exact number of cards we'll deal.
+        val selected = pool.shuffled(random).take(needed)
+
+        // The stream we deal from. Balanced → cards grouped into contiguous
+        // category blocks (still shuffled within each block, via the stable
+        // sort over the already-shuffled selection); unbalanced → as-shuffled.
+        val stream = if (balanced) selected.sortedBy { it.category.ordinal } else selected
+
+        // Deal the stream round-robin with a continuing pointer: card i goes
+        // to pack i % packCount. Because `needed` is an exact multiple of
+        // packCount every pack gets exactly packSize cards. And because each
+        // category occupies a contiguous run, that run lands on consecutive
+        // packs (mod packCount), so every pack's count of any one category
+        // differs from every other pack's by at most one — level as-fan.
+        val buckets = List(packCount) { mutableListOf<CubeCard>() }
+        stream.forEachIndexed { i, card -> buckets[i % packCount].add(card) }
+
+        // Shuffle within each pack so the deal order isn't visible to a
+        // drafter opening the pack.
+        val packs = buckets.map { it.shuffled(random) }
+        return Result.Success(Packs(packs, packSize))
+    }
+}

--- a/common/src/test/kotlin/common/mtg/AsFanTest.kt
+++ b/common/src/test/kotlin/common/mtg/AsFanTest.kt
@@ -1,0 +1,102 @@
+package common.mtg
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class AsFanTest {
+
+    @Test
+    fun `worked example from the doc - 60 removal in 540 cube, 15-card packs`() {
+        // (60 / 540) × 15 = 1.666…
+        assertEquals(1.6667, AsFan.value(60, 540, 15), 1e-4)
+    }
+
+    @Test
+    fun `as-fan of 2_0 means about two per pack`() {
+        // 72 / 540 × 15 = 2.0 exactly.
+        assertEquals(2.0, AsFan.value(72, 540, 15), 1e-9)
+    }
+
+    @Test
+    fun `zero of a type is zero as-fan`() {
+        assertEquals(0.0, AsFan.value(0, 540, 15), 1e-9)
+    }
+
+    @Test
+    fun `every card of the type yields as-fan equal to pack size`() {
+        assertEquals(15.0, AsFan.value(540, 540, 15), 1e-9)
+    }
+
+    @Test
+    fun `non-positive cube size is rejected`() {
+        assertThrows(IllegalArgumentException::class.java) { AsFan.value(1, 0, 15) }
+        assertThrows(IllegalArgumentException::class.java) { AsFan.value(1, -5, 15) }
+    }
+
+    @Test
+    fun `non-positive pack size is rejected`() {
+        assertThrows(IllegalArgumentException::class.java) { AsFan.value(1, 540, 0) }
+        assertThrows(IllegalArgumentException::class.java) { AsFan.value(1, 540, -1) }
+    }
+
+    @Test
+    fun `negative type count is rejected`() {
+        assertThrows(IllegalArgumentException::class.java) { AsFan.value(-1, 540, 15) }
+    }
+
+    @Test
+    fun `type count above cube size is rejected`() {
+        assertThrows(IllegalArgumentException::class.java) { AsFan.value(541, 540, 15) }
+    }
+
+    @Test
+    fun `categoryCounts tallies each bucket`() {
+        val counts = AsFan.categoryCounts(samplePool())
+        assertEquals(2, counts[CardCategory.RED])
+        assertEquals(1, counts[CardCategory.WHITE])
+        assertEquals(1, counts[CardCategory.MULTICOLOR])
+        assertEquals(1, counts[CardCategory.COLORLESS])
+        assertEquals(1, counts[CardCategory.LAND])
+    }
+
+    @Test
+    fun `distribution divides each bucket by the cube size times pack size`() {
+        val pool = samplePool() // 6 cards
+        val dist = AsFan.distribution(pool, packSize = 3)
+        // Red: 2/6 × 3 = 1.0; Land: 1/6 × 3 = 0.5
+        assertEquals(1.0, dist.getValue(CardCategory.RED), 1e-9)
+        assertEquals(0.5, dist.getValue(CardCategory.LAND), 1e-9)
+        assertEquals(0.5, dist.getValue(CardCategory.WHITE), 1e-9)
+    }
+
+    @Test
+    fun `distribution only includes categories present in the pool`() {
+        val dist = AsFan.distribution(samplePool(), packSize = 3)
+        assertTrue(CardCategory.BLUE !in dist)
+        assertTrue(CardCategory.GREEN !in dist)
+    }
+
+    @Test
+    fun `distribution sums to pack size across all categories`() {
+        val dist = AsFan.distribution(samplePool(), packSize = 3)
+        // Every card belongs to exactly one bucket, so the as-fans must
+        // total the pack size.
+        assertEquals(3.0, dist.values.sum(), 1e-9)
+    }
+
+    @Test
+    fun `distribution of an empty pool is empty`() {
+        assertTrue(AsFan.distribution(emptyList(), packSize = 15).isEmpty())
+    }
+
+    private fun samplePool(): List<CubeCard> = listOf(
+        CubeCard("Bolt", setOf(MtgColor.RED)),
+        CubeCard("Shock", setOf(MtgColor.RED)),
+        CubeCard("Swords", setOf(MtgColor.WHITE)),
+        CubeCard("Helix", setOf(MtgColor.RED, MtgColor.WHITE)),
+        CubeCard("Sol Ring"),
+        CubeCard("Wasteland", isLand = true),
+    )
+}

--- a/common/src/test/kotlin/common/mtg/CubeCardTest.kt
+++ b/common/src/test/kotlin/common/mtg/CubeCardTest.kt
@@ -1,0 +1,79 @@
+package common.mtg
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class CubeCardTest {
+
+    @Test
+    fun `mono-coloured card maps to its colour bucket`() {
+        assertEquals(
+            CardCategory.RED,
+            CubeCard(name = "Lightning Bolt", colors = setOf(MtgColor.RED)).category,
+        )
+        assertEquals(
+            CardCategory.WHITE,
+            CubeCard(name = "Swords to Plowshares", colors = setOf(MtgColor.WHITE)).category,
+        )
+    }
+
+    @Test
+    fun `two or more colours map to multicolour`() {
+        assertEquals(
+            CardCategory.MULTICOLOR,
+            CubeCard(name = "Lightning Helix", colors = setOf(MtgColor.RED, MtgColor.WHITE)).category,
+        )
+        assertEquals(
+            CardCategory.MULTICOLOR,
+            CubeCard(
+                name = "Niv-Mizzet Reborn",
+                colors = MtgColor.entries.toSet(),
+            ).category,
+        )
+    }
+
+    @Test
+    fun `no colours maps to colourless`() {
+        assertEquals(
+            CardCategory.COLORLESS,
+            CubeCard(name = "Sol Ring", colors = emptySet()).category,
+        )
+    }
+
+    @Test
+    fun `a land is bucketed as land even when it has a colour identity`() {
+        // A dual land taps for colours but is still "fixing", not a spell.
+        val dual = CubeCard(
+            name = "Sacred Foundry",
+            colors = setOf(MtgColor.RED, MtgColor.WHITE),
+            isLand = true,
+            typeLine = "Land — Mountain Plains",
+        )
+        assertEquals(CardCategory.LAND, dual.category)
+    }
+
+    @Test
+    fun `colourless land is still a land`() {
+        assertEquals(
+            CardCategory.LAND,
+            CubeCard(name = "Wasteland", isLand = true).category,
+        )
+    }
+
+    @Test
+    fun `ofColor covers every colour`() {
+        MtgColor.entries.forEach { color ->
+            // Round-trips: a mono-card of this colour lands in ofColor's bucket.
+            val card = CubeCard(name = color.displayName, colors = setOf(color))
+            assertEquals(CardCategory.ofColor(color), card.category)
+        }
+    }
+
+    @Test
+    fun `defaults describe a colourless zero-cost non-land`() {
+        val card = CubeCard(name = "Placeholder")
+        assertEquals(CardCategory.COLORLESS, card.category)
+        assertEquals(0.0, card.manaValue)
+        assertEquals(false, card.isLand)
+    }
+}

--- a/common/src/test/kotlin/common/mtg/MtgColorTest.kt
+++ b/common/src/test/kotlin/common/mtg/MtgColorTest.kt
@@ -1,0 +1,54 @@
+package common.mtg
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class MtgColorTest {
+
+    @Test
+    fun `every colour has the canonical mana symbol`() {
+        assertEquals('W', MtgColor.WHITE.symbol)
+        assertEquals('U', MtgColor.BLUE.symbol)
+        assertEquals('B', MtgColor.BLACK.symbol)
+        assertEquals('R', MtgColor.RED.symbol)
+        assertEquals('G', MtgColor.GREEN.symbol)
+    }
+
+    @Test
+    fun `fromSymbol resolves each colour, case-insensitively`() {
+        assertEquals(MtgColor.WHITE, MtgColor.fromSymbol('W'))
+        assertEquals(MtgColor.WHITE, MtgColor.fromSymbol('w'))
+        assertEquals(MtgColor.GREEN, MtgColor.fromSymbol('g'))
+    }
+
+    @Test
+    fun `fromSymbol returns null for an unknown symbol`() {
+        assertNull(MtgColor.fromSymbol('X'))
+        assertNull(MtgColor.fromSymbol('1'))
+    }
+
+    @Test
+    fun `parse maps a Scryfall colour array to a set`() {
+        assertEquals(setOf(MtgColor.WHITE, MtgColor.BLUE), MtgColor.parse(listOf("W", "U")))
+    }
+
+    @Test
+    fun `parse tolerates lowercase, whitespace and multi-char entries`() {
+        assertEquals(
+            setOf(MtgColor.RED, MtgColor.GREEN),
+            MtgColor.parse(listOf(" r ", "Green")),
+        )
+    }
+
+    @Test
+    fun `parse drops unrecognised symbols and dedupes`() {
+        assertEquals(setOf(MtgColor.BLACK), MtgColor.parse(listOf("B", "X", "b", "")))
+    }
+
+    @Test
+    fun `parse of an empty array is an empty set`() {
+        assertTrue(MtgColor.parse(emptyList()).isEmpty())
+    }
+}

--- a/common/src/test/kotlin/common/mtg/PackGeneratorTest.kt
+++ b/common/src/test/kotlin/common/mtg/PackGeneratorTest.kt
@@ -1,0 +1,113 @@
+package common.mtg
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import kotlin.random.Random
+
+class PackGeneratorTest {
+
+    private fun pool(size: Int): List<CubeCard> =
+        (1..size).map { CubeCard(name = "Card $it", colors = setOf(MtgColor.entries[it % 5])) }
+
+    @Test
+    fun `generates the requested number of packs each of the requested size`() {
+        val result = PackGenerator(Random(1)).generate(pool(360), packCount = 24, packSize = 15)
+        val success = assertInstanceOf(PackGenerator.Result.Success::class.java, result)
+        assertEquals(24, success.value.packCount)
+        assertTrue(success.value.packs.all { it.size == 15 })
+        assertEquals(360, success.value.cards.size)
+    }
+
+    @Test
+    fun `dealt cards are a subset of the pool with no duplicates`() {
+        val source = pool(100)
+        val result = PackGenerator(Random(7)).generate(source, packCount = 4, packSize = 15)
+        val success = assertInstanceOf(PackGenerator.Result.Success::class.java, result)
+        val dealt = success.value.cards
+        assertEquals(60, dealt.size)
+        assertEquals(60, dealt.toSet().size, "no card should be dealt twice")
+        assertTrue(source.containsAll(dealt))
+    }
+
+    @Test
+    fun `fails when the pool is too small`() {
+        val result = PackGenerator().generate(pool(10), packCount = 24, packSize = 15)
+        val failure = assertInstanceOf(PackGenerator.Result.Failure::class.java, result)
+        assertTrue(failure.reason.contains("Not enough cards"))
+    }
+
+    @Test
+    fun `fails on non-positive pack count or size`() {
+        assertInstanceOf(
+            PackGenerator.Result.Failure::class.java,
+            PackGenerator().generate(pool(100), packCount = 0, packSize = 15),
+        )
+        assertInstanceOf(
+            PackGenerator.Result.Failure::class.java,
+            PackGenerator().generate(pool(100), packCount = 4, packSize = 0),
+        )
+    }
+
+    @Test
+    fun `pool exactly the needed size succeeds and uses every card`() {
+        val source = pool(60)
+        val result = PackGenerator(Random(3)).generate(source, packCount = 4, packSize = 15)
+        val success = assertInstanceOf(PackGenerator.Result.Success::class.java, result)
+        assertEquals(source.toSet(), success.value.cards.toSet())
+    }
+
+    @Test
+    fun `balanced deal keeps each colour within one card across packs`() {
+        // 5 colours, 50 of each = 250 cards; 5 packs of 15 → each pack
+        // should hold ~3 of each colour (15 ÷ 5). Balanced dealing must
+        // keep every pack's per-colour count within 1 of every other.
+        val source = MtgColor.entries.flatMap { color ->
+            (1..50).map { CubeCard("$color $it", colors = setOf(color)) }
+        }
+        val result = PackGenerator(Random(42)).generate(source, packCount = 5, packSize = 15, balanced = true)
+        val success = assertInstanceOf(PackGenerator.Result.Success::class.java, result)
+
+        MtgColor.entries.forEach { color ->
+            val perPack = success.value.packs.map { pack ->
+                pack.count { it.colors == setOf(color) }
+            }
+            val spread = perPack.max() - perPack.min()
+            assertTrue(spread <= 1, "colour $color spread across packs was $spread ($perPack)")
+        }
+    }
+
+    @Test
+    fun `balanced deal levels lands across packs`() {
+        // 30 lands + 120 mono-coloured spells → 150 cards; 10 packs of 15.
+        // 30 lands ÷ 10 packs = 3 per pack, so a level deal gives each pack
+        // 2–4 lands, never a land-flooded or land-light pack.
+        val lands = (1..30).map { CubeCard("Land $it", isLand = true) }
+        val spells = (1..120).map { CubeCard("Spell $it", colors = setOf(MtgColor.BLUE)) }
+        val result = PackGenerator(Random(11))
+            .generate(lands + spells, packCount = 10, packSize = 15, balanced = true)
+        val success = assertInstanceOf(PackGenerator.Result.Success::class.java, result)
+
+        val landsPerPack = success.value.packs.map { pack -> pack.count { it.isLand } }
+        assertTrue(landsPerPack.max() - landsPerPack.min() <= 1, "land spread: $landsPerPack")
+    }
+
+    @Test
+    fun `unbalanced deal still produces correctly sized packs`() {
+        val result = PackGenerator(Random(5))
+            .generate(pool(100), packCount = 4, packSize = 15, balanced = false)
+        val success = assertInstanceOf(PackGenerator.Result.Success::class.java, result)
+        assertTrue(success.value.packs.all { it.size == 15 })
+        assertEquals(60, success.value.cards.size)
+    }
+
+    @Test
+    fun `same seed produces the same packs`() {
+        val a = PackGenerator(Random(99)).generate(pool(100), 4, 15)
+        val b = PackGenerator(Random(99)).generate(pool(100), 4, 15)
+        val sa = assertInstanceOf(PackGenerator.Result.Success::class.java, a)
+        val sb = assertInstanceOf(PackGenerator.Result.Success::class.java, b)
+        assertEquals(sa.value.packs, sb.value.packs)
+    }
+}

--- a/core-api/src/main/kotlin/core/managers/CommandManager.kt
+++ b/core-api/src/main/kotlin/core/managers/CommandManager.kt
@@ -17,6 +17,11 @@ interface CommandManager : NamedRegistry<Command> {
     val economyCommands: List<Command>
     val gameCommands: List<Command>
 
+    // Default-empty so implementations that don't carry MTG commands (and
+    // relaxed test mocks) don't have to override it; DefaultCommandManager
+    // supplies the real filter.
+    val mtgCommands: List<Command> get() = emptyList()
+
     fun getCommand(search: String): Command? = findByName(search)
 
     fun handle(event: SlashCommandInteractionEvent)

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeCommand.kt
@@ -1,0 +1,166 @@
+package bot.toby.command.commands.mtg
+
+import bot.toby.helpers.booleanOption
+import bot.toby.helpers.intOption
+import bot.toby.helpers.stringOption
+import common.mtg.AsFan
+import common.mtg.PackGenerator
+import core.command.Command.Companion.invokeDeleteOnMessageResponse
+import core.command.CommandContext
+import database.dto.user.UserDto
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.interactions.commands.build.OptionData
+import net.dv8tion.jda.api.interactions.commands.build.SubcommandData
+import net.dv8tion.jda.api.utils.FileUpload
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import kotlin.random.Random
+
+/**
+ * `/cube` — the cube-design tool from the doc, as a Discord command.
+ *
+ *  - `/cube asfan`    — the as-fan calculator: (type ÷ cube) × pack size.
+ *  - `/cube preview`  — fetch a pool from Scryfall and show its as-fan
+ *                       distribution across colours / colourless / lands.
+ *  - `/cube generate` — fetch a pool, randomly draw enough cards, and deal
+ *                       them into evenly-sized, as-fan-balanced packs;
+ *                       the full pack lists come back as a text file.
+ *
+ * A "cube" is defined by a Scryfall search query, so the user picks their
+ * pool with the same syntax they'd use on scryfall.com (`set:vow`,
+ * `cube:vintage`, `t:dragon`, …).
+ */
+@Component
+class CubeCommand @Autowired constructor(
+    private val fetcher: ScryfallCubeFetcher,
+) : MtgCommand {
+
+    override val name: String = "cube"
+    override val description: String = "Magic: The Gathering cube tools — as-fan maths and randomised draft packs."
+
+    override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        logger.setGuildAndMemberContext(ctx.guild, ctx.member)
+        when (ctx.event.subcommandName) {
+            SUB_ASFAN -> handleAsFan(ctx, deleteDelay)
+            SUB_PREVIEW -> handlePreview(ctx, deleteDelay)
+            SUB_GENERATE -> handleGenerate(ctx)
+            else -> reply(ctx, CubeEmbeds.errorEmbed("Pick a subcommand: asfan, preview or generate."), deleteDelay)
+        }
+    }
+
+    private fun handleAsFan(ctx: CommandContext, deleteDelay: Int) {
+        val total = ctx.event.intOption(OPT_TOTAL, 0)
+        val cubeSize = ctx.event.intOption(OPT_CUBE_SIZE, 0)
+        val packSize = ctx.event.intOption(OPT_PACK_SIZE, DEFAULT_PACK_SIZE)
+        val embed = try {
+            val value = AsFan.value(total, cubeSize, packSize)
+            CubeEmbeds.asFanEmbed(total, cubeSize, packSize, value)
+        } catch (e: IllegalArgumentException) {
+            CubeEmbeds.errorEmbed(e.message ?: "Invalid as-fan inputs.")
+        }
+        reply(ctx, embed, deleteDelay)
+    }
+
+    private fun handlePreview(ctx: CommandContext, deleteDelay: Int) {
+        val query = ctx.event.stringOption(OPT_QUERY).orEmpty()
+        val packSize = ctx.event.intOption(OPT_PACK_SIZE, DEFAULT_PACK_SIZE)
+        when (val result = fetcher.fetch(query)) {
+            is ScryfallCubeFetcher.Result.Failure -> reply(ctx, CubeEmbeds.errorEmbed(result.message), deleteDelay)
+            is ScryfallCubeFetcher.Result.Success -> {
+                val pool = result.cards
+                val embed = CubeEmbeds.previewEmbed(
+                    query = query.trim(),
+                    poolSize = pool.size,
+                    packSize = packSize,
+                    counts = AsFan.categoryCounts(pool),
+                    distribution = AsFan.distribution(pool, packSize),
+                )
+                reply(ctx, embed, deleteDelay)
+            }
+        }
+    }
+
+    private fun handleGenerate(ctx: CommandContext) {
+        val query = ctx.event.stringOption(OPT_QUERY).orEmpty()
+        val packCount = ctx.event.intOption(OPT_PACKS, DEFAULT_PACK_COUNT)
+        val packSize = ctx.event.intOption(OPT_PACK_SIZE, DEFAULT_PACK_SIZE)
+        val balanced = ctx.event.booleanOption(OPT_BALANCED, true)
+
+        when (val result = fetcher.fetch(query)) {
+            is ScryfallCubeFetcher.Result.Failure -> ctx.event.hook.sendMessageEmbeds(CubeEmbeds.errorEmbed(result.message)).queue()
+            is ScryfallCubeFetcher.Result.Success -> {
+                val pool = result.cards
+                when (val packs = PackGenerator(Random.Default).generate(pool, packCount, packSize, balanced)) {
+                    is PackGenerator.Result.Failure -> ctx.event.hook.sendMessageEmbeds(CubeEmbeds.errorEmbed(packs.reason)).queue()
+                    is PackGenerator.Result.Success -> {
+                        val selected = packs.value.cards
+                        val embed = CubeEmbeds.generateEmbed(
+                            query = query.trim(),
+                            poolSize = pool.size,
+                            packCount = packCount,
+                            packSize = packSize,
+                            balanced = balanced,
+                            selected = selected,
+                            counts = AsFan.categoryCounts(selected),
+                            distribution = AsFan.distribution(selected, packSize),
+                        )
+                        val file = FileUpload.fromData(CubeEmbeds.packsFile(packs.value.packs), ATTACHMENT_NAME)
+                        ctx.event.hook.sendMessageEmbeds(embed).addFiles(file).queue()
+                    }
+                }
+            }
+        }
+    }
+
+    private fun reply(ctx: CommandContext, embed: MessageEmbed, deleteDelay: Int) {
+        ctx.event.hook.sendMessageEmbeds(embed).queue(invokeDeleteOnMessageResponse(deleteDelay))
+    }
+
+    override val subCommands: List<SubcommandData> = listOf(
+        SubcommandData(SUB_ASFAN, "Expected copies of a card type per booster: (type ÷ cube) × pack size.")
+            .addOptions(
+                OptionData(OptionType.INTEGER, OPT_TOTAL, "How many cards of that type are in the cube.", true)
+                    .setMinValue(0),
+                OptionData(OptionType.INTEGER, OPT_CUBE_SIZE, "Total cards in the cube.", true)
+                    .setMinValue(1),
+                OptionData(OptionType.INTEGER, OPT_PACK_SIZE, "Cards per pack (default 15).", false)
+                    .setMinValue(1).setMaxValue(MAX_PACK_SIZE.toLong()),
+            ),
+        SubcommandData(SUB_PREVIEW, "Show the as-fan distribution of a Scryfall query's cards.")
+            .addOptions(
+                OptionData(OptionType.STRING, OPT_QUERY, "Scryfall search defining the cube (e.g. set:vow).", true),
+                OptionData(OptionType.INTEGER, OPT_PACK_SIZE, "Cards per pack (default 15).", false)
+                    .setMinValue(1).setMaxValue(MAX_PACK_SIZE.toLong()),
+            ),
+        SubcommandData(SUB_GENERATE, "Draw a cube from Scryfall and deal randomised, as-fan-balanced packs.")
+            .addOptions(
+                OptionData(OptionType.STRING, OPT_QUERY, "Scryfall search defining the pool (e.g. cube:vintage).", true),
+                OptionData(OptionType.INTEGER, OPT_PACKS, "How many packs to build (default 24).", false)
+                    .setMinValue(1).setMaxValue(MAX_PACK_COUNT.toLong()),
+                OptionData(OptionType.INTEGER, OPT_PACK_SIZE, "Cards per pack (default 15).", false)
+                    .setMinValue(1).setMaxValue(MAX_PACK_SIZE.toLong()),
+                OptionData(OptionType.BOOLEAN, OPT_BALANCED, "Level colours/lands across packs (default true).", false),
+            ),
+    )
+
+    companion object {
+        const val SUB_ASFAN = "asfan"
+        const val SUB_PREVIEW = "preview"
+        const val SUB_GENERATE = "generate"
+
+        const val OPT_TOTAL = "total"
+        const val OPT_CUBE_SIZE = "cube-size"
+        const val OPT_PACK_SIZE = "pack-size"
+        const val OPT_QUERY = "query"
+        const val OPT_PACKS = "packs"
+        const val OPT_BALANCED = "balanced"
+
+        const val DEFAULT_PACK_SIZE = 15
+        const val DEFAULT_PACK_COUNT = 24
+        const val MAX_PACK_SIZE = 30
+        const val MAX_PACK_COUNT = 90
+
+        private const val ATTACHMENT_NAME = "cube-packs.txt"
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
@@ -1,0 +1,102 @@
+package bot.toby.command.commands.mtg
+
+import common.discord.embed
+import common.discord.field
+import common.mtg.CardCategory
+import common.mtg.CubeCard
+import net.dv8tion.jda.api.entities.MessageEmbed
+import java.awt.Color
+import java.nio.charset.StandardCharsets
+
+/**
+ * Embed + attachment factories for `/cube`. Keeps the visual grammar of
+ * the other polished utility commands (`MemeEmbeds`, `RollEmbeds`) so the
+ * MTG tool feels like part of the set.
+ */
+internal object CubeEmbeds {
+
+    /** Magic "five-colour" gold — the cube/identity accent. */
+    val OK_COLOR: Color = Color(199, 161, 79)
+    val ERROR_COLOR: Color = Color(237, 66, 69)
+
+    private const val AUTHOR = "🃏  Cube workshop" // 🃏
+
+    fun asFanEmbed(typeCount: Int, cubeSize: Int, packSize: Int, value: Double): MessageEmbed =
+        embed(color = OK_COLOR) {
+            setAuthor(AUTHOR)
+            setTitle("As-fan")
+            setDescription(
+                "**${format(value)}** of that card type per pack.\n" +
+                    "*Expected copies a player opens in one booster.*"
+            )
+            field("Formula", "(type ÷ cube size) × pack size", inline = false)
+            field("Maths", "($typeCount ÷ $cubeSize) × $packSize = ${format(value)}", inline = false)
+        }
+
+    /** As-fan breakdown of a whole fetched pool — no pack generation. */
+    fun previewEmbed(
+        query: String,
+        poolSize: Int,
+        packSize: Int,
+        counts: Map<CardCategory, Int>,
+        distribution: Map<CardCategory, Double>,
+    ): MessageEmbed = embed(color = OK_COLOR) {
+        setAuthor(AUTHOR)
+        setTitle("Cube preview")
+        setDescription("Query `$query` → **$poolSize** cards, as-fan per **$packSize**-card pack.")
+        field("Distribution", distributionTable(counts, distribution), inline = false)
+    }
+
+    /** Summary of a generated set of packs. */
+    fun generateEmbed(
+        query: String,
+        poolSize: Int,
+        packCount: Int,
+        packSize: Int,
+        balanced: Boolean,
+        selected: List<CubeCard>,
+        counts: Map<CardCategory, Int>,
+        distribution: Map<CardCategory, Double>,
+    ): MessageEmbed = embed(color = OK_COLOR) {
+        setAuthor(AUTHOR)
+        setTitle("Generated $packCount packs of $packSize")
+        setDescription(
+            "Drew **${selected.size}** cards from the **$poolSize**-card pool matching `$query`." +
+                if (balanced) "\nAs-fan balanced across colours, colourless and lands." else ""
+        )
+        field("As-fan per pack", distributionTable(counts, distribution), inline = false)
+        setFooter("Full pack lists attached as a text file.")
+    }
+
+    fun errorEmbed(message: String): MessageEmbed = embed(color = ERROR_COLOR) {
+        setAuthor(AUTHOR)
+        setTitle("Couldn't build that cube")
+        setDescription(message)
+    }
+
+    /** A `category — count (as-fan)` table, in colour-pie order, present buckets only. */
+    private fun distributionTable(
+        counts: Map<CardCategory, Int>,
+        distribution: Map<CardCategory, Double>,
+    ): String = CardCategory.entries
+        .filter { counts[it] != null }
+        .joinToString("\n") { cat ->
+            "${cat.displayName} — ${counts[cat]} (${format(distribution[cat] ?: 0.0)}/pack)"
+        }
+        .ifEmpty { "—" }
+
+    /**
+     * Renders the dealt packs as a plain-text file body. 24 packs of 15 is
+     * far past what fits in an embed, so the full lists ride along as an
+     * attachment.
+     */
+    fun packsFile(packs: List<List<CubeCard>>): ByteArray = buildString {
+        packs.forEachIndexed { i, pack ->
+            appendLine("== Pack ${i + 1} (${pack.size} cards) ==")
+            pack.forEach { card -> appendLine("  ${card.name}") }
+            appendLine()
+        }
+    }.toByteArray(StandardCharsets.UTF_8)
+
+    private fun format(value: Double): String = String.format("%.2f", value)
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/MtgCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/MtgCommand.kt
@@ -1,0 +1,9 @@
+package bot.toby.command.commands.mtg
+
+import core.command.Command
+
+/**
+ * Magic: The Gathering cube tooling. Commands in this category build and
+ * analyse draft cubes — see [CubeCommand].
+ */
+interface MtgCommand : Command

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcher.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcher.kt
@@ -1,0 +1,123 @@
+package bot.toby.command.commands.mtg
+
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import common.logging.DiscordLogger
+import common.mtg.CubeCard
+import common.mtg.MtgColor
+import org.apache.http.client.HttpClient
+import org.apache.http.client.methods.HttpGet
+import org.apache.http.impl.client.HttpClients
+import org.apache.http.util.EntityUtils
+import org.springframework.stereotype.Component
+import java.io.InputStreamReader
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
+/**
+ * Pulls a cube's card pool from the public Scryfall search API
+ * (`/cards/search`). A "cube" here is just whatever a Scryfall query
+ * matches — e.g. `set:vow`, `is:commander`, `t:dragon`, or a curated
+ * `cube:<name>` — so a user defines their pool with the same search
+ * syntax they'd use on scryfall.com.
+ *
+ * Mirrors the HTTP/JSON approach of [bot.toby.command.commands.fetch.MemeCommand]:
+ * an injectable Apache [HttpClient] (so tests stub the transport) and
+ * Gson tree parsing. The card → [CubeCard] mapping is split into
+ * [parseCard] so it can be unit-tested without any network.
+ */
+@Component
+class ScryfallCubeFetcher {
+
+    private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
+
+    sealed interface Result {
+        data class Success(val cards: List<CubeCard>) : Result
+        data class Failure(val message: String) : Result
+    }
+
+    /**
+     * Fetches up to [maxCards] cards matching [query], following Scryfall's
+     * pagination. Creates a default HTTP client; the overload taking a
+     * client is the test seam.
+     */
+    fun fetch(query: String, maxCards: Int = DEFAULT_MAX_CARDS): Result =
+        fetch(query, maxCards, HttpClients.createDefault())
+
+    fun fetch(query: String, maxCards: Int, httpClient: HttpClient): Result {
+        val trimmed = query.trim()
+        if (trimmed.isEmpty()) return Result.Failure("Give me a Scryfall search query (e.g. `set:vow`).")
+
+        val cards = mutableListOf<CubeCard>()
+        var url: String? = searchUrl(trimmed)
+        var page = 0
+
+        try {
+            while (url != null && cards.size < maxCards && page < MAX_PAGES) {
+                if (page > 0) Thread.sleep(SCRYFALL_DELAY_MS) // be polite to the API
+                val response = httpClient.execute(HttpGet(url))
+                val status = response.statusLine.statusCode
+                if (status == 404) {
+                    EntityUtils.consume(response.entity)
+                    return Result.Failure("No cards matched `$trimmed`.")
+                }
+                if (status != 200) {
+                    EntityUtils.consume(response.entity)
+                    return Result.Failure("Scryfall returned HTTP $status. Try again later.")
+                }
+                val root = JsonParser.parseReader(InputStreamReader(response.entity.content)).asJsonObject
+                EntityUtils.consume(response.entity)
+
+                root.getAsJsonArray("data")?.forEach { element ->
+                    parseCard(element.asJsonObject)?.let(cards::add)
+                }
+
+                url = if (root.get("has_more")?.asBoolean == true) root.get("next_page")?.asString else null
+                page++
+            }
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            return Result.Failure("Lookup interrupted.")
+        } catch (e: Exception) {
+            logger.error("Scryfall fetch failed for query '$trimmed': $e")
+            return Result.Failure("Couldn't reach Scryfall: ${e.message}")
+        }
+
+        if (cards.isEmpty()) return Result.Failure("No usable cards matched `$trimmed`.")
+        return Result.Success(cards.take(maxCards))
+    }
+
+    /**
+     * Maps a single Scryfall card object to a [CubeCard]. Returns null for
+     * entries without a name (which we can't meaningfully draft). Colour
+     * comes from `color_identity` — the cube-sorting convention — and land
+     * status from the type line.
+     */
+    fun parseCard(card: JsonObject): CubeCard? {
+        val name = card.get("name")?.asString?.takeIf { it.isNotBlank() } ?: return null
+        val identity = card.getAsJsonArray("color_identity")
+            ?.map { it.asString }
+            ?: emptyList()
+        val typeLine = card.get("type_line")?.asString ?: ""
+        val manaValue = card.get("cmc")?.asDouble ?: 0.0
+        return CubeCard(
+            name = name,
+            colors = MtgColor.parse(identity),
+            isLand = typeLine.contains("Land", ignoreCase = true),
+            typeLine = typeLine,
+            manaValue = manaValue,
+        )
+    }
+
+    private fun searchUrl(query: String): String {
+        val encoded = URLEncoder.encode(query, StandardCharsets.UTF_8)
+        return "$SEARCH_ENDPOINT?q=$encoded&unique=cards"
+    }
+
+    companion object {
+        private const val SEARCH_ENDPOINT = "https://api.scryfall.com/cards/search"
+        const val DEFAULT_MAX_CARDS = 750
+        private const val MAX_PAGES = 10
+        private const val SCRYFALL_DELAY_MS = 100L
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/SlashCommandOptions.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/SlashCommandOptions.kt
@@ -20,3 +20,6 @@ fun SlashCommandInteractionEvent.intOption(name: String, default: Int = 0): Int 
 
 fun SlashCommandInteractionEvent.stringOption(name: String): String? =
     getOption(name)?.asString
+
+fun SlashCommandInteractionEvent.booleanOption(name: String, default: Boolean = false): Boolean =
+    getOption(name)?.asBoolean ?: default

--- a/discord-bot/src/main/kotlin/bot/toby/managers/DefaultCommandManager.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/managers/DefaultCommandManager.kt
@@ -7,6 +7,7 @@ import bot.toby.command.commands.fetch.FetchCommand
 import bot.toby.command.commands.game.pvp.GameCommand
 import bot.toby.command.commands.misc.MiscCommand
 import bot.toby.command.commands.moderation.ModerationCommand
+import bot.toby.command.commands.mtg.MtgCommand
 import bot.toby.command.commands.music.MusicCommand
 import bot.toby.helpers.UserDtoHelper
 import common.logging.DiscordLogger
@@ -65,6 +66,7 @@ class DefaultCommandManager @Autowired constructor(
     override val fetchCommands: List<Command> get() = commands.filterIsInstance<FetchCommand>()
     override val economyCommands: List<Command> get() = commands.filterIsInstance<EconomyCommand>()
     override val gameCommands: List<Command> get() = commands.filterIsInstance<GameCommand>()
+    override val mtgCommands: List<Command> get() = commands.filterIsInstance<MtgCommand>()
 
     override fun handle(event: SlashCommandInteractionEvent) {
         val guildId = event.guild?.id ?: return

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeCommandTest.kt
@@ -1,0 +1,194 @@
+package bot.toby.command.commands.mtg
+
+import bot.toby.command.CommandTest
+import bot.toby.command.CommandTest.Companion.event
+import bot.toby.command.CommandTest.Companion.requestingUserDto
+import bot.toby.command.CommandTest.Companion.webhookMessageCreateAction
+import bot.toby.command.DefaultCommandContext
+import common.mtg.CubeCard
+import common.mtg.MtgColor
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
+import io.mockk.verify
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.interactions.commands.OptionMapping
+import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.utils.FileUpload
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class CubeCommandTest : CommandTest {
+
+    private lateinit var fetcher: ScryfallCubeFetcher
+    private lateinit var command: CubeCommand
+
+    @BeforeEach
+    fun setUp() {
+        setUpCommonMocks()
+        fetcher = mockk()
+        command = CubeCommand(fetcher)
+        every { webhookMessageCreateAction.addFiles(any<FileUpload>()) } returns webhookMessageCreateAction
+        every { webhookMessageCreateAction.queue() } just runs
+    }
+
+    private fun intOpt(value: Int): OptionMapping = mockk { every { asInt } returns value }
+    private fun strOpt(value: String): OptionMapping = mockk { every { asString } returns value }
+    private fun boolOpt(value: Boolean): OptionMapping = mockk { every { asBoolean } returns value }
+
+    private fun run() = command.handle(DefaultCommandContext(event), requestingUserDto, deleteDelay = 0)
+
+    private fun pool(n: Int): List<CubeCard> =
+        (1..n).map { CubeCard("Card $it", colors = setOf(MtgColor.entries[it % 5])) }
+
+    // --- asfan ---------------------------------------------------------
+
+    @Test
+    fun `asfan computes the doc's worked example`() {
+        val slot = slot<MessageEmbed>()
+        every { event.hook.sendMessageEmbeds(capture(slot), *anyVararg()) } returns webhookMessageCreateAction
+        every { event.subcommandName } returns CubeCommand.SUB_ASFAN
+        every { event.getOption(CubeCommand.OPT_TOTAL) } returns intOpt(60)
+        every { event.getOption(CubeCommand.OPT_CUBE_SIZE) } returns intOpt(540)
+        every { event.getOption(CubeCommand.OPT_PACK_SIZE) } returns null // → default 15
+
+        run()
+
+        verify(exactly = 1) { event.hook.sendMessageEmbeds(any<MessageEmbed>(), *anyVararg()) }
+        val embed = slot.captured
+        assertEquals("As-fan", embed.title)
+        // (60 / 540) × 15 = 1.67
+        assertTrue(embed.description!!.contains("1.67"), "description was: ${embed.description}")
+    }
+
+    @Test
+    fun `asfan with an invalid cube size returns an error embed`() {
+        val slot = slot<MessageEmbed>()
+        every { event.hook.sendMessageEmbeds(capture(slot), *anyVararg()) } returns webhookMessageCreateAction
+        every { event.subcommandName } returns CubeCommand.SUB_ASFAN
+        every { event.getOption(CubeCommand.OPT_TOTAL) } returns intOpt(10)
+        every { event.getOption(CubeCommand.OPT_CUBE_SIZE) } returns intOpt(0) // invalid
+        every { event.getOption(CubeCommand.OPT_PACK_SIZE) } returns null
+
+        run()
+
+        assertEquals("Couldn't build that cube", slot.captured.title)
+    }
+
+    // --- preview -------------------------------------------------------
+
+    @Test
+    fun `preview shows the as-fan distribution of the fetched pool`() {
+        val slot = slot<MessageEmbed>()
+        every { event.hook.sendMessageEmbeds(capture(slot), *anyVararg()) } returns webhookMessageCreateAction
+        every { event.subcommandName } returns CubeCommand.SUB_PREVIEW
+        every { event.getOption(CubeCommand.OPT_QUERY) } returns strOpt("set:vow")
+        every { event.getOption(CubeCommand.OPT_PACK_SIZE) } returns null
+        every { fetcher.fetch(any(), any()) } returns ScryfallCubeFetcher.Result.Success(pool(50))
+
+        run()
+
+        assertEquals("Cube preview", slot.captured.title)
+        verify(exactly = 1) { fetcher.fetch(any(), any()) }
+    }
+
+    @Test
+    fun `preview surfaces a fetch failure as an error embed`() {
+        val slot = slot<MessageEmbed>()
+        every { event.hook.sendMessageEmbeds(capture(slot), *anyVararg()) } returns webhookMessageCreateAction
+        every { event.subcommandName } returns CubeCommand.SUB_PREVIEW
+        every { event.getOption(CubeCommand.OPT_QUERY) } returns strOpt("set:zzz")
+        every { event.getOption(CubeCommand.OPT_PACK_SIZE) } returns null
+        every { fetcher.fetch(any(), any()) } returns ScryfallCubeFetcher.Result.Failure("No cards matched.")
+
+        run()
+
+        assertEquals("Couldn't build that cube", slot.captured.title)
+    }
+
+    // --- generate ------------------------------------------------------
+
+    @Test
+    fun `generate deals packs and attaches the pack list as a file`() {
+        val slot = slot<MessageEmbed>()
+        every { event.hook.sendMessageEmbeds(capture(slot), *anyVararg()) } returns webhookMessageCreateAction
+        every { event.subcommandName } returns CubeCommand.SUB_GENERATE
+        every { event.getOption(CubeCommand.OPT_QUERY) } returns strOpt("cube:vintage")
+        every { event.getOption(CubeCommand.OPT_PACKS) } returns intOpt(2)
+        every { event.getOption(CubeCommand.OPT_PACK_SIZE) } returns intOpt(3)
+        every { event.getOption(CubeCommand.OPT_BALANCED) } returns boolOpt(true)
+        every { fetcher.fetch(any(), any()) } returns ScryfallCubeFetcher.Result.Success(pool(20))
+
+        run()
+
+        verify(exactly = 1) { webhookMessageCreateAction.addFiles(any<FileUpload>()) }
+        assertTrue(slot.captured.title!!.contains("Generated 2 packs of 3"))
+    }
+
+    @Test
+    fun `generate reports when the pool is too small`() {
+        val slot = slot<MessageEmbed>()
+        every { event.hook.sendMessageEmbeds(capture(slot), *anyVararg()) } returns webhookMessageCreateAction
+        every { event.subcommandName } returns CubeCommand.SUB_GENERATE
+        every { event.getOption(CubeCommand.OPT_QUERY) } returns strOpt("t:angel")
+        every { event.getOption(CubeCommand.OPT_PACKS) } returns intOpt(24)
+        every { event.getOption(CubeCommand.OPT_PACK_SIZE) } returns intOpt(15)
+        every { event.getOption(CubeCommand.OPT_BALANCED) } returns null
+        every { fetcher.fetch(any(), any()) } returns ScryfallCubeFetcher.Result.Success(pool(5))
+
+        run()
+
+        assertEquals("Couldn't build that cube", slot.captured.title)
+        verify(exactly = 0) { webhookMessageCreateAction.addFiles(any<FileUpload>()) }
+    }
+
+    @Test
+    fun `generate surfaces a fetch failure`() {
+        val slot = slot<MessageEmbed>()
+        every { event.hook.sendMessageEmbeds(capture(slot), *anyVararg()) } returns webhookMessageCreateAction
+        every { event.subcommandName } returns CubeCommand.SUB_GENERATE
+        every { event.getOption(CubeCommand.OPT_QUERY) } returns strOpt("garbage")
+        every { event.getOption(CubeCommand.OPT_PACKS) } returns null
+        every { event.getOption(CubeCommand.OPT_PACK_SIZE) } returns null
+        every { event.getOption(CubeCommand.OPT_BALANCED) } returns null
+        every { fetcher.fetch(any(), any()) } returns ScryfallCubeFetcher.Result.Failure("Scryfall returned HTTP 500.")
+
+        run()
+
+        assertEquals("Couldn't build that cube", slot.captured.title)
+    }
+
+    // --- metadata ------------------------------------------------------
+
+    @Test
+    fun `unknown subcommand replies with guidance`() {
+        val slot = slot<MessageEmbed>()
+        every { event.hook.sendMessageEmbeds(capture(slot), *anyVararg()) } returns webhookMessageCreateAction
+        every { event.subcommandName } returns null
+
+        run()
+
+        assertEquals("Couldn't build that cube", slot.captured.title)
+    }
+
+    @Test
+    fun `exposes the three subcommands with their options`() {
+        assertEquals("cube", command.name)
+        val subs = command.subCommands.associateBy { it.name }
+        assertEquals(setOf("asfan", "preview", "generate"), subs.keys)
+
+        val asfan = subs.getValue("asfan").options
+        assertEquals(OptionType.INTEGER, asfan.first { it.name == "total" }.type)
+        assertTrue(asfan.first { it.name == "total" }.isRequired)
+        assertTrue(asfan.first { it.name == "cube-size" }.isRequired)
+        assertEquals(false, asfan.first { it.name == "pack-size" }.isRequired)
+
+        val generate = subs.getValue("generate").options
+        assertEquals(OptionType.STRING, generate.first { it.name == "query" }.type)
+        assertEquals(OptionType.BOOLEAN, generate.first { it.name == "balanced" }.type)
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcherTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcherTest.kt
@@ -1,0 +1,178 @@
+package bot.toby.command.commands.mtg
+
+import com.google.gson.JsonParser
+import common.mtg.CardCategory
+import common.mtg.MtgColor
+import io.mockk.every
+import io.mockk.mockk
+import org.apache.http.HttpEntity
+import org.apache.http.HttpResponse
+import org.apache.http.StatusLine
+import org.apache.http.client.HttpClient
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+
+class ScryfallCubeFetcherTest {
+
+    private val fetcher = ScryfallCubeFetcher()
+
+    private fun obj(json: String) = JsonParser.parseString(json).asJsonObject
+
+    // --- parseCard -----------------------------------------------------
+
+    @Test
+    fun `parseCard maps name, colour identity, mana value and type`() {
+        val card = fetcher.parseCard(
+            obj("""{"name":"Lightning Bolt","color_identity":["R"],"type_line":"Instant","cmc":1.0}""")
+        )!!
+        assertEquals("Lightning Bolt", card.name)
+        assertEquals(setOf(MtgColor.RED), card.colors)
+        assertEquals(1.0, card.manaValue)
+        assertEquals(false, card.isLand)
+        assertEquals(CardCategory.RED, card.category)
+    }
+
+    @Test
+    fun `parseCard flags lands from the type line`() {
+        val card = fetcher.parseCard(
+            obj("""{"name":"Sacred Foundry","color_identity":["R","W"],"type_line":"Land — Mountain Plains"}""")
+        )!!
+        assertTrue(card.isLand)
+        assertEquals(CardCategory.LAND, card.category)
+    }
+
+    @Test
+    fun `parseCard treats a card with no colour identity as colourless`() {
+        val card = fetcher.parseCard(obj("""{"name":"Sol Ring","color_identity":[],"type_line":"Artifact"}"""))!!
+        assertEquals(CardCategory.COLORLESS, card.category)
+        assertEquals(0.0, card.manaValue, "missing cmc defaults to 0")
+    }
+
+    @Test
+    fun `parseCard returns null when there is no usable name`() {
+        assertNull(fetcher.parseCard(obj("""{"type_line":"Instant"}""")))
+        assertNull(fetcher.parseCard(obj("""{"name":"","type_line":"Instant"}""")))
+    }
+
+    // --- fetch ---------------------------------------------------------
+
+    private fun page(vararg cards: String, hasMore: Boolean = false, nextPage: String? = null): String {
+        val data = cards.joinToString(",")
+        val tail = if (hasMore) ""","has_more":true,"next_page":"${nextPage}"""" else ""","has_more":false"""
+        return """{"data":[$data]$tail}"""
+    }
+
+    private fun stubResponse(client: HttpClient, status: Int, body: String) {
+        val response = mockk<HttpResponse>()
+        val statusLine = mockk<StatusLine>()
+        val entity = mockk<HttpEntity>(relaxed = true)
+        every { client.execute(any()) } returns response
+        every { response.statusLine } returns statusLine
+        every { statusLine.statusCode } returns status
+        every { response.entity } returns entity
+        every { entity.content } returns ByteArrayInputStream(body.toByteArray())
+    }
+
+    @Test
+    fun `fetch returns parsed cards on a single page`() {
+        val client = mockk<HttpClient>()
+        stubResponse(
+            client, 200,
+            page(
+                """{"name":"Bolt","color_identity":["R"],"type_line":"Instant","cmc":1}""",
+                """{"name":"Forest","color_identity":[],"type_line":"Basic Land — Forest"}""",
+            ),
+        )
+        val result = fetcher.fetch("t:instant", maxCards = 100, httpClient = client)
+        val success = assertInstanceOf(ScryfallCubeFetcher.Result.Success::class.java, result)
+        assertEquals(2, success.cards.size)
+        assertEquals(listOf("Bolt", "Forest"), success.cards.map { it.name })
+    }
+
+    @Test
+    fun `fetch follows pagination until has_more is false`() {
+        val client = mockk<HttpClient>()
+        val response = mockk<HttpResponse>()
+        val statusLine = mockk<StatusLine>()
+        val entity = mockk<HttpEntity>(relaxed = true)
+        every { client.execute(any()) } returns response
+        every { response.statusLine } returns statusLine
+        every { statusLine.statusCode } returns 200
+        every { response.entity } returns entity
+        every { entity.content } returnsMany listOf(
+            ByteArrayInputStream(
+                page("""{"name":"A","color_identity":["U"],"type_line":"Creature"}""", hasMore = true, nextPage = "https://api.scryfall.com/next")
+                    .toByteArray()
+            ),
+            ByteArrayInputStream(
+                page("""{"name":"B","color_identity":["G"],"type_line":"Creature"}""").toByteArray()
+            ),
+        )
+        val result = fetcher.fetch("t:creature", maxCards = 100, httpClient = client)
+        val success = assertInstanceOf(ScryfallCubeFetcher.Result.Success::class.java, result)
+        assertEquals(listOf("A", "B"), success.cards.map { it.name })
+    }
+
+    @Test
+    fun `fetch caps the result at maxCards`() {
+        val client = mockk<HttpClient>()
+        stubResponse(
+            client, 200,
+            page(
+                """{"name":"A","color_identity":[],"type_line":"X"}""",
+                """{"name":"B","color_identity":[],"type_line":"X"}""",
+                """{"name":"C","color_identity":[],"type_line":"X"}""",
+            ),
+        )
+        val result = fetcher.fetch("anything", maxCards = 2, httpClient = client)
+        val success = assertInstanceOf(ScryfallCubeFetcher.Result.Success::class.java, result)
+        assertEquals(2, success.cards.size)
+    }
+
+    @Test
+    fun `fetch maps a 404 to a friendly no-matches failure`() {
+        val client = mockk<HttpClient>()
+        stubResponse(client, 404, """{"object":"error"}""")
+        val result = fetcher.fetch("set:nonsense", httpClient = client, maxCards = 10)
+        val failure = assertInstanceOf(ScryfallCubeFetcher.Result.Failure::class.java, result)
+        assertTrue(failure.message.contains("No cards matched"))
+    }
+
+    @Test
+    fun `fetch reports other HTTP errors`() {
+        val client = mockk<HttpClient>()
+        stubResponse(client, 500, "boom")
+        val result = fetcher.fetch("t:goblin", httpClient = client, maxCards = 10)
+        val failure = assertInstanceOf(ScryfallCubeFetcher.Result.Failure::class.java, result)
+        assertTrue(failure.message.contains("HTTP 500"))
+    }
+
+    @Test
+    fun `fetch rejects a blank query without touching the network`() {
+        val client = mockk<HttpClient>()
+        val result = fetcher.fetch("   ", httpClient = client, maxCards = 10)
+        assertInstanceOf(ScryfallCubeFetcher.Result.Failure::class.java, result)
+    }
+
+    @Test
+    fun `fetch fails when the page has no usable cards`() {
+        val client = mockk<HttpClient>()
+        stubResponse(client, 200, page())
+        val result = fetcher.fetch("t:nothing", httpClient = client, maxCards = 10)
+        val failure = assertInstanceOf(ScryfallCubeFetcher.Result.Failure::class.java, result)
+        assertTrue(failure.message.contains("No usable cards"))
+    }
+
+    @Test
+    fun `fetch surfaces transport exceptions as a failure`() {
+        val client = mockk<HttpClient>()
+        every { client.execute(any()) } throws java.io.IOException("network down")
+        val result = fetcher.fetch("t:elf", httpClient = client, maxCards = 10)
+        val failure = assertInstanceOf(ScryfallCubeFetcher.Result.Failure::class.java, result)
+        assertTrue(failure.message.contains("Couldn't reach Scryfall"))
+    }
+}

--- a/web/src/main/kotlin/web/configuration/WebSecurityConfig.kt
+++ b/web/src/main/kotlin/web/configuration/WebSecurityConfig.kt
@@ -21,6 +21,7 @@ class WebSecurityConfig {
                     "/v3/api-docs/**", "/swagger-ui/**", "/login", "/error",
                     "/images/**", "/js/**", "/css/**",
                     "/dnd", "/dnd/**",
+                    "/cube", "/cube/**",
                     "/sitemap.xml", "/robots.txt",
                     // Service worker for web push must be reachable
                     // unauthenticated — the browser registers it on

--- a/web/src/main/kotlin/web/controller/CommandWikiController.kt
+++ b/web/src/main/kotlin/web/controller/CommandWikiController.kt
@@ -77,7 +77,9 @@ class CommandWikiController(
         CategoryMeta("misc", "Miscellaneous", "🧰",
             "Polls, intros, achievements, and assorted small utilities.") { it.miscCommands },
         CategoryMeta("fetch", "Fetch", "🌐",
-            "Pull memes, news, and quick lookups from the web.") { it.fetchCommands }
+            "Pull memes, news, and quick lookups from the web.") { it.fetchCommands },
+        CategoryMeta("mtg", "Magic: The Gathering", "🃏",
+            "Build draft cubes and crunch as-fan from Scryfall.") { it.mtgCommands }
     )
 
     private fun toView(command: Command): CommandView {

--- a/web/src/main/kotlin/web/controller/CubeController.kt
+++ b/web/src/main/kotlin/web/controller/CubeController.kt
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseBody
 import web.service.CategoryAsFan
+import web.service.CategoryGroup
 import web.service.CubeResult
 import web.service.CubeWebService
 import web.util.displayName
@@ -55,7 +56,7 @@ class CubeController(
     ): ResponseEntity<CubePreviewResponse> =
         when (val result = cubeWebService.preview(query, packSize)) {
             is CubeResult.Success -> ResponseEntity.ok(
-                CubePreviewResponse(true, null, result.value.poolSize, result.value.distribution)
+                CubePreviewResponse(true, null, result.value.poolSize, result.value.groups)
             )
             is CubeResult.Failure -> ResponseEntity.badRequest().body(CubePreviewResponse(false, result.error, 0, emptyList()))
         }
@@ -92,7 +93,7 @@ data class CubePreviewResponse(
     val ok: Boolean,
     val error: String?,
     val poolSize: Int,
-    val distribution: List<CategoryAsFan>,
+    val groups: List<CategoryGroup>,
 )
 
 data class CubeGenerateResponse(

--- a/web/src/main/kotlin/web/controller/CubeController.kt
+++ b/web/src/main/kotlin/web/controller/CubeController.kt
@@ -1,0 +1,106 @@
+package web.controller
+
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseBody
+import web.service.CategoryAsFan
+import web.service.CubeResult
+import web.service.CubeWebService
+import web.util.displayName
+
+/**
+ * Public web surface for the MTG cube tool — the same as-fan maths and
+ * pack generation as the `/cube` Discord command, no login required (like
+ * `/dnd` and `/utils`). GET renders the page; the `/api/...` GET endpoints
+ * return JSON the page's JS renders.
+ */
+@Controller
+@RequestMapping("/cube")
+class CubeController(
+    private val cubeWebService: CubeWebService,
+) {
+
+    @GetMapping
+    fun page(
+        @AuthenticationPrincipal user: OAuth2User?,
+        model: Model,
+    ): String {
+        model.addAttribute("username", user.displayName())
+        return "cube"
+    }
+
+    @GetMapping("/api/asfan", produces = ["application/json"])
+    @ResponseBody
+    fun asFan(
+        @RequestParam("total") total: Int,
+        @RequestParam("cubeSize") cubeSize: Int,
+        @RequestParam("packSize", defaultValue = "15") packSize: Int,
+    ): ResponseEntity<CubeAsFanResponse> =
+        when (val result = cubeWebService.asFan(total, cubeSize, packSize)) {
+            is CubeResult.Success -> ResponseEntity.ok(CubeAsFanResponse(true, null, result.value))
+            is CubeResult.Failure -> ResponseEntity.badRequest().body(CubeAsFanResponse(false, result.error, null))
+        }
+
+    @GetMapping("/api/preview", produces = ["application/json"])
+    @ResponseBody
+    fun preview(
+        @RequestParam("query") query: String,
+        @RequestParam("packSize", defaultValue = "15") packSize: Int,
+    ): ResponseEntity<CubePreviewResponse> =
+        when (val result = cubeWebService.preview(query, packSize)) {
+            is CubeResult.Success -> ResponseEntity.ok(
+                CubePreviewResponse(true, null, result.value.poolSize, result.value.distribution)
+            )
+            is CubeResult.Failure -> ResponseEntity.badRequest().body(CubePreviewResponse(false, result.error, 0, emptyList()))
+        }
+
+    @GetMapping("/api/generate", produces = ["application/json"])
+    @ResponseBody
+    fun generate(
+        @RequestParam("query") query: String,
+        @RequestParam("packs", defaultValue = "24") packs: Int,
+        @RequestParam("packSize", defaultValue = "15") packSize: Int,
+        @RequestParam("balanced", defaultValue = "true") balanced: Boolean,
+    ): ResponseEntity<CubeGenerateResponse> =
+        when (val result = cubeWebService.generate(query, packs, packSize, balanced)) {
+            is CubeResult.Success -> ResponseEntity.ok(
+                CubeGenerateResponse(
+                    ok = true,
+                    error = null,
+                    poolSize = result.value.poolSize,
+                    packCount = result.value.packCount,
+                    packSize = result.value.packSize,
+                    packs = result.value.packs,
+                    distribution = result.value.distribution,
+                )
+            )
+            is CubeResult.Failure -> ResponseEntity.badRequest().body(
+                CubeGenerateResponse(false, result.error, 0, 0, 0, emptyList(), emptyList())
+            )
+        }
+}
+
+data class CubeAsFanResponse(val ok: Boolean, val error: String?, val value: Double?)
+
+data class CubePreviewResponse(
+    val ok: Boolean,
+    val error: String?,
+    val poolSize: Int,
+    val distribution: List<CategoryAsFan>,
+)
+
+data class CubeGenerateResponse(
+    val ok: Boolean,
+    val error: String?,
+    val poolSize: Int,
+    val packCount: Int,
+    val packSize: Int,
+    val packs: List<List<String>>,
+    val distribution: List<CategoryAsFan>,
+)

--- a/web/src/main/kotlin/web/service/CubeWebService.kt
+++ b/web/src/main/kotlin/web/service/CubeWebService.kt
@@ -50,7 +50,7 @@ class CubeWebService {
                     query = query.trim(),
                     poolSize = pool.value.size,
                     packSize = packSize,
-                    distribution = distribution(pool.value, packSize),
+                    groups = groups(pool.value, packSize),
                 )
             )
         }
@@ -87,6 +87,28 @@ class CubeWebService {
             .filter { counts[it] != null }
             .map { cat ->
                 CategoryAsFan(cat.displayName, counts.getValue(cat), asFans.getValue(cat))
+            }
+    }
+
+    /**
+     * Like [distribution] but carries the actual card names in each bucket
+     * (alphabetised) — so the preview can list the real cards, not just a
+     * count. Names dedupe to one entry each so a pool with duplicates
+     * doesn't repeat a card in the list.
+     */
+    fun groups(pool: List<CubeCard>, packSize: Int): List<CategoryGroup> {
+        val asFans = AsFan.distribution(pool, packSize)
+        val byCategory = pool.groupBy { it.category }
+        return CardCategory.entries
+            .filter { byCategory[it] != null }
+            .map { cat ->
+                val cards = byCategory.getValue(cat).map { it.name }.distinct().sorted()
+                CategoryGroup(
+                    category = cat.displayName,
+                    count = byCategory.getValue(cat).size,
+                    asFan = asFans.getValue(cat),
+                    cards = cards,
+                )
             }
     }
 
@@ -175,11 +197,19 @@ sealed interface CubeResult<out T> {
 
 data class CategoryAsFan(val category: String, val count: Int, val asFan: Double)
 
+/** A colour/land bucket plus the actual card names it contains. */
+data class CategoryGroup(
+    val category: String,
+    val count: Int,
+    val asFan: Double,
+    val cards: List<String>,
+)
+
 data class PreviewData(
     val query: String,
     val poolSize: Int,
     val packSize: Int,
-    val distribution: List<CategoryAsFan>,
+    val groups: List<CategoryGroup>,
 )
 
 data class GenerateData(

--- a/web/src/main/kotlin/web/service/CubeWebService.kt
+++ b/web/src/main/kotlin/web/service/CubeWebService.kt
@@ -1,0 +1,193 @@
+package web.service
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import common.mtg.AsFan
+import common.mtg.CardCategory
+import common.mtg.CubeCard
+import common.mtg.MtgColor
+import common.mtg.PackGenerator
+import org.springframework.stereotype.Service
+import java.io.IOException
+import java.net.URI
+import java.net.URLEncoder
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.charset.StandardCharsets
+import java.time.Duration
+import kotlin.random.Random
+
+/**
+ * Web-surface twin of the bot's cube tooling. Same `common.mtg` maths and
+ * pack generation, fed by the Scryfall search API over `java.net.http`
+ * (matching [UtilsWebService]'s HTTP style) so the Discord command and the
+ * web page can't drift on as-fan numbers or pack-dealing rules.
+ */
+@Service
+class CubeWebService {
+
+    private val http: HttpClient = HttpClient.newBuilder()
+        .connectTimeout(Duration.ofSeconds(5))
+        .build()
+    private val jackson = ObjectMapper()
+
+    /** The as-fan calculator: (type ÷ cube) × pack size. */
+    fun asFan(total: Int, cubeSize: Int, packSize: Int): CubeResult<Double> =
+        try {
+            CubeResult.ok(AsFan.value(total, cubeSize, packSize))
+        } catch (e: IllegalArgumentException) {
+            CubeResult.error(e.message ?: "Invalid as-fan inputs.")
+        }
+
+    /** As-fan distribution of a Scryfall query's cards, no pack generation. */
+    fun preview(query: String, packSize: Int): CubeResult<PreviewData> {
+        if (packSize <= 0) return CubeResult.error("Pack size must be at least 1.")
+        return when (val pool = fetchPool(query)) {
+            is CubeResult.Failure -> CubeResult.error(pool.error)
+            is CubeResult.Success -> CubeResult.ok(
+                PreviewData(
+                    query = query.trim(),
+                    poolSize = pool.value.size,
+                    packSize = packSize,
+                    distribution = distribution(pool.value, packSize),
+                )
+            )
+        }
+    }
+
+    /** Draws a cube from Scryfall and deals balanced packs. */
+    fun generate(query: String, packCount: Int, packSize: Int, balanced: Boolean): CubeResult<GenerateData> {
+        return when (val pool = fetchPool(query)) {
+            is CubeResult.Failure -> CubeResult.error(pool.error)
+            is CubeResult.Success -> {
+                when (val packs = PackGenerator(Random.Default).generate(pool.value, packCount, packSize, balanced)) {
+                    is PackGenerator.Result.Failure -> CubeResult.error(packs.reason)
+                    is PackGenerator.Result.Success -> CubeResult.ok(
+                        GenerateData(
+                            query = query.trim(),
+                            poolSize = pool.value.size,
+                            packCount = packCount,
+                            packSize = packSize,
+                            balanced = balanced,
+                            packs = packs.value.packs.map { pack -> pack.map { it.name } },
+                            distribution = distribution(packs.value.cards, packSize),
+                        )
+                    )
+                }
+            }
+        }
+    }
+
+    /** Builds an ordered, present-only category as-fan table. */
+    fun distribution(pool: List<CubeCard>, packSize: Int): List<CategoryAsFan> {
+        val counts = AsFan.categoryCounts(pool)
+        val asFans = AsFan.distribution(pool, packSize)
+        return CardCategory.entries
+            .filter { counts[it] != null }
+            .map { cat ->
+                CategoryAsFan(cat.displayName, counts.getValue(cat), asFans.getValue(cat))
+            }
+    }
+
+    /** Maps a Scryfall `/cards/search` JSON tree into cube cards. */
+    fun parseCards(root: JsonNode): List<CubeCard> {
+        val data = root.path("data")
+        if (!data.isArray) return emptyList()
+        return data.mapNotNull { node ->
+            val name = node.path("name").asText("").takeIf { it.isNotBlank() } ?: return@mapNotNull null
+            val identity = node.path("color_identity").mapNotNull { it.asText(null) }
+            val typeLine = node.path("type_line").asText("")
+            CubeCard(
+                name = name,
+                colors = MtgColor.parse(identity),
+                isLand = typeLine.contains("Land", ignoreCase = true),
+                typeLine = typeLine,
+                manaValue = node.path("cmc").asDouble(0.0),
+            )
+        }
+    }
+
+    private fun fetchPool(query: String): CubeResult<List<CubeCard>> {
+        val trimmed = query.trim()
+        if (trimmed.isEmpty()) return CubeResult.error("Enter a Scryfall search query (e.g. set:vow).")
+
+        val cards = mutableListOf<CubeCard>()
+        var url: String? = searchUrl(trimmed)
+        var page = 0
+        try {
+            while (url != null && cards.size < MAX_CARDS && page < MAX_PAGES) {
+                val response = http.send(
+                    HttpRequest.newBuilder(URI.create(url))
+                        .header("User-Agent", "tobybot-web/1.0")
+                        .header("Accept", "application/json")
+                        .timeout(Duration.ofSeconds(10))
+                        .GET()
+                        .build(),
+                    HttpResponse.BodyHandlers.ofString(),
+                )
+                when (response.statusCode()) {
+                    200 -> {}
+                    404 -> return CubeResult.error("No cards matched that query.")
+                    else -> return CubeResult.error("Scryfall returned ${response.statusCode()}.")
+                }
+                val root = jackson.readTree(response.body())
+                cards.addAll(parseCards(root))
+                url = if (root.path("has_more").asBoolean(false)) {
+                    root.path("next_page").asText(null)
+                } else {
+                    null
+                }
+                page++
+            }
+        } catch (e: IOException) {
+            return CubeResult.error("Could not reach Scryfall: ${e.message}")
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            return CubeResult.error("Request interrupted.")
+        }
+
+        if (cards.isEmpty()) return CubeResult.error("No usable cards matched that query.")
+        return CubeResult.ok(cards.take(MAX_CARDS))
+    }
+
+    private fun searchUrl(query: String): String {
+        val encoded = URLEncoder.encode(query, StandardCharsets.UTF_8)
+        return "$SEARCH_ENDPOINT?q=$encoded&unique=cards"
+    }
+
+    private companion object {
+        const val SEARCH_ENDPOINT = "https://api.scryfall.com/cards/search"
+        const val MAX_CARDS = 750
+        const val MAX_PAGES = 10
+    }
+}
+
+sealed interface CubeResult<out T> {
+    data class Success<T>(val value: T) : CubeResult<T>
+    data class Failure(val error: String) : CubeResult<Nothing>
+
+    companion object {
+        fun <T> ok(value: T): CubeResult<T> = Success(value)
+        fun error(message: String): CubeResult<Nothing> = Failure(message)
+    }
+}
+
+data class CategoryAsFan(val category: String, val count: Int, val asFan: Double)
+
+data class PreviewData(
+    val query: String,
+    val poolSize: Int,
+    val packSize: Int,
+    val distribution: List<CategoryAsFan>,
+)
+
+data class GenerateData(
+    val query: String,
+    val poolSize: Int,
+    val packCount: Int,
+    val packSize: Int,
+    val balanced: Boolean,
+    val packs: List<List<String>>,
+    val distribution: List<CategoryAsFan>,
+)

--- a/web/src/main/kotlin/web/service/HomeStatsService.kt
+++ b/web/src/main/kotlin/web/service/HomeStatsService.kt
@@ -70,7 +70,8 @@ class HomeStatsService(
                 economyCommands.size +
                 gameCommands.size +
                 miscCommands.size +
-                fetchCommands.size
+                fetchCommands.size +
+                mtgCommands.size
         },
         gameCount = GameCatalog.total,
         minigameCount = GameCatalog.minigameCount,

--- a/web/src/main/resources/static/css/cube.css
+++ b/web/src/main/resources/static/css/cube.css
@@ -1,6 +1,7 @@
 /* MTG Cube workshop. Gold "five-colour" accent over the dashboard's dark
-   theme, a hero band, a tabbed tool shell, colour-pie as-fan bars, and a
-   booster-pack grid. Tokens come from base.css :root. */
+   theme, a guided hero, a tabbed tool shell, and card-first results: the
+   generated packs and the preview both list real cards linked to Scryfall.
+   Tokens come from base.css :root. */
 
 :root {
     --mtg-gold: #c7a14f;
@@ -19,7 +20,7 @@
 .cube-hero {
     position: relative;
     margin: 0 calc(-1 * var(--space-4)) var(--space-6);
-    padding: var(--space-10) var(--space-4) var(--space-8);
+    padding: var(--space-10) var(--space-4) var(--space-6);
     background:
         radial-gradient(80% 70% at 50% 0%, var(--mtg-gold-soft) 0%, transparent 65%),
         var(--gradient-hero);
@@ -28,7 +29,7 @@
 }
 
 .cube-hero-inner {
-    max-width: 720px;
+    max-width: 760px;
     margin: 0 auto;
 }
 
@@ -49,47 +50,100 @@
 
 .cube-lede {
     margin: 0 auto;
-    max-width: 620px;
+    max-width: 640px;
     color: var(--text-muted);
     line-height: 1.6;
 }
 
-.cube-lede code {
-    color: var(--mtg-gold);
-}
-
-.cube-chips {
+/* How-it-works steps */
+.cube-steps {
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
-    gap: var(--space-2);
+    gap: var(--space-3);
     margin: var(--space-5) 0 0;
     padding: 0;
     list-style: none;
 }
 
-.cube-chip {
-    padding: 5px 12px;
-    background: var(--mtg-gold-soft);
-    border: 1px solid var(--mtg-gold-border);
+.cube-step {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 14px;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
     border-radius: 999px;
-    color: var(--mtg-gold);
-    font: inherit;
-    font-size: 0.85rem;
-    cursor: pointer;
-    transition: background var(--dur-fast) var(--ease-out);
+    font-size: 0.88rem;
+    color: var(--text-muted);
 }
 
-.cube-chip:hover {
-    background: rgba(199, 161, 79, 0.26);
+.cube-step strong {
+    color: var(--text);
+}
+
+.cube-step-num {
+    display: grid;
+    place-items: center;
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    background: var(--mtg-gold-soft);
+    border: 1px solid var(--mtg-gold-border);
+    color: var(--mtg-gold);
+    font-weight: 700;
+    font-size: 0.8rem;
+}
+
+/* Collapsible explainer */
+.cube-explainer {
+    max-width: 640px;
+    margin: var(--space-5) auto 0;
+    text-align: left;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    padding: 0 var(--space-4);
+}
+
+.cube-explainer summary {
+    padding: var(--space-3) 0;
+    cursor: pointer;
+    font-weight: 600;
+    color: var(--mtg-gold);
+    list-style-position: inside;
+}
+
+.cube-explainer-body {
+    padding-bottom: var(--space-3);
+    color: var(--text-muted);
+    line-height: 1.6;
+}
+
+.cube-explainer-body code,
+.cube-lede code {
+    color: var(--mtg-gold);
+}
+
+.cube-explainer-body ul {
+    margin: var(--space-2) 0;
+    padding-left: var(--space-5);
 }
 
 /* --- Tabs ------------------------------------------------------------ */
 
+.cube-tabs-hint {
+    margin: 0 0 var(--space-2);
+    font-size: 0.82rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-dim);
+}
+
 .cube-tabs {
     display: flex;
-    gap: 4px;
-    padding: 4px;
+    gap: 6px;
+    padding: 6px;
     margin-bottom: var(--space-5);
     background: var(--bg);
     border: 1px solid var(--border);
@@ -98,13 +152,16 @@
 
 .cube-tab {
     flex: 1;
-    padding: 10px 14px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    padding: 10px 12px;
     background: transparent;
     border: 0;
     border-radius: var(--radius-sm);
     color: var(--text-muted);
     font: inherit;
-    font-weight: 600;
     cursor: pointer;
     transition: background var(--dur-fast) var(--ease-out), color var(--dur-fast) var(--ease-out);
 }
@@ -113,10 +170,27 @@
     color: var(--text);
 }
 
+.cube-tab-icon {
+    font-size: 1.2rem;
+}
+
+.cube-tab-label {
+    font-weight: 600;
+}
+
+.cube-tab-sub {
+    font-size: 0.74rem;
+    color: var(--text-dim);
+}
+
 .cube-tab[aria-selected="true"] {
     background: var(--mtg-gold-soft);
     color: var(--mtg-gold);
     box-shadow: inset 0 0 0 1px var(--mtg-gold-border);
+}
+
+.cube-tab[aria-selected="true"] .cube-tab-sub {
+    color: var(--mtg-gold);
 }
 
 /* --- Panels & forms ------------------------------------------------- */
@@ -136,6 +210,7 @@
 .cube-panel-intro {
     margin-top: 0;
     color: var(--text-muted);
+    line-height: 1.5;
 }
 
 .cube-panel-intro code,
@@ -146,20 +221,41 @@
 .cube-form {
     display: flex;
     flex-wrap: wrap;
-    gap: var(--space-3);
-    align-items: end;
+    gap: var(--space-4);
+    align-items: start;
     margin-bottom: var(--space-3);
 }
 
 .cube-form label {
     display: grid;
     gap: 4px;
-    font-size: 0.85rem;
-    color: var(--text-muted);
+    font-size: 0.9rem;
+    color: var(--text);
 }
 
 .cube-form .cube-query {
-    flex: 1 1 260px;
+    flex: 1 1 280px;
+}
+
+.cube-req {
+    color: var(--text-dim);
+    font-weight: 400;
+    font-size: 0.8rem;
+}
+
+.cube-hint {
+    color: var(--text-dim);
+    font-size: 0.78rem;
+}
+
+.cube-inline-examples {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px;
+    margin-top: 4px;
+    font-size: 0.78rem;
+    color: var(--text-dim);
 }
 
 .cube-form input[type="text"],
@@ -181,12 +277,36 @@
 .cube-checkbox {
     flex-direction: row;
     align-items: center;
-    gap: 6px;
+    gap: 8px;
     grid-auto-flow: column;
+    align-self: center;
+    color: var(--text-muted);
 }
 
-.cube-form .btn {
+.cube-submit {
+    align-self: end;
     height: fit-content;
+}
+
+.cube-chip {
+    padding: 3px 10px;
+    background: var(--mtg-gold-soft);
+    border: 1px solid var(--mtg-gold-border);
+    border-radius: 999px;
+    color: var(--mtg-gold);
+    font: inherit;
+    font-size: 0.78rem;
+    cursor: pointer;
+    transition: background var(--dur-fast) var(--ease-out);
+}
+
+.cube-chip:hover {
+    background: rgba(199, 161, 79, 0.26);
+}
+
+button:disabled {
+    opacity: 0.6;
+    cursor: progress;
 }
 
 .cube-status {
@@ -199,12 +319,23 @@
     display: none;
 }
 
+.cube-empty {
+    margin: var(--space-3) 0 0;
+    padding: var(--space-4);
+    background: var(--bg);
+    border: 1px dashed var(--border-strong);
+    border-radius: var(--radius-md);
+    color: var(--text-muted);
+    text-align: center;
+}
+
+.cube-empty[hidden] {
+    display: none;
+}
+
 /* --- As-fan result -------------------------------------------------- */
 
 .cube-asfan-result {
-    display: flex;
-    align-items: baseline;
-    gap: var(--space-2);
     margin-top: var(--space-4);
     padding: var(--space-4);
     background: var(--bg);
@@ -214,6 +345,12 @@
 
 .cube-asfan-result[hidden] {
     display: none;
+}
+
+.cube-asfan-headline {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-2);
 }
 
 .cube-asfan-number {
@@ -227,21 +364,22 @@
     color: var(--text-muted);
 }
 
-/* --- As-fan bars ---------------------------------------------------- */
+.cube-asfan-sentence {
+    margin: var(--space-2) 0 0;
+    color: var(--text-muted);
+}
+
+/* --- As-fan bars (shared) ------------------------------------------- */
 
 .cube-dist {
     display: grid;
     gap: var(--space-2);
-    margin-top: var(--space-4);
-}
-
-.cube-dist[hidden] {
-    display: none;
+    margin-top: var(--space-3);
 }
 
 .cube-bar-row {
     display: grid;
-    grid-template-columns: 110px 1fr auto;
+    grid-template-columns: 130px 1fr auto;
     align-items: center;
     gap: var(--space-3);
 }
@@ -281,6 +419,62 @@
     white-space: nowrap;
 }
 
+/* --- Preview: card groups ------------------------------------------- */
+
+.cube-groups {
+    display: grid;
+    gap: var(--space-4);
+    margin-top: var(--space-4);
+}
+
+.cube-groups[hidden] {
+    display: none;
+}
+
+.cube-group {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    padding: var(--space-3) var(--space-4);
+}
+
+.cube-group-head {
+    display: grid;
+    grid-template-columns: 150px 1fr auto;
+    align-items: center;
+    gap: var(--space-3);
+    margin-bottom: var(--space-2);
+    padding-bottom: var(--space-2);
+    border-bottom: 1px solid var(--border);
+}
+
+/* --- Card lists (shared by packs + preview groups) ------------------ */
+
+.cube-card-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    columns: 2;
+    column-gap: var(--space-4);
+}
+
+.cube-card-list li {
+    break-inside: avoid;
+    line-height: 1.6;
+}
+
+.cube-card-link {
+    color: var(--text);
+    text-decoration: none;
+    font-size: 0.86rem;
+    border-bottom: 1px dotted transparent;
+}
+
+.cube-card-link:hover {
+    color: var(--mtg-gold);
+    border-bottom-color: var(--mtg-gold-border);
+}
+
 /* --- Generated packs ------------------------------------------------ */
 
 .cube-generate-summary {
@@ -292,11 +486,25 @@
     display: none;
 }
 
+.cube-result-actions {
+    margin-top: var(--space-3);
+}
+
+.cube-result-actions[hidden] {
+    display: none;
+}
+
+.btn-secondary {
+    background: var(--bg);
+    border: 1px solid var(--mtg-gold-border);
+    color: var(--mtg-gold);
+}
+
 .cube-packs {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
     gap: var(--space-3);
-    margin-top: var(--space-4);
+    margin-top: var(--space-3);
 }
 
 .cube-packs[hidden] {
@@ -309,6 +517,10 @@
     border-top: 2px solid var(--mtg-gold-border);
     border-radius: var(--radius-sm);
     padding: var(--space-3);
+}
+
+.cube-pack .cube-card-list {
+    columns: 1;
 }
 
 .cube-pack h3 {
@@ -327,12 +539,20 @@
     color: var(--text-muted);
 }
 
-.cube-pack ul {
-    margin: 0;
-    padding-left: 16px;
-    font-size: 0.82rem;
+.cube-breakdown {
+    margin-top: var(--space-4);
+    border-top: 1px solid var(--border);
+    padding-top: var(--space-3);
+}
+
+.cube-breakdown[hidden] {
+    display: none;
+}
+
+.cube-breakdown summary {
+    cursor: pointer;
     color: var(--text-muted);
-    line-height: 1.5;
+    font-size: 0.9rem;
 }
 
 @media (max-width: 600px) {
@@ -344,16 +564,26 @@
         flex-direction: column;
     }
 
+    .cube-tab {
+        flex-direction: row;
+        gap: 8px;
+    }
+
     .cube-form {
         flex-direction: column;
         align-items: stretch;
     }
 
-    .cube-form .btn {
+    .cube-submit {
         align-self: start;
     }
 
-    .cube-bar-row {
+    .cube-card-list {
+        columns: 1;
+    }
+
+    .cube-bar-row,
+    .cube-group-head {
         grid-template-columns: 90px 1fr;
         grid-template-areas:
             "label track"

--- a/web/src/main/resources/static/css/cube.css
+++ b/web/src/main/resources/static/css/cube.css
@@ -1,0 +1,121 @@
+.cube-card {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    padding: var(--space-4);
+    max-width: 860px;
+    margin-bottom: var(--space-4);
+}
+
+.cube-card h2 {
+    margin-top: 0;
+}
+
+.cube-form {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: end;
+    margin-bottom: var(--space-3);
+}
+
+.cube-form label {
+    display: grid;
+    gap: 4px;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+
+.cube-form .cube-query {
+    flex: 1 1 260px;
+}
+
+.cube-form input[type="text"],
+.cube-form input[type="number"] {
+    padding: 6px 10px;
+    background: var(--bg);
+    color: var(--text);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-sm);
+    font: inherit;
+}
+
+.cube-form .cube-checkbox {
+    flex-direction: row;
+    align-items: center;
+    gap: 6px;
+    grid-auto-flow: column;
+}
+
+.cube-form .btn {
+    height: fit-content;
+}
+
+.cube-status:empty {
+    display: none;
+}
+
+.cube-asfan-result {
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: var(--text);
+}
+
+.cube-table {
+    width: 100%;
+    max-width: 480px;
+    border-collapse: collapse;
+}
+
+.cube-table th,
+.cube-table td {
+    text-align: left;
+    padding: 6px 10px;
+    border-bottom: 1px solid var(--border);
+}
+
+.cube-table th {
+    color: var(--text-muted);
+    font-weight: 600;
+}
+
+.cube-generate-summary {
+    margin-bottom: var(--space-3);
+    color: var(--text);
+}
+
+.cube-packs {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+    gap: 12px;
+}
+
+.cube-pack {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: var(--space-3);
+}
+
+.cube-pack h3 {
+    margin: 0 0 6px;
+    font-size: 0.95rem;
+}
+
+.cube-pack ul {
+    margin: 0;
+    padding-left: 18px;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+
+@media (max-width: 600px) {
+    .cube-form {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .cube-form .btn {
+        align-self: start;
+    }
+}

--- a/web/src/main/resources/static/css/cube.css
+++ b/web/src/main/resources/static/css/cube.css
@@ -1,20 +1,152 @@
-.cube-card {
+/* MTG Cube workshop. Gold "five-colour" accent over the dashboard's dark
+   theme, a hero band, a tabbed tool shell, colour-pie as-fan bars, and a
+   booster-pack grid. Tokens come from base.css :root. */
+
+:root {
+    --mtg-gold: #c7a14f;
+    --mtg-gold-soft: rgba(199, 161, 79, 0.14);
+    --mtg-gold-border: rgba(199, 161, 79, 0.45);
+}
+
+.cube-main {
+    max-width: 1040px;
+    margin: 0 auto;
+    padding: 0 var(--space-4) var(--space-10);
+}
+
+/* --- Hero ----------------------------------------------------------- */
+
+.cube-hero {
+    position: relative;
+    margin: 0 calc(-1 * var(--space-4)) var(--space-6);
+    padding: var(--space-10) var(--space-4) var(--space-8);
+    background:
+        radial-gradient(80% 70% at 50% 0%, var(--mtg-gold-soft) 0%, transparent 65%),
+        var(--gradient-hero);
+    border-bottom: 1px solid var(--border);
+    text-align: center;
+}
+
+.cube-hero-inner {
+    max-width: 720px;
+    margin: 0 auto;
+}
+
+.cube-eyebrow {
+    margin: 0 0 var(--space-2);
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: var(--mtg-gold);
+}
+
+.cube-hero h1 {
+    margin: 0 0 var(--space-3);
+    font-size: 2.2rem;
+    color: var(--heading);
+}
+
+.cube-lede {
+    margin: 0 auto;
+    max-width: 620px;
+    color: var(--text-muted);
+    line-height: 1.6;
+}
+
+.cube-lede code {
+    color: var(--mtg-gold);
+}
+
+.cube-chips {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: var(--space-2);
+    margin: var(--space-5) 0 0;
+    padding: 0;
+    list-style: none;
+}
+
+.cube-chip {
+    padding: 5px 12px;
+    background: var(--mtg-gold-soft);
+    border: 1px solid var(--mtg-gold-border);
+    border-radius: 999px;
+    color: var(--mtg-gold);
+    font: inherit;
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition: background var(--dur-fast) var(--ease-out);
+}
+
+.cube-chip:hover {
+    background: rgba(199, 161, 79, 0.26);
+}
+
+/* --- Tabs ------------------------------------------------------------ */
+
+.cube-tabs {
+    display: flex;
+    gap: 4px;
+    padding: 4px;
+    margin-bottom: var(--space-5);
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+}
+
+.cube-tab {
+    flex: 1;
+    padding: 10px 14px;
+    background: transparent;
+    border: 0;
+    border-radius: var(--radius-sm);
+    color: var(--text-muted);
+    font: inherit;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background var(--dur-fast) var(--ease-out), color var(--dur-fast) var(--ease-out);
+}
+
+.cube-tab:hover {
+    color: var(--text);
+}
+
+.cube-tab[aria-selected="true"] {
+    background: var(--mtg-gold-soft);
+    color: var(--mtg-gold);
+    box-shadow: inset 0 0 0 1px var(--mtg-gold-border);
+}
+
+/* --- Panels & forms ------------------------------------------------- */
+
+.cube-panel {
     background: var(--bg-elevated);
     border: 1px solid var(--border);
     border-radius: var(--radius-md);
-    padding: var(--space-4);
-    max-width: 860px;
-    margin-bottom: var(--space-4);
+    padding: var(--space-5);
+    box-shadow: var(--shadow-sm);
 }
 
-.cube-card h2 {
+.cube-panel[hidden] {
+    display: none;
+}
+
+.cube-panel-intro {
     margin-top: 0;
+    color: var(--text-muted);
+}
+
+.cube-panel-intro code,
+.cube-generate-summary strong {
+    color: var(--mtg-gold);
 }
 
 .cube-form {
     display: flex;
     flex-wrap: wrap;
-    gap: 12px;
+    gap: var(--space-3);
     align-items: end;
     margin-bottom: var(--space-3);
 }
@@ -32,15 +164,21 @@
 
 .cube-form input[type="text"],
 .cube-form input[type="number"] {
-    padding: 6px 10px;
-    background: var(--bg);
+    padding: 8px 10px;
+    background: var(--bg-input);
     color: var(--text);
     border: 1px solid var(--border-strong);
     border-radius: var(--radius-sm);
     font: inherit;
 }
 
-.cube-form .cube-checkbox {
+.cube-form input:focus {
+    outline: none;
+    border-color: var(--mtg-gold);
+    box-shadow: 0 0 0 2px var(--mtg-gold-soft);
+}
+
+.cube-checkbox {
     flex-direction: row;
     align-items: center;
     gap: 6px;
@@ -51,65 +189,161 @@
     height: fit-content;
 }
 
+.cube-status {
+    margin: var(--space-2) 0;
+    color: var(--text-muted);
+    min-height: 1.2em;
+}
+
 .cube-status:empty {
     display: none;
 }
 
+/* --- As-fan result -------------------------------------------------- */
+
 .cube-asfan-result {
-    font-size: 1.25rem;
-    font-weight: 600;
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-2);
+    margin-top: var(--space-4);
+    padding: var(--space-4);
+    background: var(--bg);
+    border: 1px solid var(--mtg-gold-border);
+    border-radius: var(--radius-md);
+}
+
+.cube-asfan-result[hidden] {
+    display: none;
+}
+
+.cube-asfan-number {
+    font-size: 2.4rem;
+    font-weight: 700;
+    line-height: 1;
+    color: var(--mtg-gold);
+}
+
+.cube-asfan-unit {
+    color: var(--text-muted);
+}
+
+/* --- As-fan bars ---------------------------------------------------- */
+
+.cube-dist {
+    display: grid;
+    gap: var(--space-2);
+    margin-top: var(--space-4);
+}
+
+.cube-dist[hidden] {
+    display: none;
+}
+
+.cube-bar-row {
+    display: grid;
+    grid-template-columns: 110px 1fr auto;
+    align-items: center;
+    gap: var(--space-3);
+}
+
+.cube-bar-label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.88rem;
     color: var(--text);
 }
 
-.cube-table {
-    width: 100%;
-    max-width: 480px;
-    border-collapse: collapse;
+.cube-swatch {
+    width: 12px;
+    height: 12px;
+    border-radius: 3px;
+    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.35);
+    flex-shrink: 0;
 }
 
-.cube-table th,
-.cube-table td {
-    text-align: left;
-    padding: 6px 10px;
-    border-bottom: 1px solid var(--border);
+.cube-bar-track {
+    height: 10px;
+    background: var(--bg);
+    border-radius: 999px;
+    overflow: hidden;
 }
 
-.cube-table th {
+.cube-bar-fill {
+    height: 100%;
+    border-radius: 999px;
+    transition: width var(--dur-base) var(--ease-out);
+}
+
+.cube-bar-value {
+    font-size: 0.82rem;
     color: var(--text-muted);
-    font-weight: 600;
+    white-space: nowrap;
 }
+
+/* --- Generated packs ------------------------------------------------ */
 
 .cube-generate-summary {
-    margin-bottom: var(--space-3);
+    margin-top: var(--space-4);
     color: var(--text);
+}
+
+.cube-generate-summary[hidden] {
+    display: none;
 }
 
 .cube-packs {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
-    gap: 12px;
+    grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
+    gap: var(--space-3);
+    margin-top: var(--space-4);
+}
+
+.cube-packs[hidden] {
+    display: none;
 }
 
 .cube-pack {
     background: var(--bg);
     border: 1px solid var(--border);
+    border-top: 2px solid var(--mtg-gold-border);
     border-radius: var(--radius-sm);
     padding: var(--space-3);
 }
 
 .cube-pack h3 {
-    margin: 0 0 6px;
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: var(--space-2);
+    margin: 0 0 var(--space-2);
     font-size: 0.95rem;
+    color: var(--heading);
+}
+
+.cube-pack-count {
+    font-size: 0.72rem;
+    font-weight: 400;
+    color: var(--text-muted);
 }
 
 .cube-pack ul {
     margin: 0;
-    padding-left: 18px;
-    font-size: 0.85rem;
+    padding-left: 16px;
+    font-size: 0.82rem;
     color: var(--text-muted);
+    line-height: 1.5;
 }
 
 @media (max-width: 600px) {
+    .cube-hero h1 {
+        font-size: 1.7rem;
+    }
+
+    .cube-tabs {
+        flex-direction: column;
+    }
+
     .cube-form {
         flex-direction: column;
         align-items: stretch;
@@ -117,5 +351,24 @@
 
     .cube-form .btn {
         align-self: start;
+    }
+
+    .cube-bar-row {
+        grid-template-columns: 90px 1fr;
+        grid-template-areas:
+            "label track"
+            "value value";
+    }
+
+    .cube-bar-label {
+        grid-area: label;
+    }
+
+    .cube-bar-track {
+        grid-area: track;
+    }
+
+    .cube-bar-value {
+        grid-area: value;
     }
 }

--- a/web/src/main/resources/static/js/cube.js
+++ b/web/src/main/resources/static/js/cube.js
@@ -1,21 +1,43 @@
-// MTG cube workshop page. Three independent tools (as-fan calculator,
-// cube preview, pack generator) each POST-free GET against the /cube/api/*
-// JSON endpoints and render the result. Pure helpers (URL builders,
-// formatting, DOM renderers) are exported for Jest; the DOM wiring only
-// runs in a browser where the forms exist.
+// MTG cube workshop page. A tabbed tool (as-fan calculator / cube preview
+// / pack generator) over the /cube/api/* JSON endpoints. Pure helpers
+// (URL builders, formatting, category colours, hash↔tab mapping, DOM
+// renderers) are exported for Jest; the DOM wiring only runs in a browser
+// where the tabs and forms exist.
 (function (root) {
     'use strict';
+
+    const TABS = ['asfan', 'preview', 'generate'];
+
+    // Colour-pie palette for the as-fan bars. Tuned to read on the dark
+    // dashboard background (pure black/white would vanish), but still
+    // recognisably W/U/B/R/G + gold multicolour, silver colourless, brown land.
+    const CATEGORY_COLORS = {
+        White: '#f5edd6',
+        Blue: '#3b82f6',
+        Black: '#9aa0b5',
+        Red: '#ef4444',
+        Green: '#22c55e',
+        Multicolor: '#f1c40f',
+        Colorless: '#c7ccd4',
+        Land: '#b9895a',
+    };
+
+    function categoryColor(name) {
+        return CATEGORY_COLORS[name] || '#7a7a8a';
+    }
 
     function formatAsFan(value) {
         return Number(value).toFixed(2);
     }
 
+    /** The tab id encoded in a URL hash, or null if it isn't a real tab. */
+    function tabIdFromHash(hash) {
+        const id = (hash || '').replace(/^#/, '');
+        return TABS.indexOf(id) >= 0 ? id : null;
+    }
+
     function asfanUrl(p) {
-        const q = new URLSearchParams({
-            total: p.total,
-            cubeSize: p.cubeSize,
-            packSize: p.packSize,
-        });
+        const q = new URLSearchParams({ total: p.total, cubeSize: p.cubeSize, packSize: p.packSize });
         return '/cube/api/asfan?' + q.toString();
     }
 
@@ -34,18 +56,43 @@
         return '/cube/api/generate?' + q.toString();
     }
 
-    function renderDistribution(tbody, distribution) {
-        tbody.replaceChildren();
+    /** Renders the as-fan distribution as colour-coded, length-scaled bars. */
+    function renderDistribution(container, distribution) {
+        container.replaceChildren();
+        const max = distribution.reduce(function (m, row) { return Math.max(m, row.asFan); }, 0);
         distribution.forEach(function (row) {
-            const tr = document.createElement('tr');
-            [row.category, String(row.count), formatAsFan(row.asFan) + ' / pack'].forEach(function (text) {
-                const td = document.createElement('td');
-                td.textContent = text;
-                tr.appendChild(td);
-            });
-            tbody.appendChild(tr);
+            const color = categoryColor(row.category);
+            const pct = max > 0 ? Math.max(2, Math.round((row.asFan / max) * 100)) : 0;
+
+            const rowEl = document.createElement('div');
+            rowEl.className = 'cube-bar-row';
+
+            const label = document.createElement('span');
+            label.className = 'cube-bar-label';
+            const swatch = document.createElement('span');
+            swatch.className = 'cube-swatch';
+            swatch.style.background = color;
+            label.appendChild(swatch);
+            label.appendChild(document.createTextNode(row.category));
+
+            const track = document.createElement('div');
+            track.className = 'cube-bar-track';
+            const fill = document.createElement('div');
+            fill.className = 'cube-bar-fill';
+            fill.style.width = pct + '%';
+            fill.style.background = color;
+            track.appendChild(fill);
+
+            const value = document.createElement('span');
+            value.className = 'cube-bar-value';
+            value.textContent = formatAsFan(row.asFan) + ' / pack · ' + row.count;
+
+            rowEl.appendChild(label);
+            rowEl.appendChild(track);
+            rowEl.appendChild(value);
+            container.appendChild(rowEl);
         });
-        return tbody;
+        return container;
     }
 
     function renderPacks(container, packs) {
@@ -54,7 +101,11 @@
             const card = document.createElement('div');
             card.className = 'cube-pack';
             const heading = document.createElement('h3');
-            heading.textContent = 'Pack ' + (i + 1) + ' (' + pack.length + ')';
+            heading.textContent = 'Pack ' + (i + 1);
+            const count = document.createElement('span');
+            count.className = 'cube-pack-count';
+            count.textContent = pack.length + ' cards';
+            heading.appendChild(count);
             card.appendChild(heading);
             const list = document.createElement('ul');
             pack.forEach(function (name) {
@@ -78,11 +129,68 @@
         return doc.querySelector('[data-status="' + name + '"]');
     }
 
+    function activateTab(doc, name) {
+        if (TABS.indexOf(name) < 0) return;
+        doc.querySelectorAll('[role="tab"][data-tab]').forEach(function (tab) {
+            const selected = tab.getAttribute('data-tab') === name;
+            tab.setAttribute('aria-selected', selected ? 'true' : 'false');
+            tab.tabIndex = selected ? 0 : -1;
+        });
+        doc.querySelectorAll('[data-panel]').forEach(function (panel) {
+            panel.hidden = panel.getAttribute('data-panel') !== name;
+        });
+    }
+
+    function wireTabs(doc) {
+        const tabs = Array.prototype.slice.call(doc.querySelectorAll('[role="tab"][data-tab]'));
+        if (!tabs.length) return;
+
+        tabs.forEach(function (tab, i) {
+            tab.addEventListener('click', function () {
+                const name = tab.getAttribute('data-tab');
+                activateTab(doc, name);
+                if (root.history && root.history.replaceState) {
+                    root.history.replaceState(null, '', '#' + name);
+                }
+            });
+            tab.addEventListener('keydown', function (e) {
+                let next = -1;
+                if (e.key === 'ArrowRight') next = (i + 1) % tabs.length;
+                else if (e.key === 'ArrowLeft') next = (i - 1 + tabs.length) % tabs.length;
+                if (next >= 0) {
+                    e.preventDefault();
+                    tabs[next].focus();
+                    tabs[next].click();
+                }
+            });
+        });
+
+        const fromHash = tabIdFromHash(root.location && root.location.hash);
+        if (fromHash) activateTab(doc, fromHash);
+    }
+
+    function wireExamples(doc) {
+        doc.querySelectorAll('[data-example]').forEach(function (chip) {
+            chip.addEventListener('click', function () {
+                const value = chip.getAttribute('data-example');
+                doc.querySelectorAll('input[name="query"]').forEach(function (input) {
+                    input.value = value;
+                });
+                activateTab(doc, 'preview');
+            });
+        });
+    }
+
+    function getJson(url) {
+        return fetch(url).then(function (r) { return r.json(); });
+    }
+
     function wireAsFan(doc) {
         const form = doc.querySelector('[data-form="asfan"]');
         if (!form) return;
         const status = statusFor(doc, 'asfan');
         const result = doc.querySelector('[data-result="asfan"]');
+        const number = doc.querySelector('[data-asfan-number]');
         form.addEventListener('submit', function (e) {
             e.preventDefault();
             const data = new FormData(form);
@@ -93,12 +201,11 @@
             };
             setStatus(status, 'Calculating…');
             result.hidden = true;
-            fetch(asfanUrl(params))
-                .then(function (r) { return r.json(); })
+            getJson(asfanUrl(params))
                 .then(function (json) {
                     if (!json.ok) { setStatus(status, json.error || 'Invalid inputs.'); return; }
                     setStatus(status, '');
-                    result.textContent = formatAsFan(json.value) + ' of that type per pack.';
+                    number.textContent = formatAsFan(json.value);
                     result.hidden = false;
                 })
                 .catch(function () { setStatus(status, 'Something went wrong. Try again.'); });
@@ -109,22 +216,20 @@
         const form = doc.querySelector('[data-form="preview"]');
         if (!form) return;
         const status = statusFor(doc, 'preview');
-        const table = doc.querySelector('[data-result="preview"]');
-        const tbody = table ? table.querySelector('tbody') : null;
+        const dist = doc.querySelector('[data-result="preview"]');
         form.addEventListener('submit', function (e) {
             e.preventDefault();
             const data = new FormData(form);
             const params = { query: (data.get('query') || '').toString().trim(), packSize: data.get('packSize') };
             if (!params.query) return;
             setStatus(status, 'Fetching from Scryfall…');
-            table.hidden = true;
-            fetch(previewUrl(params))
-                .then(function (r) { return r.json(); })
+            dist.hidden = true;
+            getJson(previewUrl(params))
                 .then(function (json) {
                     if (!json.ok) { setStatus(status, json.error || 'No results.'); return; }
                     setStatus(status, params.query + ' → ' + json.poolSize + ' cards');
-                    renderDistribution(tbody, json.distribution);
-                    table.hidden = false;
+                    renderDistribution(dist, json.distribution);
+                    dist.hidden = false;
                 })
                 .catch(function () { setStatus(status, 'Something went wrong reaching Scryfall.'); });
         });
@@ -135,6 +240,7 @@
         if (!form) return;
         const status = statusFor(doc, 'generate');
         const summary = doc.querySelector('[data-summary="generate"]');
+        const dist = doc.querySelector('[data-dist="generate"]');
         const result = doc.querySelector('[data-result="generate"]');
         form.addEventListener('submit', function (e) {
             e.preventDefault();
@@ -148,15 +254,17 @@
             if (!params.query) return;
             setStatus(status, 'Building packs…');
             summary.hidden = true;
+            dist.hidden = true;
             result.hidden = true;
-            fetch(generateUrl(params))
-                .then(function (r) { return r.json(); })
+            getJson(generateUrl(params))
                 .then(function (json) {
                     if (!json.ok) { setStatus(status, json.error || 'Could not build packs.'); return; }
                     setStatus(status, '');
                     summary.textContent = 'Dealt ' + json.packCount + ' packs of ' + json.packSize +
                         ' from a ' + json.poolSize + '-card pool.';
                     summary.hidden = false;
+                    renderDistribution(dist, json.distribution);
+                    dist.hidden = false;
                     renderPacks(result, json.packs);
                     result.hidden = false;
                 })
@@ -165,6 +273,8 @@
     }
 
     function wire(doc) {
+        wireTabs(doc);
+        wireExamples(doc);
         wireAsFan(doc);
         wirePreview(doc);
         wireGenerate(doc);
@@ -174,6 +284,8 @@
 
     const api = {
         formatAsFan: formatAsFan,
+        categoryColor: categoryColor,
+        tabIdFromHash: tabIdFromHash,
         asfanUrl: asfanUrl,
         previewUrl: previewUrl,
         generateUrl: generateUrl,

--- a/web/src/main/resources/static/js/cube.js
+++ b/web/src/main/resources/static/js/cube.js
@@ -1,16 +1,17 @@
-// MTG cube workshop page. A tabbed tool (as-fan calculator / cube preview
-// / pack generator) over the /cube/api/* JSON endpoints. Pure helpers
-// (URL builders, formatting, category colours, hash↔tab mapping, DOM
-// renderers) are exported for Jest; the DOM wiring only runs in a browser
-// where the tabs and forms exist.
+// MTG cube workshop page. A guided, tabbed tool (generate packs / preview
+// a cube / as-fan calculator) over the /cube/api/* JSON endpoints. The
+// emphasis is on showing the actual CARDS: generated packs and the preview
+// both list real card names linked to Scryfall. Pure helpers (URL builders,
+// formatting, colours, card links, hash↔tab mapping, DOM renderers) are
+// exported for Jest; the DOM wiring only runs in a browser.
 (function (root) {
     'use strict';
 
-    const TABS = ['asfan', 'preview', 'generate'];
+    const TABS = ['generate', 'preview', 'asfan'];
 
-    // Colour-pie palette for the as-fan bars. Tuned to read on the dark
-    // dashboard background (pure black/white would vanish), but still
-    // recognisably W/U/B/R/G + gold multicolour, silver colourless, brown land.
+    // Colour-pie palette for swatches/bars. Tuned to read on the dark
+    // dashboard background while staying recognisably W/U/B/R/G + gold
+    // multicolour, silver colourless, brown land.
     const CATEGORY_COLORS = {
         White: '#f5edd6',
         Blue: '#3b82f6',
@@ -30,10 +31,28 @@
         return Number(value).toFixed(2);
     }
 
+    function asfanSentence(value, packSize) {
+        return 'On average you\'ll open about ' + formatAsFan(value) +
+            ' of these in a ' + packSize + '-card pack.';
+    }
+
+    /** Exact-name Scryfall search for a card, so the link opens that card. */
+    function scryfallCardUrl(name) {
+        return 'https://scryfall.com/search?q=' + encodeURIComponent('!"' + name + '"');
+    }
+
     /** The tab id encoded in a URL hash, or null if it isn't a real tab. */
     function tabIdFromHash(hash) {
         const id = (hash || '').replace(/^#/, '');
         return TABS.indexOf(id) >= 0 ? id : null;
+    }
+
+    /** Plain-text rendering of the dealt packs, for the download button. */
+    function packsToText(packs) {
+        return packs.map(function (pack, i) {
+            return '== Pack ' + (i + 1) + ' (' + pack.length + ' cards) ==\n' +
+                pack.map(function (n) { return '  ' + n; }).join('\n');
+        }).join('\n\n') + '\n';
     }
 
     function asfanUrl(p) {
@@ -56,14 +75,35 @@
         return '/cube/api/generate?' + q.toString();
     }
 
-    /** Renders the as-fan distribution as colour-coded, length-scaled bars. */
+    /** A card name as a Scryfall link (opens in a new tab). */
+    function cardLink(name) {
+        const a = document.createElement('a');
+        a.className = 'cube-card-link';
+        a.href = scryfallCardUrl(name);
+        a.target = '_blank';
+        a.rel = 'noopener';
+        a.textContent = name;
+        return a;
+    }
+
+    function asFanBar(category, asFan, max) {
+        const color = categoryColor(category);
+        const pct = max > 0 ? Math.max(2, Math.round((asFan / max) * 100)) : 0;
+        const track = document.createElement('div');
+        track.className = 'cube-bar-track';
+        const fill = document.createElement('div');
+        fill.className = 'cube-bar-fill';
+        fill.style.width = pct + '%';
+        fill.style.background = color;
+        track.appendChild(fill);
+        return track;
+    }
+
+    /** As-fan bars only (the secondary "balance" view under a generate). */
     function renderDistribution(container, distribution) {
         container.replaceChildren();
-        const max = distribution.reduce(function (m, row) { return Math.max(m, row.asFan); }, 0);
+        const max = distribution.reduce(function (m, r) { return Math.max(m, r.asFan); }, 0);
         distribution.forEach(function (row) {
-            const color = categoryColor(row.category);
-            const pct = max > 0 ? Math.max(2, Math.round((row.asFan / max) * 100)) : 0;
-
             const rowEl = document.createElement('div');
             rowEl.className = 'cube-bar-row';
 
@@ -71,26 +111,56 @@
             label.className = 'cube-bar-label';
             const swatch = document.createElement('span');
             swatch.className = 'cube-swatch';
-            swatch.style.background = color;
+            swatch.style.background = categoryColor(row.category);
             label.appendChild(swatch);
             label.appendChild(document.createTextNode(row.category));
-
-            const track = document.createElement('div');
-            track.className = 'cube-bar-track';
-            const fill = document.createElement('div');
-            fill.className = 'cube-bar-fill';
-            fill.style.width = pct + '%';
-            fill.style.background = color;
-            track.appendChild(fill);
 
             const value = document.createElement('span');
             value.className = 'cube-bar-value';
             value.textContent = formatAsFan(row.asFan) + ' / pack · ' + row.count;
 
             rowEl.appendChild(label);
-            rowEl.appendChild(track);
+            rowEl.appendChild(asFanBar(row.category, row.asFan, max));
             rowEl.appendChild(value);
             container.appendChild(rowEl);
+        });
+        return container;
+    }
+
+    /** The preview: each colour/land group with its as-fan AND its cards. */
+    function renderGroups(container, groups) {
+        container.replaceChildren();
+        const max = groups.reduce(function (m, g) { return Math.max(m, g.asFan); }, 0);
+        groups.forEach(function (group) {
+            const block = document.createElement('section');
+            block.className = 'cube-group';
+
+            const head = document.createElement('div');
+            head.className = 'cube-group-head';
+            const label = document.createElement('span');
+            label.className = 'cube-bar-label';
+            const swatch = document.createElement('span');
+            swatch.className = 'cube-swatch';
+            swatch.style.background = categoryColor(group.category);
+            label.appendChild(swatch);
+            label.appendChild(document.createTextNode(group.category + ' (' + group.count + ')'));
+            const value = document.createElement('span');
+            value.className = 'cube-bar-value';
+            value.textContent = formatAsFan(group.asFan) + ' / pack';
+            head.appendChild(label);
+            head.appendChild(asFanBar(group.category, group.asFan, max));
+            head.appendChild(value);
+            block.appendChild(head);
+
+            const list = document.createElement('ul');
+            list.className = 'cube-card-list';
+            group.cards.forEach(function (name) {
+                const li = document.createElement('li');
+                li.appendChild(cardLink(name));
+                list.appendChild(li);
+            });
+            block.appendChild(list);
+            container.appendChild(block);
         });
         return container;
     }
@@ -108,9 +178,10 @@
             heading.appendChild(count);
             card.appendChild(heading);
             const list = document.createElement('ul');
+            list.className = 'cube-card-list';
             pack.forEach(function (name) {
                 const li = document.createElement('li');
-                li.textContent = name;
+                li.appendChild(cardLink(name));
                 list.appendChild(li);
             });
             card.appendChild(list);
@@ -123,11 +194,14 @@
         if (el) el.textContent = msg;
     }
 
+    function show(el) { if (el) el.hidden = false; }
+    function hide(el) { if (el) el.hidden = true; }
+
     // --- DOM wiring (browser only) -------------------------------------
 
-    function statusFor(doc, name) {
-        return doc.querySelector('[data-status="' + name + '"]');
-    }
+    function q(doc, sel) { return doc.querySelector(sel); }
+    function statusFor(doc, name) { return q(doc, '[data-status="' + name + '"]'); }
+    function emptyFor(doc, name) { return q(doc, '[data-empty="' + name + '"]'); }
 
     function activateTab(doc, name) {
         if (TABS.indexOf(name) < 0) return;
@@ -144,7 +218,6 @@
     function wireTabs(doc) {
         const tabs = Array.prototype.slice.call(doc.querySelectorAll('[role="tab"][data-tab]'));
         if (!tabs.length) return;
-
         tabs.forEach(function (tab, i) {
             tab.addEventListener('click', function () {
                 const name = tab.getAttribute('data-tab');
@@ -164,7 +237,6 @@
                 }
             });
         });
-
         const fromHash = tabIdFromHash(root.location && root.location.hash);
         if (fromHash) activateTab(doc, fromHash);
     }
@@ -176,7 +248,6 @@
                 doc.querySelectorAll('input[name="query"]').forEach(function (input) {
                     input.value = value;
                 });
-                activateTab(doc, 'preview');
             });
         });
     }
@@ -185,63 +256,92 @@
         return fetch(url).then(function (r) { return r.json(); });
     }
 
+    /** Disables the form's submit button while a request is in flight. */
+    function withBusy(form, busy) {
+        const btn = form.querySelector('button[type="submit"]');
+        if (btn) btn.disabled = busy;
+    }
+
     function wireAsFan(doc) {
-        const form = doc.querySelector('[data-form="asfan"]');
+        const form = q(doc, '[data-form="asfan"]');
         if (!form) return;
         const status = statusFor(doc, 'asfan');
-        const result = doc.querySelector('[data-result="asfan"]');
-        const number = doc.querySelector('[data-asfan-number]');
+        const result = q(doc, '[data-result="asfan"]');
+        const number = q(doc, '[data-asfan-number]');
+        const sentence = q(doc, '[data-asfan-sentence]');
         form.addEventListener('submit', function (e) {
             e.preventDefault();
             const data = new FormData(form);
-            const params = {
-                total: data.get('total'),
-                cubeSize: data.get('cubeSize'),
-                packSize: data.get('packSize'),
-            };
+            const params = { total: data.get('total'), cubeSize: data.get('cubeSize'), packSize: data.get('packSize') };
             setStatus(status, 'Calculating…');
-            result.hidden = true;
+            hide(result);
+            withBusy(form, true);
             getJson(asfanUrl(params))
                 .then(function (json) {
                     if (!json.ok) { setStatus(status, json.error || 'Invalid inputs.'); return; }
                     setStatus(status, '');
                     number.textContent = formatAsFan(json.value);
-                    result.hidden = false;
+                    if (sentence) sentence.textContent = asfanSentence(json.value, Number(params.packSize));
+                    show(result);
                 })
-                .catch(function () { setStatus(status, 'Something went wrong. Try again.'); });
+                .catch(function () { setStatus(status, 'Something went wrong. Try again.'); })
+                .then(function () { withBusy(form, false); });
         });
     }
 
     function wirePreview(doc) {
-        const form = doc.querySelector('[data-form="preview"]');
+        const form = q(doc, '[data-form="preview"]');
         if (!form) return;
         const status = statusFor(doc, 'preview');
-        const dist = doc.querySelector('[data-result="preview"]');
+        const empty = emptyFor(doc, 'preview');
+        const groups = q(doc, '[data-result="preview"]');
         form.addEventListener('submit', function (e) {
             e.preventDefault();
             const data = new FormData(form);
             const params = { query: (data.get('query') || '').toString().trim(), packSize: data.get('packSize') };
             if (!params.query) return;
-            setStatus(status, 'Fetching from Scryfall…');
-            dist.hidden = true;
+            setStatus(status, 'Fetching cards from Scryfall…');
+            hide(groups);
+            withBusy(form, true);
             getJson(previewUrl(params))
                 .then(function (json) {
                     if (!json.ok) { setStatus(status, json.error || 'No results.'); return; }
                     setStatus(status, params.query + ' → ' + json.poolSize + ' cards');
-                    renderDistribution(dist, json.distribution);
-                    dist.hidden = false;
+                    hide(empty);
+                    renderGroups(groups, json.groups);
+                    show(groups);
                 })
-                .catch(function () { setStatus(status, 'Something went wrong reaching Scryfall.'); });
+                .catch(function () { setStatus(status, 'Something went wrong reaching Scryfall.'); })
+                .then(function () { withBusy(form, false); });
         });
     }
 
     function wireGenerate(doc) {
-        const form = doc.querySelector('[data-form="generate"]');
+        const form = q(doc, '[data-form="generate"]');
         if (!form) return;
         const status = statusFor(doc, 'generate');
-        const summary = doc.querySelector('[data-summary="generate"]');
-        const dist = doc.querySelector('[data-dist="generate"]');
-        const result = doc.querySelector('[data-result="generate"]');
+        const empty = emptyFor(doc, 'generate');
+        const summary = q(doc, '[data-summary="generate"]');
+        const actions = q(doc, '[data-actions="generate"]');
+        const breakdown = q(doc, '[data-breakdown="generate"]');
+        const dist = q(doc, '[data-dist="generate"]');
+        const result = q(doc, '[data-result="generate"]');
+        const downloadBtn = q(doc, '[data-download="generate"]');
+        let lastPacks = [];
+
+        if (downloadBtn) {
+            downloadBtn.addEventListener('click', function () {
+                if (!lastPacks.length) return;
+                const blob = new Blob([packsToText(lastPacks)], { type: 'text/plain' });
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = 'cube-packs.txt';
+                a.click();
+                URL.revokeObjectURL(url);
+            });
+        }
+
         form.addEventListener('submit', function (e) {
             e.preventDefault();
             const data = new FormData(form);
@@ -252,23 +352,26 @@
                 balanced: form.querySelector('[name="balanced"]').checked,
             };
             if (!params.query) return;
-            setStatus(status, 'Building packs…');
-            summary.hidden = true;
-            dist.hidden = true;
-            result.hidden = true;
+            setStatus(status, 'Drawing cards and dealing packs…');
+            hide(summary); hide(actions); hide(breakdown); hide(result);
+            withBusy(form, true);
             getJson(generateUrl(params))
                 .then(function (json) {
                     if (!json.ok) { setStatus(status, json.error || 'Could not build packs.'); return; }
                     setStatus(status, '');
+                    hide(empty);
+                    lastPacks = json.packs;
                     summary.textContent = 'Dealt ' + json.packCount + ' packs of ' + json.packSize +
-                        ' from a ' + json.poolSize + '-card pool.';
-                    summary.hidden = false;
-                    renderDistribution(dist, json.distribution);
-                    dist.hidden = false;
+                        ' from a ' + json.poolSize + '-card pool. Click any card to view it on Scryfall.';
+                    show(summary);
                     renderPacks(result, json.packs);
-                    result.hidden = false;
+                    show(result);
+                    show(actions);
+                    renderDistribution(dist, json.distribution);
+                    show(breakdown);
                 })
-                .catch(function () { setStatus(status, 'Something went wrong building packs.'); });
+                .catch(function () { setStatus(status, 'Something went wrong building packs.'); })
+                .then(function () { withBusy(form, false); });
         });
     }
 
@@ -284,12 +387,16 @@
 
     const api = {
         formatAsFan: formatAsFan,
+        asfanSentence: asfanSentence,
         categoryColor: categoryColor,
+        scryfallCardUrl: scryfallCardUrl,
         tabIdFromHash: tabIdFromHash,
+        packsToText: packsToText,
         asfanUrl: asfanUrl,
         previewUrl: previewUrl,
         generateUrl: generateUrl,
         renderDistribution: renderDistribution,
+        renderGroups: renderGroups,
         renderPacks: renderPacks,
     };
     if (root) root.TobyCube = api;

--- a/web/src/main/resources/static/js/cube.js
+++ b/web/src/main/resources/static/js/cube.js
@@ -1,0 +1,187 @@
+// MTG cube workshop page. Three independent tools (as-fan calculator,
+// cube preview, pack generator) each POST-free GET against the /cube/api/*
+// JSON endpoints and render the result. Pure helpers (URL builders,
+// formatting, DOM renderers) are exported for Jest; the DOM wiring only
+// runs in a browser where the forms exist.
+(function (root) {
+    'use strict';
+
+    function formatAsFan(value) {
+        return Number(value).toFixed(2);
+    }
+
+    function asfanUrl(p) {
+        const q = new URLSearchParams({
+            total: p.total,
+            cubeSize: p.cubeSize,
+            packSize: p.packSize,
+        });
+        return '/cube/api/asfan?' + q.toString();
+    }
+
+    function previewUrl(p) {
+        const q = new URLSearchParams({ query: p.query, packSize: p.packSize });
+        return '/cube/api/preview?' + q.toString();
+    }
+
+    function generateUrl(p) {
+        const q = new URLSearchParams({
+            query: p.query,
+            packs: p.packs,
+            packSize: p.packSize,
+            balanced: p.balanced ? 'true' : 'false',
+        });
+        return '/cube/api/generate?' + q.toString();
+    }
+
+    function renderDistribution(tbody, distribution) {
+        tbody.replaceChildren();
+        distribution.forEach(function (row) {
+            const tr = document.createElement('tr');
+            [row.category, String(row.count), formatAsFan(row.asFan) + ' / pack'].forEach(function (text) {
+                const td = document.createElement('td');
+                td.textContent = text;
+                tr.appendChild(td);
+            });
+            tbody.appendChild(tr);
+        });
+        return tbody;
+    }
+
+    function renderPacks(container, packs) {
+        container.replaceChildren();
+        packs.forEach(function (pack, i) {
+            const card = document.createElement('div');
+            card.className = 'cube-pack';
+            const heading = document.createElement('h3');
+            heading.textContent = 'Pack ' + (i + 1) + ' (' + pack.length + ')';
+            card.appendChild(heading);
+            const list = document.createElement('ul');
+            pack.forEach(function (name) {
+                const li = document.createElement('li');
+                li.textContent = name;
+                list.appendChild(li);
+            });
+            card.appendChild(list);
+            container.appendChild(card);
+        });
+        return container;
+    }
+
+    function setStatus(el, msg) {
+        if (el) el.textContent = msg;
+    }
+
+    // --- DOM wiring (browser only) -------------------------------------
+
+    function statusFor(doc, name) {
+        return doc.querySelector('[data-status="' + name + '"]');
+    }
+
+    function wireAsFan(doc) {
+        const form = doc.querySelector('[data-form="asfan"]');
+        if (!form) return;
+        const status = statusFor(doc, 'asfan');
+        const result = doc.querySelector('[data-result="asfan"]');
+        form.addEventListener('submit', function (e) {
+            e.preventDefault();
+            const data = new FormData(form);
+            const params = {
+                total: data.get('total'),
+                cubeSize: data.get('cubeSize'),
+                packSize: data.get('packSize'),
+            };
+            setStatus(status, 'Calculating…');
+            result.hidden = true;
+            fetch(asfanUrl(params))
+                .then(function (r) { return r.json(); })
+                .then(function (json) {
+                    if (!json.ok) { setStatus(status, json.error || 'Invalid inputs.'); return; }
+                    setStatus(status, '');
+                    result.textContent = formatAsFan(json.value) + ' of that type per pack.';
+                    result.hidden = false;
+                })
+                .catch(function () { setStatus(status, 'Something went wrong. Try again.'); });
+        });
+    }
+
+    function wirePreview(doc) {
+        const form = doc.querySelector('[data-form="preview"]');
+        if (!form) return;
+        const status = statusFor(doc, 'preview');
+        const table = doc.querySelector('[data-result="preview"]');
+        const tbody = table ? table.querySelector('tbody') : null;
+        form.addEventListener('submit', function (e) {
+            e.preventDefault();
+            const data = new FormData(form);
+            const params = { query: (data.get('query') || '').toString().trim(), packSize: data.get('packSize') };
+            if (!params.query) return;
+            setStatus(status, 'Fetching from Scryfall…');
+            table.hidden = true;
+            fetch(previewUrl(params))
+                .then(function (r) { return r.json(); })
+                .then(function (json) {
+                    if (!json.ok) { setStatus(status, json.error || 'No results.'); return; }
+                    setStatus(status, params.query + ' → ' + json.poolSize + ' cards');
+                    renderDistribution(tbody, json.distribution);
+                    table.hidden = false;
+                })
+                .catch(function () { setStatus(status, 'Something went wrong reaching Scryfall.'); });
+        });
+    }
+
+    function wireGenerate(doc) {
+        const form = doc.querySelector('[data-form="generate"]');
+        if (!form) return;
+        const status = statusFor(doc, 'generate');
+        const summary = doc.querySelector('[data-summary="generate"]');
+        const result = doc.querySelector('[data-result="generate"]');
+        form.addEventListener('submit', function (e) {
+            e.preventDefault();
+            const data = new FormData(form);
+            const params = {
+                query: (data.get('query') || '').toString().trim(),
+                packs: data.get('packs'),
+                packSize: data.get('packSize'),
+                balanced: form.querySelector('[name="balanced"]').checked,
+            };
+            if (!params.query) return;
+            setStatus(status, 'Building packs…');
+            summary.hidden = true;
+            result.hidden = true;
+            fetch(generateUrl(params))
+                .then(function (r) { return r.json(); })
+                .then(function (json) {
+                    if (!json.ok) { setStatus(status, json.error || 'Could not build packs.'); return; }
+                    setStatus(status, '');
+                    summary.textContent = 'Dealt ' + json.packCount + ' packs of ' + json.packSize +
+                        ' from a ' + json.poolSize + '-card pool.';
+                    summary.hidden = false;
+                    renderPacks(result, json.packs);
+                    result.hidden = false;
+                })
+                .catch(function () { setStatus(status, 'Something went wrong building packs.'); });
+        });
+    }
+
+    function wire(doc) {
+        wireAsFan(doc);
+        wirePreview(doc);
+        wireGenerate(doc);
+    }
+
+    if (root && root.document) wire(root.document);
+
+    const api = {
+        formatAsFan: formatAsFan,
+        asfanUrl: asfanUrl,
+        previewUrl: previewUrl,
+        generateUrl: generateUrl,
+        renderDistribution: renderDistribution,
+        renderPacks: renderPacks,
+    };
+    if (root) root.TobyCube = api;
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = api;
+    }
+})(typeof window !== 'undefined' ? window : null);

--- a/web/src/main/resources/templates/cube.html
+++ b/web/src/main/resources/templates/cube.html
@@ -11,109 +11,173 @@
             <p class="cube-eyebrow">Magic: The Gathering</p>
             <h1>Cube workshop</h1>
             <p class="cube-lede">
-                Build randomised draft packs and crunch
-                <a href="https://magic.wizards.com/en/news/making-magic/nuts-and-bolts-key-concepts-2015-08-31"
-                   target="_blank" rel="noopener">as-fan</a>
-                for your cube. Define a pool with a
-                <a href="https://scryfall.com/docs/syntax" target="_blank" rel="noopener">Scryfall search</a>,
-                draw a random subset, and deal it into balanced boosters — the same tools the
-                <code>/cube</code> Discord command uses. No login required.
+                Turn any pile of cards into a balanced draft. Pick the tool below, tell it which
+                cards you're using, and it does the maths and the shuffling for you.
             </p>
-            <ul class="cube-chips" aria-label="Example Scryfall queries">
-                <li><button type="button" class="cube-chip" data-example="cube:vintage">cube:vintage</button></li>
-                <li><button type="button" class="cube-chip" data-example="set:vow">set:vow</button></li>
-                <li><button type="button" class="cube-chip" data-example="t:dragon">t:dragon</button></li>
-                <li><button type="button" class="cube-chip" data-example="c:r t:instant">c:r t:instant</button></li>
-            </ul>
+
+            <ol class="cube-steps" aria-label="How it works">
+                <li class="cube-step">
+                    <span class="cube-step-num">1</span>
+                    <span class="cube-step-text"><strong>Describe your cube</strong> with a Scryfall search.</span>
+                </li>
+                <li class="cube-step">
+                    <span class="cube-step-num">2</span>
+                    <span class="cube-step-text"><strong>Preview</strong> to check it's balanced.</span>
+                </li>
+                <li class="cube-step">
+                    <span class="cube-step-num">3</span>
+                    <span class="cube-step-text"><strong>Generate</strong> randomised draft packs.</span>
+                </li>
+            </ol>
+
+            <details class="cube-explainer">
+                <summary>New to this? Read me first</summary>
+                <div class="cube-explainer-body">
+                    <p><strong>What's a "cube"?</strong> A custom pool of Magic cards you draft from
+                        instead of sealed boosters.</p>
+                    <p><strong>What's a "Scryfall search"?</strong> A way to describe a set of cards in
+                        words. You type it into the <em>query</em> box. For example:</p>
+                    <ul>
+                        <li><code>set:vow</code> — every card in the set <em>Crimson Vow</em></li>
+                        <li><code>t:dragon</code> — every Dragon</li>
+                        <li><code>c:r t:instant</code> — red instants</li>
+                        <li><code>cube:vintage</code> — Wizards' official Vintage Cube list</li>
+                    </ul>
+                    <p>Not sure what to type? Click an <strong>example</strong> button under any query box.
+                        Full syntax lives on
+                        <a href="https://scryfall.com/docs/syntax" target="_blank" rel="noopener">Scryfall</a>.</p>
+                    <p><strong>What's "as-fan"?</strong> The average number of a given kind of card you
+                        open per pack — so you can see your draft isn't, say, flooded with lands or
+                        starved of removal.</p>
+                </div>
+            </details>
         </div>
     </header>
 
     <div class="cube-shell">
-        <div class="cube-tabs segmented" role="tablist" aria-label="Cube tools">
-            <button type="button" id="tab-asfan" class="cube-tab" role="tab"
-                    data-tab="asfan" aria-controls="panel-asfan" aria-selected="true">
-                As-fan calculator
+        <p class="cube-tabs-hint" id="cube-tabs-hint">Choose a tool:</p>
+        <div class="cube-tabs segmented" role="tablist" aria-label="Cube tools" aria-describedby="cube-tabs-hint">
+            <button type="button" id="tab-generate" class="cube-tab" role="tab"
+                    data-tab="generate" aria-controls="panel-generate" aria-selected="true">
+                <span class="cube-tab-icon" aria-hidden="true">🃏</span>
+                <span class="cube-tab-label">Generate packs</span>
+                <span class="cube-tab-sub">Deal a draft</span>
             </button>
             <button type="button" id="tab-preview" class="cube-tab" role="tab"
                     data-tab="preview" aria-controls="panel-preview" aria-selected="false" tabindex="-1">
-                Cube preview
+                <span class="cube-tab-icon" aria-hidden="true">📊</span>
+                <span class="cube-tab-label">Preview a cube</span>
+                <span class="cube-tab-sub">Check the balance</span>
             </button>
-            <button type="button" id="tab-generate" class="cube-tab" role="tab"
-                    data-tab="generate" aria-controls="panel-generate" aria-selected="false" tabindex="-1">
-                Pack generator
+            <button type="button" id="tab-asfan" class="cube-tab" role="tab"
+                    data-tab="asfan" aria-controls="panel-asfan" aria-selected="false" tabindex="-1">
+                <span class="cube-tab-icon" aria-hidden="true">🔢</span>
+                <span class="cube-tab-label">As-fan calculator</span>
+                <span class="cube-tab-sub">Quick maths</span>
             </button>
         </div>
 
-        <!-- As-fan calculator -->
-        <section id="panel-asfan" class="cube-panel" role="tabpanel" aria-labelledby="tab-asfan" data-panel="asfan">
+        <!-- Generate -->
+        <section id="panel-generate" class="cube-panel" role="tabpanel" aria-labelledby="tab-generate"
+                 data-panel="generate">
             <p class="cube-panel-intro">
-                Expected copies of a card type you open per booster:
-                <code>(type ÷ cube size) × pack size</code>.
+                Draws cards at random and deals them into evenly-sized, balanced booster packs —
+                ready to print or share.
             </p>
-            <form class="cube-form" data-form="asfan" autocomplete="off">
-                <label>Cards of that type
-                    <input type="number" name="total" min="0" value="60" required>
+            <form class="cube-form" data-form="generate" autocomplete="off">
+                <label class="cube-query">Which cards? <span class="cube-req">(required)</span>
+                    <input type="text" name="query" placeholder="e.g. cube:vintage" required>
+                    <small class="cube-hint">A Scryfall search describing your card pool.</small>
+                    <span class="cube-inline-examples">Examples:
+                        <button type="button" class="cube-chip" data-example="cube:vintage">cube:vintage</button>
+                        <button type="button" class="cube-chip" data-example="set:vow">set:vow</button>
+                        <button type="button" class="cube-chip" data-example="t:dragon">t:dragon</button>
+                    </span>
                 </label>
-                <label>Cube size
-                    <input type="number" name="cubeSize" min="1" value="540" required>
+                <label>How many packs?
+                    <input type="number" name="packs" min="1" max="90" value="24" required>
+                    <small class="cube-hint">8 players × 3 packs = 24.</small>
                 </label>
-                <label>Pack size
+                <label>Cards per pack
                     <input type="number" name="packSize" min="1" max="30" value="15" required>
+                    <small class="cube-hint">Standard boosters hold 15.</small>
                 </label>
-                <button type="submit" class="btn">Calculate</button>
+                <label class="cube-checkbox">
+                    <input type="checkbox" name="balanced" checked>
+                    Spread colours &amp; lands evenly across packs
+                </label>
+                <button type="submit" class="btn cube-submit">Generate packs</button>
             </form>
-            <p class="cube-status" data-status="asfan" aria-live="polite"></p>
-            <div class="cube-asfan-result" data-result="asfan" hidden>
-                <span class="cube-asfan-number" data-asfan-number>0.00</span>
-                <span class="cube-asfan-unit">of that type per pack</span>
+            <p class="cube-status" data-status="generate" aria-live="polite"></p>
+            <p class="cube-empty" data-empty="generate">Fill in a query and hit <strong>Generate packs</strong> to deal a draft.</p>
+            <div class="cube-generate-summary" data-summary="generate" hidden></div>
+            <div class="cube-result-actions" data-actions="generate" hidden>
+                <button type="button" class="btn btn-secondary" data-download="generate">⬇ Download pack list (.txt)</button>
             </div>
+            <div class="cube-packs" data-result="generate" hidden></div>
+            <details class="cube-breakdown" data-breakdown="generate" hidden>
+                <summary>Show colour &amp; land balance</summary>
+                <div class="cube-dist" data-dist="generate"></div>
+            </details>
         </section>
 
         <!-- Preview -->
         <section id="panel-preview" class="cube-panel" role="tabpanel" aria-labelledby="tab-preview"
                  data-panel="preview" hidden>
             <p class="cube-panel-intro">
-                See the colour / colourless / land as-fan of every card a query matches.
+                Lists the actual cards in your pool, grouped by colour and land, with how many of
+                each kind you'd open per pack — so you can see exactly what's in the cube.
             </p>
             <form class="cube-form" data-form="preview" autocomplete="off">
-                <label class="cube-query">Scryfall query
+                <label class="cube-query">Which cards? <span class="cube-req">(required)</span>
                     <input type="text" name="query" placeholder="e.g. set:vow" required>
+                    <small class="cube-hint">A Scryfall search describing your card pool.</small>
+                    <span class="cube-inline-examples">Examples:
+                        <button type="button" class="cube-chip" data-example="set:vow">set:vow</button>
+                        <button type="button" class="cube-chip" data-example="cube:vintage">cube:vintage</button>
+                        <button type="button" class="cube-chip" data-example="c:r t:instant">c:r t:instant</button>
+                    </span>
                 </label>
-                <label>Pack size
+                <label>Cards per pack
                     <input type="number" name="packSize" min="1" max="30" value="15" required>
+                    <small class="cube-hint">Standard boosters hold 15.</small>
                 </label>
-                <button type="submit" class="btn">Preview</button>
+                <button type="submit" class="btn cube-submit">Preview balance</button>
             </form>
             <p class="cube-status" data-status="preview" aria-live="polite"></p>
-            <div class="cube-dist" data-result="preview" hidden></div>
+            <p class="cube-empty" data-empty="preview">Enter a query and hit <strong>Preview balance</strong> to list the cards.</p>
+            <div class="cube-groups" data-result="preview" hidden></div>
         </section>
 
-        <!-- Generate -->
-        <section id="panel-generate" class="cube-panel" role="tabpanel" aria-labelledby="tab-generate"
-                 data-panel="generate" hidden>
+        <!-- As-fan calculator -->
+        <section id="panel-asfan" class="cube-panel" role="tabpanel" aria-labelledby="tab-asfan"
+                 data-panel="asfan" hidden>
             <p class="cube-panel-intro">
-                Randomly draw cards from the pool and deal evenly-sized, as-fan-balanced packs.
+                Already know your numbers? Work out how many of one kind of card you'll open per pack.
             </p>
-            <form class="cube-form" data-form="generate" autocomplete="off">
-                <label class="cube-query">Scryfall query
-                    <input type="text" name="query" placeholder="e.g. cube:vintage" required>
+            <form class="cube-form" data-form="asfan" autocomplete="off">
+                <label>How many of that card type?
+                    <input type="number" name="total" min="0" value="60" required>
+                    <small class="cube-hint">e.g. 60 removal spells in the cube.</small>
                 </label>
-                <label>Packs
-                    <input type="number" name="packs" min="1" max="90" value="24" required>
+                <label>Cards in the whole cube
+                    <input type="number" name="cubeSize" min="1" value="540" required>
+                    <small class="cube-hint">Your total pool size.</small>
                 </label>
-                <label>Pack size
+                <label>Cards per pack
                     <input type="number" name="packSize" min="1" max="30" value="15" required>
+                    <small class="cube-hint">Standard boosters hold 15.</small>
                 </label>
-                <label class="cube-checkbox">
-                    <input type="checkbox" name="balanced" checked>
-                    Balance as-fan across packs
-                </label>
-                <button type="submit" class="btn">Generate</button>
+                <button type="submit" class="btn cube-submit">Calculate</button>
             </form>
-            <p class="cube-status" data-status="generate" aria-live="polite"></p>
-            <div class="cube-generate-summary" data-summary="generate" hidden></div>
-            <div class="cube-dist" data-dist="generate" hidden></div>
-            <div class="cube-packs" data-result="generate" hidden></div>
+            <p class="cube-status" data-status="asfan" aria-live="polite"></p>
+            <div class="cube-asfan-result" data-result="asfan" hidden>
+                <div class="cube-asfan-headline">
+                    <span class="cube-asfan-number" data-asfan-number>0.00</span>
+                    <span class="cube-asfan-unit">per pack</span>
+                </div>
+                <p class="cube-asfan-sentence" data-asfan-sentence></p>
+            </div>
         </section>
     </div>
 </main>

--- a/web/src/main/resources/templates/cube.html
+++ b/web/src/main/resources/templates/cube.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: head('TobyBot - MTG Cube workshop', '/css/cube.css')}"></head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<main id="main" class="container">
+    <h1 class="mb-3">MTG Cube workshop</h1>
+    <p class="muted mb-5">
+        Build randomised draft packs and crunch
+        <a href="https://magic.wizards.com/en/news/making-magic/nuts-and-bolts-key-concepts-2015-08-31"
+           target="_blank" rel="noopener">as-fan</a>
+        for a Magic: The Gathering cube. Define your pool with a
+        <a href="https://scryfall.com/docs/syntax" target="_blank" rel="noopener">Scryfall search</a>
+        (e.g. <code>cube:vintage</code>, <code>set:vow</code>, <code>t:dragon</code>). Same tools the
+        <code>/cube</code> Discord command uses, no login required.
+    </p>
+
+    <!-- As-fan calculator -->
+    <section class="cube-card">
+        <h2>As-fan calculator</h2>
+        <p class="muted">Expected copies of a card type you open per booster: <code>(type ÷ cube size) × pack size</code>.</p>
+        <form class="cube-form" data-form="asfan" autocomplete="off">
+            <label>Cards of that type
+                <input type="number" name="total" min="0" value="60" required>
+            </label>
+            <label>Cube size
+                <input type="number" name="cubeSize" min="1" value="540" required>
+            </label>
+            <label>Pack size
+                <input type="number" name="packSize" min="1" max="30" value="15" required>
+            </label>
+            <button type="submit" class="btn">Calculate</button>
+        </form>
+        <p class="cube-status muted" data-status="asfan" aria-live="polite"></p>
+        <p class="cube-asfan-result" data-result="asfan" hidden></p>
+    </section>
+
+    <!-- Preview -->
+    <section class="cube-card">
+        <h2>Cube preview</h2>
+        <p class="muted">See the colour / colourless / land as-fan of everything a query matches.</p>
+        <form class="cube-form" data-form="preview" autocomplete="off">
+            <label class="cube-query">Scryfall query
+                <input type="text" name="query" placeholder="e.g. set:vow" required>
+            </label>
+            <label>Pack size
+                <input type="number" name="packSize" min="1" max="30" value="15" required>
+            </label>
+            <button type="submit" class="btn">Preview</button>
+        </form>
+        <p class="cube-status muted" data-status="preview" aria-live="polite"></p>
+        <table class="cube-table" data-result="preview" hidden>
+            <thead><tr><th>Category</th><th>Count</th><th>As-fan / pack</th></tr></thead>
+            <tbody></tbody>
+        </table>
+    </section>
+
+    <!-- Generate -->
+    <section class="cube-card">
+        <h2>Generate packs</h2>
+        <p class="muted">Randomly draw cards from the pool and deal evenly-sized, as-fan-balanced packs.</p>
+        <form class="cube-form" data-form="generate" autocomplete="off">
+            <label class="cube-query">Scryfall query
+                <input type="text" name="query" placeholder="e.g. cube:vintage" required>
+            </label>
+            <label>Packs
+                <input type="number" name="packs" min="1" max="90" value="24" required>
+            </label>
+            <label>Pack size
+                <input type="number" name="packSize" min="1" max="30" value="15" required>
+            </label>
+            <label class="cube-checkbox">
+                <input type="checkbox" name="balanced" checked>
+                Balance as-fan across packs
+            </label>
+            <button type="submit" class="btn">Generate</button>
+        </form>
+        <p class="cube-status muted" data-status="generate" aria-live="polite"></p>
+        <div class="cube-generate-summary" data-summary="generate" hidden></div>
+        <div class="cube-packs" data-result="generate" hidden></div>
+    </section>
+</main>
+
+<script th:src="@{/js/cube.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
+</body>
+</html>

--- a/web/src/main/resources/templates/cube.html
+++ b/web/src/main/resources/templates/cube.html
@@ -5,82 +5,117 @@
 <a href="#main" class="skip-link">Skip to content</a>
 <div th:replace="~{fragments/navbar :: navbar}"></div>
 
-<main id="main" class="container">
-    <h1 class="mb-3">MTG Cube workshop</h1>
-    <p class="muted mb-5">
-        Build randomised draft packs and crunch
-        <a href="https://magic.wizards.com/en/news/making-magic/nuts-and-bolts-key-concepts-2015-08-31"
-           target="_blank" rel="noopener">as-fan</a>
-        for a Magic: The Gathering cube. Define your pool with a
-        <a href="https://scryfall.com/docs/syntax" target="_blank" rel="noopener">Scryfall search</a>
-        (e.g. <code>cube:vintage</code>, <code>set:vow</code>, <code>t:dragon</code>). Same tools the
-        <code>/cube</code> Discord command uses, no login required.
-    </p>
+<main id="main" class="cube-main">
+    <header class="cube-hero">
+        <div class="cube-hero-inner">
+            <p class="cube-eyebrow">Magic: The Gathering</p>
+            <h1>Cube workshop</h1>
+            <p class="cube-lede">
+                Build randomised draft packs and crunch
+                <a href="https://magic.wizards.com/en/news/making-magic/nuts-and-bolts-key-concepts-2015-08-31"
+                   target="_blank" rel="noopener">as-fan</a>
+                for your cube. Define a pool with a
+                <a href="https://scryfall.com/docs/syntax" target="_blank" rel="noopener">Scryfall search</a>,
+                draw a random subset, and deal it into balanced boosters — the same tools the
+                <code>/cube</code> Discord command uses. No login required.
+            </p>
+            <ul class="cube-chips" aria-label="Example Scryfall queries">
+                <li><button type="button" class="cube-chip" data-example="cube:vintage">cube:vintage</button></li>
+                <li><button type="button" class="cube-chip" data-example="set:vow">set:vow</button></li>
+                <li><button type="button" class="cube-chip" data-example="t:dragon">t:dragon</button></li>
+                <li><button type="button" class="cube-chip" data-example="c:r t:instant">c:r t:instant</button></li>
+            </ul>
+        </div>
+    </header>
 
-    <!-- As-fan calculator -->
-    <section class="cube-card">
-        <h2>As-fan calculator</h2>
-        <p class="muted">Expected copies of a card type you open per booster: <code>(type ÷ cube size) × pack size</code>.</p>
-        <form class="cube-form" data-form="asfan" autocomplete="off">
-            <label>Cards of that type
-                <input type="number" name="total" min="0" value="60" required>
-            </label>
-            <label>Cube size
-                <input type="number" name="cubeSize" min="1" value="540" required>
-            </label>
-            <label>Pack size
-                <input type="number" name="packSize" min="1" max="30" value="15" required>
-            </label>
-            <button type="submit" class="btn">Calculate</button>
-        </form>
-        <p class="cube-status muted" data-status="asfan" aria-live="polite"></p>
-        <p class="cube-asfan-result" data-result="asfan" hidden></p>
-    </section>
+    <div class="cube-shell">
+        <div class="cube-tabs segmented" role="tablist" aria-label="Cube tools">
+            <button type="button" id="tab-asfan" class="cube-tab" role="tab"
+                    data-tab="asfan" aria-controls="panel-asfan" aria-selected="true">
+                As-fan calculator
+            </button>
+            <button type="button" id="tab-preview" class="cube-tab" role="tab"
+                    data-tab="preview" aria-controls="panel-preview" aria-selected="false" tabindex="-1">
+                Cube preview
+            </button>
+            <button type="button" id="tab-generate" class="cube-tab" role="tab"
+                    data-tab="generate" aria-controls="panel-generate" aria-selected="false" tabindex="-1">
+                Pack generator
+            </button>
+        </div>
 
-    <!-- Preview -->
-    <section class="cube-card">
-        <h2>Cube preview</h2>
-        <p class="muted">See the colour / colourless / land as-fan of everything a query matches.</p>
-        <form class="cube-form" data-form="preview" autocomplete="off">
-            <label class="cube-query">Scryfall query
-                <input type="text" name="query" placeholder="e.g. set:vow" required>
-            </label>
-            <label>Pack size
-                <input type="number" name="packSize" min="1" max="30" value="15" required>
-            </label>
-            <button type="submit" class="btn">Preview</button>
-        </form>
-        <p class="cube-status muted" data-status="preview" aria-live="polite"></p>
-        <table class="cube-table" data-result="preview" hidden>
-            <thead><tr><th>Category</th><th>Count</th><th>As-fan / pack</th></tr></thead>
-            <tbody></tbody>
-        </table>
-    </section>
+        <!-- As-fan calculator -->
+        <section id="panel-asfan" class="cube-panel" role="tabpanel" aria-labelledby="tab-asfan" data-panel="asfan">
+            <p class="cube-panel-intro">
+                Expected copies of a card type you open per booster:
+                <code>(type ÷ cube size) × pack size</code>.
+            </p>
+            <form class="cube-form" data-form="asfan" autocomplete="off">
+                <label>Cards of that type
+                    <input type="number" name="total" min="0" value="60" required>
+                </label>
+                <label>Cube size
+                    <input type="number" name="cubeSize" min="1" value="540" required>
+                </label>
+                <label>Pack size
+                    <input type="number" name="packSize" min="1" max="30" value="15" required>
+                </label>
+                <button type="submit" class="btn">Calculate</button>
+            </form>
+            <p class="cube-status" data-status="asfan" aria-live="polite"></p>
+            <div class="cube-asfan-result" data-result="asfan" hidden>
+                <span class="cube-asfan-number" data-asfan-number>0.00</span>
+                <span class="cube-asfan-unit">of that type per pack</span>
+            </div>
+        </section>
 
-    <!-- Generate -->
-    <section class="cube-card">
-        <h2>Generate packs</h2>
-        <p class="muted">Randomly draw cards from the pool and deal evenly-sized, as-fan-balanced packs.</p>
-        <form class="cube-form" data-form="generate" autocomplete="off">
-            <label class="cube-query">Scryfall query
-                <input type="text" name="query" placeholder="e.g. cube:vintage" required>
-            </label>
-            <label>Packs
-                <input type="number" name="packs" min="1" max="90" value="24" required>
-            </label>
-            <label>Pack size
-                <input type="number" name="packSize" min="1" max="30" value="15" required>
-            </label>
-            <label class="cube-checkbox">
-                <input type="checkbox" name="balanced" checked>
-                Balance as-fan across packs
-            </label>
-            <button type="submit" class="btn">Generate</button>
-        </form>
-        <p class="cube-status muted" data-status="generate" aria-live="polite"></p>
-        <div class="cube-generate-summary" data-summary="generate" hidden></div>
-        <div class="cube-packs" data-result="generate" hidden></div>
-    </section>
+        <!-- Preview -->
+        <section id="panel-preview" class="cube-panel" role="tabpanel" aria-labelledby="tab-preview"
+                 data-panel="preview" hidden>
+            <p class="cube-panel-intro">
+                See the colour / colourless / land as-fan of every card a query matches.
+            </p>
+            <form class="cube-form" data-form="preview" autocomplete="off">
+                <label class="cube-query">Scryfall query
+                    <input type="text" name="query" placeholder="e.g. set:vow" required>
+                </label>
+                <label>Pack size
+                    <input type="number" name="packSize" min="1" max="30" value="15" required>
+                </label>
+                <button type="submit" class="btn">Preview</button>
+            </form>
+            <p class="cube-status" data-status="preview" aria-live="polite"></p>
+            <div class="cube-dist" data-result="preview" hidden></div>
+        </section>
+
+        <!-- Generate -->
+        <section id="panel-generate" class="cube-panel" role="tabpanel" aria-labelledby="tab-generate"
+                 data-panel="generate" hidden>
+            <p class="cube-panel-intro">
+                Randomly draw cards from the pool and deal evenly-sized, as-fan-balanced packs.
+            </p>
+            <form class="cube-form" data-form="generate" autocomplete="off">
+                <label class="cube-query">Scryfall query
+                    <input type="text" name="query" placeholder="e.g. cube:vintage" required>
+                </label>
+                <label>Packs
+                    <input type="number" name="packs" min="1" max="90" value="24" required>
+                </label>
+                <label>Pack size
+                    <input type="number" name="packSize" min="1" max="30" value="15" required>
+                </label>
+                <label class="cube-checkbox">
+                    <input type="checkbox" name="balanced" checked>
+                    Balance as-fan across packs
+                </label>
+                <button type="submit" class="btn">Generate</button>
+            </form>
+            <p class="cube-status" data-status="generate" aria-live="polite"></p>
+            <div class="cube-generate-summary" data-summary="generate" hidden></div>
+            <div class="cube-dist" data-dist="generate" hidden></div>
+            <div class="cube-packs" data-result="generate" hidden></div>
+        </section>
+    </div>
 </main>
 
 <script th:src="@{/js/cube.js}"></script>

--- a/web/src/main/resources/templates/fragments/navbar.html
+++ b/web/src/main/resources/templates/fragments/navbar.html
@@ -174,6 +174,7 @@
                 <div class="nav-dropdown-menu" role="menu">
                     <a href="/utils" role="menuitem">Utils</a>
                     <a href="/dnd" role="menuitem">D&amp;D lookups</a>
+                    <a href="/cube" role="menuitem">MTG Cube</a>
                 </div>
             </div>
         </div>

--- a/web/src/main/resources/templates/fragments/navbar.html
+++ b/web/src/main/resources/templates/fragments/navbar.html
@@ -164,6 +164,23 @@
         </div>
 
         <div class="nav-section">
+            <div class="nav-section-eyebrow">Magic</div>
+            <div class="nav-dropdown">
+                <button type="button"
+                        class="nav-dropdown-toggle"
+                        aria-haspopup="true"
+                        aria-expanded="false"
+                        onclick="toggleDropdown(this)"><span class="nav-item-icon" aria-hidden="true">&#127183;</span><span class="nav-dropdown-label">Magic</span><span class="nav-dropdown-caret" aria-hidden="true">&#9662;</span></button>
+                <div class="nav-dropdown-menu" role="menu">
+                    <a href="/cube" role="menuitem">&#129443; Cube workshop</a>
+                    <a href="/cube#asfan" role="menuitem">&#128290; As-fan calculator</a>
+                    <a href="/cube#preview" role="menuitem">&#128202; Cube preview</a>
+                    <a href="/cube#generate" role="menuitem">&#127183; Pack generator</a>
+                </div>
+            </div>
+        </div>
+
+        <div class="nav-section">
             <div class="nav-section-eyebrow">Tools</div>
             <div class="nav-dropdown">
                 <button type="button"
@@ -174,7 +191,6 @@
                 <div class="nav-dropdown-menu" role="menu">
                     <a href="/utils" role="menuitem">Utils</a>
                     <a href="/dnd" role="menuitem">D&amp;D lookups</a>
-                    <a href="/cube" role="menuitem">MTG Cube</a>
                 </div>
             </div>
         </div>

--- a/web/src/test/js/cube.test.js
+++ b/web/src/test/js/cube.test.js
@@ -1,6 +1,7 @@
-// Pure-logic tests for the cube workshop page. The URL builders and DOM
-// renderers carry the page's only real logic; pin them so the page can't
-// silently start hitting the wrong endpoint or mis-rendering results.
+// Pure-logic tests for the cube workshop page. The URL builders, tab/hash
+// mapping, category colours, and DOM renderers carry the page's only real
+// logic; pin them so the page can't silently hit the wrong endpoint, lose
+// a tab deep-link, or mis-render the as-fan bars.
 
 const Cube = require('../../main/resources/static/js/cube');
 
@@ -9,6 +10,33 @@ describe('formatAsFan', () => {
         expect(Cube.formatAsFan(1.6667)).toBe('1.67');
         expect(Cube.formatAsFan(2)).toBe('2.00');
         expect(Cube.formatAsFan(0)).toBe('0.00');
+    });
+});
+
+describe('categoryColor', () => {
+    test('maps every colour-pie bucket to a distinct swatch', () => {
+        const names = ['White', 'Blue', 'Black', 'Red', 'Green', 'Multicolor', 'Colorless', 'Land'];
+        const colors = names.map(Cube.categoryColor);
+        expect(new Set(colors).size).toBe(names.length);
+        colors.forEach((c) => expect(c).toMatch(/^#[0-9a-f]{6}$/i));
+    });
+
+    test('falls back to a neutral colour for an unknown category', () => {
+        expect(Cube.categoryColor('Eldrazi')).toBe('#7a7a8a');
+    });
+});
+
+describe('tabIdFromHash', () => {
+    test('recognises the three tab hashes', () => {
+        expect(Cube.tabIdFromHash('#asfan')).toBe('asfan');
+        expect(Cube.tabIdFromHash('#preview')).toBe('preview');
+        expect(Cube.tabIdFromHash('#generate')).toBe('generate');
+    });
+
+    test('returns null for anything else', () => {
+        expect(Cube.tabIdFromHash('#nope')).toBeNull();
+        expect(Cube.tabIdFromHash('')).toBeNull();
+        expect(Cube.tabIdFromHash(null)).toBeNull();
     });
 });
 
@@ -32,27 +60,31 @@ describe('URL builders', () => {
 });
 
 describe('renderDistribution', () => {
-    test('renders one row per category with the as-fan suffix', () => {
-        const tbody = document.createElement('tbody');
-        Cube.renderDistribution(tbody, [
-            { category: 'White', count: 36, asFan: 1.0 },
+    test('renders one colour-coded, length-scaled bar per category', () => {
+        const container = document.createElement('div');
+        Cube.renderDistribution(container, [
+            { category: 'White', count: 36, asFan: 2.0 },
             { category: 'Land', count: 18, asFan: 0.5 },
         ]);
-        const rows = tbody.querySelectorAll('tr');
+        const rows = container.querySelectorAll('.cube-bar-row');
         expect(rows).toHaveLength(2);
-        const firstCells = rows[0].querySelectorAll('td');
-        expect(firstCells[0].textContent).toBe('White');
-        expect(firstCells[1].textContent).toBe('36');
-        expect(firstCells[2].textContent).toBe('1.00 / pack');
+
+        const first = rows[0];
+        expect(first.querySelector('.cube-bar-label').textContent).toBe('White');
+        expect(first.querySelector('.cube-bar-value').textContent).toBe('2.00 / pack · 36');
+        // Largest as-fan gets a full-width bar.
+        expect(first.querySelector('.cube-bar-fill').style.width).toBe('100%');
+        // Half the max → quarter… no: 0.5 of 2.0 = 25%.
+        expect(rows[1].querySelector('.cube-bar-fill').style.width).toBe('25%');
     });
 
-    test('replaces any previous rows on re-render', () => {
-        const tbody = document.createElement('tbody');
-        Cube.renderDistribution(tbody, [{ category: 'Red', count: 1, asFan: 1 }]);
-        Cube.renderDistribution(tbody, [{ category: 'Blue', count: 2, asFan: 2 }]);
-        const rows = tbody.querySelectorAll('tr');
+    test('replaces any previous bars on re-render', () => {
+        const container = document.createElement('div');
+        Cube.renderDistribution(container, [{ category: 'Red', count: 1, asFan: 1 }]);
+        Cube.renderDistribution(container, [{ category: 'Blue', count: 2, asFan: 2 }]);
+        const rows = container.querySelectorAll('.cube-bar-row');
         expect(rows).toHaveLength(1);
-        expect(rows[0].querySelector('td').textContent).toBe('Blue');
+        expect(rows[0].querySelector('.cube-bar-label').textContent).toBe('Blue');
     });
 });
 
@@ -65,9 +97,9 @@ describe('renderPacks', () => {
         ]);
         const packs = container.querySelectorAll('.cube-pack');
         expect(packs).toHaveLength(2);
-        expect(packs[0].querySelector('h3').textContent).toBe('Pack 1 (2)');
+        expect(packs[0].querySelector('h3').textContent).toContain('Pack 1');
+        expect(packs[0].querySelector('.cube-pack-count').textContent).toBe('2 cards');
         expect(packs[0].querySelectorAll('li')).toHaveLength(2);
-        expect(packs[1].querySelector('h3').textContent).toBe('Pack 2 (1)');
         expect(packs[1].querySelector('li').textContent).toBe('Forest');
     });
 });

--- a/web/src/test/js/cube.test.js
+++ b/web/src/test/js/cube.test.js
@@ -1,7 +1,7 @@
 // Pure-logic tests for the cube workshop page. The URL builders, tab/hash
-// mapping, category colours, and DOM renderers carry the page's only real
-// logic; pin them so the page can't silently hit the wrong endpoint, lose
-// a tab deep-link, or mis-render the as-fan bars.
+// mapping, category colours, card links, and DOM renderers carry the
+// page's only real logic; pin them so the page can't silently hit the
+// wrong endpoint, lose a tab deep-link, or stop showing the actual cards.
 
 const Cube = require('../../main/resources/static/js/cube');
 
@@ -10,6 +10,13 @@ describe('formatAsFan', () => {
         expect(Cube.formatAsFan(1.6667)).toBe('1.67');
         expect(Cube.formatAsFan(2)).toBe('2.00');
         expect(Cube.formatAsFan(0)).toBe('0.00');
+    });
+});
+
+describe('asfanSentence', () => {
+    test('reads as a plain-English sentence', () => {
+        expect(Cube.asfanSentence(1.6667, 15))
+            .toBe("On average you'll open about 1.67 of these in a 15-card pack.");
     });
 });
 
@@ -26,17 +33,39 @@ describe('categoryColor', () => {
     });
 });
 
+describe('scryfallCardUrl', () => {
+    test('builds an exact-name Scryfall search link', () => {
+        expect(Cube.scryfallCardUrl('Lightning Bolt'))
+            .toBe('https://scryfall.com/search?q=' + encodeURIComponent('!"Lightning Bolt"'));
+    });
+
+    test('encodes punctuation in card names', () => {
+        // Apostrophes / commas must survive into a valid URL.
+        expect(Cube.scryfallCardUrl("Urza's Saga")).toContain(encodeURIComponent('!"Urza\'s Saga"'));
+    });
+});
+
 describe('tabIdFromHash', () => {
     test('recognises the three tab hashes', () => {
-        expect(Cube.tabIdFromHash('#asfan')).toBe('asfan');
-        expect(Cube.tabIdFromHash('#preview')).toBe('preview');
         expect(Cube.tabIdFromHash('#generate')).toBe('generate');
+        expect(Cube.tabIdFromHash('#preview')).toBe('preview');
+        expect(Cube.tabIdFromHash('#asfan')).toBe('asfan');
     });
 
     test('returns null for anything else', () => {
         expect(Cube.tabIdFromHash('#nope')).toBeNull();
         expect(Cube.tabIdFromHash('')).toBeNull();
         expect(Cube.tabIdFromHash(null)).toBeNull();
+    });
+});
+
+describe('packsToText', () => {
+    test('renders each pack as a titled, indented block', () => {
+        const text = Cube.packsToText([['Bolt', 'Shock'], ['Forest']]);
+        expect(text).toContain('== Pack 1 (2 cards) ==');
+        expect(text).toContain('  Bolt');
+        expect(text).toContain('== Pack 2 (1 cards) ==');
+        expect(text).toContain('  Forest');
     });
 });
 
@@ -59,7 +88,43 @@ describe('URL builders', () => {
     });
 });
 
-describe('renderDistribution', () => {
+describe('renderGroups (preview lists the actual cards)', () => {
+    test('renders a group per category with its cards as Scryfall links', () => {
+        const container = document.createElement('div');
+        Cube.renderGroups(container, [
+            { category: 'Red', count: 2, asFan: 2.0, cards: ['Bolt', 'Shock'] },
+            { category: 'Land', count: 1, asFan: 0.5, cards: ['Wastes'] },
+        ]);
+        const blocks = container.querySelectorAll('.cube-group');
+        expect(blocks).toHaveLength(2);
+
+        const redCards = blocks[0].querySelectorAll('.cube-card-list .cube-card-link');
+        expect(redCards).toHaveLength(2);
+        expect(redCards[0].textContent).toBe('Bolt');
+        expect(redCards[0].getAttribute('href')).toBe(Cube.scryfallCardUrl('Bolt'));
+        expect(redCards[0].getAttribute('target')).toBe('_blank');
+        // Header still shows the as-fan.
+        expect(blocks[0].querySelector('.cube-bar-value').textContent).toBe('2.00 / pack');
+    });
+});
+
+describe('renderPacks', () => {
+    test('lists each pack\'s cards as clickable Scryfall links', () => {
+        const container = document.createElement('div');
+        Cube.renderPacks(container, [['Bolt', 'Shock'], ['Forest']]);
+        const packs = container.querySelectorAll('.cube-pack');
+        expect(packs).toHaveLength(2);
+        expect(packs[0].querySelector('h3').textContent).toContain('Pack 1');
+        expect(packs[0].querySelector('.cube-pack-count').textContent).toBe('2 cards');
+        const links = packs[0].querySelectorAll('.cube-card-link');
+        expect(links).toHaveLength(2);
+        expect(links[0].textContent).toBe('Bolt');
+        expect(links[0].getAttribute('href')).toBe(Cube.scryfallCardUrl('Bolt'));
+        expect(packs[1].querySelector('.cube-card-link').textContent).toBe('Forest');
+    });
+});
+
+describe('renderDistribution (the secondary balance bars)', () => {
     test('renders one colour-coded, length-scaled bar per category', () => {
         const container = document.createElement('div');
         Cube.renderDistribution(container, [
@@ -68,38 +133,8 @@ describe('renderDistribution', () => {
         ]);
         const rows = container.querySelectorAll('.cube-bar-row');
         expect(rows).toHaveLength(2);
-
-        const first = rows[0];
-        expect(first.querySelector('.cube-bar-label').textContent).toBe('White');
-        expect(first.querySelector('.cube-bar-value').textContent).toBe('2.00 / pack · 36');
-        // Largest as-fan gets a full-width bar.
-        expect(first.querySelector('.cube-bar-fill').style.width).toBe('100%');
-        // Half the max → quarter… no: 0.5 of 2.0 = 25%.
+        expect(rows[0].querySelector('.cube-bar-value').textContent).toBe('2.00 / pack · 36');
+        expect(rows[0].querySelector('.cube-bar-fill').style.width).toBe('100%');
         expect(rows[1].querySelector('.cube-bar-fill').style.width).toBe('25%');
-    });
-
-    test('replaces any previous bars on re-render', () => {
-        const container = document.createElement('div');
-        Cube.renderDistribution(container, [{ category: 'Red', count: 1, asFan: 1 }]);
-        Cube.renderDistribution(container, [{ category: 'Blue', count: 2, asFan: 2 }]);
-        const rows = container.querySelectorAll('.cube-bar-row');
-        expect(rows).toHaveLength(1);
-        expect(rows[0].querySelector('.cube-bar-label').textContent).toBe('Blue');
-    });
-});
-
-describe('renderPacks', () => {
-    test('renders a titled card with a card list per pack', () => {
-        const container = document.createElement('div');
-        Cube.renderPacks(container, [
-            ['Bolt', 'Shock'],
-            ['Forest'],
-        ]);
-        const packs = container.querySelectorAll('.cube-pack');
-        expect(packs).toHaveLength(2);
-        expect(packs[0].querySelector('h3').textContent).toContain('Pack 1');
-        expect(packs[0].querySelector('.cube-pack-count').textContent).toBe('2 cards');
-        expect(packs[0].querySelectorAll('li')).toHaveLength(2);
-        expect(packs[1].querySelector('li').textContent).toBe('Forest');
     });
 });

--- a/web/src/test/js/cube.test.js
+++ b/web/src/test/js/cube.test.js
@@ -1,0 +1,73 @@
+// Pure-logic tests for the cube workshop page. The URL builders and DOM
+// renderers carry the page's only real logic; pin them so the page can't
+// silently start hitting the wrong endpoint or mis-rendering results.
+
+const Cube = require('../../main/resources/static/js/cube');
+
+describe('formatAsFan', () => {
+    test('formats to two decimal places', () => {
+        expect(Cube.formatAsFan(1.6667)).toBe('1.67');
+        expect(Cube.formatAsFan(2)).toBe('2.00');
+        expect(Cube.formatAsFan(0)).toBe('0.00');
+    });
+});
+
+describe('URL builders', () => {
+    test('asfanUrl carries the three calculator params', () => {
+        expect(Cube.asfanUrl({ total: 60, cubeSize: 540, packSize: 15 }))
+            .toBe('/cube/api/asfan?total=60&cubeSize=540&packSize=15');
+    });
+
+    test('previewUrl url-encodes the query', () => {
+        expect(Cube.previewUrl({ query: 't:dragon c:r', packSize: 15 }))
+            .toBe('/cube/api/preview?query=t%3Adragon+c%3Ar&packSize=15');
+    });
+
+    test('generateUrl encodes the boolean balanced flag', () => {
+        expect(Cube.generateUrl({ query: 'set:vow', packs: 24, packSize: 15, balanced: true }))
+            .toBe('/cube/api/generate?query=set%3Avow&packs=24&packSize=15&balanced=true');
+        expect(Cube.generateUrl({ query: 'set:vow', packs: 8, packSize: 15, balanced: false }))
+            .toBe('/cube/api/generate?query=set%3Avow&packs=8&packSize=15&balanced=false');
+    });
+});
+
+describe('renderDistribution', () => {
+    test('renders one row per category with the as-fan suffix', () => {
+        const tbody = document.createElement('tbody');
+        Cube.renderDistribution(tbody, [
+            { category: 'White', count: 36, asFan: 1.0 },
+            { category: 'Land', count: 18, asFan: 0.5 },
+        ]);
+        const rows = tbody.querySelectorAll('tr');
+        expect(rows).toHaveLength(2);
+        const firstCells = rows[0].querySelectorAll('td');
+        expect(firstCells[0].textContent).toBe('White');
+        expect(firstCells[1].textContent).toBe('36');
+        expect(firstCells[2].textContent).toBe('1.00 / pack');
+    });
+
+    test('replaces any previous rows on re-render', () => {
+        const tbody = document.createElement('tbody');
+        Cube.renderDistribution(tbody, [{ category: 'Red', count: 1, asFan: 1 }]);
+        Cube.renderDistribution(tbody, [{ category: 'Blue', count: 2, asFan: 2 }]);
+        const rows = tbody.querySelectorAll('tr');
+        expect(rows).toHaveLength(1);
+        expect(rows[0].querySelector('td').textContent).toBe('Blue');
+    });
+});
+
+describe('renderPacks', () => {
+    test('renders a titled card with a card list per pack', () => {
+        const container = document.createElement('div');
+        Cube.renderPacks(container, [
+            ['Bolt', 'Shock'],
+            ['Forest'],
+        ]);
+        const packs = container.querySelectorAll('.cube-pack');
+        expect(packs).toHaveLength(2);
+        expect(packs[0].querySelector('h3').textContent).toBe('Pack 1 (2)');
+        expect(packs[0].querySelectorAll('li')).toHaveLength(2);
+        expect(packs[1].querySelector('h3').textContent).toBe('Pack 2 (1)');
+        expect(packs[1].querySelector('li').textContent).toBe('Forest');
+    });
+});

--- a/web/src/test/kotlin/web/controller/CubeControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/CubeControllerTest.kt
@@ -1,0 +1,127 @@
+package web.controller
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.ui.Model
+import web.service.CategoryAsFan
+import web.service.CubeResult
+import web.service.CubeWebService
+import web.service.GenerateData
+import web.service.PreviewData
+
+class CubeControllerTest {
+
+    private lateinit var service: CubeWebService
+    private lateinit var controller: CubeController
+
+    @BeforeEach
+    fun setup() {
+        service = mockk()
+        controller = CubeController(service)
+    }
+
+    @Test
+    fun `page returns the cube template and passes displayName to the model`() {
+        val model = mockk<Model>(relaxed = true)
+        val user = mockk<OAuth2User> { every { getAttribute<String>("username") } returns "matt" }
+
+        assertEquals("cube", controller.page(user, model))
+
+        verify(exactly = 1) { model.addAttribute("username", "matt") }
+    }
+
+    @Test
+    fun `page anon user falls back to literal User`() {
+        val model = mockk<Model>(relaxed = true)
+        controller.page(null, model)
+        verify(exactly = 1) { model.addAttribute("username", "User") }
+    }
+
+    @Test
+    fun `asfan returns 200 with the value on success`() {
+        every { service.asFan(60, 540, 15) } returns CubeResult.ok(1.6667)
+        val response = controller.asFan(60, 540, 15)
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertTrue(response.body!!.ok)
+        assertEquals(1.6667, response.body!!.value)
+    }
+
+    @Test
+    fun `asfan returns 400 with the error on failure`() {
+        every { service.asFan(1, 0, 15) } returns CubeResult.error("Cube size must be positive (was 0)")
+        val response = controller.asFan(1, 0, 15)
+        assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+        assertFalse(response.body!!.ok)
+        assertEquals("Cube size must be positive (was 0)", response.body!!.error)
+    }
+
+    @Test
+    fun `preview returns 200 with the distribution on success`() {
+        val data = PreviewData(
+            query = "set:vow", poolSize = 277, packSize = 15,
+            distribution = listOf(CategoryAsFan("White", 50, 2.7)),
+        )
+        every { service.preview("set:vow", 15) } returns CubeResult.ok(data)
+
+        val response = controller.preview("set:vow", 15)
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertTrue(response.body!!.ok)
+        assertEquals(277, response.body!!.poolSize)
+        assertEquals(1, response.body!!.distribution.size)
+    }
+
+    @Test
+    fun `preview returns 400 on failure`() {
+        every { service.preview("set:zzz", 15) } returns CubeResult.error("No cards matched that query.")
+        val response = controller.preview("set:zzz", 15)
+        assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+        assertFalse(response.body!!.ok)
+        assertEquals("No cards matched that query.", response.body!!.error)
+    }
+
+    @Test
+    fun `generate returns 200 with packs on success`() {
+        val data = GenerateData(
+            query = "cube:vintage", poolSize = 540, packCount = 24, packSize = 15, balanced = true,
+            packs = listOf(listOf("Bolt", "Forest"), listOf("Sol Ring")),
+            distribution = listOf(CategoryAsFan("Red", 100, 2.7)),
+        )
+        every { service.generate("cube:vintage", 24, 15, true) } returns CubeResult.ok(data)
+
+        val response = controller.generate("cube:vintage", 24, 15, true)
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        val body = response.body!!
+        assertTrue(body.ok)
+        assertEquals(24, body.packCount)
+        assertEquals(2, body.packs.size)
+        assertEquals(listOf("Bolt", "Forest"), body.packs.first())
+    }
+
+    @Test
+    fun `generate returns 400 when the pool is too small`() {
+        every { service.generate("t:angel", 24, 15, true) } returns
+            CubeResult.error("Not enough cards: need 360 but the pool only has 30.")
+        val response = controller.generate("t:angel", 24, 15, true)
+        assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+        assertFalse(response.body!!.ok)
+        assertTrue(response.body!!.packs.isEmpty())
+    }
+
+    @Test
+    fun `generate forwards the raw params to the service`() {
+        every { service.generate("set:vow", 8, 15, false) } returns
+            CubeResult.error("whatever")
+        controller.generate("set:vow", 8, 15, false)
+        verify(exactly = 1) { service.generate("set:vow", 8, 15, false) }
+    }
+}

--- a/web/src/test/kotlin/web/controller/CubeControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/CubeControllerTest.kt
@@ -12,6 +12,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.ui.Model
 import web.service.CategoryAsFan
+import web.service.CategoryGroup
 import web.service.CubeResult
 import web.service.CubeWebService
 import web.service.GenerateData
@@ -64,10 +65,10 @@ class CubeControllerTest {
     }
 
     @Test
-    fun `preview returns 200 with the distribution on success`() {
+    fun `preview returns 200 with the card groups on success`() {
         val data = PreviewData(
             query = "set:vow", poolSize = 277, packSize = 15,
-            distribution = listOf(CategoryAsFan("White", 50, 2.7)),
+            groups = listOf(CategoryGroup("White", 50, 2.7, listOf("Sigarda's Splendor", "Sungold Sentinel"))),
         )
         every { service.preview("set:vow", 15) } returns CubeResult.ok(data)
 
@@ -76,7 +77,8 @@ class CubeControllerTest {
         assertEquals(HttpStatus.OK, response.statusCode)
         assertTrue(response.body!!.ok)
         assertEquals(277, response.body!!.poolSize)
-        assertEquals(1, response.body!!.distribution.size)
+        assertEquals(1, response.body!!.groups.size)
+        assertEquals(listOf("Sigarda's Splendor", "Sungold Sentinel"), response.body!!.groups.first().cards)
     }
 
     @Test

--- a/web/src/test/kotlin/web/service/CubeWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/CubeWebServiceTest.kt
@@ -73,6 +73,27 @@ class CubeWebServiceTest {
         assertEquals(2.0, red.asFan, 1e-9)
     }
 
+    // --- groups (cards per category) -----------------------------------
+
+    @Test
+    fun `groups lists the actual card names per category, deduped and alphabetised`() {
+        val pool = listOf(
+            CubeCard("Shock", setOf(MtgColor.RED)),
+            CubeCard("Bolt", setOf(MtgColor.RED)),
+            CubeCard("Bolt", setOf(MtgColor.RED)), // duplicate
+            CubeCard("Swords", setOf(MtgColor.WHITE)),
+            CubeCard("Wastes", isLand = true),
+        )
+        val groups = service.groups(pool, packSize = 5)
+        assertEquals(listOf("White", "Red", "Land"), groups.map { it.category })
+
+        val red = groups.first { it.category == "Red" }
+        assertEquals(listOf("Bolt", "Shock"), red.cards) // deduped + sorted
+        assertEquals(3, red.count) // count still includes the duplicate
+        // 3 red / 5 pool × 5 = 3.0
+        assertEquals(3.0, red.asFan, 1e-9)
+    }
+
     // --- preview (pure validation branch) ------------------------------
 
     @Test

--- a/web/src/test/kotlin/web/service/CubeWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/CubeWebServiceTest.kt
@@ -1,0 +1,89 @@
+package web.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import common.mtg.CardCategory
+import common.mtg.CubeCard
+import common.mtg.MtgColor
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class CubeWebServiceTest {
+
+    private val service = CubeWebService()
+    private val mapper = ObjectMapper()
+
+    // --- asFan ---------------------------------------------------------
+
+    @Test
+    fun `asFan returns the doc's worked example`() {
+        val result = assertInstanceOf(CubeResult.Success::class.java, service.asFan(60, 540, 15))
+        assertEquals(1.6667, result.value as Double, 1e-4)
+    }
+
+    @Test
+    fun `asFan returns a failure for invalid inputs`() {
+        val result = assertInstanceOf(CubeResult.Failure::class.java, service.asFan(1, 0, 15))
+        assertTrue(result.error.contains("Cube size"))
+    }
+
+    // --- parseCards ----------------------------------------------------
+
+    @Test
+    fun `parseCards maps name, colour identity, land flag and mana value`() {
+        val root = mapper.readTree(
+            """
+            {"data":[
+              {"name":"Lightning Bolt","color_identity":["R"],"type_line":"Instant","cmc":1.0},
+              {"name":"Sacred Foundry","color_identity":["R","W"],"type_line":"Land — Mountain Plains","cmc":0.0},
+              {"name":"Sol Ring","color_identity":[],"type_line":"Artifact","cmc":1.0}
+            ]}
+            """.trimIndent()
+        )
+        val cards = service.parseCards(root)
+        assertEquals(3, cards.size)
+        assertEquals(setOf(MtgColor.RED), cards[0].colors)
+        assertEquals(CardCategory.LAND, cards[1].category)
+        assertEquals(CardCategory.COLORLESS, cards[2].category)
+    }
+
+    @Test
+    fun `parseCards skips entries without a name and tolerates a missing data array`() {
+        val root = mapper.readTree("""{"data":[{"type_line":"Instant"},{"name":""}]}""")
+        assertTrue(service.parseCards(root).isEmpty())
+        assertTrue(service.parseCards(mapper.readTree("""{"object":"error"}""")).isEmpty())
+    }
+
+    // --- distribution --------------------------------------------------
+
+    @Test
+    fun `distribution returns present categories in colour-pie order with counts and as-fan`() {
+        val pool = listOf(
+            CubeCard("Bolt", setOf(MtgColor.RED)),
+            CubeCard("Shock", setOf(MtgColor.RED)),
+            CubeCard("Swords", setOf(MtgColor.WHITE)),
+            CubeCard("Wastes", isLand = true),
+        )
+        val dist = service.distribution(pool, packSize = 4)
+        assertEquals(listOf("White", "Red", "Land"), dist.map { it.category })
+        val red = dist.first { it.category == "Red" }
+        assertEquals(2, red.count)
+        // 2 / 4 × 4 = 2.0
+        assertEquals(2.0, red.asFan, 1e-9)
+    }
+
+    // --- preview (pure validation branch) ------------------------------
+
+    @Test
+    fun `preview rejects a non-positive pack size without hitting the network`() {
+        val result = assertInstanceOf(CubeResult.Failure::class.java, service.preview("set:vow", 0))
+        assertTrue(result.error.contains("Pack size"))
+    }
+
+    @Test
+    fun `preview rejects a blank query without hitting the network`() {
+        val result = assertInstanceOf(CubeResult.Failure::class.java, service.preview("   ", 15))
+        assertTrue(result.error.contains("Scryfall"))
+    }
+}


### PR DESCRIPTION
## What & why

Implements the cube-design **tool** described in [the linked doc](`https://docs.google.com/document/d/e/2PACX-1vQffWfdMahLzO5VDiL6hMGUYw8OPCmKrgiI1nwrNk77dk13UbDOYybA1-YvaVDKQEnnuqxIgelA9LQ1`/pub): take a Magic: The Gathering card pool, draw a random subset, and deal it into evenly-sized booster packs while keeping the **as-fan** distribution (colours / colourless / lands) level across packs — plus the **as-fan calculator** (`(type ÷ cube size) × pack size`).

> Note on scope: the doc's "open a pack, pick, pass left" passage describes *what drafting is* as background; the **tool** it specifies is the cube preparation + as-fan, which is what this PR builds. A live-draft engine is intentionally out of scope.

Cards come from the **Scryfall search API**, so a "cube" is just a Scryfall query (`cube:vintage`, `set:vow`, `t:dragon`, …).

## Layers

**Pure domain — `common.mtg`** (no Spring/JDA, fully unit-tested):
- `MtgColor`, `CubeCard` / `CardCategory` (colour-pie + multicolour / colourless / land buckets)
- `AsFan` — the calculator and per-category distribution
- `PackGenerator` — random selection + a balanced deal that provably keeps every category's per-pack count within one (category-blocked round-robin), so no pack is land-flooded or mono-colour by luck of the shuffle

**Discord — `/cube`** (`bot.toby.command.commands.mtg`):
- `asfan` — the calculator
- `preview` — as-fan distribution of a query's cards
- `generate` — draws a pool and deals balanced packs; the full 24×15 list rides along as a text-file attachment
- `ScryfallCubeFetcher` mirrors `MemeCommand`'s injectable Apache `HttpClient` + Gson (paginated, with a `parseCard` test seam)

**Web — `/cube` workshop page** (no login required, like `/dnd` and `/utils`):
- `CubeController` + `CubeWebService` (java.net.http + Jackson, reusing the same `common.mtg` maths so Discord and web can't drift)
- Thymeleaf page + `cube.js` + `cube.css`, linked from the Tools nav

Also wires an **`mtg`** command category into `CommandManager` (default-empty so existing mocks stay green), the home-page command count, and the commands wiki.

## Testing

Thorough tests at every layer:
- `common.mtg`: `MtgColorTest`, `CubeCardTest`, `AsFanTest` (incl. the doc's worked 60/540/15 → 1.67 example), `PackGeneratorTest` (sizes, no-dupes, failure modes, balanced-spread ≤ 1, determinism)
- `discord-bot`: `ScryfallCubeFetcherTest` (parse + paginated fetch + error mapping via mocked `HttpClient`), `CubeCommandTest` (all three subcommands, file attach, error paths, option metadata)
- `web`: `CubeWebServiceTest` (as-fan, `parseCards`, distribution, validation branches), `CubeControllerTest`, and `cube.test.js` (URL builders + DOM renderers)

Ran locally (green): `:common`, `:core-api`, `:discord-bot`, `:web` test suites, the `cube.js` Jest suite, and `stylelint` on `cube.css`. The `:application` Testcontainers integration test (`CommandManagerTest`, which I updated to include `CubeCommand`) needs Docker and will run on CI.

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs

---
_Generated by [Claude Code](https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs)_