### PR TITLE
Add shareable cube links (/cube/c/&lt;token&gt;)

### DIFF
--- a/database/src/main/kotlin/database/dto/user/SharedCubeDto.kt
+++ b/database/src/main/kotlin/database/dto/user/SharedCubeDto.kt
@@ -1,0 +1,44 @@
+package database.dto.user
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.NamedQueries
+import jakarta.persistence.NamedQuery
+import jakarta.persistence.Table
+import org.springframework.transaction.annotation.Transactional
+import java.io.Serializable
+import java.time.Instant
+
+/**
+ * An immutable, publicly-shareable snapshot of a cube card list, addressed
+ * by a short random [token] (`/cube/c/<token>`). Created by a logged-in
+ * user; readable by anyone with the link. `cards` is the raw list text so
+ * the web layer re-parses it on open (same format as [CubeListDto]).
+ */
+@NamedQueries(
+    NamedQuery(
+        name = "SharedCubeDto.get",
+        query = "select s from SharedCubeDto s where s.token = :token"
+    )
+)
+@Entity
+@Table(name = "shared_cube", schema = "public")
+@Transactional
+class SharedCubeDto(
+    @Id
+    @Column(name = "token")
+    var token: String = "",
+
+    @Column(name = "discord_id", nullable = false)
+    var discordId: Long = 0,
+
+    @Column(name = "name", nullable = false)
+    var name: String = "",
+
+    @Column(name = "cards", nullable = false)
+    var cards: String = "",
+
+    @Column(name = "created_at", nullable = false)
+    var createdAt: Instant = Instant.now(),
+) : Serializable

--- a/database/src/main/kotlin/database/persistence/user/SharedCubePersistence.kt
+++ b/database/src/main/kotlin/database/persistence/user/SharedCubePersistence.kt
@@ -1,0 +1,10 @@
+package database.persistence.user
+
+import database.dto.user.SharedCubeDto
+
+interface SharedCubePersistence {
+    fun get(token: String): SharedCubeDto?
+
+    /** Inserts a new snapshot. Tokens are unique, so this is never an update. */
+    fun insert(row: SharedCubeDto): SharedCubeDto
+}

--- a/database/src/main/kotlin/database/persistence/user/impl/DefaultSharedCubePersistence.kt
+++ b/database/src/main/kotlin/database/persistence/user/impl/DefaultSharedCubePersistence.kt
@@ -1,0 +1,30 @@
+package database.persistence.user.impl
+
+import database.dto.user.SharedCubeDto
+import database.persistence.user.SharedCubePersistence
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import jakarta.persistence.TypedQuery
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+
+@Repository
+@Transactional
+class DefaultSharedCubePersistence : SharedCubePersistence {
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    override fun get(token: String): SharedCubeDto? {
+        val q: TypedQuery<SharedCubeDto> =
+            entityManager.createNamedQuery("SharedCubeDto.get", SharedCubeDto::class.java)
+        q.setParameter("token", token)
+        return q.resultList.firstOrNull()
+    }
+
+    override fun insert(row: SharedCubeDto): SharedCubeDto {
+        entityManager.persist(row)
+        entityManager.flush()
+        return row
+    }
+}

--- a/database/src/main/kotlin/database/service/user/SharedCubeService.kt
+++ b/database/src/main/kotlin/database/service/user/SharedCubeService.kt
@@ -1,0 +1,15 @@
+package database.service.user
+
+import database.dto.user.SharedCubeDto
+import java.time.Instant
+
+interface SharedCubeService {
+    /**
+     * Mints a new shareable snapshot of [cards] under a fresh random token
+     * and returns it. Each call is a new snapshot (immutable), so editing and
+     * re-sharing produces a new link rather than changing an old one.
+     */
+    fun create(discordId: Long, name: String, cards: String, at: Instant = Instant.now()): SharedCubeDto
+
+    fun get(token: String): SharedCubeDto?
+}

--- a/database/src/main/kotlin/database/service/user/impl/DefaultSharedCubeService.kt
+++ b/database/src/main/kotlin/database/service/user/impl/DefaultSharedCubeService.kt
@@ -1,0 +1,53 @@
+package database.service.user.impl
+
+import database.dto.user.SharedCubeDto
+import database.persistence.user.SharedCubePersistence
+import database.service.user.SharedCubeService
+import org.springframework.stereotype.Service
+import java.security.SecureRandom
+import java.time.Instant
+
+@Service
+class DefaultSharedCubeService(
+    private val persistence: SharedCubePersistence,
+) : SharedCubeService {
+
+    private val random = SecureRandom()
+
+    override fun create(discordId: Long, name: String, cards: String, at: Instant): SharedCubeDto {
+        val token = freshToken()
+        return persistence.insert(
+            SharedCubeDto(
+                token = token,
+                discordId = discordId,
+                name = name,
+                cards = cards,
+                createdAt = at,
+            )
+        )
+    }
+
+    override fun get(token: String): SharedCubeDto? = persistence.get(token)
+
+    /** A random token not already taken (collisions are astronomically rare). */
+    private fun freshToken(): String {
+        repeat(MAX_TRIES) {
+            val token = randomToken()
+            if (persistence.get(token) == null) return token
+        }
+        // Exhausting MAX_TRIES against a 62^10 space is effectively impossible;
+        // surface it rather than silently loop forever.
+        throw IllegalStateException("Could not allocate a unique share token.")
+    }
+
+    private fun randomToken(): String =
+        buildString(TOKEN_LENGTH) {
+            repeat(TOKEN_LENGTH) { append(ALPHABET[random.nextInt(ALPHABET.length)]) }
+        }
+
+    private companion object {
+        const val TOKEN_LENGTH = 10
+        const val MAX_TRIES = 5
+        const val ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+    }
+}

--- a/database/src/main/resources/db/migration/V46__shared_cube.sql
+++ b/database/src/main/resources/db/migration/V46__shared_cube.sql
@@ -1,0 +1,14 @@
+-- Public, shareable snapshots of a cube card list. Anyone with the link can
+-- open it in the web tool (`/cube/c/<token>`); only a logged-in user can
+-- create one, and the creator's id is kept for moderation/cleanup.
+--
+-- `token` is a short random URL-safe string used both as the PK and as the
+-- path segment in the share link. A snapshot is immutable — re-sharing an
+-- edited cube mints a new token rather than mutating an existing row.
+CREATE TABLE shared_cube (
+    token      VARCHAR(24)  NOT NULL PRIMARY KEY,
+    discord_id BIGINT       NOT NULL,
+    name       VARCHAR(100) NOT NULL,
+    cards      TEXT         NOT NULL,
+    created_at TIMESTAMPTZ  NOT NULL DEFAULT now()
+);

--- a/database/src/test/kotlin/database/service/DefaultSharedCubeServiceTest.kt
+++ b/database/src/test/kotlin/database/service/DefaultSharedCubeServiceTest.kt
@@ -1,0 +1,61 @@
+package database.service
+
+import database.dto.user.SharedCubeDto
+import database.persistence.user.SharedCubePersistence
+import database.service.user.impl.DefaultSharedCubeService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class DefaultSharedCubeServiceTest {
+
+    private lateinit var persistence: InMemorySharedCubePersistence
+    private lateinit var service: DefaultSharedCubeService
+
+    @BeforeEach
+    fun setup() {
+        persistence = InMemorySharedCubePersistence()
+        service = DefaultSharedCubeService(persistence)
+    }
+
+    @Test
+    fun `create mints a snapshot with a non-blank token and is retrievable`() {
+        val at = Instant.parse("2026-06-05T10:00:00Z")
+        val row = service.create(100L, "My Cube", "Bolt\nForest", at)
+
+        assertTrue(row.token.isNotBlank())
+        assertEquals("My Cube", row.name)
+        assertEquals("Bolt\nForest", row.cards)
+        assertEquals(100L, row.discordId)
+        assertEquals(at, row.createdAt)
+
+        val fetched = service.get(row.token)
+        assertEquals("Bolt\nForest", fetched?.cards)
+    }
+
+    @Test
+    fun `each share gets a distinct token`() {
+        val a = service.create(100L, "A", "Bolt")
+        val b = service.create(100L, "B", "Shock")
+        assertNotEquals(a.token, b.token)
+    }
+
+    @Test
+    fun `get returns null for an unknown token`() {
+        assertNull(service.get("nope"))
+    }
+
+    /** In-memory stand-in for the JPA persistence. */
+    private class InMemorySharedCubePersistence : SharedCubePersistence {
+        private val store = mutableMapOf<String, SharedCubeDto>()
+        override fun get(token: String): SharedCubeDto? = store[token]
+        override fun insert(row: SharedCubeDto): SharedCubeDto {
+            store[row.token] = row
+            return row
+        }
+    }
+}

--- a/web/src/main/kotlin/web/configuration/WebSecurityConfig.kt
+++ b/web/src/main/kotlin/web/configuration/WebSecurityConfig.kt
@@ -21,10 +21,11 @@ class WebSecurityConfig {
                     "/v3/api-docs/**", "/swagger-ui/**", "/login", "/error",
                     "/images/**", "/js/**", "/css/**",
                     "/dnd", "/dnd/**",
-                    // The cube tool's page and its anonymous lookups are public;
-                    // the saved-lists API (/cube/api/lists) is deliberately NOT
-                    // listed here so it falls through to anyRequest().authenticated().
-                    "/cube", "/cube/api/asfan", "/cube/api/preview", "/cube/api/generate",
+                    // The cube tool's page, its anonymous lookups, and opening a
+                    // shared cube (/cube/c/**) are public; the saved-lists and
+                    // share-create APIs are deliberately NOT listed here so they
+                    // fall through to anyRequest().authenticated().
+                    "/cube", "/cube/c/**", "/cube/api/asfan", "/cube/api/preview", "/cube/api/generate",
                     "/sitemap.xml", "/robots.txt",
                     // Service worker for web push must be reachable
                     // unauthenticated — the browser registers it on

--- a/web/src/main/kotlin/web/controller/CubeController.kt
+++ b/web/src/main/kotlin/web/controller/CubeController.kt
@@ -1,6 +1,7 @@
 package web.controller
 
 import database.service.user.CubeListService
+import database.service.user.SharedCubeService
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.oauth2.core.user.OAuth2User
@@ -8,6 +9,7 @@ import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -34,13 +36,16 @@ import web.util.displayName
  * Saving a list is account-bound: the `/api/lists` endpoints require a
  * logged-in Discord user and persist per-user via [CubeListService], so a
  * saved cube follows the user across devices (unlike the rest of the page,
- * which is anonymous).
+ * which is anonymous). A logged-in user can also publish an immutable
+ * shareable snapshot via [SharedCubeService]; anyone can open it at
+ * `/cube/c/{token}` (no login).
  */
 @Controller
 @RequestMapping("/cube")
 class CubeController(
     private val cubeWebService: CubeWebService,
     private val cubeLists: CubeListService,
+    private val sharedCubes: SharedCubeService,
 ) {
 
     @GetMapping
@@ -51,6 +56,25 @@ class CubeController(
         model.addAttribute("username", user.displayName())
         // Drives the saved-lists UI: only logged-in users can save/load.
         model.addAttribute("loggedIn", user != null)
+        return "cube"
+    }
+
+    /** Opens a shared cube: same page, with the list pre-loaded. */
+    @GetMapping("/c/{token}")
+    fun sharedPage(
+        @PathVariable token: String,
+        @AuthenticationPrincipal user: OAuth2User?,
+        model: Model,
+    ): String {
+        model.addAttribute("username", user.displayName())
+        model.addAttribute("loggedIn", user != null)
+        val shared = sharedCubes.get(token)
+        if (shared != null) {
+            model.addAttribute("sharedName", shared.name)
+            model.addAttribute("sharedCards", shared.cards)
+        } else {
+            model.addAttribute("sharedMissing", true)
+        }
         return "cube"
     }
 
@@ -168,11 +192,30 @@ class CubeController(
         return ResponseEntity.noContent().build()
     }
 
+    // --- Share links (logged-in user mints a public, immutable snapshot) ---
+
+    @PostMapping("/api/share", consumes = ["application/json"], produces = ["application/json"])
+    @ResponseBody
+    fun share(
+        @RequestBody request: ShareCubeRequest,
+        @AuthenticationPrincipal user: OAuth2User?,
+    ): ResponseEntity<ShareCubeResponse> {
+        val discordId = user?.discordIdOrNull() ?: return ResponseEntity.status(401).build()
+        if (request.cards.isBlank()) return ResponseEntity.badRequest().build()
+        val name = request.name.trim().ifEmpty { "Shared cube" }.take(MAX_NAME_LENGTH)
+        val row = sharedCubes.create(discordId, name, request.cards)
+        return ResponseEntity.ok(ShareCubeResponse(token = row.token, url = "/cube/c/${row.token}", name = row.name))
+    }
+
     private companion object {
         const val MAX_NAME_LENGTH = 100
         const val MAX_LISTS_PER_USER = 50
     }
 }
+
+data class ShareCubeRequest(val name: String = "", val cards: String = "")
+
+data class ShareCubeResponse(val token: String, val url: String, val name: String)
 
 data class CubeListPreviewRequest(val list: String = "", val packSize: Int = 15)
 

--- a/web/src/main/resources/static/css/cube.css
+++ b/web/src/main/resources/static/css/cube.css
@@ -348,6 +348,54 @@
     margin-top: var(--space-3);
 }
 
+/* Share link result + the "loaded a shared cube" banner. */
+.cube-share-result {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: end;
+    gap: var(--space-2);
+    margin-top: var(--space-3);
+}
+
+.cube-share-result[hidden] {
+    display: none;
+}
+
+.cube-share-result label {
+    display: grid;
+    gap: 4px;
+    flex: 1 1 280px;
+    font-size: 0.8rem;
+    color: var(--text-muted);
+}
+
+.cube-share-result input {
+    padding: 6px 10px;
+    background: var(--bg-input);
+    color: var(--text);
+    border: 1px solid var(--mtg-gold-border);
+    border-radius: var(--radius-sm);
+    font: inherit;
+}
+
+.cube-shared-banner {
+    margin: 0 0 var(--space-3);
+    padding: 8px 12px;
+    background: var(--mtg-gold-soft);
+    border: 1px solid var(--mtg-gold-border);
+    border-radius: var(--radius-sm);
+    color: var(--text);
+}
+
+.cube-shared-missing {
+    margin: 0 0 var(--space-3);
+    padding: 8px 12px;
+    background: var(--warn-soft);
+    border: 1px solid var(--warn);
+    border-radius: var(--radius-sm);
+    color: var(--text);
+}
+
 /* --- Panels & forms ------------------------------------------------- */
 
 .cube-panel {

--- a/web/src/main/resources/static/js/cube.js
+++ b/web/src/main/resources/static/js/cube.js
@@ -335,6 +335,11 @@
         return LISTS_API + '?name=' + encodeURIComponent(name);
     }
 
+    /** Joins the page origin with a server-returned relative share path. */
+    function absoluteUrl(origin, path) {
+        return (origin || '') + path;
+    }
+
     /** Renders the "couldn't find these names" warning after a list lookup. */
     function renderNotFound(el, names) {
         if (!el) return;
@@ -457,6 +462,59 @@
             fetch(deleteListUrl(name), { method: 'DELETE' })
                 .then(function () { setStatus(status, 'Deleted “' + name + '”.'); input.value = ''; return reload(); })
                 .catch(function () { setStatus(status, 'Couldn\'t delete. Try again.'); });
+        });
+    }
+
+    /**
+     * Publishes the current list as a public, immutable snapshot (logged-in
+     * only) and shows the resulting `/cube/c/<token>` link, copying it to the
+     * clipboard. The Share controls only exist in the DOM for a logged-in user.
+     */
+    function wireShare(doc) {
+        const textarea = doc.querySelector('textarea[name="list"]');
+        const shareBtn = doc.querySelector('[data-share-list]');
+        if (!textarea || !shareBtn) return;
+        const result = doc.querySelector('[data-share-result]');
+        const urlInput = doc.querySelector('[data-share-url]');
+        const copyBtn = doc.querySelector('[data-share-copy]');
+        const status = doc.querySelector('[data-saved-status]');
+        const nameInput = doc.querySelector('[data-saved-lists]');
+
+        function copy(text) {
+            if (root.navigator && root.navigator.clipboard) {
+                root.navigator.clipboard.writeText(text).then(
+                    function () { setStatus(status, 'Share link copied to clipboard.'); },
+                    function () { /* clipboard blocked — the field is selectable */ }
+                );
+            }
+        }
+
+        shareBtn.addEventListener('click', function () {
+            const text = (textarea.value || '').trim();
+            if (!text) { setStatus(status, 'Nothing to share — paste a list first.'); return; }
+            const name = ((nameInput && nameInput.value) || '').trim();
+            setStatus(status, 'Creating link…');
+            fetch('/cube/api/share', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ name: name, cards: text }),
+            }).then(function (r) {
+                if (r.status === 401) { setStatus(status, 'Log in to create a share link.'); return null; }
+                if (!r.ok) { setStatus(status, 'Couldn\'t create a link. Try again.'); return null; }
+                return r.json();
+            }).then(function (json) {
+                if (!json) return;
+                const full = absoluteUrl(root.location && root.location.origin, json.url);
+                if (urlInput) urlInput.value = full;
+                if (result) result.hidden = false;
+                setStatus(status, 'Share link ready.');
+                copy(full);
+            }).catch(function () { setStatus(status, 'Couldn\'t create a link. Try again.'); });
+        });
+
+        if (copyBtn && urlInput) copyBtn.addEventListener('click', function () {
+            urlInput.select();
+            copy(urlInput.value);
         });
     }
 
@@ -833,7 +891,10 @@
         wireTabs(doc);
         wireSource(doc);
         wireSavedLists(doc);
+        wireShare(doc);
         wireCardAutocomplete(doc);
+        // A shared cube arrives pre-loaded in the list box — show that source.
+        if (doc.querySelector('[data-shared-banner]')) setSource(doc, 'list');
         wireExamples(doc);
         wireAsFan(doc);
         wirePreview(doc);
@@ -853,6 +914,7 @@
         tabIdFromHash: tabIdFromHash,
         zoomPosition: zoomPosition,
         deleteListUrl: deleteListUrl,
+        absoluteUrl: absoluteUrl,
         scryfallAutocompleteUrl: scryfallAutocompleteUrl,
         currentLineInfo: currentLineInfo,
         splitQuantityPrefix: splitQuantityPrefix,

--- a/web/src/main/resources/templates/cube.html
+++ b/web/src/main/resources/templates/cube.html
@@ -72,12 +72,18 @@
             </div>
 
             <div data-source-panel="list" hidden>
+                <p class="cube-shared-banner" th:if="${sharedName}" data-shared-banner
+                   th:text="'📥 Loaded shared cube: ' + ${sharedName}">Loaded shared cube</p>
+                <p class="cube-shared-missing" th:if="${sharedMissing}">
+                    That shared cube link wasn't found — it may have been mistyped.
+                </p>
                 <div class="cube-listlabel" id="cube-list-label">Your card list
                     <span class="cube-hint">— type a card to get name suggestions</span>
                 </div>
                 <div class="cube-list-wrap">
                     <textarea name="list" rows="8" spellcheck="false" aria-labelledby="cube-list-label"
                               aria-autocomplete="list" aria-controls="cube-card-suggest"
+                              th:text="${sharedCards}"
                               placeholder="One card per line:&#10;1 Lightning Bolt&#10;Sol Ring&#10;10 Forest"></textarea>
                     <ul class="cube-card-suggest" id="cube-card-suggest" data-card-suggest role="listbox" hidden></ul>
                 </div>
@@ -87,11 +93,18 @@
                     <datalist id="cube-saved-options" data-saved-options></datalist>
                     <button type="button" class="btn btn-secondary" data-save-list>Save</button>
                     <button type="button" class="btn btn-secondary" data-delete-list>Delete</button>
+                    <button type="button" class="btn btn-secondary" data-share-list>Share</button>
                     <span class="cube-saved-status muted" data-saved-status aria-live="polite"></span>
                 </div>
                 <p class="cube-saved-login muted" th:unless="${loggedIn}">
-                    <a href="/oauth2/authorization/discord">Log in with Discord</a> to save lists to your account.
+                    <a href="/oauth2/authorization/discord">Log in with Discord</a> to save &amp; share lists.
                 </p>
+                <div class="cube-share-result" data-share-result hidden>
+                    <label>Share link
+                        <input type="text" data-share-url readonly aria-label="Share link">
+                    </label>
+                    <button type="button" class="btn btn-secondary" data-share-copy>Copy</button>
+                </div>
             </div>
         </section>
 

--- a/web/src/test/js/cube.test.js
+++ b/web/src/test/js/cube.test.js
@@ -231,6 +231,17 @@ describe('deleteListUrl', () => {
     });
 });
 
+describe('absoluteUrl', () => {
+    test('joins the page origin with the relative share path', () => {
+        expect(Cube.absoluteUrl('https://toby-bot.co.uk', '/cube/c/abc123'))
+            .toBe('https://toby-bot.co.uk/cube/c/abc123');
+    });
+
+    test('tolerates a missing origin', () => {
+        expect(Cube.absoluteUrl(null, '/cube/c/abc123')).toBe('/cube/c/abc123');
+    });
+});
+
 describe('card-name autocomplete helpers', () => {
     test('scryfallAutocompleteUrl encodes the partial query', () => {
         expect(Cube.scryfallAutocompleteUrl('lightn')).toBe('https://api.scryfall.com/cards/autocomplete?q=lightn');

--- a/web/src/test/kotlin/web/controller/CubeControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/CubeControllerTest.kt
@@ -1,7 +1,9 @@
 package web.controller
 
 import database.dto.user.CubeListDto
+import database.dto.user.SharedCubeDto
 import database.service.user.CubeListService
+import database.service.user.SharedCubeService
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -28,6 +30,7 @@ class CubeControllerTest {
 
     private lateinit var service: CubeWebService
     private lateinit var cubeLists: CubeListService
+    private lateinit var sharedCubes: SharedCubeService
     private lateinit var controller: CubeController
 
     private fun loggedIn() = mockk<OAuth2User> {
@@ -40,7 +43,8 @@ class CubeControllerTest {
     fun setup() {
         service = mockk()
         cubeLists = mockk(relaxed = true)
-        controller = CubeController(service, cubeLists)
+        sharedCubes = mockk(relaxed = true)
+        controller = CubeController(service, cubeLists, sharedCubes)
     }
 
     @Test
@@ -279,5 +283,57 @@ class CubeControllerTest {
     fun `deleteList rejects an anonymous user with 401`() {
         assertEquals(HttpStatus.UNAUTHORIZED, controller.deleteList("My Cube", anon()).statusCode)
         verify(exactly = 0) { cubeLists.delete(any(), any()) }
+    }
+
+    // --- share links ----------------------------------------------------
+
+    @Test
+    fun `share mints a snapshot and returns its token and url`() {
+        every { sharedCubes.create(discordId, "My Cube", "Bolt\nForest", any()) } returns
+            SharedCubeDto("tok123", discordId, "My Cube", "Bolt\nForest", Instant.EPOCH)
+
+        val response = controller.share(ShareCubeRequest("My Cube", "Bolt\nForest"), loggedIn())
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertEquals("tok123", response.body!!.token)
+        assertEquals("/cube/c/tok123", response.body!!.url)
+    }
+
+    @Test
+    fun `share defaults a blank name and rejects blank cards`() {
+        every { sharedCubes.create(discordId, "Shared cube", "Bolt", any()) } returns
+            SharedCubeDto("t", discordId, "Shared cube", "Bolt", Instant.EPOCH)
+
+        assertEquals(HttpStatus.OK, controller.share(ShareCubeRequest("   ", "Bolt"), loggedIn()).statusCode)
+        verify(exactly = 1) { sharedCubes.create(discordId, "Shared cube", "Bolt", any()) }
+
+        assertEquals(HttpStatus.BAD_REQUEST, controller.share(ShareCubeRequest("Name", "  "), loggedIn()).statusCode)
+    }
+
+    @Test
+    fun `share rejects an anonymous user with 401`() {
+        assertEquals(HttpStatus.UNAUTHORIZED, controller.share(ShareCubeRequest("X", "Bolt"), anon()).statusCode)
+        verify(exactly = 0) { sharedCubes.create(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `sharedPage pre-loads the cube into the model when the token resolves`() {
+        val model = mockk<Model>(relaxed = true)
+        every { sharedCubes.get("tok123") } returns SharedCubeDto("tok123", discordId, "My Cube", "Bolt\nForest", Instant.EPOCH)
+
+        assertEquals("cube", controller.sharedPage("tok123", loggedIn(), model))
+
+        verify { model.addAttribute("sharedName", "My Cube") }
+        verify { model.addAttribute("sharedCards", "Bolt\nForest") }
+    }
+
+    @Test
+    fun `sharedPage flags a missing token`() {
+        val model = mockk<Model>(relaxed = true)
+        every { sharedCubes.get("nope") } returns null
+
+        assertEquals("cube", controller.sharedPage("nope", null, model))
+
+        verify { model.addAttribute("sharedMissing", true) }
     }
 }


### PR DESCRIPTION
Second of the two follow-ups (the first, #617, adds card image links to the Discord output). Per the choice of "server-stored short link".

## What it adds
A logged-in user can publish their card list as a **public, immutable snapshot** and share the link. Anyone can open it — no login to view.

- **Share** button (next to Save/Delete) posts the current list → mints a snapshot → shows and **clipboard-copies** a `/cube/c/<token>` link.
- Opening `/cube/c/<token>` drops you into the workshop with the cube **pre-loaded** in the list box and a "Loaded shared cube" banner (a bad token shows a friendly not-found note).

## How
- New **`shared_cube`** table (migration **V46**), keyed by a short random URL-safe token, with a `SharedCubeService` mirroring the saved-list stack. Tokens come from `SecureRandom` and are collision-checked. Snapshots are immutable — re-sharing an edited cube mints a new link.
- **Web:** `POST /cube/api/share` (auth) returns `{token, url}`; `GET /cube/c/{token}` (public) renders the cube page with the list pre-filled. Security permits `/cube/c/**` and keeps `/cube/api/share` behind auth (CSRF already exempt for `/cube/api/**`, same per-user rationale as the rest).

## Tests
- `SharedCubeService`: mint + retrieve, distinct tokens per share, unknown-token null.
- Share endpoint: returns token + url, defaults a blank name, 400 on blank cards, 401 for anon; shared page: pre-loads on a hit, flags a missing token.
- JS `absoluteUrl` helper (origin + relative path).

Local: `:database` (`DefaultSharedCubeServiceTest`), full `:web` suite, full JS suite (658), stylelint — all green. The Flyway migration + JPA mapping run on CI's Docker job.

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs

---
_Generated by [Claude Code](https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs)_