### PR TITLE
Show card image links in the /cube Discord pack list

### DIFF
--- a/common/src/main/kotlin/common/mtg/CubeCard.kt
+++ b/common/src/main/kotlin/common/mtg/CubeCard.kt
@@ -47,6 +47,12 @@ data class CubeCard(
     val isLand: Boolean = false,
     val typeLine: String = "",
     val manaValue: Double = 0.0,
+    /**
+     * Optional link to the card's image (Scryfall). Presentation-only — the
+     * `common` maths ignore it — but kept on the card so a surface that has
+     * it (the bot's pack list) can show it without a second lookup.
+     */
+    val imageUrl: String? = null,
 ) {
     /** Which as-fan bucket this card falls into. Lands first, then by colour count. */
     val category: CardCategory

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
@@ -93,7 +93,10 @@ internal object CubeEmbeds {
     fun packsFile(packs: List<List<CubeCard>>): ByteArray = buildString {
         packs.forEachIndexed { i, pack ->
             appendLine("== Pack ${i + 1} (${pack.size} cards) ==")
-            pack.forEach { card -> appendLine("  ${card.name}") }
+            pack.forEach { card ->
+                val image = card.imageUrl?.let { " — $it" }.orEmpty()
+                appendLine("  ${card.name}$image")
+            }
             appendLine()
         }
     }.toByteArray(StandardCharsets.UTF_8)

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcher.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcher.kt
@@ -166,7 +166,21 @@ class ScryfallCubeFetcher {
             isLand = typeLine.contains("Land", ignoreCase = true),
             typeLine = typeLine,
             manaValue = manaValue,
+            imageUrl = imageUrl(card),
         )
+    }
+
+    /**
+     * The card's `normal` image link, or null. Single-faced cards carry
+     * `image_uris` directly; double-faced cards put it on the first face.
+     */
+    fun imageUrl(card: JsonObject): String? {
+        fun normalOf(obj: JsonObject?): String? =
+            obj?.getAsJsonObject("image_uris")?.get("normal")?.asString?.takeIf { it.isNotBlank() }
+
+        normalOf(card)?.let { return it }
+        val firstFace = card.getAsJsonArray("card_faces")?.firstOrNull()?.asJsonObject
+        return normalOf(firstFace)
     }
 
     private fun searchUrl(query: String): String {

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeEmbedsTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeEmbedsTest.kt
@@ -1,0 +1,28 @@
+package bot.toby.command.commands.mtg
+
+import common.mtg.CubeCard
+import common.mtg.MtgColor
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.nio.charset.StandardCharsets
+
+class CubeEmbedsTest {
+
+    @Test
+    fun `packsFile lists each card, appending its image link when present`() {
+        val packs = listOf(
+            listOf(
+                CubeCard("Lightning Bolt", setOf(MtgColor.RED), imageUrl = "https://img/bolt.jpg"),
+                CubeCard("Forest", isLand = true), // no image
+            ),
+        )
+        val text = String(CubeEmbeds.packsFile(packs), StandardCharsets.UTF_8)
+
+        assertTrue(text.contains("== Pack 1 (2 cards) =="))
+        assertTrue(text.contains("  Lightning Bolt — https://img/bolt.jpg"))
+        // A card with no image is just its name — no trailing dash.
+        assertTrue(text.contains("  Forest\n"))
+        assertFalse(text.contains("Forest —"))
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcherTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcherTest.kt
@@ -37,6 +37,31 @@ class ScryfallCubeFetcherTest {
     }
 
     @Test
+    fun `parseCard pulls the normal image link for a single-faced card`() {
+        val card = fetcher.parseCard(
+            obj("""{"name":"Bolt","color_identity":["R"],"type_line":"Instant",
+               "image_uris":{"small":"s.jpg","normal":"https://img/bolt.jpg"}}""")
+        )!!
+        assertEquals("https://img/bolt.jpg", card.imageUrl)
+    }
+
+    @Test
+    fun `parseCard falls back to the front face image for a double-faced card`() {
+        val card = fetcher.parseCard(
+            obj("""{"name":"Delver // Aberration","color_identity":["U"],"type_line":"Creature",
+               "card_faces":[{"image_uris":{"normal":"https://img/front.jpg"}},
+                             {"image_uris":{"normal":"https://img/back.jpg"}}]}""")
+        )!!
+        assertEquals("https://img/front.jpg", card.imageUrl)
+    }
+
+    @Test
+    fun `parseCard leaves the image null when Scryfall has none`() {
+        val card = fetcher.parseCard(obj("""{"name":"Token","color_identity":[],"type_line":"Token"}"""))!!
+        assertEquals(null, card.imageUrl)
+    }
+
+    @Test
     fun `parseCard flags lands from the type line`() {
         val card = fetcher.parseCard(
             obj("""{"name":"Sacred Foundry","color_identity":["R","W"],"type_line":"Land — Mountain Plains"}""")


### PR DESCRIPTION
First of two follow-ups (the other, server-stored share links, is coming next). Per the choice of "image links in the list", the `/cube` Discord output now surfaces each card's image.

## What changed
The generated pack list (the `.txt` attachment from `/cube generate`) now appends each card's **Scryfall image link** next to its name:

```
== Pack 1 (15 cards) ==
  Lightning Bolt — https://cards.scryfall.io/normal/.../bolt.jpg
  Forest
```

(Cards Scryfall has no image for — tokens, etc. — just show the name.)

## How
- `CubeCard` gains an optional `imageUrl` (presentation-only; the `common` as-fan / pack-dealing maths ignore it, and it defaults to `null`, so nothing else changes).
- The bot's `ScryfallCubeFetcher` fills it from a card's `normal` image (front face for double-faced cards).
- `CubeEmbeds.packsFile` appends `" — <link>"` when present.

## Tests
- `parseCard` image extraction: single-faced, double-faced front-face fallback, and the no-image case.
- `CubeEmbeds.packsFile`: a card with an image renders the link; a card without one is just its name (no trailing dash).

Local: `:common` (`mtg.*`), `:discord-bot` (`mtg.*`), and `:web` (`CubeWebServiceTest`) green (offline run — a flaky remote mirror was 503-ing during dependency resolution, unrelated to the change).

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs

---
_Generated by [Claude Code](https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs)_