### PR TITLE
Move /meme Reddit fetching onto ktor + coroutines

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/misc/MemeButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/misc/MemeButton.kt
@@ -5,7 +5,6 @@ import bot.toby.command.commands.fetch.MemeEmbeds
 import core.button.Button
 import core.button.ButtonContext
 import database.dto.user.UserDto
-import org.apache.http.impl.client.HttpClients
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
@@ -30,9 +29,8 @@ class MemeButton @Autowired constructor(
         event.deferEdit().queue()
         val args = MemeEmbeds.decodeReroll(event.componentId) ?: return
         if (requestingUserDto.memePermission != true) return
-        memeCommand.fetch(
+        memeCommand.fetchAsync(
             hook = event.hook,
-            httpClient = HttpClients.createDefault(),
             subreddit = args.subreddit,
             timePeriod = args.timePeriod,
             limit = args.limit,

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/fetch/MemeCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/fetch/MemeCommand.kt
@@ -1,26 +1,27 @@
 package bot.toby.command.commands.fetch
 
-import bot.toby.dto.web.RedditAPIDto
 import bot.toby.dto.web.RedditAPIDto.TimePeriod
-import com.google.gson.Gson
-import com.google.gson.JsonParser
 import core.command.CommandContext
 import database.dto.user.UserDto
-import net.dv8tion.jda.api.entities.MessageEmbed
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import net.dv8tion.jda.api.interactions.InteractionHook
 import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.interactions.commands.build.OptionData
-import org.apache.http.client.HttpClient
-import org.apache.http.client.methods.HttpGet
-import org.apache.http.impl.client.HttpClients
-import org.apache.http.util.EntityUtils
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import java.io.IOException
-import java.io.InputStreamReader
-import kotlin.random.Random
 
 @Component
-class MemeCommand : FetchCommand {
+class MemeCommand @Autowired constructor(
+    private val fetcher: RedditMemeFetcher,
+    // Mirrors /dnd and /cube: the Reddit fetch runs on this dispatcher
+    // (tests pass Dispatchers.Unconfined so the launched work resolves
+    // synchronously).
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : FetchCommand {
+
     companion object {
         const val SUBREDDIT = "subreddit"
         const val TIME_PERIOD = "timeperiod"
@@ -28,25 +29,10 @@ class MemeCommand : FetchCommand {
     }
 
     override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
-        try {
-            logger.setGuildAndMemberContext(ctx.guild, ctx.member)
-            handle(ctx, HttpClients.createDefault(), requestingUserDto, deleteDelay)
-        } catch (e: IOException) {
-            logger.error("IOException occurred while handling command: $e")
-            throw RuntimeException(e)
-        }
-    }
-
-    fun handle(
-        ctx: CommandContext,
-        httpClient: HttpClient,
-        requestingUserDto: UserDto?,
-        deleteDelay: Int
-    ) {
         val event = ctx.event
         logger.setGuildAndMemberContext(ctx.guild, ctx.member)
 
-        if (requestingUserDto?.memePermission != true) {
+        if (requestingUserDto.memePermission != true) {
             logger.info("User ${event.member?.effectiveName} does not have meme permission")
             sendErrorMessage(event, deleteDelay)
             return
@@ -57,20 +43,39 @@ class MemeCommand : FetchCommand {
         val limit = event.getOption(LIMIT)?.asInt ?: 5
         logger.info { "Reddit API args - Subreddit: $subredditArg, Time Period: $timePeriod, Limit: $limit" }
 
-        fetch(event.hook, httpClient, subredditArg, timePeriod, limit, deleteDelay)
+        fetchAsync(event.hook, subredditArg, timePeriod, limit, deleteDelay)
     }
 
     /**
-     * Shared entry point so [bot.toby.button.buttons.MemeButton] can
-     * re-roll against the same subreddit/timeperiod/limit without
-     * re-parsing slash-command options. The caller must have already
-     * acknowledged the interaction (`deferReply()` for the slash
-     * command, `deferEdit()` for the button) so the hook is ready to
-     * edit the original message.
+     * Shared entry point so [bot.toby.button.buttons.misc.MemeButton] can
+     * re-roll against the same subreddit/timeperiod/limit without re-parsing
+     * slash-command options. The caller must have already acknowledged the
+     * interaction (`deferReply()` for the slash command, `deferEdit()` for
+     * the button) so the hook is ready to edit the original message.
+     *
+     * The fetch runs on [dispatcher] (mirroring the `/dnd` query handler) so
+     * the blocking network work never ties up the gateway or the CPU-bound
+     * default dispatcher; an unexpected failure still resolves the message
+     * with an error embed.
      */
-    fun fetch(
+    fun fetchAsync(
         hook: InteractionHook,
-        httpClient: HttpClient,
+        subreddit: String?,
+        timePeriod: String,
+        limit: Int,
+        deleteDelay: Int,
+    ) {
+        CoroutineScope(dispatcher).launch {
+            runCatching { fetch(hook, subreddit, timePeriod, limit, deleteDelay) }
+                .onFailure { e ->
+                    logger.error("Meme fetch failed for subreddit '$subreddit': $e")
+                    editError(hook, "Something went wrong fetching that meme. Try again in a moment.", deleteDelay)
+                }
+        }
+    }
+
+    private suspend fun fetch(
+        hook: InteractionHook,
         subreddit: String?,
         timePeriod: String,
         limit: Int,
@@ -84,16 +89,17 @@ class MemeCommand : FetchCommand {
             return
         }
 
-        val outcome = fetchRedditPost(subreddit, timePeriod, limit, httpClient)
-        when (outcome) {
-            is RedditOutcome.Embed -> {
+        when (val outcome = fetcher.fetch(subreddit, timePeriod, limit)) {
+            is RedditMemeFetcher.Result.Success -> {
                 logger.info("Successfully fetched meme from subreddit: $subreddit")
-                val edit = hook.editOriginalEmbeds(listOf(outcome.embed))
+                val edit = hook.editOriginalEmbeds(
+                    listOf(MemeEmbeds.resultEmbed(outcome.title, outcome.url, outcome.author, subreddit ?: "?")),
+                )
                 val row = subreddit?.let { MemeEmbeds.rerollRow(it, timePeriod, limit) }
                 if (row != null) edit.setComponents(row)
                 edit.queue { scheduleDelete(hook, deleteDelay) }
             }
-            is RedditOutcome.Error -> {
+            is RedditMemeFetcher.Result.Error -> {
                 logger.warn("Failed to fetch meme from subreddit: $subreddit — ${outcome.message}")
                 editError(hook, outcome.message, deleteDelay)
             }
@@ -113,60 +119,6 @@ class MemeCommand : FetchCommand {
                 java.util.concurrent.TimeUnit.SECONDS,
             )
         }
-    }
-
-    private sealed interface RedditOutcome {
-        data class Embed(val embed: MessageEmbed) : RedditOutcome
-        data class Error(val message: String) : RedditOutcome
-    }
-
-    private fun fetchRedditPost(
-        subreddit: String?,
-        timePeriod: String,
-        limit: Int,
-        httpClient: HttpClient,
-    ): RedditOutcome {
-        val gson = Gson()
-        val redditApiUrl = String.format(RedditAPIDto.REDDIT_PREFIX, subreddit, limit, timePeriod)
-        val request = HttpGet(redditApiUrl)
-        logger.info("Fetching Reddit post from URL: $redditApiUrl")
-        val response = httpClient.execute(request)
-        if (response.statusLine.statusCode != 200) {
-            logger.error("Error response from Reddit API: ${response.statusLine.statusCode}")
-            return RedditOutcome.Error("Failed to fetch meme. Please try again later.")
-        }
-
-        val jsonResponse = JsonParser.parseReader(InputStreamReader(response.entity.content)).asJsonObject
-        EntityUtils.consume(response.entity)
-
-        val children = jsonResponse.getAsJsonObject("data").getAsJsonArray("children")
-        if (children.size() == 0) {
-            logger.info("No memes found in subreddit: $subreddit")
-            return RedditOutcome.Error("No memes found in r/${subreddit ?: "?"}.")
-        }
-
-        val meme = children[Random.nextInt(children.size())].asJsonObject.getAsJsonObject("data")
-        val redditAPIDto = gson.fromJson(meme.toString(), RedditAPIDto::class.java)
-
-        if (redditAPIDto.isNsfw == true) {
-            logger.warn("NSFW meme detected from subreddit: $subreddit")
-            return RedditOutcome.Error(
-                "I pulled back a NSFW post — either the subreddit's flagged or Reddit picked a bad one. Skipped."
-            )
-        }
-        if (redditAPIDto.video == true) {
-            logger.warn("Video meme detected from subreddit: $subreddit")
-            return RedditOutcome.Error("I pulled back a video, whoops. Try again maybe? Or not, up to you.")
-        }
-
-        val title = meme["title"].asString
-        val url = meme["url"].asString
-        val author = meme["author"].asString
-        logger.info("Meme fetched successfully - Title: $title, Author: $author, URL: $url")
-
-        return RedditOutcome.Embed(
-            MemeEmbeds.resultEmbed(title, url, author, subreddit ?: "?"),
-        )
     }
 
     override val name: String get() = "meme"

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/fetch/RedditMemeFetcher.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/fetch/RedditMemeFetcher.kt
@@ -1,0 +1,94 @@
+package bot.toby.command.commands.fetch
+
+import bot.toby.dto.web.RedditAPIDto
+import com.google.gson.Gson
+import com.google.gson.JsonParser
+import common.logging.DiscordLogger
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.timeout
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import kotlin.random.Random
+
+/**
+ * Pulls a random SFW post off a subreddit's top listing for `/meme`.
+ *
+ * Uses the same coroutine + ktor stack as the `/dnd` and `/cube` lookups:
+ * a `suspend` function that hops onto [Dispatchers.IO] via [withContext],
+ * fed by the shared injectable ktor [HttpClient] with a per-request
+ * timeout, so the blocking network work never ties up the CPU-bound
+ * default dispatcher and a slow Reddit can't hang the calling thread.
+ * Tests drive it with a `MockEngine`.
+ */
+@Component
+class RedditMemeFetcher @Autowired constructor(
+    private val client: HttpClient,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) {
+
+    private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
+    private val gson: Gson = Gson()
+
+    sealed interface Result {
+        data class Success(val title: String, val url: String, val author: String) : Result
+        data class Error(val message: String) : Result
+    }
+
+    /** Fetches a random non-NSFW, non-video post from the top [limit] of [subreddit] over [timePeriod]. */
+    suspend fun fetch(subreddit: String?, timePeriod: String, limit: Int): Result = withContext(dispatcher) {
+        val url = String.format(RedditAPIDto.REDDIT_PREFIX, subreddit, limit, timePeriod)
+        logger.info("Fetching Reddit post from URL: $url")
+        try {
+            val response = client.get(url) {
+                header(HttpHeaders.Accept, "application/json")
+                timeout { requestTimeoutMillis = TIMEOUT_MS }
+            }
+            if (response.status.value != 200) {
+                logger.error("Error response from Reddit API: ${response.status.value}")
+                return@withContext Result.Error("Failed to fetch meme. Please try again later.")
+            }
+
+            val json = JsonParser.parseString(response.bodyAsText()).asJsonObject
+            val children = json.getAsJsonObject("data").getAsJsonArray("children")
+            if (children.size() == 0) {
+                return@withContext Result.Error("No memes found in r/${subreddit ?: "?"}.")
+            }
+
+            val meme = children[Random.nextInt(children.size())].asJsonObject.getAsJsonObject("data")
+            val dto = gson.fromJson(meme.toString(), RedditAPIDto::class.java)
+            if (dto.isNsfw == true) {
+                logger.warn("NSFW meme detected from subreddit: $subreddit")
+                return@withContext Result.Error(
+                    "I pulled back a NSFW post — either the subreddit's flagged or Reddit picked a bad one. Skipped."
+                )
+            }
+            if (dto.video == true) {
+                logger.warn("Video meme detected from subreddit: $subreddit")
+                return@withContext Result.Error("I pulled back a video, whoops. Try again maybe? Or not, up to you.")
+            }
+
+            Result.Success(
+                title = meme["title"].asString,
+                url = meme["url"].asString,
+                author = meme["author"].asString,
+            )
+        } catch (e: CancellationException) {
+            throw e // never swallow coroutine cancellation
+        } catch (e: Exception) {
+            logger.error("Reddit fetch failed for subreddit '$subreddit': $e")
+            Result.Error("Failed to fetch meme. Please try again later.")
+        }
+    }
+
+    private companion object {
+        const val TIMEOUT_MS = 10_000L
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/misc/MemeButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/misc/MemeButtonTest.kt
@@ -54,9 +54,8 @@ internal class MemeButtonTest {
 
         verify(exactly = 1) { event.deferEdit() }
         verify(exactly = 1) {
-            command.fetch(
+            command.fetchAsync(
                 hook = hook,
-                httpClient = any(),
                 subreddit = "memes",
                 timePeriod = "week",
                 limit = 25,
@@ -73,9 +72,8 @@ internal class MemeButtonTest {
         button.handle(ctx, dto, deleteDelay = 0)
 
         verify(exactly = 0) {
-            command.fetch(
+            command.fetchAsync(
                 hook = any(),
-                httpClient = any(),
                 subreddit = any(),
                 timePeriod = any(),
                 limit = any(),

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/fetch/MemeCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/fetch/MemeCommandTest.kt
@@ -5,10 +5,13 @@ import bot.toby.dto.web.RedditAPIDto
 import database.dto.user.UserDto
 import io.mockk.Runs
 import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
 import net.dv8tion.jda.api.components.actionrow.ActionRow
 import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.Message
@@ -20,21 +23,15 @@ import net.dv8tion.jda.api.interactions.commands.OptionMapping
 import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.requests.restaction.WebhookMessageEditAction
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction
-import org.apache.http.HttpEntity
-import org.apache.http.HttpResponse
-import org.apache.http.StatusLine
-import org.apache.http.client.HttpClient
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import java.io.ByteArrayInputStream
-import java.io.IOException
-import java.io.InputStream
 import java.util.Locale
 
 internal class MemeCommandTest {
 
+    private lateinit var fetcher: RedditMemeFetcher
     private lateinit var memeCommand: MemeCommand
 
     private val event: SlashCommandInteractionEvent = mockk(relaxed = true)
@@ -48,25 +45,11 @@ internal class MemeCommandTest {
 
     private val userDto: UserDto = mockk(relaxed = true)
 
-    private val jsonResponse: String = """{
-        "data": {
-            "children": [
-                {
-                    "data": {
-                        "title": "Sample Reddit Post",
-                        "url": "https://www.old.reddit.com/r/raimimemes/sample-post",
-                        "author": "sample_author",
-                        "over_18": false,
-                        "is_video": false
-                    }
-                }
-            ]
-        }
-    }"""
-
     @BeforeEach
     fun setUp() {
-        memeCommand = MemeCommand()
+        fetcher = mockk()
+        // Unconfined so the launched IO coroutine resolves synchronously in tests.
+        memeCommand = MemeCommand(fetcher, Dispatchers.Unconfined)
 
         every { event.hook } returns hook
         every { event.user } returns user
@@ -98,25 +81,13 @@ internal class MemeCommandTest {
     }
 
     @Test
-    @Throws(IOException::class)
     fun `successful fetch edits the original with a loading embed then a result embed plus a Re-roll button`() {
         val subredditOptionMapping = mockk<OptionMapping> { every { asString } returns "raimimemes" }
         every { event.getOption("subreddit") } returns subredditOptionMapping
+        coEvery { fetcher.fetch("raimimemes", "day", 1) } returns
+            RedditMemeFetcher.Result.Success("Sample Reddit Post", "https://reddit/sample", "sample_author")
 
-        val httpClient = mockk<HttpClient>()
-        val httpResponse = mockk<HttpResponse>()
-        val statusLine = mockk<StatusLine>()
-        val httpEntity = mockk<HttpEntity>()
-        val contentStream: InputStream = ByteArrayInputStream(jsonResponse.toByteArray())
-
-        every { httpClient.execute(any()) } returns httpResponse
-        every { httpResponse.statusLine } returns statusLine
-        every { statusLine.statusCode } returns 200
-        every { httpResponse.entity } returns httpEntity
-        every { httpEntity.content } returns contentStream
-        every { httpEntity.isStreaming } returns false
-
-        memeCommand.handle(DefaultCommandContext(event), httpClient, userDto, deleteDelay = 0)
+        memeCommand.handle(DefaultCommandContext(event), userDto, deleteDelay = 0)
 
         // Loading edit (immediate) + result edit (after fetch) = 2 calls.
         verify(exactly = 2) { hook.editOriginalEmbeds(any<Collection<MessageEmbed>>()) }
@@ -124,16 +95,27 @@ internal class MemeCommandTest {
     }
 
     @Test
-    fun `users without meme permission get the default permission-error followup and no edit happens`() {
-        every { userDto.memePermission } returns false
-        val httpClient = mockk<HttpClient>(relaxed = true)
-        // sendMessageFormat is used by the Command interface's default
-        // sendErrorMessage — relaxed mock auto-stubs it.
+    fun `a fetch error edits the original with just an error embed and no Re-roll button`() {
+        val subredditOptionMapping = mockk<OptionMapping> { every { asString } returns "raimimemes" }
+        every { event.getOption("subreddit") } returns subredditOptionMapping
+        coEvery { fetcher.fetch("raimimemes", "day", 1) } returns
+            RedditMemeFetcher.Result.Error("No memes found in r/raimimemes.")
 
-        memeCommand.handle(DefaultCommandContext(event), httpClient, userDto, deleteDelay = 0)
+        memeCommand.handle(DefaultCommandContext(event), userDto, deleteDelay = 0)
+
+        // Loading edit + error edit = 2 calls, but no re-roll row.
+        verify(exactly = 2) { hook.editOriginalEmbeds(any<Collection<MessageEmbed>>()) }
+        verify(exactly = 0) { editAction.setComponents(any<ActionRow>()) }
+    }
+
+    @Test
+    fun `users without meme permission get the default permission-error followup and no fetch happens`() {
+        every { userDto.memePermission } returns false
+
+        memeCommand.handle(DefaultCommandContext(event), userDto, deleteDelay = 0)
 
         verify(exactly = 0) { hook.editOriginalEmbeds(any<Collection<MessageEmbed>>()) }
-        verify(exactly = 0) { httpClient.execute(any()) }
+        coVerify(exactly = 0) { fetcher.fetch(any(), any(), any()) }
     }
 
     @Test

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/fetch/RedditMemeFetcherTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/fetch/RedditMemeFetcherTest.kt
@@ -1,0 +1,94 @@
+package bot.toby.command.commands.fetch
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.respondError
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.IOException
+
+class RedditMemeFetcherTest {
+
+    private val jsonHeaders = headersOf(HttpHeaders.ContentType, "application/json")
+
+    private fun fetcherWith(engine: MockEngine): RedditMemeFetcher =
+        RedditMemeFetcher(HttpClient(engine) { install(HttpTimeout) }, Dispatchers.Unconfined)
+
+    private fun listing(vararg posts: String): String =
+        """{"data":{"children":[${posts.joinToString(",")}]}}"""
+
+    private fun post(
+        title: String = "A meme",
+        url: String = "https://i.redd.it/x.jpg",
+        author: String = "someone",
+        nsfw: Boolean = false,
+        video: Boolean = false,
+    ): String =
+        """{"data":{"title":"$title","url":"$url","author":"$author","over_18":$nsfw,"is_video":$video}}"""
+
+    @Test
+    fun `fetch returns a parsed post on success`() = runBlocking {
+        val fetcher = fetcherWith(
+            MockEngine { respond(listing(post(title = "Spidey", url = "https://i.redd.it/s.jpg", author = "raimi")), HttpStatusCode.OK, jsonHeaders) }
+        )
+        val result = fetcher.fetch("raimimemes", "day", 1)
+        val success = assertInstanceOf(RedditMemeFetcher.Result.Success::class.java, result)
+        assertEquals("Spidey", success.title)
+        assertEquals("https://i.redd.it/s.jpg", success.url)
+        assertEquals("raimi", success.author)
+    }
+
+    @Test
+    fun `fetch hits the subreddit's top listing URL`() = runBlocking {
+        val engine = MockEngine { respond(listing(post()), HttpStatusCode.OK, jsonHeaders) }
+        fetcherWith(engine).fetch("memes", "week", 5)
+        val url = engine.requestHistory.single().url.toString()
+        assertTrue(url.contains("/r/memes/"), "url was: $url")
+        assertTrue(url.contains("limit=5"), "url was: $url")
+        assertTrue(url.contains("t=week"), "url was: $url")
+    }
+
+    @Test
+    fun `fetch maps a non-200 to a friendly error`() = runBlocking {
+        val result = fetcherWith(MockEngine { respondError(HttpStatusCode.InternalServerError) }).fetch("memes", "day", 5)
+        val error = assertInstanceOf(RedditMemeFetcher.Result.Error::class.java, result)
+        assertTrue(error.message.contains("Failed to fetch meme"))
+    }
+
+    @Test
+    fun `fetch reports an empty listing`() = runBlocking {
+        val result = fetcherWith(MockEngine { respond(listing(), HttpStatusCode.OK, jsonHeaders) }).fetch("emptysub", "day", 5)
+        val error = assertInstanceOf(RedditMemeFetcher.Result.Error::class.java, result)
+        assertTrue(error.message.contains("No memes found"))
+    }
+
+    @Test
+    fun `fetch skips an NSFW post`() = runBlocking {
+        val result = fetcherWith(MockEngine { respond(listing(post(nsfw = true)), HttpStatusCode.OK, jsonHeaders) }).fetch("memes", "day", 1)
+        val error = assertInstanceOf(RedditMemeFetcher.Result.Error::class.java, result)
+        assertTrue(error.message.contains("NSFW"))
+    }
+
+    @Test
+    fun `fetch skips a video post`() = runBlocking {
+        val result = fetcherWith(MockEngine { respond(listing(post(video = true)), HttpStatusCode.OK, jsonHeaders) }).fetch("memes", "day", 1)
+        val error = assertInstanceOf(RedditMemeFetcher.Result.Error::class.java, result)
+        assertTrue(error.message.contains("video"))
+    }
+
+    @Test
+    fun `fetch surfaces a transport failure as an error`() = runBlocking {
+        val result = fetcherWith(MockEngine { throw IOException("reddit down") }).fetch("memes", "day", 1)
+        val error = assertInstanceOf(RedditMemeFetcher.Result.Error::class.java, result)
+        assertTrue(error.message.contains("Failed to fetch meme"))
+    }
+}


### PR DESCRIPTION
## Why

Follow-up to the `/cube` ktor migration (#627). The same blocking-IO anti-pattern lived in `/meme`: it created a synchronous Apache `HttpClients.createDefault()` (**no timeout**) and called `httpClient.execute()` directly in `handle()`, which runs inside the listener's `launch { … }` on the CPU-bound `Dispatchers.Default`. A slow/unresponsive Reddit could tie up a Default-pool thread indefinitely. `MemeButton` (the re-roll) had the same issue.

## What changed

- **New `RedditMemeFetcher`** — a `suspend` fetch on `Dispatchers.IO` via the shared ktor `HttpClient`, with a 10s per-request timeout, mirroring `ScryfallCubeFetcher`. Returns parsed post data (`Success`) or a friendly `Error` (non-200, empty listing, NSFW, video, transport failure).
- **`MemeCommand`** parses the options on the calling thread, then launches the fetch on an injected `CoroutineDispatcher` (`fetchAsync`), mirroring the `/dnd` query handler. An unexpected throw resolves the message with an error embed.
- **`MemeButton`** re-rolls via `memeCommand.fetchAsync(...)` instead of constructing its own blocking Apache client (drops the `org.apache.http` dependency from the button).

## Tests

- New `RedditMemeFetcherTest` on a ktor `MockEngine` (success, non-200, empty listing, NSFW/video skips, transport failure, URL shape).
- `MemeCommandTest` now mocks the fetcher and drives the launched coroutine via `Dispatchers.Unconfined` (success → result embed + re-roll row; error → error embed, no row; no-permission → no fetch).
- `MemeButtonTest` verifies `fetchAsync` is/ isn't invoked.
- `:discord-bot:test` and `:discord-bot:koverVerify` pass. The `HttpClient` test-context bean added in #627 covers the new `RedditMemeFetcher` wiring.

Part of a series closing out the remaining blocking-IO gaps (intro attachment download and the lavaplayer gateway are separate PRs).

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs

---
_Generated by [Claude Code](https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs)_