### PR TITLE
Skip deck-export section headers when parsing a cube list

### DIFF
--- a/common/src/main/kotlin/common/mtg/CardListParser.kt
+++ b/common/src/main/kotlin/common/mtg/CardListParser.kt
@@ -7,7 +7,12 @@ package common.mtg
  *  - one card per line;
  *  - an optional leading quantity — `3 Forest`, `3x Forest`, `3X Forest`;
  *  - an optional trailing set/collector tag — `Lightning Bolt (2X2) 117`;
- *  - blank lines and `#` / `//` comments ignored.
+ *  - an optional trailing finish marker — `Sol Ring (C21) 263 *F*`;
+ *  - blank lines, `#` / `//` comments, and exporter section headers
+ *    (`Deck`, `Sideboard`, `Commander`, …) ignored.
+ *
+ * This keeps a list pasted straight out of Arena / MTGO / Moxfield from
+ * surfacing its group headers as "couldn't find" noise.
  *
  * Counts are capped at [MAX_PER_NAME] so a stray `99999 Forest` can't blow
  * up the pool.
@@ -21,16 +26,31 @@ object CardListParser {
     private val QUANTITY_PREFIX = Regex("^(\\d+)[xX]?\\s+")
     private val SET_SUFFIX = Regex("\\s+\\([^)]*\\).*$")
 
+    // A trailing finish marker some exporters append (`*F*` foil, `*E*`
+    // etched), kept separate so it's stripped even on lines without a
+    // set/collector tag for SET_SUFFIX to swallow.
+    private val FINISH_SUFFIX = Regex("\\s+\\*[^*]*\\*\\s*$")
+
+    // Standalone section headers deck exporters (Arena, MTGO, Moxfield) emit
+    // between card groups. No real Magic card is named any of these, so a
+    // line that is exactly one of them — and carries no quantity — is a
+    // header, not a card.
+    private val SECTION_HEADERS = setOf(
+        "deck", "sideboard", "commander", "companion",
+        "maybeboard", "mainboard", "tokens", "about",
+    )
+
     fun parse(text: String): List<Entry> =
         text.lineSequence().mapNotNull { raw ->
             var line = raw.trim()
             if (line.isEmpty() || line.startsWith("#") || line.startsWith("//")) return@mapNotNull null
+            if (line.lowercase() in SECTION_HEADERS) return@mapNotNull null
             var count = 1
             QUANTITY_PREFIX.find(line)?.let { match ->
                 count = match.groupValues[1].toIntOrNull()?.coerceIn(1, MAX_PER_NAME) ?: 1
                 line = line.substring(match.range.last + 1).trim()
             }
-            line = line.replace(SET_SUFFIX, "").trim()
+            line = line.replace(SET_SUFFIX, "").replace(FINISH_SUFFIX, "").trim()
             if (line.isEmpty()) null else Entry(line, count)
         }.toList()
 }

--- a/common/src/test/kotlin/common/mtg/CardListParserTest.kt
+++ b/common/src/test/kotlin/common/mtg/CardListParserTest.kt
@@ -41,6 +41,41 @@ class CardListParserTest {
     }
 
     @Test
+    fun `strips a trailing finish marker even without a set tag`() {
+        assertEquals(CardListParser.Entry("Sol Ring", 1), CardListParser.parse("Sol Ring *F*").single())
+        assertEquals(CardListParser.Entry("Lightning Bolt", 4), CardListParser.parse("4 Lightning Bolt (2X2) 117 *F*").single())
+    }
+
+    @Test
+    fun `skips exporter section headers`() {
+        val entries = CardListParser.parse(
+            """
+            Deck
+            4 Lightning Bolt (2X2) 117
+            1 Sol Ring (C21) 263
+
+            Sideboard
+            2 Shock
+            Commander
+            Companion
+            """.trimIndent()
+        )
+        assertEquals(listOf("Lightning Bolt", "Sol Ring", "Shock"), entries.map { it.name })
+        assertEquals(listOf(4, 1, 2), entries.map { it.count })
+    }
+
+    @Test
+    fun `section-header words still parse as cards when given a quantity`() {
+        // "1 Commander" is a (hypothetical) card line, not a header.
+        assertEquals(CardListParser.Entry("Commander", 1), CardListParser.parse("1 Commander").single())
+    }
+
+    @Test
+    fun `header matching is case-insensitive`() {
+        assertTrue(CardListParser.parse("SIDEBOARD\ndeck\nCommander").isEmpty())
+    }
+
+    @Test
     fun `caps an absurd quantity`() {
         assertEquals(CardListParser.MAX_PER_NAME, CardListParser.parse("99999 Forest").single().count)
     }


### PR DESCRIPTION
## Why

The cube tool's headline "paste your own list" feature feeds pasted text through `CardListParser`. Real users paste lists exported from **Arena / MTGO / Moxfield**, which include group headers (`Deck`, `Sideboard`, `Commander`, `Companion`, …) and finish markers (`*F*`/`*E*`). The parser only skipped `#`/`//` comments, so those headers were treated as card names and came back as **"couldn't find"** noise — making a perfectly good export look broken.

## What changed (`common/.../CardListParser.kt`)

- **Skip standalone section-header lines** (case-insensitive: `deck`, `sideboard`, `commander`, `companion`, `maybeboard`, `mainboard`, `tokens`, `about`). No real Magic card is named any of these. A line that carries a quantity prefix (e.g. `1 Commander`) is still parsed as a card, so nothing legitimate is lost.
- **Strip a trailing finish marker** (`*F*`, `*E*`) even on lines without a `(SET)` tag for the existing set-suffix regex to swallow.

Shared by both the web tool and the Discord command (it lives in `common.mtg`), so both surfaces benefit.

## Tests

Added `CardListParserTest` cases: section headers skipped (mixed with real cards + quantities), header words still parse as cards when given a quantity, case-insensitive header matching, and finish-marker stripping with/without a set tag. `:common:test` and `:common:koverVerify` pass.

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs

---
_Generated by [Claude Code](https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs)_