### PR TITLE
Surface dropped cards: Discord "couldn't find" + web pool-cap note

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeCommand.kt
@@ -54,9 +54,13 @@ class CubeCommand @Autowired constructor(
         }
     }
 
-    /** A draftable pool plus a human label for it (query text or cube name). */
+    /** A draftable pool plus a human label, and any names that didn't resolve. */
     private sealed interface PoolResult {
-        data class Ready(val pool: List<CubeCard>, val label: String) : PoolResult
+        data class Ready(
+            val pool: List<CubeCard>,
+            val label: String,
+            val notFound: List<String> = emptyList(),
+        ) : PoolResult
         data class Failed(val message: String) : PoolResult
     }
 
@@ -88,8 +92,11 @@ class CubeCommand @Autowired constructor(
                     val pool = entries.flatMap { entry ->
                         byName[MtgNames.lookupKey(entry.name)]?.let { card -> List(entry.count) { card } } ?: emptyList()
                     }
+                    val notFound = entries.map { it.name }
+                        .filter { byName[MtgNames.lookupKey(it)] == null }
+                        .distinct()
                     if (pool.isEmpty()) PoolResult.Failed("None of `$saved`'s cards matched Scryfall.")
-                    else PoolResult.Ready(pool, "saved cube \"$saved\"")
+                    else PoolResult.Ready(pool, "saved cube \"$saved\"", notFound)
                 }
             }
         }
@@ -129,6 +136,7 @@ class CubeCommand @Autowired constructor(
                     packSize = packSize,
                     counts = AsFan.categoryCounts(pool),
                     distribution = AsFan.distribution(pool, packSize),
+                    notFound = resolved.notFound,
                 )
                 reply(ctx, embed, deleteDelay)
             }
@@ -157,6 +165,7 @@ class CubeCommand @Autowired constructor(
                             selected = selected,
                             counts = AsFan.categoryCounts(selected),
                             distribution = AsFan.distribution(selected, packSize),
+                            notFound = resolved.notFound,
                         )
                         val file = FileUpload.fromData(CubeEmbeds.packsFile(packs.value.packs), ATTACHMENT_NAME)
                         ctx.event.hook.sendMessageEmbeds(embed).addFiles(file).queue()

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
@@ -21,6 +21,9 @@ internal object CubeEmbeds {
 
     private const val AUTHOR = "🃏  Cube workshop" // 🃏
 
+    /** Keep the "couldn't find" field under Discord's 1024-char field cap. */
+    private const val NOT_FOUND_LIMIT = 1000
+
     fun asFanEmbed(typeCount: Int, cubeSize: Int, packSize: Int, value: Double): MessageEmbed =
         embed(color = OK_COLOR) {
             setAuthor(AUTHOR)
@@ -40,11 +43,13 @@ internal object CubeEmbeds {
         packSize: Int,
         counts: Map<CardCategory, Int>,
         distribution: Map<CardCategory, Double>,
+        notFound: List<String> = emptyList(),
     ): MessageEmbed = embed(color = OK_COLOR) {
         setAuthor(AUTHOR)
         setTitle("Cube preview")
         setDescription("Query `$query` → **$poolSize** cards, as-fan per **$packSize**-card pack.")
         field("Distribution", distributionTable(counts, distribution), inline = false)
+        addNotFoundField(notFound)
     }
 
     /** Summary of a generated set of packs. */
@@ -57,6 +62,7 @@ internal object CubeEmbeds {
         selected: List<CubeCard>,
         counts: Map<CardCategory, Int>,
         distribution: Map<CardCategory, Double>,
+        notFound: List<String> = emptyList(),
     ): MessageEmbed = embed(color = OK_COLOR) {
         setAuthor(AUTHOR)
         setTitle("Generated $packCount packs of $packSize")
@@ -65,7 +71,24 @@ internal object CubeEmbeds {
                 if (balanced) "\nAs-fan balanced across colours, colourless and lands." else ""
         )
         field("As-fan per pack", distributionTable(counts, distribution), inline = false)
+        addNotFoundField(notFound)
         setFooter("Full pack lists attached as a text file.")
+    }
+
+    /**
+     * Adds a "couldn't find" field listing names Scryfall didn't resolve, so
+     * a saved cube with a typo (or a card Scryfall doesn't know) is visible
+     * rather than silently dropped. Stays within the 1024-char field limit.
+     */
+    private fun net.dv8tion.jda.api.EmbedBuilder.addNotFoundField(notFound: List<String>) {
+        if (notFound.isEmpty()) return
+        val joined = notFound.joinToString(", ")
+        val value = if (joined.length <= NOT_FOUND_LIMIT) {
+            joined
+        } else {
+            joined.take(NOT_FOUND_LIMIT).substringBeforeLast(", ") + " … (+more)"
+        }
+        field("⚠️ Couldn't find ${notFound.size}", value, inline = false)
     }
 
     fun errorEmbed(message: String): MessageEmbed = embed(color = ERROR_COLOR) {

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeCommandTest.kt
@@ -267,6 +267,28 @@ class CubeCommandTest : CommandTest {
     }
 
     @Test
+    fun `generate from a saved cube reports cards it could not resolve`() {
+        val slot = slot<MessageEmbed>()
+        every { event.hook.sendMessageEmbeds(capture(slot), *anyVararg()) } returns webhookMessageCreateAction
+        every { event.subcommandName } returns CubeCommand.SUB_GENERATE
+        every { event.getOption(CubeCommand.OPT_SAVED) } returns strOpt("My Cube")
+        every { event.getOption(CubeCommand.OPT_QUERY) } returns null
+        every { event.getOption(CubeCommand.OPT_PACKS) } returns intOpt(1)
+        every { event.getOption(CubeCommand.OPT_PACK_SIZE) } returns intOpt(1)
+        every { event.getOption(CubeCommand.OPT_BALANCED) } returns null
+        every { cubeListService.get(100L, "My Cube") } returns savedCube("My Cube", "Bolt\nNonexistent Card")
+        every { fetcher.fetchByNames(any()) } returns ScryfallCubeFetcher.Result.Success(
+            listOf(CubeCard("Bolt", setOf(MtgColor.RED))),
+        )
+
+        run()
+
+        val warning = slot.captured.fields.firstOrNull { it.name?.contains("Couldn't find") == true }
+        assertTrue(warning != null, "expected a 'couldn't find' field on the embed")
+        assertTrue(warning!!.value!!.contains("Nonexistent Card"))
+    }
+
+    @Test
     fun `preview from a saved cube shows its distribution`() {
         val slot = slot<MessageEmbed>()
         every { event.hook.sendMessageEmbeds(capture(slot), *anyVararg()) } returns webhookMessageCreateAction

--- a/web/src/main/kotlin/web/controller/CubeController.kt
+++ b/web/src/main/kotlin/web/controller/CubeController.kt
@@ -124,10 +124,10 @@ class CubeController(
     private fun previewResponse(result: CubeResult<PreviewData>): ResponseEntity<CubePreviewResponse> =
         when (result) {
             is CubeResult.Success -> ResponseEntity.ok(
-                CubePreviewResponse(true, null, result.value.poolSize, result.value.groups, result.value.notFound)
+                CubePreviewResponse(true, null, result.value.poolSize, result.value.groups, result.value.notFound, result.value.note)
             )
             is CubeResult.Failure ->
-                ResponseEntity.badRequest().body(CubePreviewResponse(false, result.error, 0, emptyList(), emptyList()))
+                ResponseEntity.badRequest().body(CubePreviewResponse(false, result.error, 0, emptyList(), emptyList(), null))
         }
 
     private fun generateResponse(result: CubeResult<GenerateData>): ResponseEntity<CubeGenerateResponse> =
@@ -142,10 +142,11 @@ class CubeController(
                     packs = result.value.packs,
                     distribution = result.value.distribution,
                     notFound = result.value.notFound,
+                    note = result.value.note,
                 )
             )
             is CubeResult.Failure -> ResponseEntity.badRequest().body(
-                CubeGenerateResponse(false, result.error, 0, 0, 0, emptyList(), emptyList(), emptyList())
+                CubeGenerateResponse(false, result.error, 0, 0, 0, emptyList(), emptyList(), emptyList(), null)
             )
         }
 
@@ -238,6 +239,7 @@ data class CubePreviewResponse(
     val poolSize: Int,
     val groups: List<CategoryGroup>,
     val notFound: List<String> = emptyList(),
+    val note: String? = null,
 )
 
 data class CubeGenerateResponse(
@@ -249,4 +251,5 @@ data class CubeGenerateResponse(
     val packs: List<List<CardView>>,
     val distribution: List<CategoryAsFan>,
     val notFound: List<String> = emptyList(),
+    val note: String? = null,
 )

--- a/web/src/main/kotlin/web/service/CubeWebService.kt
+++ b/web/src/main/kotlin/web/service/CubeWebService.kt
@@ -60,7 +60,7 @@ class CubeWebService {
         return when (val resolved = resolveList(list)) {
             is CubeResult.Failure -> CubeResult.error(resolved.error)
             is CubeResult.Success -> CubeResult.ok(
-                buildPreview("your list", resolved.value.cards, packSize, resolved.value.notFound)
+                buildPreview("your list", resolved.value.cards, packSize, resolved.value.notFound, resolved.value.note)
             )
         }
     }
@@ -77,7 +77,7 @@ class CubeWebService {
         when (val resolved = resolveList(list)) {
             is CubeResult.Failure -> CubeResult.error(resolved.error)
             is CubeResult.Success ->
-                buildGenerate("your list", resolved.value.cards, packCount, packSize, balanced, resolved.value.notFound)
+                buildGenerate("your list", resolved.value.cards, packCount, packSize, balanced, resolved.value.notFound, resolved.value.note)
         }
 
     private fun buildPreview(
@@ -85,12 +85,14 @@ class CubeWebService {
         pool: List<ScryfallCard>,
         packSize: Int,
         notFound: List<String>,
+        note: String? = null,
     ): PreviewData = PreviewData(
         query = label,
         poolSize = pool.size,
         packSize = packSize,
         groups = groups(pool, packSize),
         notFound = notFound,
+        note = note,
     )
 
     private fun buildGenerate(
@@ -100,6 +102,7 @@ class CubeWebService {
         packSize: Int,
         balanced: Boolean,
         notFound: List<String>,
+        note: String? = null,
     ): CubeResult<GenerateData> {
         val cards = pool.map { it.card }
         val viewByName = pool.associate { it.card.name to it.toView() }
@@ -117,6 +120,7 @@ class CubeWebService {
                     },
                     distribution = distribution(packs.value.cards, packSize),
                     notFound = notFound,
+                    note = note,
                 )
             )
         }
@@ -283,7 +287,14 @@ class CubeWebService {
 
         val matched = matchEntries(entries, fetched)
         if (matched.pool.isEmpty()) return CubeResult.error("None of those card names matched Scryfall. Check the spelling?")
-        return CubeResult.ok(ResolvedPool(matched.pool.take(MAX_CARDS), matched.notFound))
+        // Be transparent if we had to cap a very large pool rather than
+        // silently dropping the overflow.
+        val note = if (matched.pool.size > MAX_CARDS) {
+            "Your list resolved to ${matched.pool.size} cards; only the first $MAX_CARDS were used."
+        } else {
+            null
+        }
+        return CubeResult.ok(ResolvedPool(matched.pool.take(MAX_CARDS), matched.notFound, note))
     }
 
     /**
@@ -385,8 +396,12 @@ data class CategoryGroup(
 /** One parsed decklist line: a card name and how many copies to include. */
 data class ListEntry(val name: String, val count: Int)
 
-/** A resolved custom list: the card pool plus any names Scryfall didn't know. */
-data class ResolvedPool(val cards: List<ScryfallCard>, val notFound: List<String>)
+/** A resolved custom list: the card pool, unresolved names, and an optional note. */
+data class ResolvedPool(
+    val cards: List<ScryfallCard>,
+    val notFound: List<String>,
+    val note: String? = null,
+)
 
 /** Outcome of matching list entries to fetched cards: the pool + unresolved names. */
 data class MatchResult(val pool: List<ScryfallCard>, val notFound: List<String>)
@@ -397,6 +412,7 @@ data class PreviewData(
     val packSize: Int,
     val groups: List<CategoryGroup>,
     val notFound: List<String> = emptyList(),
+    val note: String? = null,
 )
 
 data class GenerateData(
@@ -408,4 +424,5 @@ data class GenerateData(
     val packs: List<List<CardView>>,
     val distribution: List<CategoryAsFan>,
     val notFound: List<String> = emptyList(),
+    val note: String? = null,
 )

--- a/web/src/main/resources/static/js/cube.js
+++ b/web/src/main/resources/static/js/cube.js
@@ -684,7 +684,7 @@
             request
                 .then(function (json) {
                     if (!json.ok) { setStatus(status, json.error || 'No results.'); return; }
-                    setStatus(status, sourceLabel(src) + ' → ' + json.poolSize + ' cards');
+                    setStatus(status, sourceLabel(src) + ' → ' + json.poolSize + ' cards' + (json.note ? ' · ' + json.note : ''));
                     hide(empty);
                     renderGroups(groups, json.groups);
                     show(groups);
@@ -744,7 +744,8 @@
                     hide(empty);
                     lastPacks = json.packs;
                     summary.textContent = 'Dealt ' + json.packCount + ' packs of ' + json.packSize +
-                        ' from a ' + json.poolSize + '-card pool. Click any card to view it on Scryfall.';
+                        ' from a ' + json.poolSize + '-card pool. Click any card to view it on Scryfall.' +
+                        (json.note ? ' ' + json.note : '');
                     show(summary);
                     renderPacks(result, json.packs);
                     show(result);

--- a/web/src/test/kotlin/web/controller/CubeControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/CubeControllerTest.kt
@@ -190,6 +190,20 @@ class CubeControllerTest {
     }
 
     @Test
+    fun `previewList passes a truncation note through to the response`() {
+        val data = PreviewData(
+            query = "your list", poolSize = 750, packSize = 15, groups = emptyList(),
+            notFound = emptyList(), note = "Your list resolved to 900 cards; only the first 750 were used.",
+        )
+        every { service.previewList(any(), any()) } returns CubeResult.ok(data)
+
+        val response = controller.previewList(CubeListPreviewRequest("big list", 15))
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertEquals("Your list resolved to 900 cards; only the first 750 were used.", response.body!!.note)
+    }
+
+    @Test
     fun `previewList returns 400 when the list resolves to nothing`() {
         every { service.previewList(any(), any()) } returns CubeResult.error("None of those card names matched Scryfall. Check the spelling?")
         val response = controller.previewList(CubeListPreviewRequest("asdf\nqwer", 15))

--- a/web/src/test/kotlin/web/service/CubeWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/CubeWebServiceTest.kt
@@ -272,6 +272,18 @@ class CubeWebServiceTest {
     }
 
     @Test
+    fun `matchEntries resolves a meld part like any single-faced card`() {
+        // Meld parts (e.g. Bruna, the Fading Light) are normal single-faced
+        // cards — not two faces — so they resolve by their plain name.
+        val result = service.matchEntries(
+            listOf(entry("Bruna, the Fading Light")),
+            listOf(sc("Bruna, the Fading Light")),
+        )
+        assertEquals(1, result.pool.size)
+        assertTrue(result.notFound.isEmpty())
+    }
+
+    @Test
     fun `matchEntries notFound is de-duplicated`() {
         val result = service.matchEntries(listOf(entry("Ghost"), entry("Ghost")), emptyList())
         assertTrue(result.pool.isEmpty())


### PR DESCRIPTION
The remaining transparency items from the audit ("do all").

## 1. Discord — surface unresolved cards
`/cube preview` and `/cube generate` from a saved cube used to silently drop any card Scryfall didn't resolve and deal a smaller pool. Now the embed carries a **"⚠️ Couldn't find N"** field listing those names (front/back-face aware via the existing matcher), capped to Discord's 1024-char field limit. Mirrors what the web already shows.

## 2. Web — note when a pool is capped
A pasted list that resolves to more than the 750-card cap was truncated silently. The preview/generate response now includes a **`note`** ("Your list resolved to N cards; only the first 750 were used"), shown in the status line.

## 3. Meld cards
Confirmed there's nothing to fix: meld **parts** (e.g. *Bruna, the Fading Light*) are ordinary single-faced cards and resolve by their plain name — added a `matchEntries` test documenting it. (The melded result isn't a draftable entry, which is correct.)

## Tests
- Discord: a saved cube with an unknown card surfaces it in the embed's "Couldn't find" field.
- Web: `matchEntries` resolves a meld part; controller passes the truncation `note` through to the response.

Local: `:common`, `:discord-bot` (`mtg.*`), `:web` (`CubeWebServiceTest` + `CubeControllerTest`) and the cube JS suite all green.

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs

---
_Generated by [Claude Code](https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs)_