### PR TITLE
Draft your saved cubes from the /cube Discord command

### DIFF
--- a/common/src/main/kotlin/common/mtg/CardListParser.kt
+++ b/common/src/main/kotlin/common/mtg/CardListParser.kt
@@ -1,0 +1,36 @@
+package common.mtg
+
+/**
+ * Parses a pasted decklist into (name, count) entries. Shared by the web
+ * tool and the Discord command so they agree on the format:
+ *
+ *  - one card per line;
+ *  - an optional leading quantity — `3 Forest`, `3x Forest`, `3X Forest`;
+ *  - an optional trailing set/collector tag — `Lightning Bolt (2X2) 117`;
+ *  - blank lines and `#` / `//` comments ignored.
+ *
+ * Counts are capped at [MAX_PER_NAME] so a stray `99999 Forest` can't blow
+ * up the pool.
+ */
+object CardListParser {
+
+    data class Entry(val name: String, val count: Int)
+
+    const val MAX_PER_NAME = 100
+
+    private val QUANTITY_PREFIX = Regex("^(\\d+)[xX]?\\s+")
+    private val SET_SUFFIX = Regex("\\s+\\([^)]*\\).*$")
+
+    fun parse(text: String): List<Entry> =
+        text.lineSequence().mapNotNull { raw ->
+            var line = raw.trim()
+            if (line.isEmpty() || line.startsWith("#") || line.startsWith("//")) return@mapNotNull null
+            var count = 1
+            QUANTITY_PREFIX.find(line)?.let { match ->
+                count = match.groupValues[1].toIntOrNull()?.coerceIn(1, MAX_PER_NAME) ?: 1
+                line = line.substring(match.range.last + 1).trim()
+            }
+            line = line.replace(SET_SUFFIX, "").trim()
+            if (line.isEmpty()) null else Entry(line, count)
+        }.toList()
+}

--- a/common/src/test/kotlin/common/mtg/CardListParserTest.kt
+++ b/common/src/test/kotlin/common/mtg/CardListParserTest.kt
@@ -1,0 +1,52 @@
+package common.mtg
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class CardListParserTest {
+
+    @Test
+    fun `one name per line defaults to a count of one`() {
+        val entries = CardListParser.parse("Lightning Bolt\nForest")
+        assertEquals(listOf("Lightning Bolt", "Forest"), entries.map { it.name })
+        assertEquals(listOf(1, 1), entries.map { it.count })
+    }
+
+    @Test
+    fun `honours leading quantities like 3, 3x and 3X`() {
+        assertEquals(CardListParser.Entry("Forest", 3), CardListParser.parse("3 Forest").single())
+        assertEquals(CardListParser.Entry("Island", 7), CardListParser.parse("7x Island").single())
+        assertEquals(CardListParser.Entry("Plains", 2), CardListParser.parse("2X Plains").single())
+    }
+
+    @Test
+    fun `strips trailing set and collector tags`() {
+        assertEquals(CardListParser.Entry("Lightning Bolt", 1), CardListParser.parse("1 Lightning Bolt (2X2) 117").single())
+        assertEquals(CardListParser.Entry("Sol Ring", 1), CardListParser.parse("Sol Ring (CMR)").single())
+    }
+
+    @Test
+    fun `ignores blank lines and comments`() {
+        val entries = CardListParser.parse(
+            """
+            # My cube
+            1 Bolt
+
+            // sideboard
+            Shock
+            """.trimIndent()
+        )
+        assertEquals(listOf("Bolt", "Shock"), entries.map { it.name })
+    }
+
+    @Test
+    fun `caps an absurd quantity`() {
+        assertEquals(CardListParser.MAX_PER_NAME, CardListParser.parse("99999 Forest").single().count)
+    }
+
+    @Test
+    fun `blank input yields no entries`() {
+        assertTrue(CardListParser.parse("   \n\n  ").isEmpty())
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeCommand.kt
@@ -4,10 +4,13 @@ import bot.toby.helpers.booleanOption
 import bot.toby.helpers.intOption
 import bot.toby.helpers.stringOption
 import common.mtg.AsFan
+import common.mtg.CardListParser
+import common.mtg.CubeCard
 import common.mtg.PackGenerator
 import core.command.Command.Companion.invokeDeleteOnMessageResponse
 import core.command.CommandContext
 import database.dto.user.UserDto
+import database.service.user.CubeListService
 import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.interactions.commands.build.OptionData
@@ -27,13 +30,14 @@ import kotlin.random.Random
  *                       them into evenly-sized, as-fan-balanced packs;
  *                       the full pack lists come back as a text file.
  *
- * A "cube" is defined by a Scryfall search query, so the user picks their
- * pool with the same syntax they'd use on scryfall.com (`set:vow`,
- * `cube:vintage`, `t:dragon`, …).
+ * A "cube" is defined by a Scryfall search query (`set:vow`, `cube:vintage`,
+ * `t:dragon`, …) — or, via the `saved` option, by one of the user's own
+ * cubes saved on the website (resolved name-by-name through Scryfall).
  */
 @Component
 class CubeCommand @Autowired constructor(
     private val fetcher: ScryfallCubeFetcher,
+    private val cubeListService: CubeListService,
 ) : MtgCommand {
 
     override val name: String = "cube"
@@ -43,9 +47,50 @@ class CubeCommand @Autowired constructor(
         logger.setGuildAndMemberContext(ctx.guild, ctx.member)
         when (ctx.event.subcommandName) {
             SUB_ASFAN -> handleAsFan(ctx, deleteDelay)
-            SUB_PREVIEW -> handlePreview(ctx, deleteDelay)
-            SUB_GENERATE -> handleGenerate(ctx)
+            SUB_PREVIEW -> handlePreview(ctx, requestingUserDto, deleteDelay)
+            SUB_GENERATE -> handleGenerate(ctx, requestingUserDto)
             else -> reply(ctx, CubeEmbeds.errorEmbed("Pick a subcommand: asfan, preview or generate."), deleteDelay)
+        }
+    }
+
+    /** A draftable pool plus a human label for it (query text or cube name). */
+    private sealed interface PoolResult {
+        data class Ready(val pool: List<CubeCard>, val label: String) : PoolResult
+        data class Failed(val message: String) : PoolResult
+    }
+
+    /**
+     * Resolves the card pool from whichever source the user gave: a saved
+     * cube (looked up for their Discord account, then resolved name-by-name
+     * via Scryfall) takes precedence over a Scryfall `query`.
+     */
+    private fun resolvePool(ctx: CommandContext, requestingUserDto: UserDto): PoolResult {
+        val saved = ctx.event.stringOption(OPT_SAVED)?.trim()
+        if (!saved.isNullOrEmpty()) {
+            val dto = cubeListService.get(requestingUserDto.discordId, saved)
+                ?: return PoolResult.Failed("You have no saved cube named `$saved`. Save one on the website first.")
+            val entries = CardListParser.parse(dto.cards)
+            if (entries.isEmpty()) return PoolResult.Failed("Your saved cube `$saved` is empty.")
+            return when (val res = fetcher.fetchByNames(entries.map { it.name })) {
+                is ScryfallCubeFetcher.Result.Failure -> PoolResult.Failed(res.message)
+                is ScryfallCubeFetcher.Result.Success -> {
+                    val byName = res.cards.associateBy { it.name.lowercase() }
+                    val pool = entries.flatMap { entry ->
+                        byName[entry.name.lowercase()]?.let { card -> List(entry.count) { card } } ?: emptyList()
+                    }
+                    if (pool.isEmpty()) PoolResult.Failed("None of `$saved`'s cards matched Scryfall.")
+                    else PoolResult.Ready(pool, "saved cube \"$saved\"")
+                }
+            }
+        }
+
+        val query = ctx.event.stringOption(OPT_QUERY)?.trim()
+        if (query.isNullOrEmpty()) {
+            return PoolResult.Failed("Give me a Scryfall `query`, or the `saved` name of one of your cubes.")
+        }
+        return when (val res = fetcher.fetch(query)) {
+            is ScryfallCubeFetcher.Result.Failure -> PoolResult.Failed(res.message)
+            is ScryfallCubeFetcher.Result.Success -> PoolResult.Ready(res.cards, query)
         }
     }
 
@@ -62,15 +107,14 @@ class CubeCommand @Autowired constructor(
         reply(ctx, embed, deleteDelay)
     }
 
-    private fun handlePreview(ctx: CommandContext, deleteDelay: Int) {
-        val query = ctx.event.stringOption(OPT_QUERY).orEmpty()
+    private fun handlePreview(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
         val packSize = ctx.event.intOption(OPT_PACK_SIZE, DEFAULT_PACK_SIZE)
-        when (val result = fetcher.fetch(query)) {
-            is ScryfallCubeFetcher.Result.Failure -> reply(ctx, CubeEmbeds.errorEmbed(result.message), deleteDelay)
-            is ScryfallCubeFetcher.Result.Success -> {
-                val pool = result.cards
+        when (val resolved = resolvePool(ctx, requestingUserDto)) {
+            is PoolResult.Failed -> reply(ctx, CubeEmbeds.errorEmbed(resolved.message), deleteDelay)
+            is PoolResult.Ready -> {
+                val pool = resolved.pool
                 val embed = CubeEmbeds.previewEmbed(
-                    query = query.trim(),
+                    query = resolved.label,
                     poolSize = pool.size,
                     packSize = packSize,
                     counts = AsFan.categoryCounts(pool),
@@ -81,22 +125,21 @@ class CubeCommand @Autowired constructor(
         }
     }
 
-    private fun handleGenerate(ctx: CommandContext) {
-        val query = ctx.event.stringOption(OPT_QUERY).orEmpty()
+    private fun handleGenerate(ctx: CommandContext, requestingUserDto: UserDto) {
         val packCount = ctx.event.intOption(OPT_PACKS, DEFAULT_PACK_COUNT)
         val packSize = ctx.event.intOption(OPT_PACK_SIZE, DEFAULT_PACK_SIZE)
         val balanced = ctx.event.booleanOption(OPT_BALANCED, true)
 
-        when (val result = fetcher.fetch(query)) {
-            is ScryfallCubeFetcher.Result.Failure -> ctx.event.hook.sendMessageEmbeds(CubeEmbeds.errorEmbed(result.message)).queue()
-            is ScryfallCubeFetcher.Result.Success -> {
-                val pool = result.cards
+        when (val resolved = resolvePool(ctx, requestingUserDto)) {
+            is PoolResult.Failed -> ctx.event.hook.sendMessageEmbeds(CubeEmbeds.errorEmbed(resolved.message)).queue()
+            is PoolResult.Ready -> {
+                val pool = resolved.pool
                 when (val packs = PackGenerator(Random.Default).generate(pool, packCount, packSize, balanced)) {
                     is PackGenerator.Result.Failure -> ctx.event.hook.sendMessageEmbeds(CubeEmbeds.errorEmbed(packs.reason)).queue()
                     is PackGenerator.Result.Success -> {
                         val selected = packs.value.cards
                         val embed = CubeEmbeds.generateEmbed(
-                            query = query.trim(),
+                            query = resolved.label,
                             poolSize = pool.size,
                             packCount = packCount,
                             packSize = packSize,
@@ -127,15 +170,17 @@ class CubeCommand @Autowired constructor(
                 OptionData(OptionType.INTEGER, OPT_PACK_SIZE, "Cards per pack (default 15).", false)
                     .setMinValue(1).setMaxValue(MAX_PACK_SIZE.toLong()),
             ),
-        SubcommandData(SUB_PREVIEW, "Show the as-fan distribution of a Scryfall query's cards.")
+        SubcommandData(SUB_PREVIEW, "Show the as-fan distribution of a cube (a Scryfall query or a saved cube).")
             .addOptions(
-                OptionData(OptionType.STRING, OPT_QUERY, "Scryfall search defining the cube (e.g. set:vow).", true),
+                OptionData(OptionType.STRING, OPT_QUERY, "Scryfall search defining the cube (e.g. set:vow).", false),
+                OptionData(OptionType.STRING, OPT_SAVED, "Name of a cube you saved on the website (instead of a query).", false),
                 OptionData(OptionType.INTEGER, OPT_PACK_SIZE, "Cards per pack (default 15).", false)
                     .setMinValue(1).setMaxValue(MAX_PACK_SIZE.toLong()),
             ),
-        SubcommandData(SUB_GENERATE, "Draw a cube from Scryfall and deal randomised, as-fan-balanced packs.")
+        SubcommandData(SUB_GENERATE, "Deal randomised, as-fan-balanced packs from a Scryfall query or a saved cube.")
             .addOptions(
-                OptionData(OptionType.STRING, OPT_QUERY, "Scryfall search defining the pool (e.g. cube:vintage).", true),
+                OptionData(OptionType.STRING, OPT_QUERY, "Scryfall search defining the pool (e.g. cube:vintage).", false),
+                OptionData(OptionType.STRING, OPT_SAVED, "Name of a cube you saved on the website (instead of a query).", false),
                 OptionData(OptionType.INTEGER, OPT_PACKS, "How many packs to build (default 24).", false)
                     .setMinValue(1).setMaxValue(MAX_PACK_COUNT.toLong()),
                 OptionData(OptionType.INTEGER, OPT_PACK_SIZE, "Cards per pack (default 15).", false)
@@ -153,6 +198,7 @@ class CubeCommand @Autowired constructor(
         const val OPT_CUBE_SIZE = "cube-size"
         const val OPT_PACK_SIZE = "pack-size"
         const val OPT_QUERY = "query"
+        const val OPT_SAVED = "saved"
         const val OPT_PACKS = "packs"
         const val OPT_BALANCED = "balanced"
 

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcher.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcher.kt
@@ -1,5 +1,7 @@
 package bot.toby.command.commands.mtg
 
+import com.google.gson.Gson
+import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import common.logging.DiscordLogger
@@ -7,6 +9,8 @@ import common.mtg.CubeCard
 import common.mtg.MtgColor
 import org.apache.http.client.HttpClient
 import org.apache.http.client.methods.HttpGet
+import org.apache.http.client.methods.HttpPost
+import org.apache.http.entity.StringEntity
 import org.apache.http.impl.client.HttpClients
 import org.apache.http.util.EntityUtils
 import org.springframework.stereotype.Component
@@ -30,6 +34,7 @@ import java.nio.charset.StandardCharsets
 class ScryfallCubeFetcher {
 
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
+    private val gson: Gson = Gson()
 
     sealed interface Result {
         data class Success(val cards: List<CubeCard>) : Result
@@ -88,6 +93,61 @@ class ScryfallCubeFetcher {
     }
 
     /**
+     * Resolves an explicit list of card names (e.g. a user's saved cube)
+     * into cards via Scryfall's `/cards/collection` endpoint, batched at 75
+     * identifiers per request. Returns the resolved cards (one per found
+     * name, de-duplicated by the caller's list); names Scryfall doesn't know
+     * are simply absent from the result. Creates a default client; the
+     * overload taking one is the test seam.
+     */
+    fun fetchByNames(names: List<String>): Result = fetchByNames(names, HttpClients.createDefault())
+
+    fun fetchByNames(names: List<String>, httpClient: HttpClient): Result {
+        val unique = names.map { it.trim() }.filter { it.isNotEmpty() }.distinct()
+        if (unique.isEmpty()) return Result.Failure("That cube has no card names in it.")
+
+        val cards = mutableListOf<CubeCard>()
+        try {
+            unique.chunked(COLLECTION_BATCH).forEachIndexed { index, chunk ->
+                if (index > 0) Thread.sleep(SCRYFALL_DELAY_MS) // be polite to the API
+                val post = HttpPost(COLLECTION_ENDPOINT).apply {
+                    setHeader("Content-Type", "application/json")
+                    entity = StringEntity(collectionBody(chunk), StandardCharsets.UTF_8)
+                }
+                val response = httpClient.execute(post)
+                val status = response.statusLine.statusCode
+                if (status != 200) {
+                    EntityUtils.consume(response.entity)
+                    return Result.Failure("Scryfall returned HTTP $status resolving your cube.")
+                }
+                val root = JsonParser.parseReader(InputStreamReader(response.entity.content)).asJsonObject
+                EntityUtils.consume(response.entity)
+                root.getAsJsonArray("data")?.forEach { element ->
+                    parseCard(element.asJsonObject)?.let(cards::add)
+                }
+            }
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            return Result.Failure("Lookup interrupted.")
+        } catch (e: Exception) {
+            logger.error("Scryfall collection lookup failed: $e")
+            return Result.Failure("Couldn't reach Scryfall: ${e.message}")
+        }
+
+        if (cards.isEmpty()) return Result.Failure("None of those card names matched Scryfall.")
+        return Result.Success(cards)
+    }
+
+    /** Builds the `{"identifiers":[{"name":...}]}` body, escaping names via Gson. */
+    private fun collectionBody(names: List<String>): String {
+        val identifiers = JsonArray()
+        names.forEach { name ->
+            identifiers.add(JsonObject().apply { addProperty("name", name) })
+        }
+        return JsonObject().apply { add("identifiers", identifiers) }.let(gson::toJson)
+    }
+
+    /**
      * Maps a single Scryfall card object to a [CubeCard]. Returns null for
      * entries without a name (which we can't meaningfully draft). Colour
      * comes from `color_identity` — the cube-sorting convention — and land
@@ -116,8 +176,10 @@ class ScryfallCubeFetcher {
 
     companion object {
         private const val SEARCH_ENDPOINT = "https://api.scryfall.com/cards/search"
+        private const val COLLECTION_ENDPOINT = "https://api.scryfall.com/cards/collection"
         const val DEFAULT_MAX_CARDS = 750
         private const val MAX_PAGES = 10
+        private const val COLLECTION_BATCH = 75
         private const val SCRYFALL_DELAY_MS = 100L
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeCommandTest.kt
@@ -7,6 +7,8 @@ import bot.toby.command.CommandTest.Companion.webhookMessageCreateAction
 import bot.toby.command.DefaultCommandContext
 import common.mtg.CubeCard
 import common.mtg.MtgColor
+import database.dto.user.CubeListDto
+import database.service.user.CubeListService
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -21,17 +23,21 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.time.Instant
 
 class CubeCommandTest : CommandTest {
 
     private lateinit var fetcher: ScryfallCubeFetcher
+    private lateinit var cubeListService: CubeListService
     private lateinit var command: CubeCommand
 
     @BeforeEach
     fun setUp() {
         setUpCommonMocks()
         fetcher = mockk()
-        command = CubeCommand(fetcher)
+        cubeListService = mockk(relaxed = true)
+        command = CubeCommand(fetcher, cubeListService)
+        every { requestingUserDto.discordId } returns 100L
         every { webhookMessageCreateAction.addFiles(any<FileUpload>()) } returns webhookMessageCreateAction
         every { webhookMessageCreateAction.queue() } just runs
     }
@@ -162,6 +168,87 @@ class CubeCommandTest : CommandTest {
         assertEquals("Couldn't build that cube", slot.captured.title)
     }
 
+    // --- saved cubes ---------------------------------------------------
+
+    private fun savedCube(name: String, cards: String) =
+        CubeListDto(discordId = 100L, name = name, cards = cards, createdAt = Instant.EPOCH, updatedAt = Instant.EPOCH)
+
+    @Test
+    fun `generate from a saved cube resolves the names and deals packs`() {
+        val slot = slot<MessageEmbed>()
+        every { event.hook.sendMessageEmbeds(capture(slot), *anyVararg()) } returns webhookMessageCreateAction
+        every { event.subcommandName } returns CubeCommand.SUB_GENERATE
+        every { event.getOption(CubeCommand.OPT_SAVED) } returns strOpt("My Cube")
+        every { event.getOption(CubeCommand.OPT_QUERY) } returns null
+        every { event.getOption(CubeCommand.OPT_PACKS) } returns intOpt(1)
+        every { event.getOption(CubeCommand.OPT_PACK_SIZE) } returns intOpt(3)
+        every { event.getOption(CubeCommand.OPT_BALANCED) } returns null
+        every { cubeListService.get(100L, "My Cube") } returns savedCube("My Cube", "3 Bolt\nForest")
+        every { fetcher.fetchByNames(any()) } returns ScryfallCubeFetcher.Result.Success(
+            listOf(CubeCard("Bolt", setOf(MtgColor.RED)), CubeCard("Forest", isLand = true)),
+        )
+
+        run()
+
+        verify(exactly = 1) { cubeListService.get(100L, "My Cube") }
+        verify(exactly = 1) { webhookMessageCreateAction.addFiles(any<FileUpload>()) }
+        assertTrue(slot.captured.title!!.contains("Generated 1 packs of 3"))
+        assertTrue(slot.captured.description!!.contains("My Cube"))
+    }
+
+    @Test
+    fun `preview from a saved cube shows its distribution`() {
+        val slot = slot<MessageEmbed>()
+        every { event.hook.sendMessageEmbeds(capture(slot), *anyVararg()) } returns webhookMessageCreateAction
+        every { event.subcommandName } returns CubeCommand.SUB_PREVIEW
+        every { event.getOption(CubeCommand.OPT_SAVED) } returns strOpt("My Cube")
+        every { event.getOption(CubeCommand.OPT_QUERY) } returns null
+        every { event.getOption(CubeCommand.OPT_PACK_SIZE) } returns null
+        every { cubeListService.get(100L, "My Cube") } returns savedCube("My Cube", "Bolt\nForest")
+        every { fetcher.fetchByNames(any()) } returns ScryfallCubeFetcher.Result.Success(
+            listOf(CubeCard("Bolt", setOf(MtgColor.RED)), CubeCard("Forest", isLand = true)),
+        )
+
+        run()
+
+        assertEquals("Cube preview", slot.captured.title)
+        assertTrue(slot.captured.description!!.contains("My Cube"))
+    }
+
+    @Test
+    fun `generate with an unknown saved cube name errors`() {
+        val slot = slot<MessageEmbed>()
+        every { event.hook.sendMessageEmbeds(capture(slot), *anyVararg()) } returns webhookMessageCreateAction
+        every { event.subcommandName } returns CubeCommand.SUB_GENERATE
+        every { event.getOption(CubeCommand.OPT_SAVED) } returns strOpt("Nope")
+        every { event.getOption(CubeCommand.OPT_QUERY) } returns null
+        every { event.getOption(CubeCommand.OPT_PACKS) } returns null
+        every { event.getOption(CubeCommand.OPT_PACK_SIZE) } returns null
+        every { event.getOption(CubeCommand.OPT_BALANCED) } returns null
+        every { cubeListService.get(100L, "Nope") } returns null
+
+        run()
+
+        assertEquals("Couldn't build that cube", slot.captured.title)
+        verify(exactly = 0) { fetcher.fetchByNames(any()) }
+    }
+
+    @Test
+    fun `generate with neither query nor saved errors`() {
+        val slot = slot<MessageEmbed>()
+        every { event.hook.sendMessageEmbeds(capture(slot), *anyVararg()) } returns webhookMessageCreateAction
+        every { event.subcommandName } returns CubeCommand.SUB_GENERATE
+        every { event.getOption(CubeCommand.OPT_SAVED) } returns null
+        every { event.getOption(CubeCommand.OPT_QUERY) } returns null
+        every { event.getOption(CubeCommand.OPT_PACKS) } returns null
+        every { event.getOption(CubeCommand.OPT_PACK_SIZE) } returns null
+        every { event.getOption(CubeCommand.OPT_BALANCED) } returns null
+
+        run()
+
+        assertEquals("Couldn't build that cube", slot.captured.title)
+    }
+
     // --- metadata ------------------------------------------------------
 
     @Test
@@ -190,5 +277,8 @@ class CubeCommandTest : CommandTest {
         val generate = subs.getValue("generate").options
         assertEquals(OptionType.STRING, generate.first { it.name == "query" }.type)
         assertEquals(OptionType.BOOLEAN, generate.first { it.name == "balanced" }.type)
+        // query and saved are both optional (one-of, validated at runtime).
+        assertEquals(false, generate.first { it.name == "query" }.isRequired)
+        assertEquals(false, generate.first { it.name == "saved" }.isRequired)
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcherTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcherTest.kt
@@ -77,6 +77,46 @@ class ScryfallCubeFetcherTest {
         every { entity.content } returns ByteArrayInputStream(body.toByteArray())
     }
 
+    // --- fetchByNames (saved-cube resolution via /cards/collection) ----
+
+    @Test
+    fun `fetchByNames resolves a list of names into cards`() {
+        val client = mockk<HttpClient>()
+        stubResponse(
+            client, 200,
+            """{"data":[
+                {"name":"Lightning Bolt","color_identity":["R"],"type_line":"Instant","cmc":1},
+                {"name":"Forest","color_identity":[],"type_line":"Basic Land — Forest"}
+            ]}""",
+        )
+        val result = fetcher.fetchByNames(listOf("Lightning Bolt", "Forest"), client)
+        val success = assertInstanceOf(ScryfallCubeFetcher.Result.Success::class.java, result)
+        assertEquals(listOf("Lightning Bolt", "Forest"), success.cards.map { it.name })
+    }
+
+    @Test
+    fun `fetchByNames fails fast on an empty list without calling the network`() {
+        val client = mockk<HttpClient>()
+        assertInstanceOf(ScryfallCubeFetcher.Result.Failure::class.java, fetcher.fetchByNames(listOf("  ", ""), client))
+    }
+
+    @Test
+    fun `fetchByNames reports an HTTP error`() {
+        val client = mockk<HttpClient>()
+        stubResponse(client, 500, "boom")
+        val result = fetcher.fetchByNames(listOf("Bolt"), client)
+        val failure = assertInstanceOf(ScryfallCubeFetcher.Result.Failure::class.java, result)
+        assertTrue(failure.message.contains("HTTP 500"))
+    }
+
+    @Test
+    fun `fetchByNames fails when nothing resolves`() {
+        val client = mockk<HttpClient>()
+        stubResponse(client, 200, """{"data":[]}""")
+        val result = fetcher.fetchByNames(listOf("Definitely Not A Card"), client)
+        assertInstanceOf(ScryfallCubeFetcher.Result.Failure::class.java, result)
+    }
+
     @Test
     fun `fetch returns parsed cards on a single page`() {
         val client = mockk<HttpClient>()

--- a/web/src/main/kotlin/web/service/CubeWebService.kt
+++ b/web/src/main/kotlin/web/service/CubeWebService.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import common.mtg.AsFan
 import common.mtg.CardCategory
+import common.mtg.CardListParser
 import common.mtg.CubeCard
 import common.mtg.MtgColor
 import common.mtg.PackGenerator
@@ -250,23 +251,12 @@ class CubeWebService {
     }
 
     /**
-     * Parses a pasted decklist into (name, count) entries. Accepts one card
-     * per line, with an optional leading quantity (`3 Forest`, `3x Forest`)
-     * and an optional trailing set/collector tag (`Bolt (2X2) 117`). Blank
-     * lines and `#` / `//` comments are ignored.
+     * Parses a pasted decklist into (name, count) entries. Delegates to the
+     * shared [CardListParser] so the web tool and the Discord command agree
+     * on the accepted format.
      */
     fun parseList(text: String): List<ListEntry> =
-        text.lineSequence().mapNotNull { raw ->
-            var line = raw.trim()
-            if (line.isEmpty() || line.startsWith("#") || line.startsWith("//")) return@mapNotNull null
-            var count = 1
-            QUANTITY_PREFIX.find(line)?.let { m ->
-                count = m.groupValues[1].toIntOrNull()?.coerceIn(1, MAX_PER_NAME) ?: 1
-                line = line.substring(m.range.last + 1).trim()
-            }
-            line = line.replace(SET_SUFFIX, "").trim()
-            if (line.isEmpty()) null else ListEntry(line, count)
-        }.toList()
+        CardListParser.parse(text).map { ListEntry(it.name, it.count) }
 
     /**
      * Resolves a pasted list into a card pool by looking the names up via
@@ -329,9 +319,6 @@ class CubeWebService {
         const val MAX_CARDS = 750
         const val MAX_PAGES = 10
         const val COLLECTION_BATCH = 75
-        const val MAX_PER_NAME = 100
-        val QUANTITY_PREFIX = Regex("^(\\d+)[xX]?\\s+")
-        val SET_SUFFIX = Regex("\\s+\\([^)]*\\).*$")
     }
 }
 


### PR DESCRIPTION
Follow-up to #614 (merged) — lets the Discord `/cube` command draft a cube you saved on the website.

## What it adds
A `saved` option on **`/cube preview`** and **`/cube generate`**:

```
/cube generate saved:"My Vintage Cube" packs:24
/cube preview  saved:"Pauper Cube"
```

It looks up the named cube **for your Discord account**, resolves the card names through Scryfall, and runs the exact same pack-generation / as-fan path as a query. `query` is now optional — give a Scryfall `query` **or** a `saved` name (saved takes precedence; giving neither is a friendly error).

## How
- **`ScryfallCubeFetcher.fetchByNames`** resolves an explicit name list via Scryfall's `/cards/collection` endpoint (batched ≤75, Gson-escaped body), so saved cubes get real colours/types/mana values.
- **`CubeCommand`** injects `CubeListService`, looks the cube up by `(discordId, name)`, expands quantities (`10 Forest` → 10), and feeds the pool through the shared generate/preview code.
- Decklist parsing is now a shared **`common.mtg.CardListParser`** used by both the bot and the web service (web's `parseList` delegates to it), so the two surfaces can't drift on the accepted format.

## Tests
- `CardListParserTest` (quantities, set tags, comments, cap, blanks).
- `ScryfallCubeFetcher.fetchByNames`: resolve, empty-list fast-fail, HTTP error, no-match.
- `CubeCommand`: saved-cube **preview** and **generate** (resolves + deals + labels the embed), unknown-name error, and "neither query nor saved" error — plus the metadata now asserting both options are optional.

Local: `:common`, `:web` (`CubeWebServiceTest`), and `:discord-bot` (`mtg.*`) suites green. The Spring-wired integration runs on CI's Docker job.

_Rebased onto `main` after #614 merged; base retargeted from the #614 branch to `main`._

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs