### PR TITLE
Guard pack generation against an Int-overflow OOM (web DoS)

### DIFF
--- a/common/src/main/kotlin/common/mtg/PackGenerator.kt
+++ b/common/src/main/kotlin/common/mtg/PackGenerator.kt
@@ -47,7 +47,12 @@ class PackGenerator(private val random: Random = Random.Default) {
     ): Result {
         if (packCount <= 0) return Result.Failure("Pack count must be at least 1 (was $packCount).")
         if (packSize <= 0) return Result.Failure("Pack size must be at least 1 (was $packSize).")
-        val needed = packCount * packSize
+        // Long multiply: packCount × packSize can overflow Int (e.g. a crafted
+        // web request with packs=2^30, packSize=4 wraps to 0 and would slip past
+        // this guard into a huge List(packCount) allocation — an OOM). With the
+        // pool check below, anything that passes has needed ≤ pool.size, so it
+        // safely fits back in an Int.
+        val needed = packCount.toLong() * packSize.toLong()
         if (pool.size < needed) {
             return Result.Failure(
                 "Not enough cards: need $needed ($packCount × $packSize) but the pool only has ${pool.size}."
@@ -55,7 +60,7 @@ class PackGenerator(private val random: Random = Random.Default) {
         }
 
         // Randomly select the exact number of cards we'll deal.
-        val selected = pool.shuffled(random).take(needed)
+        val selected = pool.shuffled(random).take(needed.toInt())
 
         // The stream we deal from. Balanced → cards grouped into contiguous
         // category blocks (still shuffled within each block, via the stable

--- a/common/src/test/kotlin/common/mtg/PackGeneratorTest.kt
+++ b/common/src/test/kotlin/common/mtg/PackGeneratorTest.kt
@@ -12,6 +12,22 @@ class PackGeneratorTest {
         (1..size).map { CubeCard(name = "Card $it", colors = setOf(MtgColor.entries[it % 5])) }
 
     @Test
+    fun `a pack count that would overflow Int fails cleanly instead of OOMing`() {
+        // packCount × packSize as Int overflows: 2^30 × 4 wraps to 0, which
+        // used to slip past the pool check into List(2^30) (an OOM). Long maths
+        // must reject it as "not enough cards" — and return fast.
+        val result = PackGenerator(Random(1)).generate(pool(10), packCount = 1_073_741_824, packSize = 4)
+        val failure = assertInstanceOf(PackGenerator.Result.Failure::class.java, result)
+        assertTrue(failure.reason.contains("Not enough cards"))
+    }
+
+    @Test
+    fun `a near-Int-max pack size fails cleanly`() {
+        val result = PackGenerator(Random(1)).generate(pool(10), packCount = 5, packSize = Int.MAX_VALUE)
+        assertInstanceOf(PackGenerator.Result.Failure::class.java, result)
+    }
+
+    @Test
     fun `generates the requested number of packs each of the requested size`() {
         val result = PackGenerator(Random(1)).generate(pool(360), packCount = 24, packSize = 15)
         val success = assertInstanceOf(PackGenerator.Result.Success::class.java, result)


### PR DESCRIPTION
Another from the deeper audit — a more serious one: an **OOM / DoS** in pack generation reachable from the web.

## Bug
`PackGenerator.generate` computed `val needed = packCount * packSize` as an **Int** multiply, and the web `/cube/api/generate` endpoint puts **no upper bound** on `packs` / `packSize`. So a crafted request — e.g. `?query=is:land&packs=1073741824&packSize=4` — overflows `needed` to `0`, which slips past the `pool.size < needed` guard and reaches `List(packCount) { … }`, a ~1-billion-element allocation → out of memory.

(The Discord command is unaffected — its options cap at 90 packs / 30 size — but the web endpoint had no such cap.)

## Fix
Compute `needed` as a **Long**. An oversized request now correctly fails the pool check and returns a clean error (a 400 on the web). Anything that passes the check has `needed ≤ pool size ≤ 750`, so it still fits an `Int` for the draw and the `List(packCount)` allocation is bounded. One-line change in the shared domain, so it protects every caller (web query, web list, Discord).

## Test
- `packs = 2^30, packSize = 4` → returns a "Not enough cards" `Failure` **fast** (no OOM).
- `packSize = Int.MAX_VALUE` → clean `Failure`.

Local: `:common` `PackGeneratorTest` green.

_Independent of #621 (different file); both branch off `main`._

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs

---
_Generated by [Claude Code](https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs)_