### PR TITLE
Draft from your own card list, saved to your account

### DIFF
--- a/database/src/main/kotlin/database/dto/user/CubeListDto.kt
+++ b/database/src/main/kotlin/database/dto/user/CubeListDto.kt
@@ -1,0 +1,55 @@
+package database.dto.user
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.NamedQueries
+import jakarta.persistence.NamedQuery
+import jakarta.persistence.Table
+import org.springframework.transaction.annotation.Transactional
+import java.io.Serializable
+import java.time.Instant
+
+/**
+ * A cube card list a user saved on the `/cube` web tool, keyed by
+ * (discord_id, name) so a name is unique per account and re-saving the same
+ * name upserts. `cards` is the raw pasted text (one card per line); the web
+ * layer re-parses it on load so the format can evolve without a migration.
+ *
+ * Composite key via two `@Id` fields + `Serializable`, matching [UserDto].
+ */
+@NamedQueries(
+    NamedQuery(
+        name = "CubeListDto.listForUser",
+        query = "select c from CubeListDto c where c.discordId = :discordId order by c.name"
+    ),
+    NamedQuery(
+        name = "CubeListDto.get",
+        query = "select c from CubeListDto c where c.discordId = :discordId and c.name = :name"
+    ),
+    NamedQuery(
+        name = "CubeListDto.deleteByUserAndName",
+        query = "delete from CubeListDto c where c.discordId = :discordId and c.name = :name"
+    )
+)
+@Entity
+@Table(name = "cube_list", schema = "public")
+@Transactional
+class CubeListDto(
+    @Id
+    @Column(name = "discord_id")
+    var discordId: Long = 0,
+
+    @Id
+    @Column(name = "name")
+    var name: String = "",
+
+    @Column(name = "cards", nullable = false)
+    var cards: String = "",
+
+    @Column(name = "created_at", nullable = false)
+    var createdAt: Instant = Instant.now(),
+
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: Instant = Instant.now(),
+) : Serializable

--- a/database/src/main/kotlin/database/persistence/user/CubeListPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/user/CubeListPersistence.kt
@@ -1,0 +1,19 @@
+package database.persistence.user
+
+import database.dto.user.CubeListDto
+
+interface CubeListPersistence {
+    fun listForUser(discordId: Long): List<CubeListDto>
+
+    fun get(discordId: Long, name: String): CubeListDto?
+
+    /**
+     * Insert when no row matches the (discord_id, name) key; otherwise refresh
+     * the existing row's `cards` and `updated_at`. Re-saving a list under a
+     * name the user already used overwrites it rather than erroring.
+     */
+    fun upsert(row: CubeListDto): CubeListDto
+
+    /** Idempotent — returns the number of rows actually removed (0 or 1). */
+    fun delete(discordId: Long, name: String): Int
+}

--- a/database/src/main/kotlin/database/persistence/user/impl/DefaultCubeListPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/user/impl/DefaultCubeListPersistence.kt
@@ -1,0 +1,54 @@
+package database.persistence.user.impl
+
+import database.dto.user.CubeListDto
+import database.persistence.user.CubeListPersistence
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import jakarta.persistence.TypedQuery
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+
+@Repository
+@Transactional
+class DefaultCubeListPersistence : CubeListPersistence {
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    override fun listForUser(discordId: Long): List<CubeListDto> {
+        val q: TypedQuery<CubeListDto> =
+            entityManager.createNamedQuery("CubeListDto.listForUser", CubeListDto::class.java)
+        q.setParameter("discordId", discordId)
+        return q.resultList
+    }
+
+    override fun get(discordId: Long, name: String): CubeListDto? {
+        val q: TypedQuery<CubeListDto> =
+            entityManager.createNamedQuery("CubeListDto.get", CubeListDto::class.java)
+        q.setParameter("discordId", discordId)
+        q.setParameter("name", name)
+        return q.resultList.firstOrNull()
+    }
+
+    override fun upsert(row: CubeListDto): CubeListDto {
+        val existing = get(row.discordId, row.name)
+        return if (existing == null) {
+            entityManager.persist(row)
+            entityManager.flush()
+            row
+        } else {
+            existing.cards = row.cards
+            existing.updatedAt = row.updatedAt
+            entityManager.merge(existing)
+            entityManager.flush()
+            existing
+        }
+    }
+
+    override fun delete(discordId: Long, name: String): Int {
+        val q = entityManager.createNamedQuery("CubeListDto.deleteByUserAndName")
+        q.setParameter("discordId", discordId)
+        q.setParameter("name", name)
+        return q.executeUpdate()
+    }
+}

--- a/database/src/main/kotlin/database/service/user/CubeListService.kt
+++ b/database/src/main/kotlin/database/service/user/CubeListService.kt
@@ -1,0 +1,20 @@
+package database.service.user
+
+import database.dto.user.CubeListDto
+import java.time.Instant
+
+interface CubeListService {
+    fun listForUser(discordId: Long): List<CubeListDto>
+
+    fun get(discordId: Long, name: String): CubeListDto?
+
+    /**
+     * Save (or overwrite) the list named [name] for [discordId]. Idempotent
+     * on the name: re-saving refreshes the cards and bumps `updated_at` while
+     * preserving the original `created_at`.
+     */
+    fun save(discordId: Long, name: String, cards: String, at: Instant = Instant.now()): CubeListDto
+
+    /** Idempotent — true if a row was actually removed. */
+    fun delete(discordId: Long, name: String): Boolean
+}

--- a/database/src/main/kotlin/database/service/user/impl/DefaultCubeListService.kt
+++ b/database/src/main/kotlin/database/service/user/impl/DefaultCubeListService.kt
@@ -1,0 +1,35 @@
+package database.service.user.impl
+
+import database.dto.user.CubeListDto
+import database.persistence.user.CubeListPersistence
+import database.service.user.CubeListService
+import org.springframework.stereotype.Service
+import java.time.Instant
+
+@Service
+class DefaultCubeListService(
+    private val persistence: CubeListPersistence,
+) : CubeListService {
+
+    override fun listForUser(discordId: Long): List<CubeListDto> =
+        persistence.listForUser(discordId)
+
+    override fun get(discordId: Long, name: String): CubeListDto? =
+        persistence.get(discordId, name)
+
+    override fun save(discordId: Long, name: String, cards: String, at: Instant): CubeListDto {
+        val existing = persistence.get(discordId, name)
+        return persistence.upsert(
+            CubeListDto(
+                discordId = discordId,
+                name = name,
+                cards = cards,
+                createdAt = existing?.createdAt ?: at,
+                updatedAt = at,
+            )
+        )
+    }
+
+    override fun delete(discordId: Long, name: String): Boolean =
+        persistence.delete(discordId, name) > 0
+}

--- a/database/src/main/resources/db/migration/V45__cube_list.sql
+++ b/database/src/main/resources/db/migration/V45__cube_list.sql
@@ -1,0 +1,16 @@
+-- Per-user saved cube lists for the `/cube` web tool. A user pastes a card
+-- list, names it, and it's stored against their Discord account so they can
+-- reload it later from any device.
+--
+-- A name is unique per user, so the natural key is (discord_id, name); the
+-- PK doubles as the "list this user's cubes" index since discord_id is its
+-- leading column. Re-saving an existing name upserts (refreshes `cards` and
+-- `updated_at`).
+CREATE TABLE cube_list (
+    discord_id BIGINT       NOT NULL,
+    name       VARCHAR(100) NOT NULL,
+    cards      TEXT         NOT NULL,
+    created_at TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    PRIMARY KEY (discord_id, name)
+);

--- a/database/src/test/kotlin/database/service/DefaultCubeListServiceTest.kt
+++ b/database/src/test/kotlin/database/service/DefaultCubeListServiceTest.kt
@@ -1,0 +1,104 @@
+package database.service
+
+import database.dto.user.CubeListDto
+import database.persistence.user.CubeListPersistence
+import database.service.user.impl.DefaultCubeListService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class DefaultCubeListServiceTest {
+
+    private val discordId = 100L
+
+    private lateinit var persistence: InMemoryCubeListPersistence
+    private lateinit var service: DefaultCubeListService
+
+    @BeforeEach
+    fun setup() {
+        persistence = InMemoryCubeListPersistence()
+        service = DefaultCubeListService(persistence)
+    }
+
+    @Test
+    fun `save persists a new list and listForUser returns it`() {
+        val at = Instant.parse("2026-06-05T10:00:00Z")
+        val row = service.save(discordId, "My Cube", "Lightning Bolt\nForest", at)
+        assertEquals("My Cube", row.name)
+        assertEquals("Lightning Bolt\nForest", row.cards)
+        assertEquals(at, row.createdAt)
+        assertEquals(at, row.updatedAt)
+
+        val list = service.listForUser(discordId)
+        assertEquals(1, list.size)
+        assertEquals("My Cube", list[0].name)
+    }
+
+    @Test
+    fun `re-saving the same name overwrites cards and bumps updatedAt but keeps createdAt`() {
+        val first = Instant.parse("2026-06-05T10:00:00Z")
+        val second = Instant.parse("2026-06-06T10:00:00Z")
+        service.save(discordId, "My Cube", "Bolt", first)
+        val updated = service.save(discordId, "My Cube", "Bolt\nShock", second)
+
+        assertEquals("Bolt\nShock", updated.cards)
+        assertEquals(first, updated.createdAt, "createdAt should be preserved")
+        assertEquals(second, updated.updatedAt)
+        // Still a single list under that name.
+        assertEquals(1, service.listForUser(discordId).size)
+    }
+
+    @Test
+    fun `lists are scoped per user`() {
+        service.save(discordId, "Mine", "Bolt")
+        service.save(200L, "Theirs", "Shock")
+        assertEquals(listOf("Mine"), service.listForUser(discordId).map { it.name })
+        assertEquals(listOf("Theirs"), service.listForUser(200L).map { it.name })
+    }
+
+    @Test
+    fun `get returns a saved list or null`() {
+        service.save(discordId, "My Cube", "Bolt")
+        assertEquals("Bolt", service.get(discordId, "My Cube")?.cards)
+        assertNull(service.get(discordId, "Nope"))
+        assertNull(service.get(999L, "My Cube"))
+    }
+
+    @Test
+    fun `delete removes the list and reports whether anything was removed`() {
+        service.save(discordId, "My Cube", "Bolt")
+        assertTrue(service.delete(discordId, "My Cube"))
+        assertFalse(service.delete(discordId, "My Cube")) // already gone
+        assertTrue(service.listForUser(discordId).isEmpty())
+    }
+
+    /** Minimal in-memory stand-in for the JPA-backed persistence. */
+    private class InMemoryCubeListPersistence : CubeListPersistence {
+        private val store = linkedMapOf<Pair<Long, String>, CubeListDto>()
+
+        override fun listForUser(discordId: Long): List<CubeListDto> =
+            store.values.filter { it.discordId == discordId }.sortedBy { it.name }
+
+        override fun get(discordId: Long, name: String): CubeListDto? = store[discordId to name]
+
+        override fun upsert(row: CubeListDto): CubeListDto {
+            val key = row.discordId to row.name
+            val existing = store[key]
+            return if (existing == null) {
+                store[key] = row
+                row
+            } else {
+                existing.cards = row.cards
+                existing.updatedAt = row.updatedAt
+                existing
+            }
+        }
+
+        override fun delete(discordId: Long, name: String): Int =
+            if (store.remove(discordId to name) != null) 1 else 0
+    }
+}

--- a/web/src/main/kotlin/web/configuration/WebSecurityConfig.kt
+++ b/web/src/main/kotlin/web/configuration/WebSecurityConfig.kt
@@ -21,7 +21,10 @@ class WebSecurityConfig {
                     "/v3/api-docs/**", "/swagger-ui/**", "/login", "/error",
                     "/images/**", "/js/**", "/css/**",
                     "/dnd", "/dnd/**",
-                    "/cube", "/cube/**",
+                    // The cube tool's page and its anonymous lookups are public;
+                    // the saved-lists API (/cube/api/lists) is deliberately NOT
+                    // listed here so it falls through to anyRequest().authenticated().
+                    "/cube", "/cube/api/asfan", "/cube/api/preview", "/cube/api/generate",
                     "/sitemap.xml", "/robots.txt",
                     // Service worker for web push must be reachable
                     // unauthenticated — the browser registers it on
@@ -67,6 +70,12 @@ class WebSecurityConfig {
                 csrf.ignoringRequestMatchers(
                     "/v3/api-docs/**", "/swagger-ui/**",
                     "/api/engagement/**",
+                    // The cube tool's write endpoints: the anonymous custom-list
+                    // preview/generate POSTs are stateless read-only lookups, and
+                    // the saved-lists PUT/DELETE operate only on the authenticated
+                    // user's own rows (discord id from the session) — same per-user
+                    // ownership rationale as the engagement API below.
+                    "/cube/api/**",
                     // Push subscription lifecycle (subscribe / unsubscribe)
                     // is called from the same authenticated dashboard JS
                     // and protected by the same OAuth2 session + per-user

--- a/web/src/main/kotlin/web/controller/CubeController.kt
+++ b/web/src/main/kotlin/web/controller/CubeController.kt
@@ -1,11 +1,16 @@
 package web.controller
 
+import database.service.user.CubeListService
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseBody
@@ -14,18 +19,28 @@ import web.service.CategoryAsFan
 import web.service.CategoryGroup
 import web.service.CubeResult
 import web.service.CubeWebService
+import web.service.GenerateData
+import web.service.PreviewData
+import web.util.discordIdOrNull
 import web.util.displayName
 
 /**
  * Public web surface for the MTG cube tool — the same as-fan maths and
  * pack generation as the `/cube` Discord command, no login required (like
- * `/dnd` and `/utils`). GET renders the page; the `/api/...` GET endpoints
- * return JSON the page's JS renders.
+ * `/dnd` and `/utils`). GET renders the page. The `/api/...` GET endpoints
+ * take a Scryfall query; the POST variants take the user's own pasted card
+ * list (too large for a query string) — both return the same JSON.
+ *
+ * Saving a list is account-bound: the `/api/lists` endpoints require a
+ * logged-in Discord user and persist per-user via [CubeListService], so a
+ * saved cube follows the user across devices (unlike the rest of the page,
+ * which is anonymous).
  */
 @Controller
 @RequestMapping("/cube")
 class CubeController(
     private val cubeWebService: CubeWebService,
+    private val cubeLists: CubeListService,
 ) {
 
     @GetMapping
@@ -34,6 +49,8 @@ class CubeController(
         model: Model,
     ): String {
         model.addAttribute("username", user.displayName())
+        // Drives the saved-lists UI: only logged-in users can save/load.
+        model.addAttribute("loggedIn", user != null)
         return "cube"
     }
 
@@ -54,13 +71,14 @@ class CubeController(
     fun preview(
         @RequestParam("query") query: String,
         @RequestParam("packSize", defaultValue = "15") packSize: Int,
+    ): ResponseEntity<CubePreviewResponse> = previewResponse(cubeWebService.preview(query, packSize))
+
+    @PostMapping("/api/preview", consumes = ["application/json"], produces = ["application/json"])
+    @ResponseBody
+    fun previewList(
+        @RequestBody request: CubeListPreviewRequest,
     ): ResponseEntity<CubePreviewResponse> =
-        when (val result = cubeWebService.preview(query, packSize)) {
-            is CubeResult.Success -> ResponseEntity.ok(
-                CubePreviewResponse(true, null, result.value.poolSize, result.value.groups)
-            )
-            is CubeResult.Failure -> ResponseEntity.badRequest().body(CubePreviewResponse(false, result.error, 0, emptyList()))
-        }
+        previewResponse(cubeWebService.previewList(request.list, request.packSize))
 
     @GetMapping("/api/generate", produces = ["application/json"])
     @ResponseBody
@@ -70,7 +88,26 @@ class CubeController(
         @RequestParam("packSize", defaultValue = "15") packSize: Int,
         @RequestParam("balanced", defaultValue = "true") balanced: Boolean,
     ): ResponseEntity<CubeGenerateResponse> =
-        when (val result = cubeWebService.generate(query, packs, packSize, balanced)) {
+        generateResponse(cubeWebService.generate(query, packs, packSize, balanced))
+
+    @PostMapping("/api/generate", consumes = ["application/json"], produces = ["application/json"])
+    @ResponseBody
+    fun generateList(
+        @RequestBody request: CubeListGenerateRequest,
+    ): ResponseEntity<CubeGenerateResponse> =
+        generateResponse(cubeWebService.generateList(request.list, request.packs, request.packSize, request.balanced))
+
+    private fun previewResponse(result: CubeResult<PreviewData>): ResponseEntity<CubePreviewResponse> =
+        when (result) {
+            is CubeResult.Success -> ResponseEntity.ok(
+                CubePreviewResponse(true, null, result.value.poolSize, result.value.groups, result.value.notFound)
+            )
+            is CubeResult.Failure ->
+                ResponseEntity.badRequest().body(CubePreviewResponse(false, result.error, 0, emptyList(), emptyList()))
+        }
+
+    private fun generateResponse(result: CubeResult<GenerateData>): ResponseEntity<CubeGenerateResponse> =
+        when (result) {
             is CubeResult.Success -> ResponseEntity.ok(
                 CubeGenerateResponse(
                     ok = true,
@@ -80,13 +117,75 @@ class CubeController(
                     packSize = result.value.packSize,
                     packs = result.value.packs,
                     distribution = result.value.distribution,
+                    notFound = result.value.notFound,
                 )
             )
             is CubeResult.Failure -> ResponseEntity.badRequest().body(
-                CubeGenerateResponse(false, result.error, 0, 0, 0, emptyList(), emptyList())
+                CubeGenerateResponse(false, result.error, 0, 0, 0, emptyList(), emptyList(), emptyList())
             )
         }
+
+    // --- Saved lists (account-bound; require a logged-in Discord user) ---
+
+    @GetMapping("/api/lists", produces = ["application/json"])
+    @ResponseBody
+    fun savedLists(@AuthenticationPrincipal user: OAuth2User?): ResponseEntity<List<SavedCubeList>> {
+        val discordId = user?.discordIdOrNull() ?: return ResponseEntity.status(401).build()
+        val rows = cubeLists.listForUser(discordId).map {
+            SavedCubeList(it.name, it.cards, it.updatedAt.toString())
+        }
+        return ResponseEntity.ok(rows)
+    }
+
+    @PutMapping("/api/lists", consumes = ["application/json"], produces = ["application/json"])
+    @ResponseBody
+    fun saveList(
+        @RequestBody request: SaveCubeListRequest,
+        @AuthenticationPrincipal user: OAuth2User?,
+    ): ResponseEntity<SavedCubeList> {
+        val discordId = user?.discordIdOrNull() ?: return ResponseEntity.status(401).build()
+        val name = request.name.trim()
+        if (name.isEmpty() || name.length > MAX_NAME_LENGTH || request.cards.isBlank()) {
+            return ResponseEntity.badRequest().build()
+        }
+        // Cap how many cubes one account can hoard; overwriting an existing
+        // name is always allowed.
+        if (cubeLists.get(discordId, name) == null && cubeLists.listForUser(discordId).size >= MAX_LISTS_PER_USER) {
+            return ResponseEntity.status(409).build()
+        }
+        val row = cubeLists.save(discordId, name, request.cards)
+        return ResponseEntity.ok(SavedCubeList(row.name, row.cards, row.updatedAt.toString()))
+    }
+
+    @DeleteMapping("/api/lists")
+    @ResponseBody
+    fun deleteList(
+        @RequestParam("name") name: String,
+        @AuthenticationPrincipal user: OAuth2User?,
+    ): ResponseEntity<Void> {
+        val discordId = user?.discordIdOrNull() ?: return ResponseEntity.status(401).build()
+        cubeLists.delete(discordId, name)
+        return ResponseEntity.noContent().build()
+    }
+
+    private companion object {
+        const val MAX_NAME_LENGTH = 100
+        const val MAX_LISTS_PER_USER = 50
+    }
 }
+
+data class CubeListPreviewRequest(val list: String = "", val packSize: Int = 15)
+
+data class CubeListGenerateRequest(
+    val list: String = "",
+    val packs: Int = 24,
+    val packSize: Int = 15,
+    val balanced: Boolean = true,
+)
+
+data class SaveCubeListRequest(val name: String = "", val cards: String = "")
+
+data class SavedCubeList(val name: String, val cards: String, val updatedAt: String)
 
 data class CubeAsFanResponse(val ok: Boolean, val error: String?, val value: Double?)
 
@@ -95,6 +194,7 @@ data class CubePreviewResponse(
     val error: String?,
     val poolSize: Int,
     val groups: List<CategoryGroup>,
+    val notFound: List<String> = emptyList(),
 )
 
 data class CubeGenerateResponse(
@@ -105,4 +205,5 @@ data class CubeGenerateResponse(
     val packSize: Int,
     val packs: List<List<CardView>>,
     val distribution: List<CategoryAsFan>,
+    val notFound: List<String> = emptyList(),
 )

--- a/web/src/main/kotlin/web/service/CubeWebService.kt
+++ b/web/src/main/kotlin/web/service/CubeWebService.kt
@@ -45,41 +45,78 @@ class CubeWebService {
         if (packSize <= 0) return CubeResult.error("Pack size must be at least 1.")
         return when (val pool = fetchPool(query)) {
             is CubeResult.Failure -> CubeResult.error(pool.error)
+            is CubeResult.Success -> CubeResult.ok(buildPreview(query.trim(), pool.value, packSize, emptyList()))
+        }
+    }
+
+    /**
+     * Like [preview] but the pool is the user's own pasted card list,
+     * resolved against Scryfall, rather than a search query.
+     */
+    fun previewList(list: String, packSize: Int): CubeResult<PreviewData> {
+        if (packSize <= 0) return CubeResult.error("Pack size must be at least 1.")
+        return when (val resolved = resolveList(list)) {
+            is CubeResult.Failure -> CubeResult.error(resolved.error)
             is CubeResult.Success -> CubeResult.ok(
-                PreviewData(
-                    query = query.trim(),
-                    poolSize = pool.value.size,
-                    packSize = packSize,
-                    groups = groups(pool.value, packSize),
-                )
+                buildPreview("your list", resolved.value.cards, packSize, resolved.value.notFound)
             )
         }
     }
 
-    /** Draws a cube from Scryfall and deals balanced packs. */
-    fun generate(query: String, packCount: Int, packSize: Int, balanced: Boolean): CubeResult<GenerateData> {
-        return when (val pool = fetchPool(query)) {
+    /** Draws a cube from a Scryfall query and deals balanced packs. */
+    fun generate(query: String, packCount: Int, packSize: Int, balanced: Boolean): CubeResult<GenerateData> =
+        when (val pool = fetchPool(query)) {
             is CubeResult.Failure -> CubeResult.error(pool.error)
-            is CubeResult.Success -> {
-                val cards = pool.value.map { it.card }
-                val viewByName = pool.value.associate { it.card.name to it.toView() }
-                when (val packs = PackGenerator(Random.Default).generate(cards, packCount, packSize, balanced)) {
-                    is PackGenerator.Result.Failure -> CubeResult.error(packs.reason)
-                    is PackGenerator.Result.Success -> CubeResult.ok(
-                        GenerateData(
-                            query = query.trim(),
-                            poolSize = pool.value.size,
-                            packCount = packCount,
-                            packSize = packSize,
-                            balanced = balanced,
-                            packs = packs.value.packs.map { pack ->
-                                pack.map { viewByName[it.name] ?: CardView(it.name, null, null, it.typeLine, it.manaValue) }
-                            },
-                            distribution = distribution(packs.value.cards, packSize),
-                        )
-                    )
-                }
-            }
+            is CubeResult.Success -> buildGenerate(query.trim(), pool.value, packCount, packSize, balanced, emptyList())
+        }
+
+    /** Like [generate] but deals from the user's own pasted card list. */
+    fun generateList(list: String, packCount: Int, packSize: Int, balanced: Boolean): CubeResult<GenerateData> =
+        when (val resolved = resolveList(list)) {
+            is CubeResult.Failure -> CubeResult.error(resolved.error)
+            is CubeResult.Success ->
+                buildGenerate("your list", resolved.value.cards, packCount, packSize, balanced, resolved.value.notFound)
+        }
+
+    private fun buildPreview(
+        label: String,
+        pool: List<ScryfallCard>,
+        packSize: Int,
+        notFound: List<String>,
+    ): PreviewData = PreviewData(
+        query = label,
+        poolSize = pool.size,
+        packSize = packSize,
+        groups = groups(pool, packSize),
+        notFound = notFound,
+    )
+
+    private fun buildGenerate(
+        label: String,
+        pool: List<ScryfallCard>,
+        packCount: Int,
+        packSize: Int,
+        balanced: Boolean,
+        notFound: List<String>,
+    ): CubeResult<GenerateData> {
+        val cards = pool.map { it.card }
+        val viewByName = pool.associate { it.card.name to it.toView() }
+        return when (val packs = PackGenerator(Random.Default).generate(cards, packCount, packSize, balanced)) {
+            is PackGenerator.Result.Failure -> CubeResult.error(packs.reason)
+            is PackGenerator.Result.Success -> CubeResult.ok(
+                GenerateData(
+                    query = label,
+                    poolSize = pool.size,
+                    packCount = packCount,
+                    packSize = packSize,
+                    balanced = balanced,
+                    packs = packs.value.packs.map { pack ->
+                        pack.map { viewByName[it.name] ?: CardView(it.name, null, null, it.typeLine, it.manaValue) }
+                    },
+                    distribution = distribution(packs.value.cards, packSize),
+                    notFound = notFound,
+                )
+            )
         }
     }
 
@@ -212,10 +249,89 @@ class CubeWebService {
         return "$SEARCH_ENDPOINT?q=$encoded&unique=cards"
     }
 
+    /**
+     * Parses a pasted decklist into (name, count) entries. Accepts one card
+     * per line, with an optional leading quantity (`3 Forest`, `3x Forest`)
+     * and an optional trailing set/collector tag (`Bolt (2X2) 117`). Blank
+     * lines and `#` / `//` comments are ignored.
+     */
+    fun parseList(text: String): List<ListEntry> =
+        text.lineSequence().mapNotNull { raw ->
+            var line = raw.trim()
+            if (line.isEmpty() || line.startsWith("#") || line.startsWith("//")) return@mapNotNull null
+            var count = 1
+            QUANTITY_PREFIX.find(line)?.let { m ->
+                count = m.groupValues[1].toIntOrNull()?.coerceIn(1, MAX_PER_NAME) ?: 1
+                line = line.substring(m.range.last + 1).trim()
+            }
+            line = line.replace(SET_SUFFIX, "").trim()
+            if (line.isEmpty()) null else ListEntry(line, count)
+        }.toList()
+
+    /**
+     * Resolves a pasted list into a card pool by looking the names up via
+     * Scryfall's `/cards/collection` endpoint (batched, ≤75 per request).
+     * Quantities expand the pool (`3 Forest` → three Forests); names that
+     * don't resolve are reported in [ResolvedPool.notFound].
+     */
+    private fun resolveList(text: String): CubeResult<ResolvedPool> {
+        val entries = parseList(text)
+        if (entries.isEmpty()) return CubeResult.error("Paste at least one card name, one per line.")
+
+        val resolved = HashMap<String, ScryfallCard>()
+        for (chunk in entries.map { it.name }.distinct().chunked(COLLECTION_BATCH)) {
+            when (val batch = fetchCollection(chunk)) {
+                is CubeResult.Failure -> return CubeResult.error(batch.error)
+                is CubeResult.Success -> batch.value.forEach { resolved[it.card.name.lowercase()] = it }
+            }
+        }
+
+        val pool = mutableListOf<ScryfallCard>()
+        val notFound = mutableListOf<String>()
+        for (entry in entries) {
+            val card = resolved[entry.name.lowercase()]
+            if (card == null) notFound.add(entry.name) else repeat(entry.count) { pool.add(card) }
+        }
+        if (pool.isEmpty()) return CubeResult.error("None of those card names matched Scryfall. Check the spelling?")
+        return CubeResult.ok(ResolvedPool(pool.take(MAX_CARDS), notFound.distinct()))
+    }
+
+    /** One `/cards/collection` POST for up to 75 names. */
+    private fun fetchCollection(names: List<String>): CubeResult<List<ScryfallCard>> {
+        val identifiers = names.joinToString(",") { """{"name":${jackson.writeValueAsString(it)}}""" }
+        val body = """{"identifiers":[$identifiers]}"""
+        return try {
+            val response = http.send(
+                HttpRequest.newBuilder(URI.create(COLLECTION_ENDPOINT))
+                    .header("User-Agent", "tobybot-web/1.0")
+                    .header("Accept", "application/json")
+                    .header("Content-Type", "application/json")
+                    .timeout(Duration.ofSeconds(10))
+                    .POST(HttpRequest.BodyPublishers.ofString(body))
+                    .build(),
+                HttpResponse.BodyHandlers.ofString(),
+            )
+            if (response.statusCode() != 200) {
+                return CubeResult.error("Scryfall returned ${response.statusCode()} resolving your list.")
+            }
+            CubeResult.ok(parseScryfall(jackson.readTree(response.body())))
+        } catch (e: IOException) {
+            CubeResult.error("Could not reach Scryfall: ${e.message}")
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            CubeResult.error("Request interrupted.")
+        }
+    }
+
     private companion object {
         const val SEARCH_ENDPOINT = "https://api.scryfall.com/cards/search"
+        const val COLLECTION_ENDPOINT = "https://api.scryfall.com/cards/collection"
         const val MAX_CARDS = 750
         const val MAX_PAGES = 10
+        const val COLLECTION_BATCH = 75
+        const val MAX_PER_NAME = 100
+        val QUANTITY_PREFIX = Regex("^(\\d+)[xX]?\\s+")
+        val SET_SUFFIX = Regex("\\s+\\([^)]*\\).*$")
     }
 }
 
@@ -258,11 +374,18 @@ data class CategoryGroup(
     val cards: List<CardView>,
 )
 
+/** One parsed decklist line: a card name and how many copies to include. */
+data class ListEntry(val name: String, val count: Int)
+
+/** A resolved custom list: the card pool plus any names Scryfall didn't know. */
+data class ResolvedPool(val cards: List<ScryfallCard>, val notFound: List<String>)
+
 data class PreviewData(
     val query: String,
     val poolSize: Int,
     val packSize: Int,
     val groups: List<CategoryGroup>,
+    val notFound: List<String> = emptyList(),
 )
 
 data class GenerateData(
@@ -273,4 +396,5 @@ data class GenerateData(
     val balanced: Boolean,
     val packs: List<List<CardView>>,
     val distribution: List<CategoryAsFan>,
+    val notFound: List<String> = emptyList(),
 )

--- a/web/src/main/resources/static/css/cube.css
+++ b/web/src/main/resources/static/css/cube.css
@@ -193,6 +193,116 @@
     color: var(--mtg-gold);
 }
 
+/* --- Card source card (search vs paste-a-list) --------------------- */
+
+.cube-source-card {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--mtg-gold-border);
+    border-radius: var(--radius-md);
+    padding: var(--space-4) var(--space-5);
+    margin-bottom: var(--space-5);
+}
+
+.cube-source-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: var(--space-3);
+    margin-bottom: var(--space-3);
+}
+
+.cube-source-head h2 {
+    margin: 0;
+    font-size: 1.1rem;
+}
+
+.cube-source-note {
+    font-size: 0.78rem;
+    color: var(--text-dim);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+}
+
+.cube-source-toggle {
+    display: inline-flex;
+    gap: 4px;
+    padding: 4px;
+    margin-bottom: var(--space-3);
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+}
+
+.cube-source-btn {
+    padding: 6px 14px;
+    background: transparent;
+    border: 0;
+    border-radius: var(--radius-sm);
+    color: var(--text-muted);
+    font: inherit;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.cube-source-btn[aria-selected="true"] {
+    background: var(--mtg-gold-soft);
+    color: var(--mtg-gold);
+    box-shadow: inset 0 0 0 1px var(--mtg-gold-border);
+}
+
+.cube-listlabel {
+    display: grid;
+    gap: 4px;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+
+.cube-listlabel textarea {
+    width: 100%;
+    box-sizing: border-box;
+    resize: vertical;
+    padding: 10px;
+    background: var(--bg-input);
+    color: var(--text);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-sm);
+    font: inherit;
+    line-height: 1.5;
+}
+
+.cube-listlabel textarea:focus {
+    outline: none;
+    border-color: var(--mtg-gold);
+    box-shadow: 0 0 0 2px var(--mtg-gold-soft);
+}
+
+.cube-saved {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-2);
+    margin-top: var(--space-3);
+}
+
+.cube-saved select {
+    padding: 6px 10px;
+    background: var(--bg-input);
+    color: var(--text);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-sm);
+    font: inherit;
+    min-width: 160px;
+}
+
+.cube-saved-status:empty {
+    display: none;
+}
+
+.cube-saved-login {
+    margin-top: var(--space-3);
+}
+
 /* --- Panels & forms ------------------------------------------------- */
 
 .cube-panel {
@@ -330,6 +440,20 @@ button:disabled {
 }
 
 .cube-empty[hidden] {
+    display: none;
+}
+
+.cube-notfound {
+    margin: var(--space-2) 0 0;
+    padding: 8px 12px;
+    background: var(--warn-soft);
+    border: 1px solid var(--warn);
+    border-radius: var(--radius-sm);
+    color: var(--text);
+    font-size: 0.85rem;
+}
+
+.cube-notfound[hidden] {
     display: none;
 }
 

--- a/web/src/main/resources/static/js/cube.js
+++ b/web/src/main/resources/static/js/cube.js
@@ -312,10 +312,154 @@
         return fetch(url).then(function (r) { return r.json(); });
     }
 
+    function postJson(url, body) {
+        return fetch(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+        }).then(function (r) { return r.json(); });
+    }
+
     /** Disables the form's submit button while a request is in flight. */
     function withBusy(form, busy) {
         const btn = form.querySelector('button[type="submit"]');
         if (btn) btn.disabled = busy;
+    }
+
+    // --- Saved lists (account-bound; persisted server-side) ------------
+
+    const LISTS_API = '/cube/api/lists';
+
+    /** DELETE URL for a saved list, with the name safely encoded. */
+    function deleteListUrl(name) {
+        return LISTS_API + '?name=' + encodeURIComponent(name);
+    }
+
+    /** Renders the "couldn't find these names" warning after a list lookup. */
+    function renderNotFound(el, names) {
+        if (!el) return;
+        if (!names || !names.length) {
+            el.hidden = true;
+            el.textContent = '';
+            return;
+        }
+        el.textContent = 'Couldn’t find ' + names.length + ' card' + (names.length > 1 ? 's' : '') +
+            ': ' + names.join(', ');
+        el.hidden = false;
+    }
+
+    // --- Card source (Scryfall search vs pasted list) ------------------
+
+    /** Which source is active and its value. */
+    function activeSource(doc) {
+        const listTab = doc.querySelector('[data-source-tab="list"]');
+        if (listTab && listTab.getAttribute('aria-selected') === 'true') {
+            const ta = doc.querySelector('[data-source-panel="list"] textarea[name="list"]');
+            return { mode: 'list', list: ((ta && ta.value) || '').trim() };
+        }
+        const input = doc.querySelector('[data-source-panel="search"] input[name="query"]');
+        return { mode: 'search', query: ((input && input.value) || '').trim() };
+    }
+
+    function setSource(doc, mode) {
+        doc.querySelectorAll('[data-source-tab]').forEach(function (b) {
+            b.setAttribute('aria-selected', b.getAttribute('data-source-tab') === mode ? 'true' : 'false');
+        });
+        doc.querySelectorAll('[data-source-panel]').forEach(function (p) {
+            p.hidden = p.getAttribute('data-source-panel') !== mode;
+        });
+    }
+
+    function wireSource(doc) {
+        doc.querySelectorAll('[data-source-tab]').forEach(function (btn) {
+            btn.addEventListener('click', function () { setSource(doc, btn.getAttribute('data-source-tab')); });
+        });
+    }
+
+    /** Repopulates every saved-list <select> from the cached {name: cards} map. */
+    function fillSavedSelects(doc, cache) {
+        const names = Object.keys(cache).sort();
+        doc.querySelectorAll('[data-saved-lists]').forEach(function (sel) {
+            const keep = sel.value;
+            sel.replaceChildren();
+            const ph = document.createElement('option');
+            ph.value = '';
+            ph.textContent = names.length ? 'Load a saved list…' : 'No saved lists yet';
+            sel.appendChild(ph);
+            names.forEach(function (name) {
+                const opt = document.createElement('option');
+                opt.value = name;
+                opt.textContent = name;
+                sel.appendChild(opt);
+            });
+            if (cache[keep] != null) sel.value = keep;
+        });
+    }
+
+    /**
+     * Account-bound saved lists: the cube list is persisted server-side
+     * against the logged-in Discord user via the `/cube/api/lists` endpoints,
+     * so it follows them across devices. The controls only exist in the DOM
+     * when the page rendered for a logged-in user (see cube.html), so this is
+     * a no-op for anonymous visitors.
+     */
+    function wireSavedLists(doc) {
+        const textarea = doc.querySelector('textarea[name="list"]');
+        const sel = doc.querySelector('[data-saved-lists]');
+        if (!textarea || !sel) return;
+        const saveBtn = doc.querySelector('[data-save-list]');
+        const delBtn = doc.querySelector('[data-delete-list]');
+        const status = doc.querySelector('[data-saved-status]');
+        let cache = {};
+
+        function reload() {
+            return getJson(LISTS_API)
+                .then(function (rows) {
+                    cache = {};
+                    (rows || []).forEach(function (row) { cache[row.name] = row.cards; });
+                    fillSavedSelects(doc, cache);
+                })
+                .catch(function () { /* leave the selects as-is on a transient error */ });
+        }
+
+        reload();
+
+        if (saveBtn) saveBtn.addEventListener('click', function () {
+            const text = (textarea.value || '').trim();
+            if (!text) { setStatus(status, 'Nothing to save — paste a list first.'); return; }
+            const name = root.prompt ? root.prompt('Name this cube list:') : null;
+            if (!name || !name.trim()) return;
+            setStatus(status, 'Saving…');
+            fetch(LISTS_API, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ name: name.trim(), cards: text }),
+            }).then(function (r) {
+                if (r.status === 409) { setStatus(status, 'You\'ve hit the saved-list limit (50).'); return null; }
+                if (!r.ok) { setStatus(status, 'Couldn\'t save. Are you still logged in?'); return null; }
+                return r.json();
+            }).then(function (saved) {
+                if (!saved) return;
+                setStatus(status, 'Saved “' + saved.name + '”.');
+                reload().then(function () { if (sel) sel.value = saved.name; });
+            }).catch(function () { setStatus(status, 'Couldn\'t save. Try again.'); });
+        });
+
+        if (sel) sel.addEventListener('change', function () {
+            if (!sel.value || cache[sel.value] == null) return;
+            textarea.value = cache[sel.value];
+            setSource(doc, 'list');
+            setStatus(status, 'Loaded “' + sel.value + '”.');
+        });
+
+        if (delBtn) delBtn.addEventListener('click', function () {
+            if (!sel || !sel.value) return;
+            const name = sel.value;
+            setStatus(status, 'Deleting…');
+            fetch(deleteListUrl(name), { method: 'DELETE' })
+                .then(function () { setStatus(status, 'Deleted “' + name + '”.'); return reload(); })
+                .catch(function () { setStatus(status, 'Couldn\'t delete. Try again.'); });
+        });
     }
 
     function wireAsFan(doc) {
@@ -345,29 +489,45 @@
         });
     }
 
+    /** Validates the active source; returns an error string or null. */
+    function sourceError(src) {
+        if (src.mode === 'list') return src.list ? null : 'Paste a card list first (under "Your cube").';
+        return src.query ? null : 'Enter a Scryfall search first (under "Your cube").';
+    }
+
+    function sourceLabel(src) {
+        return src.mode === 'list' ? 'Your list' : src.query;
+    }
+
     function wirePreview(doc) {
         const form = q(doc, '[data-form="preview"]');
         if (!form) return;
         const status = statusFor(doc, 'preview');
         const empty = emptyFor(doc, 'preview');
         const groups = q(doc, '[data-result="preview"]');
+        const notFound = q(doc, '[data-notfound="preview"]');
         form.addEventListener('submit', function (e) {
             e.preventDefault();
-            const data = new FormData(form);
-            const params = { query: (data.get('query') || '').toString().trim(), packSize: data.get('packSize') };
-            if (!params.query) return;
-            setStatus(status, 'Fetching cards from Scryfall…');
-            hide(groups);
+            const packSize = new FormData(form).get('packSize');
+            const src = activeSource(doc);
+            const err = sourceError(src);
+            if (err) { setStatus(status, err); return; }
+            setStatus(status, src.mode === 'list' ? 'Resolving your list…' : 'Fetching cards from Scryfall…');
+            hide(groups); hide(notFound);
             withBusy(form, true);
-            getJson(previewUrl(params))
+            const request = src.mode === 'list'
+                ? postJson('/cube/api/preview', { list: src.list, packSize: Number(packSize) })
+                : getJson(previewUrl({ query: src.query, packSize: packSize }));
+            request
                 .then(function (json) {
                     if (!json.ok) { setStatus(status, json.error || 'No results.'); return; }
-                    setStatus(status, params.query + ' → ' + json.poolSize + ' cards');
+                    setStatus(status, sourceLabel(src) + ' → ' + json.poolSize + ' cards');
                     hide(empty);
                     renderGroups(groups, json.groups);
                     show(groups);
+                    renderNotFound(notFound, json.notFound);
                 })
-                .catch(function () { setStatus(status, 'Something went wrong reaching Scryfall.'); })
+                .catch(function () { setStatus(status, 'Something went wrong. Try again.'); })
                 .then(function () { withBusy(form, false); });
         });
     }
@@ -382,6 +542,7 @@
         const breakdown = q(doc, '[data-breakdown="generate"]');
         const dist = q(doc, '[data-dist="generate"]');
         const result = q(doc, '[data-result="generate"]');
+        const notFound = q(doc, '[data-notfound="generate"]');
         const downloadBtn = q(doc, '[data-download="generate"]');
         let lastPacks = [];
 
@@ -401,17 +562,19 @@
         form.addEventListener('submit', function (e) {
             e.preventDefault();
             const data = new FormData(form);
-            const params = {
-                query: (data.get('query') || '').toString().trim(),
-                packs: data.get('packs'),
-                packSize: data.get('packSize'),
-                balanced: form.querySelector('[name="balanced"]').checked,
-            };
-            if (!params.query) return;
-            setStatus(status, 'Drawing cards and dealing packs…');
-            hide(summary); hide(actions); hide(breakdown); hide(result);
+            const packs = data.get('packs');
+            const packSize = data.get('packSize');
+            const balanced = form.querySelector('[name="balanced"]').checked;
+            const src = activeSource(doc);
+            const err = sourceError(src);
+            if (err) { setStatus(status, err); return; }
+            setStatus(status, src.mode === 'list' ? 'Resolving your list and dealing packs…' : 'Drawing cards and dealing packs…');
+            hide(summary); hide(actions); hide(breakdown); hide(result); hide(notFound);
             withBusy(form, true);
-            getJson(generateUrl(params))
+            const request = src.mode === 'list'
+                ? postJson('/cube/api/generate', { list: src.list, packs: Number(packs), packSize: Number(packSize), balanced: balanced })
+                : getJson(generateUrl({ query: src.query, packs: packs, packSize: packSize, balanced: balanced }));
+            request
                 .then(function (json) {
                     if (!json.ok) { setStatus(status, json.error || 'Could not build packs.'); return; }
                     setStatus(status, '');
@@ -425,6 +588,7 @@
                     show(actions);
                     renderDistribution(dist, json.distribution);
                     show(breakdown);
+                    renderNotFound(notFound, json.notFound);
                 })
                 .catch(function () { setStatus(status, 'Something went wrong building packs.'); })
                 .then(function () { withBusy(form, false); });
@@ -562,6 +726,8 @@
 
     function wire(doc) {
         wireTabs(doc);
+        wireSource(doc);
+        wireSavedLists(doc);
         wireExamples(doc);
         wireAsFan(doc);
         wirePreview(doc);
@@ -580,6 +746,7 @@
         cardStatline: cardStatline,
         tabIdFromHash: tabIdFromHash,
         zoomPosition: zoomPosition,
+        deleteListUrl: deleteListUrl,
         packsToText: packsToText,
         asfanUrl: asfanUrl,
         previewUrl: previewUrl,

--- a/web/src/main/resources/static/js/cube.js
+++ b/web/src/main/resources/static/js/cube.js
@@ -427,7 +427,11 @@
         if (saveBtn) saveBtn.addEventListener('click', function () {
             const text = (textarea.value || '').trim();
             if (!text) { setStatus(status, 'Nothing to save — paste a list first.'); return; }
-            const name = root.prompt ? root.prompt('Name this cube list:') : null;
+            // Default the prompt to the currently-loaded list's name so editing
+            // and re-saving overwrites it in one step (Enter), while typing a
+            // new name saves a separate copy.
+            const suggested = (sel && sel.value) || '';
+            const name = root.prompt ? root.prompt('Name this cube list (same name overwrites):', suggested) : null;
             if (!name || !name.trim()) return;
             setStatus(status, 'Saving…');
             fetch(LISTS_API, {

--- a/web/src/main/resources/templates/cube.html
+++ b/web/src/main/resources/templates/cube.html
@@ -11,23 +11,17 @@
             <p class="cube-eyebrow">Magic: The Gathering</p>
             <h1>Cube workshop</h1>
             <p class="cube-lede">
-                Turn any pile of cards into a balanced draft. Pick the tool below, tell it which
-                cards you're using, and it does the maths and the shuffling for you.
+                Turn any pile of cards into a balanced draft. Tell it which cards you're using —
+                a Scryfall search or your own list — then preview the balance or deal the packs.
             </p>
 
             <ol class="cube-steps" aria-label="How it works">
-                <li class="cube-step">
-                    <span class="cube-step-num">1</span>
-                    <span class="cube-step-text"><strong>Describe your cube</strong> with a Scryfall search.</span>
-                </li>
-                <li class="cube-step">
-                    <span class="cube-step-num">2</span>
-                    <span class="cube-step-text"><strong>Preview</strong> to check it's balanced.</span>
-                </li>
-                <li class="cube-step">
-                    <span class="cube-step-num">3</span>
-                    <span class="cube-step-text"><strong>Generate</strong> randomised draft packs.</span>
-                </li>
+                <li class="cube-step"><span class="cube-step-num">1</span>
+                    <span class="cube-step-text"><strong>Choose your cards</strong> (search or paste a list).</span></li>
+                <li class="cube-step"><span class="cube-step-num">2</span>
+                    <span class="cube-step-text"><strong>Preview</strong> to check it's balanced.</span></li>
+                <li class="cube-step"><span class="cube-step-num">3</span>
+                    <span class="cube-step-text"><strong>Generate</strong> randomised draft packs.</span></li>
             </ol>
 
             <details class="cube-explainer">
@@ -35,27 +29,68 @@
                 <div class="cube-explainer-body">
                     <p><strong>What's a "cube"?</strong> A custom pool of Magic cards you draft from
                         instead of sealed boosters.</p>
-                    <p><strong>What's a "Scryfall search"?</strong> A way to describe a set of cards in
-                        words. You type it into the <em>query</em> box. For example:</p>
+                    <p><strong>Two ways to define one:</strong></p>
                     <ul>
-                        <li><code>set:vow</code> — every card in the set <em>Crimson Vow</em></li>
-                        <li><code>t:dragon</code> — every Dragon</li>
-                        <li><code>c:r t:instant</code> — red instants</li>
-                        <li><code>cube:vintage</code> — Wizards' official Vintage Cube list</li>
+                        <li><strong>Scryfall search</strong> — describe a set of cards, e.g.
+                            <code>set:vow</code>, <code>t:dragon</code>, <code>cube:vintage</code>.</li>
+                        <li><strong>My card list</strong> — paste your own decklist, one card per line
+                            (an optional count works too, like <code>10 Forest</code>).</li>
                     </ul>
-                    <p>Not sure what to type? Click an <strong>example</strong> button under any query box.
-                        Full syntax lives on
-                        <a href="https://scryfall.com/docs/syntax" target="_blank" rel="noopener">Scryfall</a>.</p>
                     <p><strong>What's "as-fan"?</strong> The average number of a given kind of card you
-                        open per pack — so you can see your draft isn't, say, flooded with lands or
-                        starved of removal.</p>
+                        open per pack — so you can see your draft isn't flooded with lands or starved
+                        of removal.</p>
                 </div>
             </details>
         </div>
     </header>
 
     <div class="cube-shell">
-        <p class="cube-tabs-hint" id="cube-tabs-hint">Choose a tool:</p>
+        <!-- Shared card source, used by Preview and Generate -->
+        <section class="cube-source-card">
+            <div class="cube-source-head">
+                <h2>Your cube</h2>
+                <span class="cube-source-note">Used by Preview &amp; Generate</span>
+            </div>
+            <div class="cube-source-toggle segmented" role="group" aria-label="Card source">
+                <button type="button" class="cube-source-btn" data-source-tab="search" aria-selected="true">
+                    Scryfall search
+                </button>
+                <button type="button" class="cube-source-btn" data-source-tab="list" aria-selected="false">
+                    My card list
+                </button>
+            </div>
+
+            <div data-source-panel="search">
+                <label class="cube-query">Scryfall search
+                    <input type="text" name="query" placeholder="e.g. cube:vintage" autocomplete="off">
+                </label>
+                <span class="cube-inline-examples">Examples:
+                    <button type="button" class="cube-chip" data-example="cube:vintage">cube:vintage</button>
+                    <button type="button" class="cube-chip" data-example="set:vow">set:vow</button>
+                    <button type="button" class="cube-chip" data-example="t:dragon">t:dragon</button>
+                </span>
+            </div>
+
+            <div data-source-panel="list" hidden>
+                <label class="cube-listlabel">Your card list
+                    <textarea name="list" rows="8" spellcheck="false"
+                              placeholder="One card per line:&#10;1 Lightning Bolt&#10;Sol Ring&#10;10 Forest"></textarea>
+                </label>
+                <div class="cube-saved" th:if="${loggedIn}">
+                    <select data-saved-lists aria-label="Saved lists">
+                        <option value="">No saved lists yet</option>
+                    </select>
+                    <button type="button" class="btn btn-secondary" data-save-list>Save</button>
+                    <button type="button" class="btn btn-secondary" data-delete-list>Delete</button>
+                    <span class="cube-saved-status muted" data-saved-status aria-live="polite"></span>
+                </div>
+                <p class="cube-saved-login muted" th:unless="${loggedIn}">
+                    <a href="/oauth2/authorization/discord">Log in with Discord</a> to save lists to your account.
+                </p>
+            </div>
+        </section>
+
+        <p class="cube-tabs-hint" id="cube-tabs-hint">Then pick a tool:</p>
         <div class="cube-tabs segmented" role="tablist" aria-label="Cube tools" aria-describedby="cube-tabs-hint">
             <button type="button" id="tab-generate" class="cube-tab" role="tab"
                     data-tab="generate" aria-controls="panel-generate" aria-selected="true">
@@ -81,19 +116,10 @@
         <section id="panel-generate" class="cube-panel" role="tabpanel" aria-labelledby="tab-generate"
                  data-panel="generate">
             <p class="cube-panel-intro">
-                Draws cards at random and deals them into evenly-sized, balanced booster packs —
-                ready to print or share.
+                Draws cards at random from <strong>your cube</strong> above and deals them into
+                evenly-sized, balanced booster packs.
             </p>
             <form class="cube-form" data-form="generate" autocomplete="off">
-                <label class="cube-query">Which cards? <span class="cube-req">(required)</span>
-                    <input type="text" name="query" placeholder="e.g. cube:vintage" required>
-                    <small class="cube-hint">A Scryfall search describing your card pool.</small>
-                    <span class="cube-inline-examples">Examples:
-                        <button type="button" class="cube-chip" data-example="cube:vintage">cube:vintage</button>
-                        <button type="button" class="cube-chip" data-example="set:vow">set:vow</button>
-                        <button type="button" class="cube-chip" data-example="t:dragon">t:dragon</button>
-                    </span>
-                </label>
                 <label>How many packs?
                     <input type="number" name="packs" min="1" max="90" value="24" required>
                     <small class="cube-hint">8 players × 3 packs = 24.</small>
@@ -104,13 +130,14 @@
                 </label>
                 <label class="cube-checkbox">
                     <input type="checkbox" name="balanced" checked>
-                    Spread colours &amp; lands evenly across packs
+                    Spread colours &amp; lands evenly
                 </label>
                 <button type="submit" class="btn cube-submit">Generate packs</button>
             </form>
             <p class="cube-status" data-status="generate" aria-live="polite"></p>
-            <p class="cube-empty" data-empty="generate">Fill in a query and hit <strong>Generate packs</strong> to deal a draft.</p>
+            <p class="cube-empty" data-empty="generate">Choose your cards above, then hit <strong>Generate packs</strong>.</p>
             <div class="cube-generate-summary" data-summary="generate" hidden></div>
+            <p class="cube-notfound" data-notfound="generate" hidden></p>
             <div class="cube-result-actions" data-actions="generate" hidden>
                 <button type="button" class="btn btn-secondary" data-download="generate">⬇ Download pack list (.txt)</button>
             </div>
@@ -125,19 +152,10 @@
         <section id="panel-preview" class="cube-panel" role="tabpanel" aria-labelledby="tab-preview"
                  data-panel="preview" hidden>
             <p class="cube-panel-intro">
-                Lists the actual cards in your pool, grouped by colour and land, with how many of
-                each kind you'd open per pack — so you can see exactly what's in the cube.
+                Lists every card in <strong>your cube</strong>, grouped by colour and land, with how
+                many of each kind you'd open per pack.
             </p>
             <form class="cube-form" data-form="preview" autocomplete="off">
-                <label class="cube-query">Which cards? <span class="cube-req">(required)</span>
-                    <input type="text" name="query" placeholder="e.g. set:vow" required>
-                    <small class="cube-hint">A Scryfall search describing your card pool.</small>
-                    <span class="cube-inline-examples">Examples:
-                        <button type="button" class="cube-chip" data-example="set:vow">set:vow</button>
-                        <button type="button" class="cube-chip" data-example="cube:vintage">cube:vintage</button>
-                        <button type="button" class="cube-chip" data-example="c:r t:instant">c:r t:instant</button>
-                    </span>
-                </label>
                 <label>Cards per pack
                     <input type="number" name="packSize" min="1" max="30" value="15" required>
                     <small class="cube-hint">Standard boosters hold 15.</small>
@@ -145,7 +163,8 @@
                 <button type="submit" class="btn cube-submit">Preview balance</button>
             </form>
             <p class="cube-status" data-status="preview" aria-live="polite"></p>
-            <p class="cube-empty" data-empty="preview">Enter a query and hit <strong>Preview balance</strong> to list the cards.</p>
+            <p class="cube-empty" data-empty="preview">Choose your cards above, then hit <strong>Preview balance</strong>.</p>
+            <p class="cube-notfound" data-notfound="preview" hidden></p>
             <div class="cube-groups" data-result="preview" hidden></div>
         </section>
 

--- a/web/src/test/js/cube.test.js
+++ b/web/src/test/js/cube.test.js
@@ -224,6 +224,13 @@ describe('hover-to-enlarge', () => {
     });
 });
 
+describe('deleteListUrl', () => {
+    test('encodes the saved-list name into the delete query', () => {
+        expect(Cube.deleteListUrl('My Cube')).toBe('/cube/api/lists?name=My%20Cube');
+        expect(Cube.deleteListUrl('Pauper / Peasant')).toBe('/cube/api/lists?name=Pauper%20%2F%20Peasant');
+    });
+});
+
 describe('tap-to-enlarge (touch / no-hover devices)', () => {
     const realMatchMedia = window.matchMedia;
     afterEach(() => { window.matchMedia = realMatchMedia; });

--- a/web/src/test/kotlin/web/controller/CubeControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/CubeControllerTest.kt
@@ -1,5 +1,7 @@
 package web.controller
 
+import database.dto.user.CubeListDto
+import database.service.user.CubeListService
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -18,16 +20,27 @@ import web.service.CubeResult
 import web.service.CubeWebService
 import web.service.GenerateData
 import web.service.PreviewData
+import java.time.Instant
 
 class CubeControllerTest {
 
+    private val discordId = 100L
+
     private lateinit var service: CubeWebService
+    private lateinit var cubeLists: CubeListService
     private lateinit var controller: CubeController
+
+    private fun loggedIn() = mockk<OAuth2User> {
+        every { getAttribute<String>("id") } returns discordId.toString()
+        every { getAttribute<String>("username") } returns "matt"
+    }
+    private fun anon() = mockk<OAuth2User> { every { getAttribute<String>("id") } returns null }
 
     @BeforeEach
     fun setup() {
         service = mockk()
-        controller = CubeController(service)
+        cubeLists = mockk(relaxed = true)
+        controller = CubeController(service, cubeLists)
     }
 
     @Test
@@ -138,10 +151,133 @@ class CubeControllerTest {
     }
 
     @Test
+    fun `previewList resolves a pasted list and surfaces unresolved names`() {
+        val data = PreviewData(
+            query = "your list", poolSize = 2, packSize = 15,
+            groups = listOf(CategoryGroup("Red", 2, 2.0, listOf(CardView("Bolt", null, null, "Instant", 1.0)))),
+            notFound = listOf("Definitely Not A Card"),
+        )
+        every { service.previewList("3 Bolt\nDefinitely Not A Card", 15) } returns CubeResult.ok(data)
+
+        val response = controller.previewList(CubeListPreviewRequest("3 Bolt\nDefinitely Not A Card", 15))
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertTrue(response.body!!.ok)
+        assertEquals(listOf("Definitely Not A Card"), response.body!!.notFound)
+        assertEquals(1, response.body!!.groups.size)
+    }
+
+    @Test
+    fun `generateList deals from a pasted list and surfaces unresolved names`() {
+        val data = GenerateData(
+            query = "your list", poolSize = 60, packCount = 4, packSize = 15, balanced = true,
+            packs = listOf(listOf(CardView("Bolt", null, null, "Instant", 1.0))),
+            distribution = listOf(CategoryAsFan("Red", 60, 15.0)),
+            notFound = listOf("Mystery Card"),
+        )
+        every { service.generateList("60 Bolt\nMystery Card", 4, 15, true) } returns CubeResult.ok(data)
+
+        val response = controller.generateList(CubeListGenerateRequest("60 Bolt\nMystery Card", 4, 15, true))
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertTrue(response.body!!.ok)
+        assertEquals(listOf("Mystery Card"), response.body!!.notFound)
+        assertEquals(1, response.body!!.packs.size)
+    }
+
+    @Test
+    fun `previewList returns 400 when the list resolves to nothing`() {
+        every { service.previewList(any(), any()) } returns CubeResult.error("None of those card names matched Scryfall. Check the spelling?")
+        val response = controller.previewList(CubeListPreviewRequest("asdf\nqwer", 15))
+        assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+        assertFalse(response.body!!.ok)
+    }
+
+    @Test
     fun `generate forwards the raw params to the service`() {
         every { service.generate("set:vow", 8, 15, false) } returns
             CubeResult.error("whatever")
         controller.generate("set:vow", 8, 15, false)
         verify(exactly = 1) { service.generate("set:vow", 8, 15, false) }
+    }
+
+    // --- saved lists (account-bound) -----------------------------------
+
+    @Test
+    fun `page flags whether the user is logged in`() {
+        val model = mockk<Model>(relaxed = true)
+        controller.page(loggedIn(), model)
+        verify { model.addAttribute("loggedIn", true) }
+
+        val anonModel = mockk<Model>(relaxed = true)
+        controller.page(null, anonModel)
+        verify { anonModel.addAttribute("loggedIn", false) }
+    }
+
+    @Test
+    fun `savedLists returns the user's lists`() {
+        every { cubeLists.listForUser(discordId) } returns listOf(
+            CubeListDto(discordId, "My Cube", "Bolt\nForest", Instant.EPOCH, Instant.EPOCH),
+        )
+        val response = controller.savedLists(loggedIn())
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertEquals(listOf("My Cube"), response.body!!.map { it.name })
+        assertEquals("Bolt\nForest", response.body!!.first().cards)
+    }
+
+    @Test
+    fun `savedLists rejects an anonymous user with 401`() {
+        assertEquals(HttpStatus.UNAUTHORIZED, controller.savedLists(anon()).statusCode)
+        verify(exactly = 0) { cubeLists.listForUser(any()) }
+    }
+
+    @Test
+    fun `saveList upserts and returns the saved list`() {
+        every { cubeLists.get(discordId, "My Cube") } returns null
+        every { cubeLists.listForUser(discordId) } returns emptyList()
+        every { cubeLists.save(discordId, "My Cube", "Bolt\nForest", any()) } returns
+            CubeListDto(discordId, "My Cube", "Bolt\nForest", Instant.EPOCH, Instant.EPOCH)
+
+        val response = controller.saveList(SaveCubeListRequest("My Cube", "Bolt\nForest"), loggedIn())
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertEquals("My Cube", response.body!!.name)
+        verify(exactly = 1) { cubeLists.save(discordId, "My Cube", "Bolt\nForest", any()) }
+    }
+
+    @Test
+    fun `saveList rejects a blank name or empty cards`() {
+        assertEquals(HttpStatus.BAD_REQUEST, controller.saveList(SaveCubeListRequest("  ", "Bolt"), loggedIn()).statusCode)
+        assertEquals(HttpStatus.BAD_REQUEST, controller.saveList(SaveCubeListRequest("Name", "  "), loggedIn()).statusCode)
+        verify(exactly = 0) { cubeLists.save(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `saveList rejects an anonymous user with 401`() {
+        assertEquals(HttpStatus.UNAUTHORIZED, controller.saveList(SaveCubeListRequest("X", "Bolt"), anon()).statusCode)
+    }
+
+    @Test
+    fun `saveList refuses a new list once the per-user cap is hit`() {
+        every { cubeLists.get(discordId, "New") } returns null
+        every { cubeLists.listForUser(discordId) } returns (1..50).map {
+            CubeListDto(discordId, "cube$it", "Bolt", Instant.EPOCH, Instant.EPOCH)
+        }
+        val response = controller.saveList(SaveCubeListRequest("New", "Bolt"), loggedIn())
+        assertEquals(HttpStatus.CONFLICT, response.statusCode)
+        verify(exactly = 0) { cubeLists.save(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `deleteList removes the named list for the user`() {
+        val response = controller.deleteList("My Cube", loggedIn())
+        assertEquals(HttpStatus.NO_CONTENT, response.statusCode)
+        verify(exactly = 1) { cubeLists.delete(discordId, "My Cube") }
+    }
+
+    @Test
+    fun `deleteList rejects an anonymous user with 401`() {
+        assertEquals(HttpStatus.UNAUTHORIZED, controller.deleteList("My Cube", anon()).statusCode)
+        verify(exactly = 0) { cubeLists.delete(any(), any()) }
     }
 }

--- a/web/src/test/kotlin/web/service/CubeWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/CubeWebServiceTest.kt
@@ -135,6 +135,53 @@ class CubeWebServiceTest {
         assertEquals(null, parsed.imageUrlLarge)
     }
 
+    // --- parseList (pasted decklist parsing) ---------------------------
+
+    @Test
+    fun `parseList reads one name per line, defaulting to a count of one`() {
+        val entries = service.parseList("Lightning Bolt\nForest")
+        assertEquals(listOf("Lightning Bolt", "Forest"), entries.map { it.name })
+        assertEquals(listOf(1, 1), entries.map { it.count })
+    }
+
+    @Test
+    fun `parseList honours leading quantities like 3 and 3x`() {
+        assertEquals(ListEntry("Forest", 3), service.parseList("3 Forest").single())
+        assertEquals(ListEntry("Island", 7), service.parseList("7x Island").single())
+        assertEquals(ListEntry("Plains", 2), service.parseList("2X Plains").single())
+    }
+
+    @Test
+    fun `parseList strips trailing set and collector tags`() {
+        assertEquals(ListEntry("Lightning Bolt", 1), service.parseList("1 Lightning Bolt (2X2) 117").single())
+        assertEquals(ListEntry("Sol Ring", 1), service.parseList("Sol Ring (CMR)").single())
+    }
+
+    @Test
+    fun `parseList ignores blank lines and comments`() {
+        val entries = service.parseList(
+            """
+            # My cube
+            1 Bolt
+
+            // sideboard
+            Shock
+            """.trimIndent()
+        )
+        assertEquals(listOf("Bolt", "Shock"), entries.map { it.name })
+    }
+
+    @Test
+    fun `parseList caps an absurd quantity`() {
+        // Guards the pool against "99999 Forest" blowing memory.
+        assertEquals(100, service.parseList("99999 Forest").single().count)
+    }
+
+    @Test
+    fun `parseList of blank input is empty`() {
+        assertTrue(service.parseList("   \n\n  ").isEmpty())
+    }
+
     // --- preview (pure validation branch) ------------------------------
 
     @Test
@@ -147,5 +194,17 @@ class CubeWebServiceTest {
     fun `preview rejects a blank query without hitting the network`() {
         val result = assertInstanceOf(CubeResult.Failure::class.java, service.preview("   ", 15))
         assertTrue(result.error.contains("Scryfall"))
+    }
+
+    @Test
+    fun `previewList rejects an empty list without hitting the network`() {
+        val result = assertInstanceOf(CubeResult.Failure::class.java, service.previewList("\n  \n", 15))
+        assertTrue(result.error.contains("at least one card"))
+    }
+
+    @Test
+    fun `generateList rejects an empty list without hitting the network`() {
+        val result = assertInstanceOf(CubeResult.Failure::class.java, service.generateList("# just a comment", 24, 15, true))
+        assertTrue(result.error.contains("at least one card"))
     }
 }


### PR DESCRIPTION
Two related additions to the `/cube` web tool.

## 1. Paste your own list
A new shared **"Your cube"** source lets you define the pool with either a **Scryfall search** (as before) or **your own pasted decklist** — one card per line, with optional quantities (`10 Forest`) and set/collector tags (`Bolt (2X2) 117`) tolerated, and `#`/`//` comments ignored.

- Names resolve via Scryfall's `/cards/collection` endpoint (batched ≤75), so list-based cubes still get colours, types, **and images** — the preview/generate/hover/lightbox all work the same.
- Names Scryfall doesn't recognise are reported back ("Couldn't find: …").
- **Preview** and **Generate** share the one source; list-based requests `POST` to `/cube/api/preview` / `/cube/api/generate` (the list is too big for a query string), Scryfall-search requests stay `GET`.

## 2. Save lists to your account
Logged-in users can **name and save** a list, then reload it from any device.

- Persisted server-side in a new `cube_list` table (migration **V45**), keyed by `(discord_id, name)`, via `CubeListService` (mirrors the push-subscription stack).
- `GET` / `PUT` / `DELETE /cube/api/lists` require a logged-in Discord user and only ever read/write **the caller's own rows** (discord id from the session). Per-user cap of 50 lists; re-saving a name overwrites.
- Anonymous visitors see a **"Log in with Discord to save"** prompt — the paste-and-draft flow itself stays login-free. Security narrows the public `/cube/**` matcher to the page + anonymous lookups so `/cube/api/lists` falls through to `authenticated()`.

> On the earlier "save it locally" idea: this supersedes it — lists are now account-bound (server-side), per your follow-up, so they travel with you rather than living in one browser.

## Tests
- **Domain/service:** list parsing (quantities, set tags, comments, count cap, blanks); `CubeListService` save/overwrite/scoping/get/delete with an in-memory persistence.
- **Web:** preview/generate-from-list + `notFound` surfacing; the account `list`/`save`/`delete` endpoints incl. 401s for anon, blank-input 400s, and the per-user-cap 409.
- **JS:** `deleteListUrl` name encoding (plus the existing render/zoom/lightbox/tab suite).

Local: full web Kotlin suite + `DefaultCubeListServiceTest` green, full JS suite (651) green, stylelint clean. The Flyway migration + JPA mapping get their first real exercise on CI's Docker-backed integration run.

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs

---
_Generated by [Claude Code](https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs)_