### PR TITLE
Add /cube saved subcommand to list saved cubes in Discord

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeCommand.kt
@@ -30,6 +30,9 @@ import kotlin.random.Random
  *  - `/cube generate` — fetch a pool, randomly draw enough cards, and deal
  *                       them into evenly-sized, as-fan-balanced packs;
  *                       the full pack lists come back as a text file.
+ *  - `/cube saved`    — list the cubes the user saved on the website, each
+ *                       with its card count, ready to feed back into the
+ *                       `saved` option of preview/generate.
  *
  * A "cube" is defined by a Scryfall search query (`set:vow`, `cube:vintage`,
  * `t:dragon`, …) — or, via the `saved` option, by one of the user's own
@@ -50,7 +53,8 @@ class CubeCommand @Autowired constructor(
             SUB_ASFAN -> handleAsFan(ctx, deleteDelay)
             SUB_PREVIEW -> handlePreview(ctx, requestingUserDto, deleteDelay)
             SUB_GENERATE -> handleGenerate(ctx, requestingUserDto)
-            else -> reply(ctx, CubeEmbeds.errorEmbed("Pick a subcommand: asfan, preview or generate."), deleteDelay)
+            SUB_SAVED -> handleSaved(ctx, requestingUserDto, deleteDelay)
+            else -> reply(ctx, CubeEmbeds.errorEmbed("Pick a subcommand: asfan, preview, generate or saved."), deleteDelay)
         }
     }
 
@@ -175,6 +179,12 @@ class CubeCommand @Autowired constructor(
         }
     }
 
+    /** Lists the cubes this user has saved on the website. */
+    private fun handleSaved(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val saved = cubeListService.listForUser(requestingUserDto.discordId)
+        reply(ctx, CubeEmbeds.savedCubesEmbed(saved), deleteDelay)
+    }
+
     private fun reply(ctx: CommandContext, embed: MessageEmbed, deleteDelay: Int) {
         ctx.event.hook.sendMessageEmbeds(embed).queue(invokeDeleteOnMessageResponse(deleteDelay))
     }
@@ -208,12 +218,14 @@ class CubeCommand @Autowired constructor(
                     .setMinValue(1).setMaxValue(MAX_PACK_SIZE.toLong()),
                 OptionData(OptionType.BOOLEAN, OPT_BALANCED, "Level colours/lands across packs (default true).", false),
             ),
+        SubcommandData(SUB_SAVED, "List the cubes you've saved on the website."),
     )
 
     companion object {
         const val SUB_ASFAN = "asfan"
         const val SUB_PREVIEW = "preview"
         const val SUB_GENERATE = "generate"
+        const val SUB_SAVED = "saved"
 
         const val OPT_TOTAL = "total"
         const val OPT_CUBE_SIZE = "cube-size"

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
@@ -3,7 +3,9 @@ package bot.toby.command.commands.mtg
 import common.discord.embed
 import common.discord.field
 import common.mtg.CardCategory
+import common.mtg.CardListParser
 import common.mtg.CubeCard
+import database.dto.user.CubeListDto
 import net.dv8tion.jda.api.entities.MessageEmbed
 import java.awt.Color
 import java.nio.charset.StandardCharsets
@@ -89,6 +91,36 @@ internal object CubeEmbeds {
             joined.take(NOT_FOUND_LIMIT).substringBeforeLast(", ") + " … (+more)"
         }
         field("⚠️ Couldn't find ${notFound.size}", value, inline = false)
+    }
+
+    /** Keep the saved-cube listing under Discord's 4096-char description cap. */
+    private const val SAVED_LIST_LIMIT = 25
+
+    /**
+     * Lists the cubes a user has saved on the website, each with its card
+     * count, so they can see what's available to `/cube preview` or
+     * `/cube generate` without leaving Discord. Shows an empty-state nudge
+     * when they have none saved yet.
+     */
+    fun savedCubesEmbed(saved: List<CubeListDto>): MessageEmbed = embed(color = OK_COLOR) {
+        setAuthor(AUTHOR)
+        setTitle("Your saved cubes")
+        if (saved.isEmpty()) {
+            setDescription(
+                "You haven't saved any cubes yet. Build one on the website's " +
+                    "Cube workshop, hit **Save**, then use it here with " +
+                    "`/cube preview saved:` or `/cube generate saved:`."
+            )
+            return@embed
+        }
+        val shown = saved.take(SAVED_LIST_LIMIT)
+        val lines = shown.joinToString("\n") { dto ->
+            val count = CardListParser.parse(dto.cards).sumOf { it.count }
+            "• **${dto.name}** — $count card${if (count == 1) "" else "s"}"
+        }
+        val more = if (saved.size > shown.size) "\n…and ${saved.size - shown.size} more." else ""
+        setDescription(lines + more)
+        setFooter("Use one with /cube preview saved: or /cube generate saved:")
     }
 
     fun errorEmbed(message: String): MessageEmbed = embed(color = ERROR_COLOR) {

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeCommandTest.kt
@@ -355,10 +355,45 @@ class CubeCommandTest : CommandTest {
     }
 
     @Test
-    fun `exposes the three subcommands with their options`() {
+    fun `lists the user's saved cubes with their card counts`() {
+        val slot = slot<MessageEmbed>()
+        every { event.hook.sendMessageEmbeds(capture(slot), *anyVararg()) } returns webhookMessageCreateAction
+        every { event.subcommandName } returns CubeCommand.SUB_SAVED
+        every { cubeListService.listForUser(100L) } returns listOf(
+            savedCube("Vintage", "3 Bolt\nForest"),
+            savedCube("Pauper", "Lightning Bolt"),
+        )
+
+        run()
+
+        verify(exactly = 1) { cubeListService.listForUser(100L) }
+        assertEquals("Your saved cubes", slot.captured.title)
+        val desc = slot.captured.description!!
+        assertTrue(desc.contains("Vintage"), "description was: $desc")
+        // 3 Bolt + 1 Forest counts copies, not lines.
+        assertTrue(desc.contains("4 cards"), "description was: $desc")
+        assertTrue(desc.contains("Pauper"))
+        assertTrue(desc.contains("1 card") && !desc.contains("1 cards"), "singular card count: $desc")
+    }
+
+    @Test
+    fun `saved with no saved cubes nudges the user to the website`() {
+        val slot = slot<MessageEmbed>()
+        every { event.hook.sendMessageEmbeds(capture(slot), *anyVararg()) } returns webhookMessageCreateAction
+        every { event.subcommandName } returns CubeCommand.SUB_SAVED
+        every { cubeListService.listForUser(100L) } returns emptyList()
+
+        run()
+
+        assertEquals("Your saved cubes", slot.captured.title)
+        assertTrue(slot.captured.description!!.contains("haven't saved any"))
+    }
+
+    @Test
+    fun `exposes the four subcommands with their options`() {
         assertEquals("cube", command.name)
         val subs = command.subCommands.associateBy { it.name }
-        assertEquals(setOf("asfan", "preview", "generate"), subs.keys)
+        assertEquals(setOf("asfan", "preview", "generate", "saved"), subs.keys)
 
         val asfan = subs.getValue("asfan").options
         assertEquals(OptionType.INTEGER, asfan.first { it.name == "total" }.type)


### PR DESCRIPTION
## What

Adds a `/cube saved` subcommand that lists the cubes a user has saved on the website, each with its card count — the last of the four usability items selected earlier ("Discord: list saved cubes").

Until now, saved cubes were only discoverable via the `saved:` option's autocomplete on `/cube preview` and `/cube generate`. This gives users a direct way to see what they've saved without leaving Discord.

## Details

- **`CubeCommand`**: new `SUB_SAVED = "saved"` const, dispatch case, `handleSaved` (calls `cubeListService.listForUser`), and a `SubcommandData(SUB_SAVED, …)` registration with no options.
- **`CubeEmbeds.savedCubesEmbed`**: renders each saved cube as `• **name** — N cards` (counting copies via `CardListParser.parse(...).sumOf { it.count }`, with singular/plural handling), capped at 25 entries with an "…and N more" suffix. Shows an empty-state nudge pointing to the website when the user has nothing saved.

## Tests

- `/cube saved` lists cubes with correct (copy-counting, singular/plural) card counts.
- Empty state nudges the user to the website.
- Updated the metadata test to assert all four subcommands.

`./gradlew --offline :discord-bot:test --tests "bot.toby.command.commands.mtg.CubeCommandTest"` passes. Adding a subcommand doesn't change command/handler counts, so the manager tests are unaffected.

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs

---
_Generated by [Claude Code](https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs)_