### PR TITLE
Move cube Scryfall fetching onto ktor + coroutines

### DIFF
--- a/discord-bot/src/main/kotlin/bot/configuration/AppConfig.kt
+++ b/discord-bot/src/main/kotlin/bot/configuration/AppConfig.kt
@@ -4,6 +4,7 @@ import bot.toby.handler.EventWaiter
 import bot.toby.helpers.HttpHelper
 import io.ktor.client.*
 import io.ktor.client.engine.okhttp.*
+import io.ktor.client.plugins.*
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.serialization.kotlinx.json.*
 import kotlinx.serialization.json.Json
@@ -21,6 +22,9 @@ class AppConfig {
             install(ContentNegotiation) {
                 json(Json { ignoreUnknownKeys = true })
             }
+            // No global timeout (callers opt in per request, e.g. the cube
+            // fetcher) — installing the plugin just enables that capability.
+            install(HttpTimeout)
         }
     }
 

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeCommand.kt
@@ -12,6 +12,10 @@ import core.command.Command.Companion.invokeDeleteOnMessageResponse
 import core.command.CommandContext
 import database.dto.user.UserDto
 import database.service.user.CubeListService
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.interactions.commands.build.OptionData
@@ -42,6 +46,10 @@ import kotlin.random.Random
 class CubeCommand @Autowired constructor(
     private val fetcher: ScryfallCubeFetcher,
     private val cubeListService: CubeListService,
+    // Mirrors the /dnd command: IO-bound subcommands run on this dispatcher
+    // (tests pass Dispatchers.Unconfined so the launched work resolves
+    // synchronously).
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : MtgCommand {
 
     override val name: String = "cube"
@@ -50,20 +58,39 @@ class CubeCommand @Autowired constructor(
     override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
         logger.setGuildAndMemberContext(ctx.guild, ctx.member)
         when (ctx.event.subcommandName) {
-            SUB_ASFAN -> handleAsFan(ctx, deleteDelay)
-            SUB_PREVIEW -> handlePreview(ctx, requestingUserDto, deleteDelay)
-            SUB_GENERATE -> handleGenerate(ctx, requestingUserDto)
-            SUB_SAVED -> handleSaved(ctx, requestingUserDto, deleteDelay)
+            SUB_ASFAN -> handleAsFan(ctx, deleteDelay) // pure maths, no IO
+            SUB_PREVIEW -> launchHandling(ctx) { handlePreview(ctx, requestingUserDto, deleteDelay) }
+            SUB_GENERATE -> launchHandling(ctx) { handleGenerate(ctx, requestingUserDto) }
+            SUB_SAVED -> launchHandling(ctx) { handleSaved(ctx, requestingUserDto, deleteDelay) }
             else -> reply(ctx, CubeEmbeds.errorEmbed("Pick a subcommand: asfan, preview, generate or saved."), deleteDelay)
         }
     }
 
-    /** A draftable pool plus a human label, and any names that didn't resolve. */
+    /**
+     * Runs an IO-bound subcommand on [dispatcher] (the Scryfall fetch and the
+     * saved-cube DB read both block), mirroring the `/dnd` query handler, so
+     * the work never ties up the gateway or the CPU-bound default dispatcher.
+     * An unexpected failure resolves the deferred reply with an error embed
+     * rather than leaving Discord's "thinking…" spinner hanging.
+     */
+    private fun launchHandling(ctx: CommandContext, block: suspend () -> Unit) {
+        CoroutineScope(dispatcher).launch {
+            runCatching { block() }.onFailure { e ->
+                logger.error("Cube subcommand '${ctx.event.subcommandName}' failed: $e")
+                ctx.event.hook.sendMessageEmbeds(
+                    CubeEmbeds.errorEmbed("Something went wrong building that cube. Try again in a moment.")
+                ).queue({}, {})
+            }
+        }
+    }
+
+    /** A draftable pool plus a human label, any names that didn't resolve, and an optional note. */
     private sealed interface PoolResult {
         data class Ready(
             val pool: List<CubeCard>,
             val label: String,
             val notFound: List<String> = emptyList(),
+            val note: String? = null,
         ) : PoolResult
         data class Failed(val message: String) : PoolResult
     }
@@ -73,7 +100,7 @@ class CubeCommand @Autowired constructor(
      * cube (looked up for their Discord account, then resolved name-by-name
      * via Scryfall) takes precedence over a Scryfall `query`.
      */
-    private fun resolvePool(ctx: CommandContext, requestingUserDto: UserDto): PoolResult {
+    private suspend fun resolvePool(ctx: CommandContext, requestingUserDto: UserDto): PoolResult {
         val saved = ctx.event.stringOption(OPT_SAVED)?.trim()
         if (!saved.isNullOrEmpty()) {
             val dto = cubeListService.get(requestingUserDto.discordId, saved)
@@ -100,7 +127,7 @@ class CubeCommand @Autowired constructor(
                         .filter { byName[MtgNames.lookupKey(it)] == null }
                         .distinct()
                     if (pool.isEmpty()) PoolResult.Failed("None of `$saved`'s cards matched Scryfall.")
-                    else PoolResult.Ready(pool, "saved cube \"$saved\"", notFound)
+                    else PoolResult.Ready(pool, "saved cube \"$saved\"", notFound, capNote(res.capped))
                 }
             }
         }
@@ -111,9 +138,14 @@ class CubeCommand @Autowired constructor(
         }
         return when (val res = fetcher.fetch(query)) {
             is ScryfallCubeFetcher.Result.Failure -> PoolResult.Failed(res.message)
-            is ScryfallCubeFetcher.Result.Success -> PoolResult.Ready(res.cards, query)
+            is ScryfallCubeFetcher.Result.Success -> PoolResult.Ready(res.cards, query, note = capNote(res.capped))
         }
     }
+
+    /** A user-facing note when the pool was truncated to the Scryfall fetch ceiling. */
+    private fun capNote(capped: Boolean): String? =
+        if (capped) "Matched more than ${ScryfallCubeFetcher.DEFAULT_MAX_CARDS} cards; only the first ${ScryfallCubeFetcher.DEFAULT_MAX_CARDS} were used."
+        else null
 
     private fun handleAsFan(ctx: CommandContext, deleteDelay: Int) {
         val total = ctx.event.intOption(OPT_TOTAL, 0)
@@ -128,7 +160,7 @@ class CubeCommand @Autowired constructor(
         reply(ctx, embed, deleteDelay)
     }
 
-    private fun handlePreview(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
+    private suspend fun handlePreview(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
         val packSize = ctx.event.intOption(OPT_PACK_SIZE, DEFAULT_PACK_SIZE)
         when (val resolved = resolvePool(ctx, requestingUserDto)) {
             is PoolResult.Failed -> reply(ctx, CubeEmbeds.errorEmbed(resolved.message), deleteDelay)
@@ -141,13 +173,14 @@ class CubeCommand @Autowired constructor(
                     counts = AsFan.categoryCounts(pool),
                     distribution = AsFan.distribution(pool, packSize),
                     notFound = resolved.notFound,
+                    note = resolved.note,
                 )
                 reply(ctx, embed, deleteDelay)
             }
         }
     }
 
-    private fun handleGenerate(ctx: CommandContext, requestingUserDto: UserDto) {
+    private suspend fun handleGenerate(ctx: CommandContext, requestingUserDto: UserDto) {
         val packCount = ctx.event.intOption(OPT_PACKS, DEFAULT_PACK_COUNT)
         val packSize = ctx.event.intOption(OPT_PACK_SIZE, DEFAULT_PACK_SIZE)
         val balanced = ctx.event.booleanOption(OPT_BALANCED, true)
@@ -170,6 +203,7 @@ class CubeCommand @Autowired constructor(
                             counts = AsFan.categoryCounts(selected),
                             distribution = AsFan.distribution(selected, packSize),
                             notFound = resolved.notFound,
+                            note = resolved.note,
                         )
                         val file = FileUpload.fromData(CubeEmbeds.packsFile(packs.value.packs), ATTACHMENT_NAME)
                         ctx.event.hook.sendMessageEmbeds(embed).addFiles(file).queue()
@@ -180,7 +214,7 @@ class CubeCommand @Autowired constructor(
     }
 
     /** Lists the cubes this user has saved on the website. */
-    private fun handleSaved(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
+    private suspend fun handleSaved(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
         val saved = cubeListService.listForUser(requestingUserDto.discordId)
         reply(ctx, CubeEmbeds.savedCubesEmbed(saved), deleteDelay)
     }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
@@ -46,10 +46,14 @@ internal object CubeEmbeds {
         counts: Map<CardCategory, Int>,
         distribution: Map<CardCategory, Double>,
         notFound: List<String> = emptyList(),
+        note: String? = null,
     ): MessageEmbed = embed(color = OK_COLOR) {
         setAuthor(AUTHOR)
         setTitle("Cube preview")
-        setDescription("Query `$query` → **$poolSize** cards, as-fan per **$packSize**-card pack.")
+        setDescription(
+            "Query `$query` → **$poolSize** cards, as-fan per **$packSize**-card pack." +
+                note.orEmpty().let { if (it.isNotEmpty()) "\nℹ️ $it" else "" }
+        )
         field("Distribution", distributionTable(counts, distribution), inline = false)
         addNotFoundField(notFound)
     }
@@ -65,12 +69,14 @@ internal object CubeEmbeds {
         counts: Map<CardCategory, Int>,
         distribution: Map<CardCategory, Double>,
         notFound: List<String> = emptyList(),
+        note: String? = null,
     ): MessageEmbed = embed(color = OK_COLOR) {
         setAuthor(AUTHOR)
         setTitle("Generated $packCount packs of $packSize")
         setDescription(
             "Drew **${selected.size}** cards from the **$poolSize**-card pool matching `$query`." +
-                if (balanced) "\nAs-fan balanced across colours, colourless and lands." else ""
+                (if (balanced) "\nAs-fan balanced across colours, colourless and lands." else "") +
+                note.orEmpty().let { if (it.isNotEmpty()) "\nℹ️ $it" else "" }
         )
         field("As-fan per pack", distributionTable(counts, distribution), inline = false)
         addNotFoundField(notFound)

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcher.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcher.kt
@@ -7,14 +7,28 @@ import com.google.gson.JsonParser
 import common.logging.DiscordLogger
 import common.mtg.CubeCard
 import common.mtg.MtgColor
-import org.apache.http.client.HttpClient
-import org.apache.http.client.methods.HttpGet
-import org.apache.http.client.methods.HttpPost
-import org.apache.http.entity.StringEntity
-import org.apache.http.impl.client.HttpClients
-import org.apache.http.util.EntityUtils
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.timeout
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.content.TextContent
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+import kotlinx.coroutines.withContext
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import java.io.InputStreamReader
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
@@ -25,33 +39,43 @@ import java.nio.charset.StandardCharsets
  * `cube:<name>` — so a user defines their pool with the same search
  * syntax they'd use on scryfall.com.
  *
- * Mirrors the HTTP/JSON approach of [bot.toby.command.commands.fetch.MemeCommand]:
- * an injectable Apache [HttpClient] (so tests stub the transport) and
- * Gson tree parsing. The card → [CubeCard] mapping is split into
- * [parseCard] so it can be unit-tested without any network.
+ * Uses the same coroutine + ktor stack as the `/dnd` lookups
+ * ([bot.toby.helpers.HttpHelper]): `suspend` functions that hop onto
+ * [Dispatchers.IO] via [withContext], fed by the shared injectable ktor
+ * [HttpClient] (so blocking network work never ties up the CPU-bound
+ * default dispatcher, and tests can drive it with a `MockEngine`). The
+ * card → [CubeCard] mapping is split into [parseCard] so it can be
+ * unit-tested without any network.
  */
 @Component
-class ScryfallCubeFetcher {
+class ScryfallCubeFetcher @Autowired constructor(
+    private val client: HttpClient,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) {
 
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
     private val gson: Gson = Gson()
 
     sealed interface Result {
-        data class Success(val cards: List<CubeCard>) : Result
+        /**
+         * [capped] is true when the pool was truncated to the [DEFAULT_MAX_CARDS]
+         * ceiling — i.e. the query matched (or the list named) more cards than
+         * we deal from — so callers can tell the user rather than silently
+         * dropping the overflow.
+         */
+        data class Success(val cards: List<CubeCard>, val capped: Boolean = false) : Result
         data class Failure(val message: String) : Result
     }
 
     /**
      * Fetches up to [maxCards] cards matching [query], following Scryfall's
-     * pagination. Creates a default HTTP client; the overload taking a
-     * client is the test seam.
+     * pagination. Suspends on [Dispatchers.IO]; the pages are inherently
+     * sequential (each `next_page` comes from the previous response), which
+     * also naturally spaces the requests.
      */
-    fun fetch(query: String, maxCards: Int = DEFAULT_MAX_CARDS): Result =
-        fetch(query, maxCards, HttpClients.createDefault())
-
-    fun fetch(query: String, maxCards: Int, httpClient: HttpClient): Result {
+    suspend fun fetch(query: String, maxCards: Int = DEFAULT_MAX_CARDS): Result = withContext(dispatcher) {
         val trimmed = query.trim()
-        if (trimmed.isEmpty()) return Result.Failure("Give me a Scryfall search query (e.g. `set:vow`).")
+        if (trimmed.isEmpty()) return@withContext Result.Failure("Give me a Scryfall search query (e.g. `set:vow`).")
 
         val cards = mutableListOf<CubeCard>()
         var url: String? = searchUrl(trimmed)
@@ -59,86 +83,96 @@ class ScryfallCubeFetcher {
 
         try {
             while (url != null && cards.size < maxCards && page < MAX_PAGES) {
-                if (page > 0) Thread.sleep(SCRYFALL_DELAY_MS) // be polite to the API
-                val response = httpClient.execute(HttpGet(url))
-                val status = response.statusLine.statusCode
-                if (status == 404) {
-                    EntityUtils.consume(response.entity)
-                    return Result.Failure("No cards matched `$trimmed`.")
+                val response = client.get(url) {
+                    header(HttpHeaders.Accept, "application/json")
+                    timeout { requestTimeoutMillis = TIMEOUT_MS }
                 }
-                if (status != 200) {
-                    EntityUtils.consume(response.entity)
-                    return Result.Failure("Scryfall returned HTTP $status. Try again later.")
-                }
-                val root = JsonParser.parseReader(InputStreamReader(response.entity.content)).asJsonObject
-                EntityUtils.consume(response.entity)
+                val status = response.status.value
+                if (status == 404) return@withContext Result.Failure("No cards matched `$trimmed`.")
+                if (status != 200) return@withContext Result.Failure("Scryfall returned HTTP $status. Try again later.")
 
+                val root = JsonParser.parseString(response.bodyAsText()).asJsonObject
                 root.getAsJsonArray("data")?.forEach { element ->
                     parseCard(element.asJsonObject)?.let(cards::add)
                 }
-
                 url = if (root.get("has_more")?.asBoolean == true) root.get("next_page")?.asString else null
                 page++
             }
-        } catch (e: InterruptedException) {
-            Thread.currentThread().interrupt()
-            return Result.Failure("Lookup interrupted.")
+        } catch (e: CancellationException) {
+            throw e // never swallow coroutine cancellation
         } catch (e: Exception) {
             logger.error("Scryfall fetch failed for query '$trimmed': $e")
-            return Result.Failure("Couldn't reach Scryfall: ${e.message}")
+            return@withContext Result.Failure("Couldn't reach Scryfall: ${e.message}")
         }
 
-        if (cards.isEmpty()) return Result.Failure("No usable cards matched `$trimmed`.")
-        return Result.Success(cards.take(maxCards))
+        if (cards.isEmpty()) return@withContext Result.Failure("No usable cards matched `$trimmed`.")
+        // The query matched more than we deal from if we overshot the ceiling
+        // on the last page, or stopped with pages still unfetched.
+        val capped = cards.size > maxCards || url != null
+        Result.Success(cards.take(maxCards), capped)
     }
 
     /**
      * Resolves an explicit list of card names (e.g. a user's saved cube)
      * into cards via Scryfall's `/cards/collection` endpoint, batched at 75
-     * identifiers per request. Returns the resolved cards (one per found
-     * name, de-duplicated by the caller's list); names Scryfall doesn't know
-     * are simply absent from the result. Creates a default client; the
-     * overload taking one is the test seam.
+     * identifiers per request. The batches run concurrently (bounded by
+     * [MAX_CONCURRENT_BATCHES] so we don't burst past Scryfall's rate limit)
+     * on [Dispatchers.IO]. Names Scryfall doesn't know are simply absent from
+     * the result; the caller ties the returned cards back to its list.
      */
-    fun fetchByNames(names: List<String>): Result = fetchByNames(names, HttpClients.createDefault())
-
-    fun fetchByNames(names: List<String>, httpClient: HttpClient): Result {
+    suspend fun fetchByNames(names: List<String>): Result = withContext(dispatcher) {
         // Cap distinct lookups: a draft can't use more than DEFAULT_MAX_CARDS,
-        // so resolving more would just spam Scryfall (one POST per 75 names)
-        // and block the bot thread on the inter-batch delays.
-        val unique = names.map { it.trim() }.filter { it.isNotEmpty() }.distinct().take(DEFAULT_MAX_CARDS)
-        if (unique.isEmpty()) return Result.Failure("That cube has no card names in it.")
+        // so resolving more would just spam Scryfall (one POST per 75 names).
+        val distinctNames = names.map { it.trim() }.filter { it.isNotEmpty() }.distinct()
+        val unique = distinctNames.take(DEFAULT_MAX_CARDS)
+        if (unique.isEmpty()) return@withContext Result.Failure("That cube has no card names in it.")
 
-        val cards = mutableListOf<CubeCard>()
-        try {
-            unique.chunked(COLLECTION_BATCH).forEachIndexed { index, chunk ->
-                if (index > 0) Thread.sleep(SCRYFALL_DELAY_MS) // be polite to the API
-                val post = HttpPost(COLLECTION_ENDPOINT).apply {
-                    setHeader("Content-Type", "application/json")
-                    entity = StringEntity(collectionBody(chunk), StandardCharsets.UTF_8)
-                }
-                val response = httpClient.execute(post)
-                val status = response.statusLine.statusCode
-                if (status != 200) {
-                    EntityUtils.consume(response.entity)
-                    return Result.Failure("Scryfall returned HTTP $status resolving your cube.")
-                }
-                val root = JsonParser.parseReader(InputStreamReader(response.entity.content)).asJsonObject
-                EntityUtils.consume(response.entity)
-                root.getAsJsonArray("data")?.forEach { element ->
-                    parseCard(element.asJsonObject)?.let(cards::add)
-                }
+        val gate = Semaphore(MAX_CONCURRENT_BATCHES)
+        val batches = try {
+            coroutineScope {
+                unique.chunked(COLLECTION_BATCH)
+                    .map { chunk -> async { gate.withPermit { fetchCollectionBatch(chunk) } } }
+                    .awaitAll()
             }
-        } catch (e: InterruptedException) {
-            Thread.currentThread().interrupt()
-            return Result.Failure("Lookup interrupted.")
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             logger.error("Scryfall collection lookup failed: $e")
-            return Result.Failure("Couldn't reach Scryfall: ${e.message}")
+            return@withContext Result.Failure("Couldn't reach Scryfall: ${e.message}")
         }
 
-        if (cards.isEmpty()) return Result.Failure("None of those card names matched Scryfall.")
-        return Result.Success(cards)
+        val cards = mutableListOf<CubeCard>()
+        for (batch in batches) {
+            when (batch) {
+                is BatchResult.Failure -> return@withContext Result.Failure(batch.message)
+                is BatchResult.Success -> cards.addAll(batch.cards)
+            }
+        }
+
+        if (cards.isEmpty()) return@withContext Result.Failure("None of those card names matched Scryfall.")
+        Result.Success(cards, capped = distinctNames.size > DEFAULT_MAX_CARDS)
+    }
+
+    private sealed interface BatchResult {
+        data class Success(val cards: List<CubeCard>) : BatchResult
+        data class Failure(val message: String) : BatchResult
+    }
+
+    /** One `/cards/collection` POST for up to 75 names. */
+    private suspend fun fetchCollectionBatch(chunk: List<String>): BatchResult {
+        val response: HttpResponse = client.post(COLLECTION_ENDPOINT) {
+            header(HttpHeaders.Accept, "application/json")
+            timeout { requestTimeoutMillis = TIMEOUT_MS }
+            setBody(TextContent(collectionBody(chunk), ContentType.Application.Json))
+        }
+        val status = response.status.value
+        if (status != 200) return BatchResult.Failure("Scryfall returned HTTP $status resolving your cube.")
+        val root = JsonParser.parseString(response.bodyAsText()).asJsonObject
+        val cards = mutableListOf<CubeCard>()
+        root.getAsJsonArray("data")?.forEach { element ->
+            parseCard(element.asJsonObject)?.let(cards::add)
+        }
+        return BatchResult.Success(cards)
     }
 
     /** Builds the `{"identifiers":[{"name":...}]}` body, escaping names via Gson. */
@@ -197,6 +231,9 @@ class ScryfallCubeFetcher {
         const val DEFAULT_MAX_CARDS = 750
         private const val MAX_PAGES = 10
         private const val COLLECTION_BATCH = 75
-        private const val SCRYFALL_DELAY_MS = 100L
+
+        /** Bounds the concurrent `/cards/collection` POSTs to stay polite to Scryfall. */
+        private const val MAX_CONCURRENT_BATCHES = 3
+        private const val TIMEOUT_MS = 10_000L
     }
 }

--- a/discord-bot/src/test/kotlin/bot/configuration/TestAppConfig.kt
+++ b/discord-bot/src/test/kotlin/bot/configuration/TestAppConfig.kt
@@ -2,6 +2,7 @@ package bot.configuration
 
 import bot.toby.handler.EventWaiter
 import bot.toby.helpers.HttpHelper
+import io.ktor.client.HttpClient
 import io.mockk.mockk
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
@@ -10,6 +11,13 @@ import org.springframework.context.annotation.Profile
 @Profile("test")
 @TestConfiguration
 open class TestAppConfig {
+
+    // The cube fetcher injects the shared ktor client; the integration
+    // context never makes real Scryfall calls, so a relaxed mock suffices.
+    @Bean
+    open fun httpClient(): HttpClient {
+        return mockk(relaxed = true)
+    }
 
     @Bean
     open fun httpHelper(): HttpHelper {

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeCommandTest.kt
@@ -9,12 +9,15 @@ import common.mtg.CubeCard
 import common.mtg.MtgColor
 import database.dto.user.CubeListDto
 import database.service.user.CubeListService
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.slot
 import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
 import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.interactions.commands.OptionMapping
 import net.dv8tion.jda.api.interactions.commands.OptionType
@@ -36,7 +39,8 @@ class CubeCommandTest : CommandTest {
         setUpCommonMocks()
         fetcher = mockk()
         cubeListService = mockk(relaxed = true)
-        command = CubeCommand(fetcher, cubeListService)
+        // Unconfined so the launched IO coroutine resolves synchronously in tests.
+        command = CubeCommand(fetcher, cubeListService, Dispatchers.Unconfined)
         every { requestingUserDto.discordId } returns 100L
         every { webhookMessageCreateAction.addFiles(any<FileUpload>()) } returns webhookMessageCreateAction
         every { webhookMessageCreateAction.queue() } just runs
@@ -94,12 +98,12 @@ class CubeCommandTest : CommandTest {
         every { event.subcommandName } returns CubeCommand.SUB_PREVIEW
         every { event.getOption(CubeCommand.OPT_QUERY) } returns strOpt("set:vow")
         every { event.getOption(CubeCommand.OPT_PACK_SIZE) } returns null
-        every { fetcher.fetch(any(), any()) } returns ScryfallCubeFetcher.Result.Success(pool(50))
+        coEvery { fetcher.fetch(any(), any()) } returns ScryfallCubeFetcher.Result.Success(pool(50))
 
         run()
 
         assertEquals("Cube preview", slot.captured.title)
-        verify(exactly = 1) { fetcher.fetch(any(), any()) }
+        coVerify(exactly = 1) { fetcher.fetch(any(), any()) }
     }
 
     @Test
@@ -109,7 +113,7 @@ class CubeCommandTest : CommandTest {
         every { event.subcommandName } returns CubeCommand.SUB_PREVIEW
         every { event.getOption(CubeCommand.OPT_QUERY) } returns strOpt("set:zzz")
         every { event.getOption(CubeCommand.OPT_PACK_SIZE) } returns null
-        every { fetcher.fetch(any(), any()) } returns ScryfallCubeFetcher.Result.Failure("No cards matched.")
+        coEvery { fetcher.fetch(any(), any()) } returns ScryfallCubeFetcher.Result.Failure("No cards matched.")
 
         run()
 
@@ -127,7 +131,7 @@ class CubeCommandTest : CommandTest {
         every { event.getOption(CubeCommand.OPT_PACKS) } returns intOpt(2)
         every { event.getOption(CubeCommand.OPT_PACK_SIZE) } returns intOpt(3)
         every { event.getOption(CubeCommand.OPT_BALANCED) } returns boolOpt(true)
-        every { fetcher.fetch(any(), any()) } returns ScryfallCubeFetcher.Result.Success(pool(20))
+        coEvery { fetcher.fetch(any(), any()) } returns ScryfallCubeFetcher.Result.Success(pool(20))
 
         run()
 
@@ -144,7 +148,7 @@ class CubeCommandTest : CommandTest {
         every { event.getOption(CubeCommand.OPT_PACKS) } returns intOpt(24)
         every { event.getOption(CubeCommand.OPT_PACK_SIZE) } returns intOpt(15)
         every { event.getOption(CubeCommand.OPT_BALANCED) } returns null
-        every { fetcher.fetch(any(), any()) } returns ScryfallCubeFetcher.Result.Success(pool(5))
+        coEvery { fetcher.fetch(any(), any()) } returns ScryfallCubeFetcher.Result.Success(pool(5))
 
         run()
 
@@ -161,11 +165,40 @@ class CubeCommandTest : CommandTest {
         every { event.getOption(CubeCommand.OPT_PACKS) } returns null
         every { event.getOption(CubeCommand.OPT_PACK_SIZE) } returns null
         every { event.getOption(CubeCommand.OPT_BALANCED) } returns null
-        every { fetcher.fetch(any(), any()) } returns ScryfallCubeFetcher.Result.Failure("Scryfall returned HTTP 500.")
+        coEvery { fetcher.fetch(any(), any()) } returns ScryfallCubeFetcher.Result.Failure("Scryfall returned HTTP 500.")
 
         run()
 
         assertEquals("Couldn't build that cube", slot.captured.title)
+    }
+
+    @Test
+    fun `preview surfaces the capped-pool note when the query overflows`() {
+        val slot = slot<MessageEmbed>()
+        every { event.hook.sendMessageEmbeds(capture(slot), *anyVararg()) } returns webhookMessageCreateAction
+        every { event.subcommandName } returns CubeCommand.SUB_PREVIEW
+        every { event.getOption(CubeCommand.OPT_QUERY) } returns strOpt("t:creature")
+        every { event.getOption(CubeCommand.OPT_PACK_SIZE) } returns null
+        coEvery { fetcher.fetch(any(), any()) } returns ScryfallCubeFetcher.Result.Success(pool(50), capped = true)
+
+        run()
+
+        assertTrue(slot.captured.description!!.contains("only the first 750"), "note was: ${slot.captured.description}")
+    }
+
+    @Test
+    fun `an unexpected failure resolves the interaction with an error embed`() {
+        val slot = slot<MessageEmbed>()
+        every { event.hook.sendMessageEmbeds(capture(slot), *anyVararg()) } returns webhookMessageCreateAction
+        every { event.subcommandName } returns CubeCommand.SUB_PREVIEW
+        every { event.getOption(CubeCommand.OPT_QUERY) } returns strOpt("set:vow")
+        every { event.getOption(CubeCommand.OPT_PACK_SIZE) } returns null
+        coEvery { fetcher.fetch(any(), any()) } throws RuntimeException("scryfall exploded")
+
+        run()
+
+        assertEquals("Couldn't build that cube", slot.captured.title)
+        assertTrue(slot.captured.description!!.contains("Something went wrong"))
     }
 
     // --- saved cubes ---------------------------------------------------
@@ -184,7 +217,7 @@ class CubeCommandTest : CommandTest {
         every { event.getOption(CubeCommand.OPT_PACK_SIZE) } returns intOpt(3)
         every { event.getOption(CubeCommand.OPT_BALANCED) } returns null
         every { cubeListService.get(100L, "My Cube") } returns savedCube("My Cube", "3 Bolt\nForest")
-        every { fetcher.fetchByNames(any()) } returns ScryfallCubeFetcher.Result.Success(
+        coEvery { fetcher.fetchByNames(any()) } returns ScryfallCubeFetcher.Result.Success(
             listOf(CubeCard("Bolt", setOf(MtgColor.RED)), CubeCard("Forest", isLand = true)),
         )
 
@@ -208,7 +241,7 @@ class CubeCommandTest : CommandTest {
         every { event.getOption(CubeCommand.OPT_BALANCED) } returns null
         // The user pasted only the front face; Scryfall returns the full name.
         every { cubeListService.get(100L, "My Cube") } returns savedCube("My Cube", "Archangel Avacyn")
-        every { fetcher.fetchByNames(any()) } returns ScryfallCubeFetcher.Result.Success(
+        coEvery { fetcher.fetchByNames(any()) } returns ScryfallCubeFetcher.Result.Success(
             listOf(CubeCard("Archangel Avacyn // Avacyn, the Purifier", setOf(MtgColor.WHITE))),
         )
 
@@ -233,7 +266,7 @@ class CubeCommandTest : CommandTest {
         every { cubeListService.get(100L, "My Cube") } returns
             savedCube("My Cube", "Archangel Avacyn // Avacyn, the Purifier")
         val requested = slot<List<String>>()
-        every { fetcher.fetchByNames(capture(requested)) } returns ScryfallCubeFetcher.Result.Success(
+        coEvery { fetcher.fetchByNames(capture(requested)) } returns ScryfallCubeFetcher.Result.Success(
             listOf(CubeCard("Archangel Avacyn // Avacyn, the Purifier", setOf(MtgColor.WHITE))),
         )
 
@@ -256,7 +289,7 @@ class CubeCommandTest : CommandTest {
         every { event.getOption(CubeCommand.OPT_PACK_SIZE) } returns intOpt(1)
         every { event.getOption(CubeCommand.OPT_BALANCED) } returns null
         every { cubeListService.get(100L, "My Cube") } returns savedCube("My Cube", "Avacyn, the Purifier")
-        every { fetcher.fetchByNames(any()) } returns ScryfallCubeFetcher.Result.Success(
+        coEvery { fetcher.fetchByNames(any()) } returns ScryfallCubeFetcher.Result.Success(
             listOf(CubeCard("Archangel Avacyn // Avacyn, the Purifier", setOf(MtgColor.WHITE))),
         )
 
@@ -277,7 +310,7 @@ class CubeCommandTest : CommandTest {
         every { event.getOption(CubeCommand.OPT_PACK_SIZE) } returns intOpt(1)
         every { event.getOption(CubeCommand.OPT_BALANCED) } returns null
         every { cubeListService.get(100L, "My Cube") } returns savedCube("My Cube", "Bolt\nNonexistent Card")
-        every { fetcher.fetchByNames(any()) } returns ScryfallCubeFetcher.Result.Success(
+        coEvery { fetcher.fetchByNames(any()) } returns ScryfallCubeFetcher.Result.Success(
             listOf(CubeCard("Bolt", setOf(MtgColor.RED))),
         )
 
@@ -297,7 +330,7 @@ class CubeCommandTest : CommandTest {
         every { event.getOption(CubeCommand.OPT_QUERY) } returns null
         every { event.getOption(CubeCommand.OPT_PACK_SIZE) } returns null
         every { cubeListService.get(100L, "My Cube") } returns savedCube("My Cube", "Bolt\nForest")
-        every { fetcher.fetchByNames(any()) } returns ScryfallCubeFetcher.Result.Success(
+        coEvery { fetcher.fetchByNames(any()) } returns ScryfallCubeFetcher.Result.Success(
             listOf(CubeCard("Bolt", setOf(MtgColor.RED)), CubeCard("Forest", isLand = true)),
         )
 
@@ -322,7 +355,7 @@ class CubeCommandTest : CommandTest {
         run()
 
         assertEquals("Couldn't build that cube", slot.captured.title)
-        verify(exactly = 0) { fetcher.fetchByNames(any()) }
+        coVerify(exactly = 0) { fetcher.fetchByNames(any()) }
     }
 
     @Test

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcherTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcherTest.kt
@@ -3,22 +3,34 @@ package bot.toby.command.commands.mtg
 import com.google.gson.JsonParser
 import common.mtg.CardCategory
 import common.mtg.MtgColor
-import io.mockk.every
-import io.mockk.mockk
-import org.apache.http.HttpEntity
-import org.apache.http.HttpResponse
-import org.apache.http.StatusLine
-import org.apache.http.client.HttpClient
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.respondError
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import java.io.ByteArrayInputStream
+import java.io.IOException
 
 class ScryfallCubeFetcherTest {
 
-    private val fetcher = ScryfallCubeFetcher()
+    private val jsonHeaders = headersOf(HttpHeaders.ContentType, "application/json")
+
+    /** Builds a fetcher whose ktor client is driven by [engine]; runs on Unconfined for fast tests. */
+    private fun fetcherWith(engine: MockEngine): ScryfallCubeFetcher =
+        ScryfallCubeFetcher(HttpClient(engine) { install(HttpTimeout) }, Dispatchers.Unconfined)
+
+    /** A fetcher with a never-called engine — for the pure [ScryfallCubeFetcher.parseCard] tests. */
+    private val fetcher = fetcherWith(MockEngine { respond("{}", HttpStatusCode.OK, jsonHeaders) })
 
     private fun obj(json: String) = JsonParser.parseString(json).asJsonObject
 
@@ -102,7 +114,7 @@ class ScryfallCubeFetcherTest {
         assertNull(fetcher.parseCard(obj("""{"name":"","type_line":"Instant"}""")))
     }
 
-    // --- fetch ---------------------------------------------------------
+    // --- helpers -------------------------------------------------------
 
     private fun page(vararg cards: String, hasMore: Boolean = false, nextPage: String? = null): String {
         val data = cards.joinToString(",")
@@ -110,170 +122,184 @@ class ScryfallCubeFetcherTest {
         return """{"data":[$data]$tail}"""
     }
 
-    private fun stubResponse(client: HttpClient, status: Int, body: String) {
-        val response = mockk<HttpResponse>()
-        val statusLine = mockk<StatusLine>()
-        val entity = mockk<HttpEntity>(relaxed = true)
-        every { client.execute(any()) } returns response
-        every { response.statusLine } returns statusLine
-        every { statusLine.statusCode } returns status
-        every { response.entity } returns entity
-        every { entity.content } returns ByteArrayInputStream(body.toByteArray())
-    }
-
     // --- fetchByNames (saved-cube resolution via /cards/collection) ----
 
     @Test
-    fun `fetchByNames resolves a list of names into cards`() {
-        val client = mockk<HttpClient>()
-        stubResponse(
-            client, 200,
-            """{"data":[
-                {"name":"Lightning Bolt","color_identity":["R"],"type_line":"Instant","cmc":1},
-                {"name":"Forest","color_identity":[],"type_line":"Basic Land — Forest"}
-            ]}""",
+    fun `fetchByNames resolves a list of names into cards`() = runBlocking {
+        val fetcher = fetcherWith(
+            MockEngine {
+                respond(
+                    """{"data":[
+                        {"name":"Lightning Bolt","color_identity":["R"],"type_line":"Instant","cmc":1},
+                        {"name":"Forest","color_identity":[],"type_line":"Basic Land — Forest"}
+                    ]}""",
+                    HttpStatusCode.OK, jsonHeaders,
+                )
+            }
         )
-        val result = fetcher.fetchByNames(listOf("Lightning Bolt", "Forest"), client)
+        val result = fetcher.fetchByNames(listOf("Lightning Bolt", "Forest"))
         val success = assertInstanceOf(ScryfallCubeFetcher.Result.Success::class.java, result)
-        assertEquals(listOf("Lightning Bolt", "Forest"), success.cards.map { it.name })
+        assertEquals(setOf("Lightning Bolt", "Forest"), success.cards.map { it.name }.toSet())
     }
 
     @Test
-    fun `fetchByNames fails fast on an empty list without calling the network`() {
-        val client = mockk<HttpClient>()
-        assertInstanceOf(ScryfallCubeFetcher.Result.Failure::class.java, fetcher.fetchByNames(listOf("  ", ""), client))
+    fun `fetchByNames fails fast on an empty list without calling the network`() = runBlocking {
+        val engine = MockEngine { respond("{}", HttpStatusCode.OK, jsonHeaders) }
+        val result = fetcherWith(engine).fetchByNames(listOf("  ", ""))
+        assertInstanceOf(ScryfallCubeFetcher.Result.Failure::class.java, result)
+        assertEquals(0, engine.requestHistory.size)
     }
 
     @Test
-    fun `fetchByNames reports an HTTP error`() {
-        val client = mockk<HttpClient>()
-        stubResponse(client, 500, "boom")
-        val result = fetcher.fetchByNames(listOf("Bolt"), client)
+    fun `fetchByNames reports an HTTP error`() = runBlocking {
+        val result = fetcherWith(MockEngine { respondError(HttpStatusCode.InternalServerError) })
+            .fetchByNames(listOf("Bolt"))
         val failure = assertInstanceOf(ScryfallCubeFetcher.Result.Failure::class.java, result)
         assertTrue(failure.message.contains("HTTP 500"))
     }
 
     @Test
-    fun `fetchByNames caps how many names it looks up`() {
+    fun `fetchByNames caps how many names it looks up`() = runBlocking {
         // 800 distinct names → capped at 750 → ceil(750/75) = 10 batches,
-        // not ceil(800/75) = 11. Guards against spamming Scryfall. Each call
-        // gets a fresh (unconsumed) response stream.
-        val client = mockk<HttpClient>()
-        every { client.execute(any()) } answers {
-            mockk<HttpResponse>(relaxed = true) {
-                every { statusLine } returns mockk { every { statusCode } returns 200 }
-                every { entity } returns mockk(relaxed = true) {
-                    every { content } returns ByteArrayInputStream("""{"data":[]}""".toByteArray())
-                }
-            }
-        }
-        fetcher.fetchByNames((1..800).map { "Card $it" }, client)
-        io.mockk.verify(exactly = 10) { client.execute(any()) }
-    }
-
-    @Test
-    fun `fetchByNames fails when nothing resolves`() {
-        val client = mockk<HttpClient>()
-        stubResponse(client, 200, """{"data":[]}""")
-        val result = fetcher.fetchByNames(listOf("Definitely Not A Card"), client)
+        // not ceil(800/75) = 11. Guards against spamming Scryfall.
+        val engine = MockEngine { respond("""{"data":[]}""", HttpStatusCode.OK, jsonHeaders) }
+        val result = fetcherWith(engine).fetchByNames((1..800).map { "Card $it" })
+        assertEquals(10, engine.requestHistory.size)
+        // All ten POSTs returned no cards, so nothing resolved.
         assertInstanceOf(ScryfallCubeFetcher.Result.Failure::class.java, result)
     }
 
     @Test
-    fun `fetch returns parsed cards on a single page`() {
-        val client = mockk<HttpClient>()
-        stubResponse(
-            client, 200,
-            page(
-                """{"name":"Bolt","color_identity":["R"],"type_line":"Instant","cmc":1}""",
-                """{"name":"Forest","color_identity":[],"type_line":"Basic Land — Forest"}""",
-            ),
-        )
-        val result = fetcher.fetch("t:instant", maxCards = 100, httpClient = client)
+    fun `fetchByNames flags a list capped past the ceiling`() = runBlocking {
+        // 760 names → over the 750 ceiling → capped, and at least one resolves.
+        val engine = MockEngine {
+            respond(
+                """{"data":[{"name":"Card 1","color_identity":["R"],"type_line":"Instant"}]}""",
+                HttpStatusCode.OK, jsonHeaders,
+            )
+        }
+        val result = fetcherWith(engine).fetchByNames((1..760).map { "Card $it" })
         val success = assertInstanceOf(ScryfallCubeFetcher.Result.Success::class.java, result)
-        assertEquals(2, success.cards.size)
-        assertEquals(listOf("Bolt", "Forest"), success.cards.map { it.name })
+        assertTrue(success.capped, "a 760-name list should be flagged as capped")
     }
 
     @Test
-    fun `fetch follows pagination until has_more is false`() {
-        val client = mockk<HttpClient>()
-        val response = mockk<HttpResponse>()
-        val statusLine = mockk<StatusLine>()
-        val entity = mockk<HttpEntity>(relaxed = true)
-        every { client.execute(any()) } returns response
-        every { response.statusLine } returns statusLine
-        every { statusLine.statusCode } returns 200
-        every { response.entity } returns entity
-        every { entity.content } returnsMany listOf(
-            ByteArrayInputStream(
-                page("""{"name":"A","color_identity":["U"],"type_line":"Creature"}""", hasMore = true, nextPage = "https://api.scryfall.com/next")
-                    .toByteArray()
-            ),
-            ByteArrayInputStream(
-                page("""{"name":"B","color_identity":["G"],"type_line":"Creature"}""").toByteArray()
-            ),
+    fun `fetchByNames fails when nothing resolves`() = runBlocking {
+        val result = fetcherWith(MockEngine { respond("""{"data":[]}""", HttpStatusCode.OK, jsonHeaders) })
+            .fetchByNames(listOf("Definitely Not A Card"))
+        assertInstanceOf(ScryfallCubeFetcher.Result.Failure::class.java, result)
+    }
+
+    @Test
+    fun `fetchByNames posts to the collection endpoint`() = runBlocking {
+        val engine = MockEngine {
+            respond(
+                """{"data":[{"name":"Bolt","color_identity":["R"],"type_line":"Instant"}]}""",
+                HttpStatusCode.OK, jsonHeaders,
+            )
+        }
+        fetcherWith(engine).fetchByNames(listOf("Bolt"))
+        val request = engine.requestHistory.single()
+        assertEquals(HttpMethod.Post, request.method)
+        assertTrue(request.url.toString().endsWith("/cards/collection"))
+    }
+
+    // --- fetch ---------------------------------------------------------
+
+    @Test
+    fun `fetch returns parsed cards on a single page`() = runBlocking {
+        val fetcher = fetcherWith(
+            MockEngine {
+                respond(
+                    page(
+                        """{"name":"Bolt","color_identity":["R"],"type_line":"Instant","cmc":1}""",
+                        """{"name":"Forest","color_identity":[],"type_line":"Basic Land — Forest"}""",
+                    ),
+                    HttpStatusCode.OK, jsonHeaders,
+                )
+            }
         )
-        val result = fetcher.fetch("t:creature", maxCards = 100, httpClient = client)
+        val result = fetcher.fetch("t:instant", maxCards = 100)
+        val success = assertInstanceOf(ScryfallCubeFetcher.Result.Success::class.java, result)
+        assertEquals(2, success.cards.size)
+        assertEquals(listOf("Bolt", "Forest"), success.cards.map { it.name })
+        assertEquals(false, success.capped)
+    }
+
+    @Test
+    fun `fetch follows pagination until has_more is false`() = runBlocking {
+        val fetcher = fetcherWith(
+            MockEngine { request ->
+                if (request.url.toString().contains("page=2")) {
+                    respond(page("""{"name":"B","color_identity":["G"],"type_line":"Creature"}"""), HttpStatusCode.OK, jsonHeaders)
+                } else {
+                    respond(
+                        page(
+                            """{"name":"A","color_identity":["U"],"type_line":"Creature"}""",
+                            hasMore = true, nextPage = "https://api.scryfall.com/cards/search?page=2",
+                        ),
+                        HttpStatusCode.OK, jsonHeaders,
+                    )
+                }
+            }
+        )
+        val result = fetcher.fetch("t:creature", maxCards = 100)
         val success = assertInstanceOf(ScryfallCubeFetcher.Result.Success::class.java, result)
         assertEquals(listOf("A", "B"), success.cards.map { it.name })
     }
 
     @Test
-    fun `fetch caps the result at maxCards`() {
-        val client = mockk<HttpClient>()
-        stubResponse(
-            client, 200,
-            page(
-                """{"name":"A","color_identity":[],"type_line":"X"}""",
-                """{"name":"B","color_identity":[],"type_line":"X"}""",
-                """{"name":"C","color_identity":[],"type_line":"X"}""",
-            ),
+    fun `fetch caps the result at maxCards and flags it`() = runBlocking {
+        val fetcher = fetcherWith(
+            MockEngine {
+                respond(
+                    page(
+                        """{"name":"A","color_identity":[],"type_line":"X"}""",
+                        """{"name":"B","color_identity":[],"type_line":"X"}""",
+                        """{"name":"C","color_identity":[],"type_line":"X"}""",
+                    ),
+                    HttpStatusCode.OK, jsonHeaders,
+                )
+            }
         )
-        val result = fetcher.fetch("anything", maxCards = 2, httpClient = client)
+        val result = fetcher.fetch("anything", maxCards = 2)
         val success = assertInstanceOf(ScryfallCubeFetcher.Result.Success::class.java, result)
         assertEquals(2, success.cards.size)
+        assertTrue(success.capped, "overshooting maxCards should flag the pool as capped")
     }
 
     @Test
-    fun `fetch maps a 404 to a friendly no-matches failure`() {
-        val client = mockk<HttpClient>()
-        stubResponse(client, 404, """{"object":"error"}""")
-        val result = fetcher.fetch("set:nonsense", httpClient = client, maxCards = 10)
+    fun `fetch maps a 404 to a friendly no-matches failure`() = runBlocking {
+        val result = fetcherWith(MockEngine { respondError(HttpStatusCode.NotFound) }).fetch("set:nonsense", maxCards = 10)
         val failure = assertInstanceOf(ScryfallCubeFetcher.Result.Failure::class.java, result)
         assertTrue(failure.message.contains("No cards matched"))
     }
 
     @Test
-    fun `fetch reports other HTTP errors`() {
-        val client = mockk<HttpClient>()
-        stubResponse(client, 500, "boom")
-        val result = fetcher.fetch("t:goblin", httpClient = client, maxCards = 10)
+    fun `fetch reports other HTTP errors`() = runBlocking {
+        val result = fetcherWith(MockEngine { respondError(HttpStatusCode.InternalServerError) }).fetch("t:goblin", maxCards = 10)
         val failure = assertInstanceOf(ScryfallCubeFetcher.Result.Failure::class.java, result)
         assertTrue(failure.message.contains("HTTP 500"))
     }
 
     @Test
-    fun `fetch rejects a blank query without touching the network`() {
-        val client = mockk<HttpClient>()
-        val result = fetcher.fetch("   ", httpClient = client, maxCards = 10)
+    fun `fetch rejects a blank query without touching the network`() = runBlocking {
+        val engine = MockEngine { respond("{}", HttpStatusCode.OK, jsonHeaders) }
+        val result = fetcherWith(engine).fetch("   ", maxCards = 10)
         assertInstanceOf(ScryfallCubeFetcher.Result.Failure::class.java, result)
+        assertEquals(0, engine.requestHistory.size)
     }
 
     @Test
-    fun `fetch fails when the page has no usable cards`() {
-        val client = mockk<HttpClient>()
-        stubResponse(client, 200, page())
-        val result = fetcher.fetch("t:nothing", httpClient = client, maxCards = 10)
+    fun `fetch fails when the page has no usable cards`() = runBlocking {
+        val result = fetcherWith(MockEngine { respond(page(), HttpStatusCode.OK, jsonHeaders) }).fetch("t:nothing", maxCards = 10)
         val failure = assertInstanceOf(ScryfallCubeFetcher.Result.Failure::class.java, result)
         assertTrue(failure.message.contains("No usable cards"))
     }
 
     @Test
-    fun `fetch surfaces transport exceptions as a failure`() {
-        val client = mockk<HttpClient>()
-        every { client.execute(any()) } throws java.io.IOException("network down")
-        val result = fetcher.fetch("t:elf", httpClient = client, maxCards = 10)
+    fun `fetch surfaces transport exceptions as a failure`() = runBlocking {
+        val result = fetcherWith(MockEngine { throw IOException("network down") }).fetch("t:elf", maxCards = 10)
         val failure = assertInstanceOf(ScryfallCubeFetcher.Result.Failure::class.java, result)
         assertTrue(failure.message.contains("Couldn't reach Scryfall"))
     }


### PR DESCRIPTION
## Why

Audit follow-up. The `/cube` Scryfall lookups used a **synchronous Apache HttpClient** (`.execute()`), which:

1. **Blocked a `Dispatchers.Default` thread** — every slash command runs inside `SlashCommandEventListener`'s `launch { … }` on the CPU-bound default dispatcher, so the blocking network call tied up a thread from a pool sized for CPU work. Under concurrent load that can starve the pool.
2. **Had no HTTP timeout** — a slow/unresponsive Scryfall could hang the thread indefinitely (Apache's blocking `.execute()` isn't cancellable by coroutine cancellation).

`/dnd` already uses the shared suspending **ktor** client on `Dispatchers.IO` via `HttpHelper`. This brings `/cube` in line with that pattern.

## What changed

- **`ScryfallCubeFetcher`** now injects the shared ktor `HttpClient` and is a pair of `suspend` functions that hop onto `Dispatchers.IO` (`withContext`), with a **10s per-request timeout**. The `/cards/collection` batches now resolve **concurrently** (bounded by a small semaphore to stay polite to Scryfall's rate limit) instead of one-at-a-time.
- **`CubeCommand`** launches the IO-bound subcommands (`preview`/`generate`/`saved`) on an injected `CoroutineDispatcher` (default `Dispatchers.IO`), mirroring the `/dnd` query handler, and resolves the deferred reply with an error embed if the work throws (no more hung "thinking…" spinner).
- **`AppConfig`**: enabled the `HttpTimeout` plugin on the shared ktor client bean. No global timeout is set, so `/dnd` behaviour is unchanged — it just enables callers (the cube fetcher) to opt in per request.
- **Capped-pool transparency**: when a query/list overflows the 750-card fetch ceiling, the embed now says so (matching the web tool) instead of silently dropping the overflow.

## Tests

- Rewrote `ScryfallCubeFetcherTest` onto a ktor `MockEngine` (pagination, 404/500, cap-at-750, capped flag, collection POST, transport failure).
- `CubeCommandTest` drives the launched coroutines via `Dispatchers.Unconfined`; added cases for the capped-pool note and the unexpected-failure → error-embed path.
- Full `:discord-bot:test` and `:discord-bot:koverVerify` pass.

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs

---
_Generated by [Claude Code](https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs)_