### PR TITLE
Resolve double-faced cards by either face in pasted cube lists

### DIFF
--- a/common/src/main/kotlin/common/mtg/MtgNames.kt
+++ b/common/src/main/kotlin/common/mtg/MtgNames.kt
@@ -1,0 +1,36 @@
+package common.mtg
+
+/**
+ * Card-name matching helpers that cope with multi-faced cards.
+ *
+ * Scryfall returns a double-faced / split card under its **full** name —
+ * e.g. `Huntmaster of the Fells // Ravager of the Fells` — but a user
+ * pasting a decklist usually writes just the front face
+ * (`Huntmaster of the Fells`). [matchKeys] yields every name a card can be
+ * looked up by (full name plus each face), all lower-cased, so resolving a
+ * pasted list against fetched cards matches whichever form the user wrote.
+ */
+object MtgNames {
+
+    private const val FACE_SEPARATOR = "//"
+
+    /**
+     * Lower-cased lookup keys for [fullName]: the whole name, plus each face
+     * of a multi-faced name. Order is full-name-first; duplicates removed.
+     */
+    fun matchKeys(fullName: String): List<String> {
+        val full = fullName.trim()
+        val keys = LinkedHashSet<String>()
+        if (full.isNotEmpty()) keys.add(full.lowercase())
+        if (full.contains(FACE_SEPARATOR)) {
+            full.split(FACE_SEPARATOR)
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+                .forEach { keys.add(it.lowercase()) }
+        }
+        return keys.toList()
+    }
+
+    /** The lookup key for a user-entered name (trimmed, lower-cased). */
+    fun lookupKey(name: String): String = name.trim().lowercase()
+}

--- a/common/src/test/kotlin/common/mtg/MtgNamesTest.kt
+++ b/common/src/test/kotlin/common/mtg/MtgNamesTest.kt
@@ -1,0 +1,97 @@
+package common.mtg
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class MtgNamesTest {
+
+    @Test
+    fun `a single-faced card matches only by its full name`() {
+        assertEquals(listOf("lightning bolt"), MtgNames.matchKeys("Lightning Bolt"))
+    }
+
+    @Test
+    fun `a double-faced card matches by its full name and each face`() {
+        assertEquals(
+            listOf(
+                "huntmaster of the fells // ravager of the fells",
+                "huntmaster of the fells",
+                "ravager of the fells",
+            ),
+            MtgNames.matchKeys("Huntmaster of the Fells // Ravager of the Fells"),
+        )
+    }
+
+    @Test
+    fun `keys are trimmed and lower-cased and de-duplicated`() {
+        // Same text on both faces collapses to two keys (full + the one face).
+        assertEquals(listOf("a // a", "a"), MtgNames.matchKeys("  A // A  "))
+    }
+
+    @Test
+    fun `lookupKey trims and lower-cases a user-entered name`() {
+        assertEquals("huntmaster of the fells", MtgNames.lookupKey("  Huntmaster of the Fells "))
+    }
+
+    @Test
+    fun `a front-face entry resolves against a fetched full name`() {
+        // Mirrors how the web/Discord resolvers match a pasted face name.
+        val byKey = MtgNames.matchKeys("Huntmaster of the Fells // Ravager of the Fells").associateWith { it }
+        assertEquals(true, byKey.containsKey(MtgNames.lookupKey("Huntmaster of the Fells")))
+    }
+
+    @Test
+    fun `the back face also resolves against the full name`() {
+        val keys = MtgNames.matchKeys("Archangel Avacyn // Avacyn, the Purifier")
+        assertTrue(keys.contains(MtgNames.lookupKey("Avacyn, the Purifier")))
+        assertTrue(keys.contains(MtgNames.lookupKey("Archangel Avacyn")))
+        assertTrue(keys.contains(MtgNames.lookupKey("Archangel Avacyn // Avacyn, the Purifier")))
+    }
+
+    @Test
+    fun `split cards expose both halves`() {
+        // e.g. Fire // Ice — paste either half.
+        val keys = MtgNames.matchKeys("Fire // Ice")
+        assertEquals(listOf("fire // ice", "fire", "ice"), keys)
+    }
+
+    @Test
+    fun `adventure cards expose the creature and the adventure name`() {
+        val keys = MtgNames.matchKeys("Brazen Borrower // Petty Theft")
+        assertTrue(keys.contains("brazen borrower"))
+        assertTrue(keys.contains("petty theft"))
+    }
+
+    @Test
+    fun `a face name with commas and apostrophes is preserved`() {
+        val keys = MtgNames.matchKeys("Jace, Vryn's Prodigy // Jace, Telepath Unbound")
+        assertTrue(keys.contains("jace, vryn's prodigy"))
+        assertTrue(keys.contains("jace, telepath unbound"))
+    }
+
+    @Test
+    fun `a single-faced name containing no separator yields exactly one key`() {
+        assertEquals(1, MtgNames.matchKeys("Sol Ring").size)
+    }
+
+    @Test
+    fun `blank or whitespace names yield no keys`() {
+        assertTrue(MtgNames.matchKeys("").isEmpty())
+        assertTrue(MtgNames.matchKeys("   ").isEmpty())
+    }
+
+    @Test
+    fun `empty faces around a separator are dropped`() {
+        // Defensive: a stray "Name //" shouldn't add a blank key.
+        val keys = MtgNames.matchKeys("Name //")
+        assertEquals(listOf("name //", "name"), keys)
+    }
+
+    @Test
+    fun `lookupKey is the inverse used for matching`() {
+        val keys = MtgNames.matchKeys("Wear // Tear")
+        assertTrue(keys.contains(MtgNames.lookupKey("  WEAR  ")))
+        assertTrue(keys.contains(MtgNames.lookupKey("tear")))
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeCommand.kt
@@ -6,6 +6,7 @@ import bot.toby.helpers.stringOption
 import common.mtg.AsFan
 import common.mtg.CardListParser
 import common.mtg.CubeCard
+import common.mtg.MtgNames
 import common.mtg.PackGenerator
 import core.command.Command.Companion.invokeDeleteOnMessageResponse
 import core.command.CommandContext
@@ -74,9 +75,15 @@ class CubeCommand @Autowired constructor(
             return when (val res = fetcher.fetchByNames(entries.map { it.name })) {
                 is ScryfallCubeFetcher.Result.Failure -> PoolResult.Failed(res.message)
                 is ScryfallCubeFetcher.Result.Success -> {
-                    val byName = res.cards.associateBy { it.name.lowercase() }
+                    // Index by full name AND each face so a pasted front-face
+                    // name (e.g. "Archangel Avacyn") matches a transform card's
+                    // full name ("Archangel Avacyn // Avacyn, the Purifier").
+                    val byName = HashMap<String, CubeCard>()
+                    res.cards.forEach { card ->
+                        MtgNames.matchKeys(card.name).forEach { key -> byName.putIfAbsent(key, card) }
+                    }
                     val pool = entries.flatMap { entry ->
-                        byName[entry.name.lowercase()]?.let { card -> List(entry.count) { card } } ?: emptyList()
+                        byName[MtgNames.lookupKey(entry.name)]?.let { card -> List(entry.count) { card } } ?: emptyList()
                     }
                     if (pool.isEmpty()) PoolResult.Failed("None of `$saved`'s cards matched Scryfall.")
                     else PoolResult.Ready(pool, "saved cube \"$saved\"")

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeCommandTest.kt
@@ -197,6 +197,50 @@ class CubeCommandTest : CommandTest {
     }
 
     @Test
+    fun `a saved cube's front-face name resolves a transform card`() {
+        val slot = slot<MessageEmbed>()
+        every { event.hook.sendMessageEmbeds(capture(slot), *anyVararg()) } returns webhookMessageCreateAction
+        every { event.subcommandName } returns CubeCommand.SUB_GENERATE
+        every { event.getOption(CubeCommand.OPT_SAVED) } returns strOpt("My Cube")
+        every { event.getOption(CubeCommand.OPT_QUERY) } returns null
+        every { event.getOption(CubeCommand.OPT_PACKS) } returns intOpt(1)
+        every { event.getOption(CubeCommand.OPT_PACK_SIZE) } returns intOpt(1)
+        every { event.getOption(CubeCommand.OPT_BALANCED) } returns null
+        // The user pasted only the front face; Scryfall returns the full name.
+        every { cubeListService.get(100L, "My Cube") } returns savedCube("My Cube", "Archangel Avacyn")
+        every { fetcher.fetchByNames(any()) } returns ScryfallCubeFetcher.Result.Success(
+            listOf(CubeCard("Archangel Avacyn // Avacyn, the Purifier", setOf(MtgColor.WHITE))),
+        )
+
+        run()
+
+        // Resolved (not "none matched"): a pack is dealt and attached.
+        verify(exactly = 1) { webhookMessageCreateAction.addFiles(any<FileUpload>()) }
+        assertTrue(slot.captured.title!!.contains("Generated 1 packs of 1"))
+    }
+
+    @Test
+    fun `a saved cube's back-face name also resolves a transform card`() {
+        val slot = slot<MessageEmbed>()
+        every { event.hook.sendMessageEmbeds(capture(slot), *anyVararg()) } returns webhookMessageCreateAction
+        every { event.subcommandName } returns CubeCommand.SUB_GENERATE
+        every { event.getOption(CubeCommand.OPT_SAVED) } returns strOpt("My Cube")
+        every { event.getOption(CubeCommand.OPT_QUERY) } returns null
+        every { event.getOption(CubeCommand.OPT_PACKS) } returns intOpt(1)
+        every { event.getOption(CubeCommand.OPT_PACK_SIZE) } returns intOpt(1)
+        every { event.getOption(CubeCommand.OPT_BALANCED) } returns null
+        every { cubeListService.get(100L, "My Cube") } returns savedCube("My Cube", "Avacyn, the Purifier")
+        every { fetcher.fetchByNames(any()) } returns ScryfallCubeFetcher.Result.Success(
+            listOf(CubeCard("Archangel Avacyn // Avacyn, the Purifier", setOf(MtgColor.WHITE))),
+        )
+
+        run()
+
+        verify(exactly = 1) { webhookMessageCreateAction.addFiles(any<FileUpload>()) }
+        assertTrue(slot.captured.title!!.contains("Generated 1 packs of 1"))
+    }
+
+    @Test
     fun `preview from a saved cube shows its distribution`() {
         val slot = slot<MessageEmbed>()
         every { event.hook.sendMessageEmbeds(capture(slot), *anyVararg()) } returns webhookMessageCreateAction

--- a/web/src/main/kotlin/web/service/CubeWebService.kt
+++ b/web/src/main/kotlin/web/service/CubeWebService.kt
@@ -6,6 +6,7 @@ import common.mtg.AsFan
 import common.mtg.CardCategory
 import common.mtg.CardListParser
 import common.mtg.CubeCard
+import common.mtg.MtgNames
 import common.mtg.MtgColor
 import common.mtg.PackGenerator
 import org.springframework.stereotype.Service
@@ -268,22 +269,38 @@ class CubeWebService {
         val entries = parseList(text)
         if (entries.isEmpty()) return CubeResult.error("Paste at least one card name, one per line.")
 
-        val resolved = HashMap<String, ScryfallCard>()
+        val fetched = mutableListOf<ScryfallCard>()
         for (chunk in entries.map { it.name }.distinct().chunked(COLLECTION_BATCH)) {
             when (val batch = fetchCollection(chunk)) {
                 is CubeResult.Failure -> return CubeResult.error(batch.error)
-                is CubeResult.Success -> batch.value.forEach { resolved[it.card.name.lowercase()] = it }
+                is CubeResult.Success -> fetched.addAll(batch.value)
             }
         }
 
+        val matched = matchEntries(entries, fetched)
+        if (matched.pool.isEmpty()) return CubeResult.error("None of those card names matched Scryfall. Check the spelling?")
+        return CubeResult.ok(ResolvedPool(matched.pool.take(MAX_CARDS), matched.notFound))
+    }
+
+    /**
+     * Matches parsed list entries to fetched cards and expands quantities.
+     * Each card is indexed by its full name AND each face, so a pasted
+     * front-face name (e.g. "Archangel Avacyn") matches the full name
+     * Scryfall returns for a transform card ("Archangel Avacyn // Avacyn,
+     * the Purifier"). Entries that don't resolve go into [MatchResult.notFound].
+     */
+    fun matchEntries(entries: List<ListEntry>, cards: List<ScryfallCard>): MatchResult {
+        val byKey = HashMap<String, ScryfallCard>()
+        cards.forEach { card ->
+            MtgNames.matchKeys(card.card.name).forEach { key -> byKey.putIfAbsent(key, card) }
+        }
         val pool = mutableListOf<ScryfallCard>()
         val notFound = mutableListOf<String>()
         for (entry in entries) {
-            val card = resolved[entry.name.lowercase()]
+            val card = byKey[MtgNames.lookupKey(entry.name)]
             if (card == null) notFound.add(entry.name) else repeat(entry.count) { pool.add(card) }
         }
-        if (pool.isEmpty()) return CubeResult.error("None of those card names matched Scryfall. Check the spelling?")
-        return CubeResult.ok(ResolvedPool(pool.take(MAX_CARDS), notFound.distinct()))
+        return MatchResult(pool, notFound.distinct())
     }
 
     /** One `/cards/collection` POST for up to 75 names. */
@@ -366,6 +383,9 @@ data class ListEntry(val name: String, val count: Int)
 
 /** A resolved custom list: the card pool plus any names Scryfall didn't know. */
 data class ResolvedPool(val cards: List<ScryfallCard>, val notFound: List<String>)
+
+/** Outcome of matching list entries to fetched cards: the pool + unresolved names. */
+data class MatchResult(val pool: List<ScryfallCard>, val notFound: List<String>)
 
 data class PreviewData(
     val query: String,

--- a/web/src/test/kotlin/web/service/CubeWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/CubeWebServiceTest.kt
@@ -207,4 +207,74 @@ class CubeWebServiceTest {
         val result = assertInstanceOf(CubeResult.Failure::class.java, service.generateList("# just a comment", 24, 15, true))
         assertTrue(result.error.contains("at least one card"))
     }
+
+    // --- matchEntries (pasted names ↔ fetched cards, incl. multi-faced) ---
+
+    private fun sc(name: String) = ScryfallCard(CubeCard(name), null, null)
+    private fun entry(name: String, count: Int = 1) = ListEntry(name, count)
+
+    private val avacyn = sc("Archangel Avacyn // Avacyn, the Purifier")
+
+    @Test
+    fun `matchEntries resolves a transform card by its front face`() {
+        val result = service.matchEntries(listOf(entry("Archangel Avacyn")), listOf(avacyn))
+        assertEquals(1, result.pool.size)
+        assertEquals("Archangel Avacyn // Avacyn, the Purifier", result.pool.first().card.name)
+        assertTrue(result.notFound.isEmpty())
+    }
+
+    @Test
+    fun `matchEntries resolves a transform card by its back face`() {
+        val result = service.matchEntries(listOf(entry("Avacyn, the Purifier")), listOf(avacyn))
+        assertEquals(1, result.pool.size)
+        assertTrue(result.notFound.isEmpty())
+    }
+
+    @Test
+    fun `matchEntries resolves a transform card by its full name`() {
+        val result = service.matchEntries(
+            listOf(entry("Archangel Avacyn // Avacyn, the Purifier")), listOf(avacyn),
+        )
+        assertEquals(1, result.pool.size)
+    }
+
+    @Test
+    fun `matchEntries matches case-insensitively and trims whitespace`() {
+        val result = service.matchEntries(listOf(entry("  archangel AVACYN ")), listOf(avacyn))
+        assertEquals(1, result.pool.size)
+        assertTrue(result.notFound.isEmpty())
+    }
+
+    @Test
+    fun `matchEntries expands quantities`() {
+        val result = service.matchEntries(listOf(entry("Forest", 10)), listOf(sc("Forest")))
+        assertEquals(10, result.pool.size)
+    }
+
+    @Test
+    fun `matchEntries reports names that don't resolve`() {
+        val result = service.matchEntries(
+            listOf(entry("Bolt"), entry("Definitely Not A Card")),
+            listOf(sc("Bolt")),
+        )
+        assertEquals(1, result.pool.size)
+        assertEquals(listOf("Definitely Not A Card"), result.notFound)
+    }
+
+    @Test
+    fun `matchEntries handles a mix of single and multi-faced cards`() {
+        val result = service.matchEntries(
+            listOf(entry("Petty Theft"), entry("Lightning Bolt"), entry("Bogus")),
+            listOf(sc("Brazen Borrower // Petty Theft"), sc("Lightning Bolt")),
+        )
+        assertEquals(setOf("Brazen Borrower // Petty Theft", "Lightning Bolt"), result.pool.map { it.card.name }.toSet())
+        assertEquals(listOf("Bogus"), result.notFound)
+    }
+
+    @Test
+    fun `matchEntries notFound is de-duplicated`() {
+        val result = service.matchEntries(listOf(entry("Ghost"), entry("Ghost")), emptyList())
+        assertTrue(result.pool.isEmpty())
+        assertEquals(listOf("Ghost"), result.notFound)
+    }
 }


### PR DESCRIPTION
Fixes double-faced / transform cards not resolving from a pasted list when you write just one face.

## The bug
A transform card like [Archangel Avacyn // Avacyn, the Purifier](https://scryfall.com/card/inr/11/archangel-avacyn-avacyn-the-purifier) (you flip it over to "transform") comes back from Scryfall under its **full** name. The list resolver indexed fetched cards only by that full name, so pasting just the front face (`Archangel Avacyn`) never matched → it was reported as "not found." Picking the autocomplete worked only because it fills the full `// ` name.

## The fix
Each fetched card is now indexed by its **full name and each face**, so a pasted front- **or** back-face name resolves. The logic lives in a new, shared `common.mtg.MtgNames` (`matchKeys` / `lookupKey`) used by **both** the web list resolver (`CubeWebService.matchEntries`, extracted so it's unit-testable) and the Discord saved-cube resolver — so the two can't drift. Quantities and not-found reporting are unchanged.

## Tests (lots, as requested)
- **`MtgNames`**: key generation for single-faced, transform, split (`Fire // Ice`), and adventure (`Brazen Borrower // Petty Theft`) names; commas/apostrophes preserved; blank/whitespace → no keys; empty face dropped; case/whitespace via `lookupKey`.
- **Web `matchEntries`**: resolve a transform card by front face, back face, and full name; case-insensitive + trimmed; quantity expansion; not-found reporting + de-dupe; a mixed single/multi-faced pool.
- **Discord**: a saved cube resolves a transform card by its front-face **and** back-face name.

Local: `:common` (`mtg.*`), `:web` (`CubeWebServiceTest` + `CubeControllerTest`), `:discord-bot` (`mtg.*`) all green (offline run — a remote mirror was flaky).

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs

---
_Generated by [Claude Code](https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs)_