### PR TITLE
Web cube UX: shareable query links, live card count, loading spinner

### DIFF
--- a/web/src/main/resources/static/css/cube.css
+++ b/web/src/main/resources/static/css/cube.css
@@ -512,6 +512,12 @@ button:disabled {
     cursor: progress;
 }
 
+.cube-statusline {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+}
+
 .cube-status {
     margin: var(--space-2) 0;
     color: var(--text-muted);
@@ -520,6 +526,54 @@ button:disabled {
 
 .cube-status:empty {
     display: none;
+}
+
+/* In-progress spinner shown next to the status while Scryfall is fetched. */
+.cube-spinner {
+    width: 16px;
+    height: 16px;
+    border: 2px solid var(--border-strong);
+    border-top-color: var(--mtg-gold);
+    border-radius: 50%;
+    flex-shrink: 0;
+    animation: cube-spin 0.7s linear infinite;
+}
+
+.cube-spinner[hidden] {
+    display: none;
+}
+
+@keyframes cube-spin {
+    to { transform: rotate(360deg); }
+}
+
+/* Card-count + clear row under the paste box, and the "copy link" button. */
+.cube-list-meta {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-2);
+    margin-top: 6px;
+}
+
+.cube-card-count {
+    font-size: 0.8rem;
+    color: var(--text-dim);
+}
+
+.cube-link-btn {
+    background: none;
+    border: 0;
+    padding: 0;
+    color: var(--mtg-gold);
+    font: inherit;
+    font-size: 0.82rem;
+    cursor: pointer;
+    text-decoration: underline;
+}
+
+.cube-link-btn:hover {
+    color: var(--accent-light);
 }
 
 .cube-empty {

--- a/web/src/main/resources/static/js/cube.js
+++ b/web/src/main/resources/static/js/cube.js
@@ -320,6 +320,93 @@
         }).then(function (r) { return r.json(); });
     }
 
+    // --- Deep links, card count, in-progress spinner -------------------
+
+    /** A shareable URL that pre-loads a Scryfall query (no login needed). */
+    function queryShareUrl(origin, query) {
+        return (origin || '') + '/cube?q=' + encodeURIComponent(query);
+    }
+
+    /** Reads ?q= / ?list= prefill params from a URL search string. */
+    function readUrlPrefill(search) {
+        const params = new URLSearchParams(search || '');
+        const out = {};
+        const q = params.get('q');
+        const list = params.get('list');
+        if (q) out.q = q;
+        if (list) out.list = list;
+        return out;
+    }
+
+    /** Counts the card lines in a pasted list (skips blanks and comments). */
+    function countCards(text) {
+        return (text || '').split('\n')
+            .map(function (line) { return line.trim(); })
+            .filter(function (line) {
+                return line !== '' && line.indexOf('#') !== 0 && line.indexOf('//') !== 0;
+            })
+            .length;
+    }
+
+    function setSpinner(doc, name, on) {
+        const el = doc.querySelector('[data-spinner="' + name + '"]');
+        if (el) el.hidden = !on;
+    }
+
+    /** Live "N cards" counter + a clear button for the paste box. */
+    function wireCardCount(doc) {
+        const textarea = doc.querySelector('textarea[name="list"]');
+        const count = doc.querySelector('[data-card-count]');
+        if (!textarea || !count) return;
+        function update() {
+            const n = countCards(textarea.value);
+            count.textContent = n + (n === 1 ? ' card' : ' cards');
+        }
+        textarea.addEventListener('input', update);
+        update(); // initial (a shared/prefilled list arrives populated)
+        const clear = doc.querySelector('[data-clear-list]');
+        if (clear) clear.addEventListener('click', function () {
+            textarea.value = '';
+            update();
+            textarea.focus();
+        });
+    }
+
+    /** "Copy link" for the current Scryfall search → /cube?q=... */
+    function wireCopyQuery(doc) {
+        const btn = doc.querySelector('[data-copy-query]');
+        const input = doc.querySelector('[data-source-panel="search"] input[name="query"]');
+        if (!btn || !input) return;
+        const label = btn.textContent;
+        btn.addEventListener('click', function () {
+            const q = (input.value || '').trim();
+            if (!q) { btn.textContent = 'Enter a search first'; root.setTimeout(function () { btn.textContent = label; }, 1500); return; }
+            const url = queryShareUrl(root.location && root.location.origin, q);
+            if (root.navigator && root.navigator.clipboard) {
+                root.navigator.clipboard.writeText(url).then(
+                    function () { btn.textContent = '✓ Link copied'; root.setTimeout(function () { btn.textContent = label; }, 2000); },
+                    function () { btn.textContent = url; }
+                );
+            } else {
+                btn.textContent = url;
+            }
+        });
+    }
+
+    /** Pre-loads the source from ?q= / ?list= so a shared link lands ready. */
+    function prefillFromUrl(doc) {
+        const pre = readUrlPrefill(root.location && root.location.search);
+        if (pre.q != null) {
+            const input = doc.querySelector('[data-source-panel="search"] input[name="query"]');
+            if (input) input.value = pre.q;
+            setSource(doc, 'search');
+        } else if (pre.list != null) {
+            const textarea = doc.querySelector('textarea[name="list"]');
+            if (textarea) textarea.value = pre.list;
+            setSource(doc, 'list');
+        }
+    }
+
     /** Disables the form's submit button while a request is in flight. */
     function withBusy(form, busy) {
         const btn = form.querySelector('button[type="submit"]');
@@ -678,6 +765,7 @@
             setStatus(status, src.mode === 'list' ? 'Resolving your list…' : 'Fetching cards from Scryfall…');
             hide(groups); hide(notFound);
             withBusy(form, true);
+            setSpinner(doc, 'preview', true);
             const request = src.mode === 'list'
                 ? postJson('/cube/api/preview', { list: src.list, packSize: Number(packSize) })
                 : getJson(previewUrl({ query: src.query, packSize: packSize }));
@@ -691,7 +779,7 @@
                     renderNotFound(notFound, json.notFound);
                 })
                 .catch(function () { setStatus(status, 'Something went wrong. Try again.'); })
-                .then(function () { withBusy(form, false); });
+                .then(function () { withBusy(form, false); setSpinner(doc, 'preview', false); });
         });
     }
 
@@ -734,6 +822,7 @@
             setStatus(status, src.mode === 'list' ? 'Resolving your list and dealing packs…' : 'Drawing cards and dealing packs…');
             hide(summary); hide(actions); hide(breakdown); hide(result); hide(notFound);
             withBusy(form, true);
+            setSpinner(doc, 'generate', true);
             const request = src.mode === 'list'
                 ? postJson('/cube/api/generate', { list: src.list, packs: Number(packs), packSize: Number(packSize), balanced: balanced })
                 : getJson(generateUrl({ query: src.query, packs: packs, packSize: packSize, balanced: balanced }));
@@ -755,7 +844,7 @@
                     renderNotFound(notFound, json.notFound);
                 })
                 .catch(function () { setStatus(status, 'Something went wrong building packs.'); })
-                .then(function () { withBusy(form, false); });
+                .then(function () { withBusy(form, false); setSpinner(doc, 'generate', false); });
         });
     }
 
@@ -894,8 +983,12 @@
         wireSavedLists(doc);
         wireShare(doc);
         wireCardAutocomplete(doc);
-        // A shared cube arrives pre-loaded in the list box — show that source.
+        prefillFromUrl(doc);
+        // A shared cube arrives pre-loaded in the list box — show that source
+        // (this wins over a ?q= / ?list= prefill).
         if (doc.querySelector('[data-shared-banner]')) setSource(doc, 'list');
+        wireCardCount(doc);
+        wireCopyQuery(doc);
         wireExamples(doc);
         wireAsFan(doc);
         wirePreview(doc);
@@ -916,6 +1009,9 @@
         zoomPosition: zoomPosition,
         deleteListUrl: deleteListUrl,
         absoluteUrl: absoluteUrl,
+        queryShareUrl: queryShareUrl,
+        readUrlPrefill: readUrlPrefill,
+        countCards: countCards,
         scryfallAutocompleteUrl: scryfallAutocompleteUrl,
         currentLineInfo: currentLineInfo,
         splitQuantityPrefix: splitQuantityPrefix,

--- a/web/src/main/resources/templates/cube.html
+++ b/web/src/main/resources/templates/cube.html
@@ -69,6 +69,7 @@
                     <button type="button" class="cube-chip" data-example="set:vow">set:vow</button>
                     <button type="button" class="cube-chip" data-example="t:dragon">t:dragon</button>
                 </span>
+                <button type="button" class="cube-link-btn" data-copy-query>🔗 Copy a shareable link to this search</button>
             </div>
 
             <div data-source-panel="list" hidden>
@@ -86,6 +87,10 @@
                               th:text="${sharedCards}"
                               placeholder="One card per line:&#10;1 Lightning Bolt&#10;Sol Ring&#10;10 Forest"></textarea>
                     <ul class="cube-card-suggest" id="cube-card-suggest" data-card-suggest role="listbox" hidden></ul>
+                </div>
+                <div class="cube-list-meta">
+                    <span class="cube-card-count" data-card-count aria-live="polite">0 cards</span>
+                    <button type="button" class="cube-link-btn" data-clear-list>Clear</button>
                 </div>
                 <div class="cube-saved" th:if="${loggedIn}">
                     <input type="text" class="cube-saved-input" data-saved-lists list="cube-saved-options"
@@ -152,7 +157,10 @@
                 </label>
                 <button type="submit" class="btn cube-submit">Generate packs</button>
             </form>
-            <p class="cube-status" data-status="generate" aria-live="polite"></p>
+            <div class="cube-statusline">
+                <span class="cube-spinner" data-spinner="generate" hidden aria-hidden="true"></span>
+                <p class="cube-status" data-status="generate" aria-live="polite"></p>
+            </div>
             <p class="cube-empty" data-empty="generate">Choose your cards above, then hit <strong>Generate packs</strong>.</p>
             <div class="cube-generate-summary" data-summary="generate" hidden></div>
             <p class="cube-notfound" data-notfound="generate" hidden></p>
@@ -180,7 +188,10 @@
                 </label>
                 <button type="submit" class="btn cube-submit">Preview balance</button>
             </form>
-            <p class="cube-status" data-status="preview" aria-live="polite"></p>
+            <div class="cube-statusline">
+                <span class="cube-spinner" data-spinner="preview" hidden aria-hidden="true"></span>
+                <p class="cube-status" data-status="preview" aria-live="polite"></p>
+            </div>
             <p class="cube-empty" data-empty="preview">Choose your cards above, then hit <strong>Preview balance</strong>.</p>
             <p class="cube-notfound" data-notfound="preview" hidden></p>
             <div class="cube-groups" data-result="preview" hidden></div>

--- a/web/src/test/js/cube.test.js
+++ b/web/src/test/js/cube.test.js
@@ -242,6 +242,36 @@ describe('absoluteUrl', () => {
     });
 });
 
+describe('queryShareUrl', () => {
+    test('builds a ?q= deep link, encoding the query', () => {
+        expect(Cube.queryShareUrl('https://toby-bot.co.uk', 't:dragon c:r'))
+            .toBe('https://toby-bot.co.uk/cube?q=t%3Adragon%20c%3Ar');
+    });
+});
+
+describe('readUrlPrefill', () => {
+    test('reads a ?q= query param', () => {
+        expect(Cube.readUrlPrefill('?q=set%3Avow')).toEqual({ q: 'set:vow' });
+    });
+    test('reads a ?list= param', () => {
+        expect(Cube.readUrlPrefill('?list=Bolt%0AForest')).toEqual({ list: 'Bolt\nForest' });
+    });
+    test('is empty when neither is present', () => {
+        expect(Cube.readUrlPrefill('?foo=bar')).toEqual({});
+        expect(Cube.readUrlPrefill('')).toEqual({});
+    });
+});
+
+describe('countCards', () => {
+    test('counts non-blank, non-comment lines', () => {
+        expect(Cube.countCards('Bolt\nForest\n\n# comment\n// also\n3 Island')).toBe(3);
+    });
+    test('is zero for empty or comment-only text', () => {
+        expect(Cube.countCards('')).toBe(0);
+        expect(Cube.countCards('# just a note\n\n')).toBe(0);
+    });
+});
+
 describe('card-name autocomplete helpers', () => {
     test('scryfallAutocompleteUrl encodes the partial query', () => {
         expect(Cube.scryfallAutocompleteUrl('lightn')).toBe('https://api.scryfall.com/cards/autocomplete?q=lightn');


### PR DESCRIPTION
First of two UX-polish PRs (the other adds `/cube saved` in Discord). Closes three of the usability gaps from the review.

## 1. Shareable query links
The page now reads **`?q=<scryfall>`** (and `?list=`) on load and pre-fills the source — so anyone can share a query cube by URL, **no login or saved snapshot needed** (which the existing `/cube/c/<token>` share links required). A **"Copy a shareable link to this search"** button builds the `/cube?q=…` URL and copies it. Fills the gap that query cubes previously had no shareable link at all.

## 2. Live card count + clear
The paste box shows **"N cards"** live as you type/paste (skipping blanks & comments, matching the parser), with a **Clear** button.

## 3. Loading spinner
Preview/Generate show a spinner next to the status while Scryfall is fetched, so a slow lookup doesn't look frozen.

## Tests
New pure helpers `queryShareUrl`, `readUrlPrefill`, `countCards` are exported and unit-tested (encoding, param parsing, line counting). The DOM wiring (copy button, counter, prefill, spinner) is browser-only.

Web-only change. Local: full JS suite (664) green, stylelint clean.

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs

---
_Generated by [Claude Code](https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs)_