### PR TITLE
Autocomplete saved cubes (Discord + web) and card names (web)

### DIFF
--- a/application/src/test/kotlin/integration/bot/AutocompleteManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/AutocompleteManagerTest.kt
@@ -4,6 +4,7 @@ import app.Application
 import bot.configuration.TestAppConfig
 import bot.configuration.TestBotConfig
 import bot.configuration.TestManagerConfig
+import bot.toby.autocomplete.autocompletes.CubeAutoComplete
 import bot.toby.autocomplete.autocompletes.DnDAutoComplete
 import bot.toby.autocomplete.autocompletes.HelpAutoComplete
 import bot.toby.managers.DefaultAutoCompleteManager
@@ -52,9 +53,10 @@ internal class AutocompleteManagerTest {
     fun testAllHandlers() {
         val availableHandlers: List<Class<out AutocompleteHandler>> = listOf(
             HelpAutoComplete::class.java,
-            DnDAutoComplete::class.java
+            DnDAutoComplete::class.java,
+            CubeAutoComplete::class.java
         )
-        assertEquals(2, autocompleteManager.handlers.size)
+        assertEquals(3, autocompleteManager.handlers.size)
         assertTrue(availableHandlers.containsAll(autocompleteManager.handlers.map { it.javaClass }.toList()))
     }
 

--- a/discord-bot/src/main/kotlin/bot/toby/autocomplete/autocompletes/CubeAutoComplete.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/autocomplete/autocompletes/CubeAutoComplete.kt
@@ -1,0 +1,40 @@
+package bot.toby.autocomplete.autocompletes
+
+import bot.toby.command.commands.mtg.CubeCommand
+import core.autocomplete.AutocompleteHandler
+import database.service.user.CubeListService
+import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent
+import net.dv8tion.jda.api.interactions.commands.Command
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+/**
+ * Suggests the requesting user's own saved cube names as they type the
+ * `saved` option of `/cube preview` / `/cube generate`. Saved cubes are
+ * keyed per Discord account, so the lookup uses the autocomplete event's
+ * own user id — a user only ever sees their own cubes.
+ */
+@Component
+class CubeAutoComplete @Autowired constructor(
+    private val cubeListService: CubeListService,
+) : AutocompleteHandler {
+
+    override val name = "cube"
+
+    override fun handle(event: CommandAutoCompleteInteractionEvent) {
+        if (event.focusedOption.name != CubeCommand.OPT_SAVED) return
+        val input = event.focusedOption.value
+        val choices = cubeListService.listForUser(event.user.idLong)
+            .asSequence()
+            .map { it.name }
+            .filter { it.contains(input, ignoreCase = true) }
+            .take(MAX_CHOICES)
+            .map { Command.Choice(it, it) }
+            .toList()
+        event.replyChoices(choices).queue()
+    }
+
+    companion object {
+        const val MAX_CHOICES = 25
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeCommand.kt
@@ -173,14 +173,16 @@ class CubeCommand @Autowired constructor(
         SubcommandData(SUB_PREVIEW, "Show the as-fan distribution of a cube (a Scryfall query or a saved cube).")
             .addOptions(
                 OptionData(OptionType.STRING, OPT_QUERY, "Scryfall search defining the cube (e.g. set:vow).", false),
-                OptionData(OptionType.STRING, OPT_SAVED, "Name of a cube you saved on the website (instead of a query).", false),
+                OptionData(OptionType.STRING, OPT_SAVED, "Name of a cube you saved on the website (instead of a query).", false)
+                    .setAutoComplete(true),
                 OptionData(OptionType.INTEGER, OPT_PACK_SIZE, "Cards per pack (default 15).", false)
                     .setMinValue(1).setMaxValue(MAX_PACK_SIZE.toLong()),
             ),
         SubcommandData(SUB_GENERATE, "Deal randomised, as-fan-balanced packs from a Scryfall query or a saved cube.")
             .addOptions(
                 OptionData(OptionType.STRING, OPT_QUERY, "Scryfall search defining the pool (e.g. cube:vintage).", false),
-                OptionData(OptionType.STRING, OPT_SAVED, "Name of a cube you saved on the website (instead of a query).", false),
+                OptionData(OptionType.STRING, OPT_SAVED, "Name of a cube you saved on the website (instead of a query).", false)
+                    .setAutoComplete(true),
                 OptionData(OptionType.INTEGER, OPT_PACKS, "How many packs to build (default 24).", false)
                     .setMinValue(1).setMaxValue(MAX_PACK_COUNT.toLong()),
                 OptionData(OptionType.INTEGER, OPT_PACK_SIZE, "Cards per pack (default 15).", false)

--- a/discord-bot/src/test/kotlin/bot/toby/autocomplete/autocompletes/CubeAutoCompleteTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/autocomplete/autocompletes/CubeAutoCompleteTest.kt
@@ -1,0 +1,105 @@
+package bot.toby.autocomplete.autocompletes
+
+import bot.toby.command.commands.mtg.CubeCommand
+import database.dto.user.CubeListDto
+import database.service.user.CubeListService
+import io.mockk.Runs
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent
+import net.dv8tion.jda.api.interactions.commands.Command.Choice
+import net.dv8tion.jda.api.requests.restaction.interactions.AutoCompleteCallbackAction
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class CubeAutoCompleteTest {
+
+    private val discordId = 100L
+    private val cubeListService: CubeListService = mockk(relaxed = true)
+    private val event: CommandAutoCompleteInteractionEvent = mockk(relaxed = true)
+    private val callback: AutoCompleteCallbackAction = mockk(relaxed = true)
+    private lateinit var autoComplete: CubeAutoComplete
+
+    private fun cube(name: String) =
+        CubeListDto(discordId, name, "Bolt", Instant.EPOCH, Instant.EPOCH)
+
+    @BeforeEach
+    fun setUp() {
+        autoComplete = CubeAutoComplete(cubeListService)
+        every { event.user.idLong } returns discordId
+        every { event.replyChoices(any<Collection<Choice>>()) } returns callback
+        every { callback.queue() } just Runs
+    }
+
+    @AfterEach
+    fun tearDown() = clearAllMocks()
+
+    @Test
+    fun `suggests the user's saved cubes matching the typed prefix`() {
+        every { event.focusedOption.name } returns CubeCommand.OPT_SAVED
+        every { event.focusedOption.value } returns "vin"
+        every { cubeListService.listForUser(discordId) } returns
+            listOf(cube("Vintage Cube"), cube("Pauper Cube"), cube("My Vintage 360"))
+
+        val choices = slot<Collection<Choice>>()
+        every { event.replyChoices(capture(choices)) } returns callback
+
+        autoComplete.handle(event)
+
+        verify(exactly = 1) { cubeListService.listForUser(discordId) }
+        assertEquals(setOf("Vintage Cube", "My Vintage 360"), choices.captured.map { it.name }.toSet())
+    }
+
+    @Test
+    fun `matches case-insensitively and returns the name as both label and value`() {
+        every { event.focusedOption.name } returns CubeCommand.OPT_SAVED
+        every { event.focusedOption.value } returns "PAUPER"
+        every { cubeListService.listForUser(discordId) } returns listOf(cube("Pauper Cube"))
+
+        val choices = slot<Collection<Choice>>()
+        every { event.replyChoices(capture(choices)) } returns callback
+
+        autoComplete.handle(event)
+
+        val choice = choices.captured.single()
+        assertEquals("Pauper Cube", choice.name)
+        assertEquals("Pauper Cube", choice.asString)
+    }
+
+    @Test
+    fun `an empty input lists all of the user's cubes, capped at 25`() {
+        every { event.focusedOption.name } returns CubeCommand.OPT_SAVED
+        every { event.focusedOption.value } returns ""
+        every { cubeListService.listForUser(discordId) } returns (1..30).map { cube("Cube $it") }
+
+        val choices = slot<Collection<Choice>>()
+        every { event.replyChoices(capture(choices)) } returns callback
+
+        autoComplete.handle(event)
+
+        assertTrue(choices.captured.size <= 25)
+    }
+
+    @Test
+    fun `does nothing for a different focused option`() {
+        every { event.focusedOption.name } returns "query"
+
+        autoComplete.handle(event)
+
+        verify(exactly = 0) { cubeListService.listForUser(any()) }
+        verify(exactly = 0) { event.replyChoices(any<Collection<Choice>>()) }
+    }
+
+    @Test
+    fun `is registered against the cube command`() {
+        assertEquals("cube", autoComplete.name)
+    }
+}

--- a/web/src/main/resources/static/css/cube.css
+++ b/web/src/main/resources/static/css/cube.css
@@ -252,13 +252,16 @@
 }
 
 .cube-listlabel {
-    display: grid;
-    gap: 4px;
+    margin-bottom: 4px;
     font-size: 0.85rem;
     color: var(--text-muted);
 }
 
-.cube-listlabel textarea {
+.cube-list-wrap {
+    position: relative;
+}
+
+.cube-list-wrap textarea {
     width: 100%;
     box-sizing: border-box;
     resize: vertical;
@@ -271,10 +274,46 @@
     line-height: 1.5;
 }
 
-.cube-listlabel textarea:focus {
+.cube-list-wrap textarea:focus {
     outline: none;
     border-color: var(--mtg-gold);
     box-shadow: 0 0 0 2px var(--mtg-gold-soft);
+}
+
+/* Scryfall card-name suggestions under the list box. */
+.cube-card-suggest {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 100%;
+    z-index: 20;
+    margin: 2px 0 0;
+    padding: 4px;
+    max-height: 260px;
+    overflow-y: auto;
+    list-style: none;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-sm);
+    box-shadow: var(--shadow-md);
+}
+
+.cube-card-suggest[hidden] {
+    display: none;
+}
+
+.cube-card-suggest-item {
+    padding: 6px 10px;
+    border-radius: var(--radius-sm);
+    font-size: 0.88rem;
+    color: var(--text);
+    cursor: pointer;
+}
+
+.cube-card-suggest-item:hover,
+.cube-card-suggest-item.is-active {
+    background: var(--mtg-gold-soft);
+    color: var(--mtg-gold);
 }
 
 .cube-saved {
@@ -285,14 +324,20 @@
     margin-top: var(--space-3);
 }
 
-.cube-saved select {
+.cube-saved-input {
     padding: 6px 10px;
     background: var(--bg-input);
     color: var(--text);
     border: 1px solid var(--border-strong);
     border-radius: var(--radius-sm);
     font: inherit;
-    min-width: 160px;
+    min-width: 180px;
+}
+
+.cube-saved-input:focus {
+    outline: none;
+    border-color: var(--mtg-gold);
+    box-shadow: 0 0 0 2px var(--mtg-gold-soft);
 }
 
 .cube-saved-status:empty {

--- a/web/src/main/resources/static/js/cube.js
+++ b/web/src/main/resources/static/js/cube.js
@@ -376,37 +376,30 @@
         });
     }
 
-    /** Repopulates every saved-list <select> from the cached {name: cards} map. */
-    function fillSavedSelects(doc, cache) {
+    /** Repopulates the saved-cube datalist(s) from the cached {name: cards} map. */
+    function fillSavedOptions(doc, cache) {
         const names = Object.keys(cache).sort();
-        doc.querySelectorAll('[data-saved-lists]').forEach(function (sel) {
-            const keep = sel.value;
-            sel.replaceChildren();
-            const ph = document.createElement('option');
-            ph.value = '';
-            ph.textContent = names.length ? 'Load a saved list…' : 'No saved lists yet';
-            sel.appendChild(ph);
+        doc.querySelectorAll('[data-saved-options]').forEach(function (dl) {
+            dl.replaceChildren();
             names.forEach(function (name) {
                 const opt = document.createElement('option');
                 opt.value = name;
-                opt.textContent = name;
-                sel.appendChild(opt);
+                dl.appendChild(opt);
             });
-            if (cache[keep] != null) sel.value = keep;
         });
     }
 
     /**
-     * Account-bound saved lists: the cube list is persisted server-side
-     * against the logged-in Discord user via the `/cube/api/lists` endpoints,
-     * so it follows them across devices. The controls only exist in the DOM
-     * when the page rendered for a logged-in user (see cube.html), so this is
-     * a no-op for anonymous visitors.
+     * Account-bound saved lists: persisted server-side against the logged-in
+     * Discord user via `/cube/api/lists`, so they follow the user across
+     * devices. The saved-cube picker is a datalist-backed typeahead — type to
+     * filter your cube names, pick one to load it. The controls only exist in
+     * the DOM for a logged-in user (see cube.html), so this no-ops otherwise.
      */
     function wireSavedLists(doc) {
         const textarea = doc.querySelector('textarea[name="list"]');
-        const sel = doc.querySelector('[data-saved-lists]');
-        if (!textarea || !sel) return;
+        const input = doc.querySelector('[data-saved-lists]');
+        if (!textarea || !input) return;
         const saveBtn = doc.querySelector('[data-save-list]');
         const delBtn = doc.querySelector('[data-delete-list]');
         const status = doc.querySelector('[data-saved-status]');
@@ -417,20 +410,28 @@
                 .then(function (rows) {
                     cache = {};
                     (rows || []).forEach(function (row) { cache[row.name] = row.cards; });
-                    fillSavedSelects(doc, cache);
+                    fillSavedOptions(doc, cache);
                 })
-                .catch(function () { /* leave the selects as-is on a transient error */ });
+                .catch(function () { /* leave options as-is on a transient error */ });
         }
 
         reload();
 
+        // Typeahead: picking (or typing) a known saved name loads that cube.
+        input.addEventListener('change', function () {
+            const name = (input.value || '').trim();
+            if (cache[name] == null) return;
+            textarea.value = cache[name];
+            setSource(doc, 'list');
+            setStatus(status, 'Loaded “' + name + '”.');
+        });
+
         if (saveBtn) saveBtn.addEventListener('click', function () {
             const text = (textarea.value || '').trim();
             if (!text) { setStatus(status, 'Nothing to save — paste a list first.'); return; }
-            // Default the prompt to the currently-loaded list's name so editing
-            // and re-saving overwrites it in one step (Enter), while typing a
-            // new name saves a separate copy.
-            const suggested = (sel && sel.value) || '';
+            // Default the prompt to the name in the picker so editing and
+            // re-saving overwrites it in one step (Enter); a new name forks it.
+            const suggested = (input.value || '').trim();
             const name = root.prompt ? root.prompt('Name this cube list (same name overwrites):', suggested) : null;
             if (!name || !name.trim()) return;
             setStatus(status, 'Saving…');
@@ -445,25 +446,125 @@
             }).then(function (saved) {
                 if (!saved) return;
                 setStatus(status, 'Saved “' + saved.name + '”.');
-                reload().then(function () { if (sel) sel.value = saved.name; });
+                reload().then(function () { input.value = saved.name; });
             }).catch(function () { setStatus(status, 'Couldn\'t save. Try again.'); });
         });
 
-        if (sel) sel.addEventListener('change', function () {
-            if (!sel.value || cache[sel.value] == null) return;
-            textarea.value = cache[sel.value];
-            setSource(doc, 'list');
-            setStatus(status, 'Loaded “' + sel.value + '”.');
-        });
-
         if (delBtn) delBtn.addEventListener('click', function () {
-            if (!sel || !sel.value) return;
-            const name = sel.value;
+            const name = (input.value || '').trim();
+            if (!name) return;
             setStatus(status, 'Deleting…');
             fetch(deleteListUrl(name), { method: 'DELETE' })
-                .then(function () { setStatus(status, 'Deleted “' + name + '”.'); return reload(); })
+                .then(function () { setStatus(status, 'Deleted “' + name + '”.'); input.value = ''; return reload(); })
                 .catch(function () { setStatus(status, 'Couldn\'t delete. Try again.'); });
         });
+    }
+
+    // --- Card-name autocomplete (Scryfall) -----------------------------
+
+    const MAX_CARD_SUGGEST = 10;
+
+    function scryfallAutocompleteUrl(query) {
+        return 'https://api.scryfall.com/cards/autocomplete?q=' + encodeURIComponent(query);
+    }
+
+    /** The line of [value] the caret sits on: its bounds and text. */
+    function currentLineInfo(value, caret) {
+        const start = value.lastIndexOf('\n', caret - 1) + 1;
+        let end = value.indexOf('\n', caret);
+        if (end < 0) end = value.length;
+        return { start: start, end: end, text: value.slice(start, end) };
+    }
+
+    /** Splits a leading quantity (`3 `, `3x `) off a decklist line. */
+    function splitQuantityPrefix(line) {
+        const m = line.match(/^(\d+[xX]?\s+)/);
+        return m ? { prefix: m[1], name: line.slice(m[1].length) } : { prefix: '', name: line };
+    }
+
+    /** Replaces the card name on the caret's line with [choice], keeping the quantity. */
+    function applyCardChoice(value, caret, choice) {
+        const line = currentLineInfo(value, caret);
+        const newLine = splitQuantityPrefix(line.text).prefix + choice;
+        return {
+            value: value.slice(0, line.start) + newLine + value.slice(line.end),
+            caret: line.start + newLine.length,
+        };
+    }
+
+    /**
+     * As the user types a card name in the list box, suggests real card names
+     * from Scryfall's autocomplete API and completes the current line on pick
+     * (keeping any leading quantity). Arrow keys + Enter/Escape, plus mouse.
+     */
+    function wireCardAutocomplete(doc) {
+        const textarea = doc.querySelector('textarea[name="list"]');
+        const box = doc.querySelector('[data-card-suggest]');
+        if (!textarea || !box) return;
+        let timer = null;
+        let controller = null;
+        let items = [];
+        let active = -1;
+
+        function close() { box.hidden = true; box.replaceChildren(); items = []; active = -1; }
+
+        function setActive(i) {
+            const lis = box.querySelectorAll('.cube-card-suggest-item');
+            lis.forEach(function (el) { el.classList.remove('is-active'); });
+            if (i < 0 || i >= lis.length) { active = -1; return; }
+            active = i;
+            lis[i].classList.add('is-active');
+            lis[i].scrollIntoView({ block: 'nearest' });
+        }
+
+        function pick(name) {
+            const applied = applyCardChoice(textarea.value, textarea.selectionStart, name);
+            textarea.value = applied.value;
+            textarea.selectionStart = textarea.selectionEnd = applied.caret;
+            close();
+            textarea.focus();
+        }
+
+        function render(names) {
+            box.replaceChildren();
+            items = names;
+            active = -1;
+            if (!names.length) { close(); return; }
+            names.forEach(function (name) {
+                const li = document.createElement('li');
+                li.className = 'cube-card-suggest-item';
+                li.setAttribute('role', 'option');
+                li.textContent = name;
+                li.addEventListener('mousedown', function (e) { e.preventDefault(); pick(name); });
+                box.appendChild(li);
+            });
+            box.hidden = false;
+        }
+
+        function suggest() {
+            const info = currentLineInfo(textarea.value, textarea.selectionStart);
+            const partial = splitQuantityPrefix(info.text).name.trim();
+            if (partial.length < 2) { close(); return; }
+            if (controller) controller.abort();
+            controller = (typeof AbortController !== 'undefined') ? new AbortController() : null;
+            fetch(scryfallAutocompleteUrl(partial), controller ? { signal: controller.signal } : undefined)
+                .then(function (r) { return r.ok ? r.json() : { data: [] }; })
+                .then(function (json) { render((json.data || []).slice(0, MAX_CARD_SUGGEST)); })
+                .catch(function () { /* aborted or offline — leave the box as it is */ });
+        }
+
+        textarea.addEventListener('input', function () {
+            if (timer) clearTimeout(timer);
+            timer = setTimeout(suggest, 160);
+        });
+        textarea.addEventListener('keydown', function (e) {
+            if (box.hidden) return;
+            if (e.key === 'ArrowDown') { e.preventDefault(); setActive(Math.min(active + 1, items.length - 1)); }
+            else if (e.key === 'ArrowUp') { e.preventDefault(); setActive(Math.max(active - 1, 0)); }
+            else if (e.key === 'Enter' && active >= 0) { e.preventDefault(); pick(items[active]); }
+            else if (e.key === 'Escape') { close(); }
+        });
+        textarea.addEventListener('blur', function () { setTimeout(close, 150); });
     }
 
     function wireAsFan(doc) {
@@ -732,6 +833,7 @@
         wireTabs(doc);
         wireSource(doc);
         wireSavedLists(doc);
+        wireCardAutocomplete(doc);
         wireExamples(doc);
         wireAsFan(doc);
         wirePreview(doc);
@@ -751,6 +853,10 @@
         tabIdFromHash: tabIdFromHash,
         zoomPosition: zoomPosition,
         deleteListUrl: deleteListUrl,
+        scryfallAutocompleteUrl: scryfallAutocompleteUrl,
+        currentLineInfo: currentLineInfo,
+        splitQuantityPrefix: splitQuantityPrefix,
+        applyCardChoice: applyCardChoice,
         packsToText: packsToText,
         asfanUrl: asfanUrl,
         previewUrl: previewUrl,

--- a/web/src/main/resources/templates/cube.html
+++ b/web/src/main/resources/templates/cube.html
@@ -72,14 +72,19 @@
             </div>
 
             <div data-source-panel="list" hidden>
-                <label class="cube-listlabel">Your card list
-                    <textarea name="list" rows="8" spellcheck="false"
+                <div class="cube-listlabel" id="cube-list-label">Your card list
+                    <span class="cube-hint">— type a card to get name suggestions</span>
+                </div>
+                <div class="cube-list-wrap">
+                    <textarea name="list" rows="8" spellcheck="false" aria-labelledby="cube-list-label"
+                              aria-autocomplete="list" aria-controls="cube-card-suggest"
                               placeholder="One card per line:&#10;1 Lightning Bolt&#10;Sol Ring&#10;10 Forest"></textarea>
-                </label>
+                    <ul class="cube-card-suggest" id="cube-card-suggest" data-card-suggest role="listbox" hidden></ul>
+                </div>
                 <div class="cube-saved" th:if="${loggedIn}">
-                    <select data-saved-lists aria-label="Saved lists">
-                        <option value="">No saved lists yet</option>
-                    </select>
+                    <input type="text" class="cube-saved-input" data-saved-lists list="cube-saved-options"
+                           autocomplete="off" placeholder="Find a saved cube…" aria-label="Saved cubes">
+                    <datalist id="cube-saved-options" data-saved-options></datalist>
                     <button type="button" class="btn btn-secondary" data-save-list>Save</button>
                     <button type="button" class="btn btn-secondary" data-delete-list>Delete</button>
                     <span class="cube-saved-status muted" data-saved-status aria-live="polite"></span>

--- a/web/src/test/js/cube.test.js
+++ b/web/src/test/js/cube.test.js
@@ -231,6 +231,40 @@ describe('deleteListUrl', () => {
     });
 });
 
+describe('card-name autocomplete helpers', () => {
+    test('scryfallAutocompleteUrl encodes the partial query', () => {
+        expect(Cube.scryfallAutocompleteUrl('lightn')).toBe('https://api.scryfall.com/cards/autocomplete?q=lightn');
+        expect(Cube.scryfallAutocompleteUrl('sol r')).toBe('https://api.scryfall.com/cards/autocomplete?q=sol%20r');
+    });
+
+    test('currentLineInfo finds the line the caret sits on', () => {
+        const value = 'Bolt\n3 ForE\nSol Ring';
+        // caret inside the middle line ("3 ForE", positions 5..11)
+        const info = Cube.currentLineInfo(value, 9);
+        expect(info.text).toBe('3 ForE');
+        expect(value.slice(info.start, info.end)).toBe('3 ForE');
+    });
+
+    test('splitQuantityPrefix peels a leading count off the card name', () => {
+        expect(Cube.splitQuantityPrefix('3 Forest')).toEqual({ prefix: '3 ', name: 'Forest' });
+        expect(Cube.splitQuantityPrefix('10x Island')).toEqual({ prefix: '10x ', name: 'Island' });
+        expect(Cube.splitQuantityPrefix('Sol Ring')).toEqual({ prefix: '', name: 'Sol Ring' });
+    });
+
+    test('applyCardChoice completes the caret line, keeping the quantity', () => {
+        const value = 'Bolt\n3 ForE\nSol Ring';
+        const result = Cube.applyCardChoice(value, 9, 'Forest');
+        expect(result.value).toBe('Bolt\n3 Forest\nSol Ring');
+        // caret lands at the end of the completed line ("...3 Forest")
+        expect(result.value.slice(0, result.caret)).toBe('Bolt\n3 Forest');
+    });
+
+    test('applyCardChoice works on the only line with no quantity', () => {
+        const result = Cube.applyCardChoice('light', 5, 'Lightning Bolt');
+        expect(result.value).toBe('Lightning Bolt');
+    });
+});
+
 describe('tap-to-enlarge (touch / no-hover devices)', () => {
     const realMatchMedia = window.matchMedia;
     afterEach(() => { window.matchMedia = realMatchMedia; });


### PR DESCRIPTION
Adds autocomplete to the cube tooling — saved cubes (Discord + web) and card names (web).

## Discord — saved-cube autocomplete
A `CubeAutoComplete` handler suggests **your own saved cube names** as you type the `saved` option on `/cube preview` and `/cube generate`:

```
/cube generate saved:vin▏     →  Vintage Cube · My Vintage 360
```

The option is marked `setAutoComplete(true)`, and the lookup is scoped to the **autocomplete event's user id** via `CubeListService`, so you only ever see your own cubes (case-insensitive, capped at Discord's 25 choices).

## Web — saved-cube typeahead
The saved-cube picker is now a **datalist-backed typeahead** (type to filter your cube names) instead of a plain dropdown — pick one to load it; Save/Delete act on the name in the box.

## Web — card-name suggestions
As you type a card in the **"My card list"** box, real card names are suggested from **Scryfall's autocomplete API**; picking one completes the current line and **keeps any leading quantity** (`3 forE` → `3 Forest`). Arrow keys + Enter/Escape, plus mouse; debounced and abortable.

## Tests
- `CubeAutoCompleteTest`: prefix match, case-insensitivity, 25-cap, ignores other options, name binding.
- Integration `AutocompleteManagerTest`: handler-set count bumped 2 → 3 (now includes `CubeAutoComplete`).
- Web JS: the card-autocomplete pure helpers — `scryfallAutocompleteUrl`, `currentLineInfo`, `splitQuantityPrefix`, `applyCardChoice`.

Local: `:discord-bot` (`CubeAutoCompleteTest` + `mtg.*`) green; full JS suite (656) green; stylelint clean. The Spring-wired handler registration runs on CI's Docker job.

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs

---
_Generated by [Claude Code](https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs)_