### PR TITLE
Resolve full double-faced names by requesting Scryfall by front face

### DIFF
--- a/common/src/main/kotlin/common/mtg/MtgNames.kt
+++ b/common/src/main/kotlin/common/mtg/MtgNames.kt
@@ -33,4 +33,19 @@ object MtgNames {
 
     /** The lookup key for a user-entered name (trimmed, lower-cased). */
     fun lookupKey(name: String): String = name.trim().lowercase()
+
+    /**
+     * The identifier to send to Scryfall's collection lookup for [name].
+     * Scryfall matches a card by a single face, **not** by its full
+     * `A // B` name, so a pasted full name (e.g.
+     * `Archangel Avacyn // Avacyn, the Purifier`) must be reduced to its
+     * front face or it comes back "not found". Single-faced and front-face
+     * names pass through unchanged; the returned card (under its full name)
+     * is tied back to the original entry by [matchKeys].
+     */
+    fun requestName(name: String): String {
+        val trimmed = name.trim()
+        val idx = trimmed.indexOf(FACE_SEPARATOR)
+        return if (idx >= 0) trimmed.substring(0, idx).trim() else trimmed
+    }
 }

--- a/common/src/test/kotlin/common/mtg/MtgNamesTest.kt
+++ b/common/src/test/kotlin/common/mtg/MtgNamesTest.kt
@@ -94,4 +94,31 @@ class MtgNamesTest {
         assertTrue(keys.contains(MtgNames.lookupKey("  WEAR  ")))
         assertTrue(keys.contains(MtgNames.lookupKey("tear")))
     }
+
+    @Test
+    fun `requestName reduces a full multi-faced name to its front face`() {
+        assertEquals("Archangel Avacyn", MtgNames.requestName("Archangel Avacyn // Avacyn, the Purifier"))
+        assertEquals("Fire", MtgNames.requestName("Fire // Ice"))
+        assertEquals("Huntmaster of the Fells", MtgNames.requestName("Huntmaster of the Fells // Ravager of the Fells"))
+    }
+
+    @Test
+    fun `requestName leaves single-faced and front-face names unchanged`() {
+        assertEquals("Lightning Bolt", MtgNames.requestName("Lightning Bolt"))
+        assertEquals("Archangel Avacyn", MtgNames.requestName("Archangel Avacyn"))
+    }
+
+    @Test
+    fun `requestName trims surrounding and around-separator whitespace`() {
+        assertEquals("Fire", MtgNames.requestName("  Fire // Ice  "))
+        assertEquals("Commit", MtgNames.requestName("Commit//Memory"))
+    }
+
+    @Test
+    fun `the front face requestName resolves back via matchKeys`() {
+        // End-to-end of the fix: send the front face, match the full name back.
+        val request = MtgNames.requestName("Archangel Avacyn // Avacyn, the Purifier")
+        val fullNameKeys = MtgNames.matchKeys("Archangel Avacyn // Avacyn, the Purifier")
+        assertTrue(fullNameKeys.contains(MtgNames.lookupKey(request)))
+    }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeCommand.kt
@@ -72,7 +72,10 @@ class CubeCommand @Autowired constructor(
                 ?: return PoolResult.Failed("You have no saved cube named `$saved`. Save one on the website first.")
             val entries = CardListParser.parse(dto.cards)
             if (entries.isEmpty()) return PoolResult.Failed("Your saved cube `$saved` is empty.")
-            return when (val res = fetcher.fetchByNames(entries.map { it.name })) {
+            // Resolve by front face — Scryfall's collection lookup matches a
+            // single face, not the full "A // B" name; matchKeys ties the
+            // returned full-name cards back to the entries below.
+            return when (val res = fetcher.fetchByNames(entries.map { MtgNames.requestName(it.name) })) {
                 is ScryfallCubeFetcher.Result.Failure -> PoolResult.Failed(res.message)
                 is ScryfallCubeFetcher.Result.Success -> {
                     // Index by full name AND each face so a pasted front-face

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeCommandTest.kt
@@ -220,6 +220,32 @@ class CubeCommandTest : CommandTest {
     }
 
     @Test
+    fun `a saved cube with full DFC names requests Scryfall by front face`() {
+        val slot = slot<MessageEmbed>()
+        every { event.hook.sendMessageEmbeds(capture(slot), *anyVararg()) } returns webhookMessageCreateAction
+        every { event.subcommandName } returns CubeCommand.SUB_GENERATE
+        every { event.getOption(CubeCommand.OPT_SAVED) } returns strOpt("My Cube")
+        every { event.getOption(CubeCommand.OPT_QUERY) } returns null
+        every { event.getOption(CubeCommand.OPT_PACKS) } returns intOpt(1)
+        every { event.getOption(CubeCommand.OPT_PACK_SIZE) } returns intOpt(1)
+        every { event.getOption(CubeCommand.OPT_BALANCED) } returns null
+        // The cube stores the full "//" name (as exported from a deckbuilder).
+        every { cubeListService.get(100L, "My Cube") } returns
+            savedCube("My Cube", "Archangel Avacyn // Avacyn, the Purifier")
+        val requested = slot<List<String>>()
+        every { fetcher.fetchByNames(capture(requested)) } returns ScryfallCubeFetcher.Result.Success(
+            listOf(CubeCard("Archangel Avacyn // Avacyn, the Purifier", setOf(MtgColor.WHITE))),
+        )
+
+        run()
+
+        // Scryfall is asked for the front face only (the full "//" name 404s).
+        assertEquals(listOf("Archangel Avacyn"), requested.captured)
+        // …and the returned full-name card still resolves into a dealt pack.
+        verify(exactly = 1) { webhookMessageCreateAction.addFiles(any<FileUpload>()) }
+    }
+
+    @Test
     fun `a saved cube's back-face name also resolves a transform card`() {
         val slot = slot<MessageEmbed>()
         every { event.hook.sendMessageEmbeds(capture(slot), *anyVararg()) } returns webhookMessageCreateAction

--- a/web/src/main/kotlin/web/service/CubeWebService.kt
+++ b/web/src/main/kotlin/web/service/CubeWebService.kt
@@ -270,7 +270,11 @@ class CubeWebService {
         if (entries.isEmpty()) return CubeResult.error("Paste at least one card name, one per line.")
 
         val fetched = mutableListOf<ScryfallCard>()
-        for (chunk in entries.map { it.name }.distinct().chunked(COLLECTION_BATCH)) {
+        // Look cards up by their front face: Scryfall's collection lookup
+        // matches a single face, not the full "A // B" name. matchEntries
+        // ties the full-name cards Scryfall returns back to the entries.
+        val requestNames = entries.map { MtgNames.requestName(it.name) }.filter { it.isNotEmpty() }.distinct()
+        for (chunk in requestNames.chunked(COLLECTION_BATCH)) {
             when (val batch = fetchCollection(chunk)) {
                 is CubeResult.Failure -> return CubeResult.error(batch.error)
                 is CubeResult.Success -> fetched.addAll(batch.value)


### PR DESCRIPTION
Fixes the screenshot bug: a cube whose list contains the **full** double-faced names (`Archangel Avacyn // Avacyn, the Purifier`, `Fire // Ice`, `Huntmaster of the Fells // Ravager of the Fells`, …) reported all 9 as "Couldn't find".

## Why
#619 fixed the *matching* side (a fetched card is indexed by full name + each face). But the *request* side still sent the full `A // B` string to Scryfall's `/cards/collection`, which matches a card by a **single face**, not its full name — so those lookups returned nothing and the cards were never fetched.

## Fix
Send the **front face** as the lookup identifier (`MtgNames.requestName` strips everything from `//` on), then `matchKeys` (from #619) ties the returned full-name card back to the original entry — whichever form the user wrote (full, front, or back). Applied to both the web list resolver and the Discord saved-cube resolver. Single-faced and front-face names pass through unchanged.

## Tests
- `MtgNames.requestName`: full → front face; single-faced / front-face unchanged; whitespace incl. the separator-less `Commit//Memory`; and a front-face → `matchKeys` round-trip proving the returned full name still resolves.
- Discord: a saved cube of **full `//` names** is shown to request Scryfall by **front face** (`["Archangel Avacyn"]`) and still deals a pack (captured the `fetchByNames` argument).

Local: `:common` (`mtg.*`), `:discord-bot` (`mtg.*`), `:web` (`CubeWebServiceTest`) green (offline run).

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs

---
_Generated by [Claude Code](https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs)_