### PR TITLE
Richer cube preview cards: mana cost, DFC backs, copy counts

### DIFF
--- a/web/src/main/kotlin/web/service/CubeWebService.kt
+++ b/web/src/main/kotlin/web/service/CubeWebService.kt
@@ -150,10 +150,13 @@ class CubeWebService {
             .filter { byCategory[it] != null }
             .map { cat ->
                 val bucket = byCategory.getValue(cat)
+                // De-dupe by name so a pool with ten Forests shows one tile,
+                // but carry the copy count onto that tile so it's not hidden.
+                val counts = bucket.groupingBy { it.card.name }.eachCount()
                 val cards = bucket
                     .distinctBy { it.card.name }
                     .sortedBy { it.card.name }
-                    .map { it.toView() }
+                    .map { it.toView().copy(count = counts.getValue(it.card.name)) }
                 CategoryGroup(
                     category = cat.displayName,
                     count = bucket.size,
@@ -188,6 +191,8 @@ class CubeWebService {
                 ),
                 imageUrl = imageOf(node, "small"),
                 imageUrlLarge = imageOf(node, "normal"),
+                imageUrlBack = backImageOf(node),
+                manaCost = manaCostOf(node),
             )
         }
     }
@@ -203,6 +208,34 @@ class CubeWebService {
         val faces = node.path("card_faces")
         if (faces.isArray && faces.size() > 0) {
             faces[0].path("image_uris").path(size).asText("").takeIf { it.isNotBlank() }?.let { return it }
+        }
+        return null
+    }
+
+    /**
+     * The back-face `normal` image for a double-faced card (transform / modal
+     * DFC), or null. Only true two-faced cards carry per-face `image_uris`;
+     * split, adventure and aftermath cards share one image, so they correctly
+     * return null here (no spurious "flip" affordance).
+     */
+    private fun backImageOf(node: JsonNode): String? {
+        val faces = node.path("card_faces")
+        if (faces.isArray && faces.size() > 1) {
+            faces[1].path("image_uris").path("normal").asText("").takeIf { it.isNotBlank() }?.let { return it }
+        }
+        return null
+    }
+
+    /**
+     * The card's mana cost string (e.g. `{1}{R}{R}`). Single-faced cards carry
+     * it directly; double-faced cards put it on the front face. Null when the
+     * card has none (most lands).
+     */
+    private fun manaCostOf(node: JsonNode): String? {
+        node.path("mana_cost").asText("").takeIf { it.isNotBlank() }?.let { return it }
+        val faces = node.path("card_faces")
+        if (faces.isArray && faces.size() > 0) {
+            faces[0].path("mana_cost").asText("").takeIf { it.isNotBlank() }?.let { return it }
         }
         return null
     }
@@ -374,15 +407,23 @@ sealed interface CubeResult<out T> {
 data class CategoryAsFan(val category: String, val count: Int, val asFan: Double)
 
 /** A card paired with its Scryfall images, kept only inside the service. */
-data class ScryfallCard(val card: CubeCard, val imageUrl: String?, val imageUrlLarge: String?) {
-    fun toView(): CardView = CardView(card.name, imageUrl, imageUrlLarge, card.typeLine, card.manaValue)
+data class ScryfallCard(
+    val card: CubeCard,
+    val imageUrl: String?,
+    val imageUrlLarge: String?,
+    val imageUrlBack: String? = null,
+    val manaCost: String? = null,
+) {
+    fun toView(): CardView =
+        CardView(card.name, imageUrl, imageUrlLarge, card.typeLine, card.manaValue, manaCost, imageUrlBack)
 }
 
 /**
  * A single card the page renders: display name, small thumbnail, the larger
- * image used for the hover-to-enlarge preview, and the stat line (type +
- * mana value) shown under that preview. Either image may be null when
- * Scryfall has none.
+ * image used for the hover-to-enlarge preview, the stat line (type + mana
+ * value), the mana cost, the back-face image for double-faced cards, and how
+ * many copies sit in the pool (>1 only in the de-duped preview groups). Any
+ * image or the mana cost may be null when Scryfall has none.
  */
 data class CardView(
     val name: String,
@@ -390,6 +431,9 @@ data class CardView(
     val imageUrlLarge: String?,
     val typeLine: String,
     val manaValue: Double,
+    val manaCost: String? = null,
+    val imageUrlBack: String? = null,
+    val count: Int = 1,
 )
 
 /** A colour/land bucket plus the actual cards it contains. */

--- a/web/src/main/resources/static/css/cube.css
+++ b/web/src/main/resources/static/css/cube.css
@@ -729,6 +729,7 @@ button:disabled {
 }
 
 .cube-card {
+    position: relative;
     display: flex;
     flex-direction: column;
     gap: 4px;
@@ -773,6 +774,66 @@ button:disabled {
 
 .cube-card:hover .cube-card-name {
     color: var(--mtg-gold);
+}
+
+/* Mana cost: a centered row of small Scryfall symbol SVGs under the name. */
+.cube-card-mana {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 2px;
+}
+
+.cube-mana-symbol {
+    width: 13px;
+    height: 13px;
+}
+
+/* Copy-count badge for de-duped preview tiles ("×10"). */
+.cube-card-qty {
+    position: absolute;
+    top: 4px;
+    left: 4px;
+    padding: 1px 6px;
+    font-size: 0.72rem;
+    font-weight: 600;
+    line-height: 1.4;
+    color: var(--text);
+    background: rgb(0 0 0 / 72%);
+    border-radius: 999px;
+    pointer-events: none;
+}
+
+/* Flip control on double-faced card tiles. */
+.cube-card-flip {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    width: 24px;
+    height: 24px;
+    display: grid;
+    place-items: center;
+    padding: 0;
+    font-size: 0.85rem;
+    color: var(--text);
+    background: rgb(0 0 0 / 72%);
+    border: 1px solid var(--mtg-gold-border);
+    border-radius: 999px;
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity var(--dur-fast) var(--ease-out);
+}
+
+.cube-card:hover .cube-card-flip,
+.cube-card-flip:focus-visible {
+    opacity: 1;
+}
+
+/* Touch devices have no hover — keep the flip control visible there. */
+@media (hover: none) {
+    .cube-card-flip {
+        opacity: 1;
+    }
 }
 
 /* Hover-to-enlarge: a single floating full-size card + stat line,

--- a/web/src/main/resources/static/js/cube.js
+++ b/web/src/main/resources/static/js/cube.js
@@ -49,6 +49,27 @@
         return parts.join(' · ');
     }
 
+    /**
+     * Scryfall card-symbol SVG URLs for a mana cost like "{1}{R}{R}". Each
+     * {sym} maps to svgs.scryfall.io/card-symbols/<code>.svg, where <code> is
+     * the symbol with braces and slashes removed ({W/U} -> WU). Pure, so it's
+     * unit-testable; returns [] for null/empty/costless cards.
+     */
+    function manaSymbolUrls(manaCost) {
+        if (!manaCost) return [];
+        const out = [];
+        const re = /\{([^}]+)\}/g;
+        let m;
+        while ((m = re.exec(manaCost)) !== null) {
+            const code = m[1].replace(/\//g, '').toUpperCase();
+            out.push({
+                symbol: '{' + m[1] + '}',
+                url: 'https://svgs.scryfall.io/card-symbols/' + encodeURIComponent(code) + '.svg',
+            });
+        }
+        return out;
+    }
+
     /** Exact-name Scryfall search for a card, so the link opens that card. */
     function scryfallCardUrl(name) {
         return 'https://scryfall.com/search?q=' + encodeURIComponent('!"' + name + '"');
@@ -121,6 +142,46 @@
         name.className = 'cube-card-name';
         name.textContent = card.name;
         a.appendChild(name);
+
+        // Mana cost as a row of Scryfall symbol SVGs, so the cost is scannable
+        // without squinting at the thumbnail.
+        const symbols = manaSymbolUrls(card.manaCost);
+        if (symbols.length) {
+            const mana = document.createElement('span');
+            mana.className = 'cube-card-mana';
+            symbols.forEach(function (s) {
+                const sym = document.createElement('img');
+                sym.className = 'cube-mana-symbol';
+                sym.src = s.url;
+                sym.alt = s.symbol;
+                sym.setAttribute('loading', 'lazy');
+                mana.appendChild(sym);
+            });
+            a.appendChild(mana);
+        }
+
+        // Copy count for de-duped preview tiles ("×10 Forest").
+        if (card.count && card.count > 1) {
+            const qty = document.createElement('span');
+            qty.className = 'cube-card-qty';
+            qty.textContent = '×' + card.count;
+            a.appendChild(qty);
+        }
+
+        // Double-faced cards get a flip control that swaps the thumbnail and
+        // the hover/lightbox image between the front and back faces.
+        if (card.imageUrlBack) {
+            a.setAttribute('data-back', card.imageUrlBack);
+            a.setAttribute('data-front-large', card.imageUrlLarge || card.imageUrl || '');
+            a.setAttribute('data-front-thumb', card.imageUrl || card.imageUrlLarge || '');
+            const flip = document.createElement('button');
+            flip.type = 'button';
+            flip.className = 'cube-card-flip';
+            flip.setAttribute('aria-label', 'Flip card');
+            flip.title = 'Flip card';
+            flip.textContent = '⇄';
+            a.appendChild(flip);
+        }
         return a;
     }
 
@@ -962,6 +1023,8 @@
         }
 
         doc.addEventListener('click', function (e) {
+            // A flip-button tap is handled by wireCardFlip, not the lightbox.
+            if (e.target.closest && e.target.closest('.cube-card-flip')) return;
             const card = e.target.closest && e.target.closest('.cube-card[data-large]');
             if (card && prefersTap()) {
                 e.preventDefault();
@@ -974,6 +1037,35 @@
         });
         doc.addEventListener('keydown', function (e) {
             if (e.key === 'Escape' && !modal.hidden) close();
+        });
+    }
+
+    /**
+     * Flips a double-faced card's tile in place: swaps the thumbnail image and
+     * the `data-large` URL (which drives the hover-zoom and lightbox) between
+     * the front and back faces. Event-delegated so it covers tiles rendered
+     * after load. preventDefault stops the tile's Scryfall link from firing.
+     */
+    function wireCardFlip(doc) {
+        doc.addEventListener('click', function (e) {
+            const flip = e.target.closest && e.target.closest('.cube-card-flip');
+            if (!flip) return;
+            e.preventDefault();
+            e.stopPropagation();
+            const card = flip.closest('.cube-card');
+            if (!card || !card.getAttribute('data-back')) return;
+            const img = card.querySelector('img.cube-card-img');
+            const flipped = card.getAttribute('data-flipped') === 'true';
+            if (flipped) {
+                card.setAttribute('data-large', card.getAttribute('data-front-large') || '');
+                if (img) img.src = card.getAttribute('data-front-thumb') || img.src;
+                card.setAttribute('data-flipped', 'false');
+            } else {
+                const back = card.getAttribute('data-back');
+                card.setAttribute('data-large', back);
+                if (img) img.src = back;
+                card.setAttribute('data-flipped', 'true');
+            }
         });
     }
 
@@ -993,6 +1085,7 @@
         wireAsFan(doc);
         wirePreview(doc);
         wireGenerate(doc);
+        wireCardFlip(doc);
         wireZoom(doc);
         wireLightbox(doc);
     }
@@ -1005,6 +1098,7 @@
         categoryColor: categoryColor,
         scryfallCardUrl: scryfallCardUrl,
         cardStatline: cardStatline,
+        manaSymbolUrls: manaSymbolUrls,
         tabIdFromHash: tabIdFromHash,
         zoomPosition: zoomPosition,
         deleteListUrl: deleteListUrl,

--- a/web/src/test/js/cube.test.js
+++ b/web/src/test/js/cube.test.js
@@ -166,6 +166,75 @@ describe('renderPacks', () => {
     });
 });
 
+describe('manaSymbolUrls', () => {
+    test('maps each {sym} to a Scryfall symbol SVG, stripping braces and slashes', () => {
+        const urls = Cube.manaSymbolUrls('{1}{W/U}{R}');
+        expect(urls.map((u) => u.symbol)).toEqual(['{1}', '{W/U}', '{R}']);
+        expect(urls[0].url).toBe('https://svgs.scryfall.io/card-symbols/1.svg');
+        expect(urls[1].url).toBe('https://svgs.scryfall.io/card-symbols/WU.svg');
+        expect(urls[2].url).toBe('https://svgs.scryfall.io/card-symbols/R.svg');
+    });
+    test('returns an empty list for a costless / null cost', () => {
+        expect(Cube.manaSymbolUrls(null)).toEqual([]);
+        expect(Cube.manaSymbolUrls('')).toEqual([]);
+    });
+});
+
+describe('cardTile enrichments (via renderGroups)', () => {
+    function tileFor(card) {
+        const container = document.createElement('div');
+        Cube.renderGroups(container, [{ category: 'Red', count: card.count || 1, asFan: 1.0, cards: [card] }]);
+        return container.querySelector('.cube-card');
+    }
+
+    test('renders a mana-symbol row from the mana cost', () => {
+        const tile = tileFor({ name: 'Bolt', imageUrl: 'i', imageUrlLarge: 'l', typeLine: 'Instant', manaValue: 1, manaCost: '{R}' });
+        const syms = tile.querySelectorAll('.cube-card-mana .cube-mana-symbol');
+        expect(syms).toHaveLength(1);
+        expect(syms[0].getAttribute('src')).toBe('https://svgs.scryfall.io/card-symbols/R.svg');
+    });
+
+    test('shows a copy-count badge only when count > 1', () => {
+        const many = tileFor({ name: 'Forest', imageUrl: 'i', imageUrlLarge: 'l', typeLine: 'Basic Land — Forest', manaValue: 0, count: 10 });
+        expect(many.querySelector('.cube-card-qty').textContent).toBe('×10');
+        const one = tileFor({ name: 'Sol Ring', imageUrl: 'i', imageUrlLarge: 'l', typeLine: 'Artifact', manaValue: 1, count: 1 });
+        expect(one.querySelector('.cube-card-qty')).toBeNull();
+    });
+
+    test('a double-faced card gets a flip control and back-face data; a single-faced one does not', () => {
+        const dfc = tileFor({ name: 'Huntmaster', imageUrl: 'front-sm', imageUrlLarge: 'front-lg', imageUrlBack: 'back', typeLine: 'Creature', manaValue: 3 });
+        expect(dfc.getAttribute('data-back')).toBe('back');
+        expect(dfc.querySelector('.cube-card-flip')).not.toBeNull();
+        const plain = tileFor({ name: 'Bolt', imageUrl: 'i', imageUrlLarge: 'l', typeLine: 'Instant', manaValue: 1 });
+        expect(plain.querySelector('.cube-card-flip')).toBeNull();
+    });
+});
+
+describe('card flip wiring', () => {
+    test('flipping swaps the thumbnail and the hover/lightbox image to the back face and back', () => {
+        const container = document.createElement('div');
+        document.body.appendChild(container);
+        Cube.renderGroups(container, [{
+            category: 'Red', count: 1, asFan: 1.0, cards: [
+                { name: 'DFC', imageUrl: 'front-sm', imageUrlLarge: 'front-lg', imageUrlBack: 'back', typeLine: 'Creature', manaValue: 3 },
+            ],
+        }]);
+        const tile = container.querySelector('.cube-card');
+        const img = tile.querySelector('img.cube-card-img');
+        const flip = tile.querySelector('.cube-card-flip');
+        expect(tile.getAttribute('data-large')).toBe('front-lg');
+
+        flip.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+        expect(tile.getAttribute('data-large')).toBe('back');
+        expect(img.getAttribute('src')).toBe('back');
+
+        flip.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+        expect(tile.getAttribute('data-large')).toBe('front-lg');
+        expect(img.getAttribute('src')).toBe('front-sm');
+        document.body.removeChild(container);
+    });
+});
+
 describe('zoomPosition', () => {
     const VW = 1000;
     const VH = 800;

--- a/web/src/test/kotlin/web/service/CubeWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/CubeWebServiceTest.kt
@@ -96,6 +96,9 @@ class CubeWebServiceTest {
         assertEquals("Instant", red.cards.first().typeLine)
         assertEquals(1.0, red.cards.first().manaValue, 1e-9)
         assertEquals(3, red.count) // count still includes the duplicate
+        // Each deduped tile carries its own copy count so duplicates aren't hidden.
+        assertEquals(2, red.cards.first { it.name == "Bolt" }.count)
+        assertEquals(1, red.cards.first { it.name == "Shock" }.count)
         // 3 red / 5 pool × 5 = 3.0
         assertEquals(3.0, red.asFan, 1e-9)
     }
@@ -145,6 +148,29 @@ class CubeWebServiceTest {
                "type_line":"Land // Creature — Demon","cmc":0.0}]}"""
         )
         assertEquals(CardCategory.LAND, service.parseScryfall(root).first().card.category)
+    }
+
+    @Test
+    fun `parseScryfall pulls the mana cost and the back-face image for a double-faced card`() {
+        val root = mapper.readTree(
+            """{"data":[{"name":"Huntmaster of the Fells // Ravager of the Fells","color_identity":["R","G"],
+               "type_line":"Creature","mana_cost":"","card_faces":[
+                 {"mana_cost":"{2}{R}{G}","image_uris":{"small":"f-sm.jpg","normal":"f-lg.jpg"}},
+                 {"image_uris":{"small":"b-sm.jpg","normal":"b-lg.jpg"}}]}]}"""
+        )
+        val parsed = service.parseScryfall(root).first()
+        assertEquals("{2}{R}{G}", parsed.manaCost) // falls back to the front face
+        assertEquals("b-lg.jpg", parsed.imageUrlBack)
+    }
+
+    @Test
+    fun `parseScryfall pulls the mana cost for a single-faced card and leaves no back image`() {
+        val root = mapper.readTree(
+            """{"data":[{"name":"Bolt","color_identity":["R"],"type_line":"Instant","mana_cost":"{R}"}]}"""
+        )
+        val parsed = service.parseScryfall(root).first()
+        assertEquals("{R}", parsed.manaCost)
+        assertEquals(null, parsed.imageUrlBack)
     }
 
     @Test


### PR DESCRIPTION
## Why

Three MTG-player-facing enhancements to the web cube preview/results tiles, from the MTG gap review:

1. **Mana cost** — tiles showed type + numeric mana value only; cube designers evaluate curve/fixing by the actual cost.
2. **Double-faced cards** — only the front face was shown, with no way to see the back (a pain for DFC-heavy cubes).
3. **Duplicate counts** — the de-duped preview shows one tile per name, so "10 Forest" looked like a single card.

## What changed

**Backend (`CubeWebService.kt`)**
- `parseScryfall` now extracts each card's `mana_cost` (front face for DFCs) and the **back-face** `normal` image (only true two-faced cards carry per-face `image_uris`, so split/adventure/aftermath cards correctly get no back image / flip).
- `groups()` attaches the per-name copy **count** to each de-duped tile.
- `CardView`/`ScryfallCard` gain `manaCost`, `imageUrlBack`, `count` — added as trailing defaulted fields so existing positional construction is unaffected; flows to JSON automatically.

**Frontend (`cube.js` / `cube.css`)**
- New pure `manaSymbolUrls(manaCost)` → Scryfall card-symbol SVG URLs (`{W/U}` → `…/WU.svg`).
- `cardTile` renders a mana-symbol row, an `×N` badge when count > 1, and (for DFCs) a flip control that swaps the thumbnail + the `data-large` URL driving the hover-zoom/lightbox. Flip is event-delegated; `preventDefault` stops the tile's Scryfall link, and the lightbox handler ignores flip taps.
- CSS for the mana row, count badge, and flip button (visible on hover, always visible on touch).

## Tests
- jest: `manaSymbolUrls`, enriched-tile rendering (mana row / count badge / flip presence), and flip-wiring (swaps to back face and back). 670 jest tests pass; stylelint clean.
- Kotlin: `parseScryfall` mana-cost + back-image extraction (DFC and single-faced), and per-name counts in `groups()`. `:web:test` and `:web:koverVerify` pass.

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs

---
_Generated by [Claude Code](https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs)_