### PR TITLE
Bound oversized cube inputs (Scryfall lookups + stored text)

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcher.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcher.kt
@@ -103,7 +103,10 @@ class ScryfallCubeFetcher {
     fun fetchByNames(names: List<String>): Result = fetchByNames(names, HttpClients.createDefault())
 
     fun fetchByNames(names: List<String>, httpClient: HttpClient): Result {
-        val unique = names.map { it.trim() }.filter { it.isNotEmpty() }.distinct()
+        // Cap distinct lookups: a draft can't use more than DEFAULT_MAX_CARDS,
+        // so resolving more would just spam Scryfall (one POST per 75 names)
+        // and block the bot thread on the inter-batch delays.
+        val unique = names.map { it.trim() }.filter { it.isNotEmpty() }.distinct().take(DEFAULT_MAX_CARDS)
         if (unique.isEmpty()) return Result.Failure("That cube has no card names in it.")
 
         val cards = mutableListOf<CubeCard>()

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcherTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcherTest.kt
@@ -135,6 +135,24 @@ class ScryfallCubeFetcherTest {
     }
 
     @Test
+    fun `fetchByNames caps how many names it looks up`() {
+        // 800 distinct names → capped at 750 → ceil(750/75) = 10 batches,
+        // not ceil(800/75) = 11. Guards against spamming Scryfall. Each call
+        // gets a fresh (unconsumed) response stream.
+        val client = mockk<HttpClient>()
+        every { client.execute(any()) } answers {
+            mockk<HttpResponse>(relaxed = true) {
+                every { statusLine } returns mockk { every { statusCode } returns 200 }
+                every { entity } returns mockk(relaxed = true) {
+                    every { content } returns ByteArrayInputStream("""{"data":[]}""".toByteArray())
+                }
+            }
+        }
+        fetcher.fetchByNames((1..800).map { "Card $it" }, client)
+        io.mockk.verify(exactly = 10) { client.execute(any()) }
+    }
+
+    @Test
     fun `fetchByNames fails when nothing resolves`() {
         val client = mockk<HttpClient>()
         stubResponse(client, 200, """{"data":[]}""")

--- a/web/src/main/kotlin/web/controller/CubeController.kt
+++ b/web/src/main/kotlin/web/controller/CubeController.kt
@@ -169,7 +169,9 @@ class CubeController(
     ): ResponseEntity<SavedCubeList> {
         val discordId = user?.discordIdOrNull() ?: return ResponseEntity.status(401).build()
         val name = request.name.trim()
-        if (name.isEmpty() || name.length > MAX_NAME_LENGTH || request.cards.isBlank()) {
+        if (name.isEmpty() || name.length > MAX_NAME_LENGTH ||
+            request.cards.isBlank() || request.cards.length > MAX_CARDS_LENGTH
+        ) {
             return ResponseEntity.badRequest().build()
         }
         // Cap how many cubes one account can hoard; overwriting an existing
@@ -201,7 +203,9 @@ class CubeController(
         @AuthenticationPrincipal user: OAuth2User?,
     ): ResponseEntity<ShareCubeResponse> {
         val discordId = user?.discordIdOrNull() ?: return ResponseEntity.status(401).build()
-        if (request.cards.isBlank()) return ResponseEntity.badRequest().build()
+        if (request.cards.isBlank() || request.cards.length > MAX_CARDS_LENGTH) {
+            return ResponseEntity.badRequest().build()
+        }
         val name = request.name.trim().ifEmpty { "Shared cube" }.take(MAX_NAME_LENGTH)
         val row = sharedCubes.create(discordId, name, request.cards)
         return ResponseEntity.ok(ShareCubeResponse(token = row.token, url = "/cube/c/${row.token}", name = row.name))
@@ -210,6 +214,10 @@ class CubeController(
     private companion object {
         const val MAX_NAME_LENGTH = 100
         const val MAX_LISTS_PER_USER = 50
+
+        // Generous ceiling on stored list text — comfortably fits a 750-card
+        // cube with set tags, while bounding what an account can persist.
+        const val MAX_CARDS_LENGTH = 100_000
     }
 }
 

--- a/web/src/main/kotlin/web/service/CubeWebService.kt
+++ b/web/src/main/kotlin/web/service/CubeWebService.kt
@@ -273,7 +273,14 @@ class CubeWebService {
         // Look cards up by their front face: Scryfall's collection lookup
         // matches a single face, not the full "A // B" name. matchEntries
         // ties the full-name cards Scryfall returns back to the entries.
-        val requestNames = entries.map { MtgNames.requestName(it.name) }.filter { it.isNotEmpty() }.distinct()
+        // Cap how many distinct names we look up: the pool is capped at
+        // MAX_CARDS anyway, so resolving more would just hammer Scryfall (one
+        // POST per 75 names) and tie up the request thread for no benefit.
+        // Names past the cap fall through to notFound.
+        val requestNames = entries.map { MtgNames.requestName(it.name) }
+            .filter { it.isNotEmpty() }
+            .distinct()
+            .take(MAX_CARDS)
         for (chunk in requestNames.chunked(COLLECTION_BATCH)) {
             when (val batch = fetchCollection(chunk)) {
                 is CubeResult.Failure -> return CubeResult.error(batch.error)

--- a/web/src/test/kotlin/web/controller/CubeControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/CubeControllerTest.kt
@@ -257,6 +257,22 @@ class CubeControllerTest {
     }
 
     @Test
+    fun `saveList rejects an oversized cards payload`() {
+        val huge = "x".repeat(100_001)
+        val response = controller.saveList(SaveCubeListRequest("My Cube", huge), loggedIn())
+        assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+        verify(exactly = 0) { cubeLists.save(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `share rejects an oversized cards payload`() {
+        val huge = "x".repeat(100_001)
+        val response = controller.share(ShareCubeRequest("My Cube", huge), loggedIn())
+        assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+        verify(exactly = 0) { sharedCubes.create(any(), any(), any(), any()) }
+    }
+
+    @Test
     fun `saveList rejects an anonymous user with 401`() {
         assertEquals(HttpStatus.UNAUTHORIZED, controller.saveList(SaveCubeListRequest("X", "Bolt"), anon()).statusCode)
     }


### PR DESCRIPTION
A second audit pass — three unbounded-input issues that could exhaust resources or get us rate-limited.

## Findings
1. **Web list resolver looked up every distinct name, uncapped.** A pasted/saved list fires one Scryfall `/cards/collection` POST per 75 names, so a 50k-name list = ~670 sequential API calls — tying up a request thread and risking a Scryfall ban. The pool is capped at 750 *after* fetching, so everything past 750 was wasted work anyway.
2. **Discord `fetchByNames` had the same uncapped loop** — worse, since it blocks a bot thread through the 100 ms inter-batch delays.
3. **`save` / `share` accepted unbounded `cards` text** (authenticated, but a storage-bloat vector).

## Fix
- Cap distinct lookups at **750** (`MAX_CARDS` / `DEFAULT_MAX_CARDS`) in both resolvers — you can't draft more than that. Names past the cap fall through to the existing "not found" reporting.
- Cap stored `cards` at **100 KB** on save/share → `400` otherwise (comfortably fits a 750-card cube with set tags).

## Tests
- `fetchByNames` makes exactly **10** batched calls for 800 names (not 11) — proves the cap.
- `saveList` and `share` reject a >100 KB payload with `400` (and never call the service).

Local: `:discord-bot` (`mtg.*`) and `:web` (`CubeControllerTest` + `CubeWebServiceTest`) green.

### Lower-priority notes (not fixed)
- The web resolver fires its (now ≤10) collection POSTs back-to-back with no inter-batch delay, unlike the Discord side. Within Scryfall's burst tolerance at ≤10, but a small delay would be tidier. Adding blocking sleeps on a servlet thread is a trade-off, so I left it.

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs

---
_Generated by [Claude Code](https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs)_