### PR TITLE
Classify modal land-back cards by their front face (as-fan fix)

### DIFF
--- a/common/src/main/kotlin/common/mtg/CubeCard.kt
+++ b/common/src/main/kotlin/common/mtg/CubeCard.kt
@@ -62,4 +62,18 @@ data class CubeCard(
             colors.size >= 2 -> CardCategory.MULTICOLOR
             else -> CardCategory.ofColor(colors.first())
         }
+
+    companion object {
+        /**
+         * Whether a Scryfall `type_line` denotes a land, judged by the
+         * **front face** only. A modal/transform card's combined type line
+         * (e.g. "Legendary Enchantment // Legendary Land" for
+         * Legion's Landing) mentions "Land" on the back, but the card is
+         * drafted and cast as its front face — so it shouldn't be bucketed
+         * as a land. Only when the front face itself is a land (e.g.
+         * "Land // Creature" for Westvale Abbey) is it a land.
+         */
+        fun isLandType(typeLine: String): Boolean =
+            typeLine.substringBefore("//").contains("Land", ignoreCase = true)
+    }
 }

--- a/common/src/test/kotlin/common/mtg/CubeCardTest.kt
+++ b/common/src/test/kotlin/common/mtg/CubeCardTest.kt
@@ -1,9 +1,40 @@
 package common.mtg
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class CubeCardTest {
+
+    @Test
+    fun `isLandType recognises a plain land`() {
+        assertTrue(CubeCard.isLandType("Basic Land — Forest"))
+        assertTrue(CubeCard.isLandType("Land — Mountain Plains"))
+        assertTrue(CubeCard.isLandType("Legendary Land"))
+    }
+
+    @Test
+    fun `isLandType is false for non-lands`() {
+        assertFalse(CubeCard.isLandType("Instant"))
+        assertFalse(CubeCard.isLandType("Creature — Human Wizard"))
+        assertFalse(CubeCard.isLandType("Artifact"))
+    }
+
+    @Test
+    fun `isLandType judges a modal card by its front face, not the land back`() {
+        // Legion's Landing // Adanto, the First Fort — an enchantment you cast,
+        // not a land, even though the back face is a land.
+        assertFalse(CubeCard.isLandType("Legendary Enchantment // Legendary Land"))
+        // Search for Azcanta // Azcanta, the Sunken Ruin.
+        assertFalse(CubeCard.isLandType("Legendary Enchantment // Legendary Land — Island"))
+    }
+
+    @Test
+    fun `isLandType is true when the front face itself is a land`() {
+        // Westvale Abbey // Ormendahl, Profane Prince — a land you play.
+        assertTrue(CubeCard.isLandType("Land // Creature — Demon"))
+    }
 
     @Test
     fun `mono-coloured card maps to its colour bucket`() {

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcher.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcher.kt
@@ -163,7 +163,7 @@ class ScryfallCubeFetcher {
         return CubeCard(
             name = name,
             colors = MtgColor.parse(identity),
-            isLand = typeLine.contains("Land", ignoreCase = true),
+            isLand = CubeCard.isLandType(typeLine),
             typeLine = typeLine,
             manaValue = manaValue,
             imageUrl = imageUrl(card),

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcherTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcherTest.kt
@@ -62,6 +62,25 @@ class ScryfallCubeFetcherTest {
     }
 
     @Test
+    fun `parseCard buckets a modal land-back card by its front face, not as a land`() {
+        val card = fetcher.parseCard(
+            obj("""{"name":"Legion's Landing // Adanto, the First Fort","color_identity":["W"],
+               "type_line":"Legendary Enchantment // Legendary Land"}""")
+        )!!
+        assertEquals(false, card.isLand)
+        assertEquals(CardCategory.WHITE, card.category)
+    }
+
+    @Test
+    fun `parseCard keeps a front-face land as a land`() {
+        val card = fetcher.parseCard(
+            obj("""{"name":"Westvale Abbey // Ormendahl, Profane Prince","color_identity":[],
+               "type_line":"Land // Creature — Demon"}""")
+        )!!
+        assertEquals(CardCategory.LAND, card.category)
+    }
+
+    @Test
     fun `parseCard flags lands from the type line`() {
         val card = fetcher.parseCard(
             obj("""{"name":"Sacred Foundry","color_identity":["R","W"],"type_line":"Land — Mountain Plains"}""")

--- a/web/src/main/kotlin/web/service/CubeWebService.kt
+++ b/web/src/main/kotlin/web/service/CubeWebService.kt
@@ -178,7 +178,7 @@ class CubeWebService {
                 card = CubeCard(
                     name = name,
                     colors = MtgColor.parse(identity),
-                    isLand = typeLine.contains("Land", ignoreCase = true),
+                    isLand = CubeCard.isLandType(typeLine),
                     typeLine = typeLine,
                     manaValue = node.path("cmc").asDouble(0.0),
                 ),

--- a/web/src/test/kotlin/web/service/CubeWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/CubeWebServiceTest.kt
@@ -128,6 +128,26 @@ class CubeWebServiceTest {
     }
 
     @Test
+    fun `parseScryfall buckets a modal land-back card by its front face, not as a land`() {
+        val root = mapper.readTree(
+            """{"data":[{"name":"Legion's Landing // Adanto, the First Fort","color_identity":["W"],
+               "type_line":"Legendary Enchantment // Legendary Land","cmc":1.0}]}"""
+        )
+        val card = service.parseScryfall(root).first().card
+        assertEquals(false, card.isLand)
+        assertEquals(CardCategory.WHITE, card.category)
+    }
+
+    @Test
+    fun `parseScryfall keeps a front-face land as a land`() {
+        val root = mapper.readTree(
+            """{"data":[{"name":"Westvale Abbey // Ormendahl, Profane Prince","color_identity":[],
+               "type_line":"Land // Creature — Demon","cmc":0.0}]}"""
+        )
+        assertEquals(CardCategory.LAND, service.parseScryfall(root).first().card.category)
+    }
+
+    @Test
     fun `parseScryfall yields null images when Scryfall has none`() {
         val root = mapper.readTree("""{"data":[{"name":"Imageless","color_identity":[],"type_line":"Token"}]}""")
         val parsed = service.parseScryfall(root).first()


### PR DESCRIPTION
From the "any other latent bugs?" audit — a real as-fan miscount.

## Bug
`isLand` was computed from the **whole** type line (`typeLine.contains("Land")`). A modal/transform card with a land on the **back face** therefore counted as a Land. Example straight from your cube: **Legion's Landing // Adanto, the First Fort** — `Legendary Enchantment // Legendary Land` — is a white enchantment you draft and cast, but was bucketed as a Land in the as-fan (inflating the land count and under-counting White). Same for Search for Azcanta, etc.

## Fix
Classification now keys off the **front face** only — `CubeCard.isLandType` splits on `//` and checks the part before it. A card whose *front* face is itself a land (e.g. **Westvale Abbey // Ormendahl, Profane Prince**, `Land // Creature`) still counts as a Land. Applied in both the web and Discord Scryfall parsers so they stay consistent.

## Tests
- `CubeCard.isLandType`: plain land, non-land, modal land-**back** → false, front-face land → true.
- Parse-level in both surfaces: Legion's Landing → **White**, Westvale Abbey → **Land**.

Local: `:common`, `:web` (`CubeWebServiceTest`), `:discord-bot` (`mtg.*`) green.

---

### Other things the audit turned up (not in this PR — your call)
- **Discord silently drops unresolved cards.** The web shows "Couldn't find N cards"; `/cube generate|preview` just builds a smaller pool without saying so. Could add a one-line note to the embed. *(minor UX)*
- **Web caps a pasted pool at 750 cards silently.** A bigger cube is truncated with no notice. *(minor; rare)*
- **Meld cards** (e.g. *Brisela*) — these are two *separate* cards that combine, not two faces, so the meld result isn't a draftable entry. Pasting the meld name won't resolve. *(niche)*

Want me to fix any of those? The Discord "couldn't find" notice is the most user-visible.

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs

---
_Generated by [Claude Code](https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs)_