### PR TITLE
Switch cube tab on hash change so navbar deep-links work in-page

### DIFF
--- a/web/src/main/resources/static/js/cube.js
+++ b/web/src/main/resources/static/js/cube.js
@@ -358,6 +358,20 @@
         if (fromHash) activateTab(doc, fromHash);
     }
 
+    /**
+     * Re-activate the matching tab when only the URL hash changes — i.e. a
+     * deep-link like /cube#preview clicked while already on /cube (e.g. from
+     * the navbar dropdown), where no reload fires wireTabs again. Registered
+     * unconditionally so it's live even if wireTabs bailed for lack of tabs.
+     */
+    function wireHashChange(doc) {
+        if (!root || !root.addEventListener) return;
+        root.addEventListener('hashchange', function () {
+            const name = tabIdFromHash(root.location && root.location.hash);
+            if (name) activateTab(doc, name);
+        });
+    }
+
     function wireExamples(doc) {
         doc.querySelectorAll('[data-example]').forEach(function (chip) {
             chip.addEventListener('click', function () {
@@ -1071,6 +1085,7 @@
 
     function wire(doc) {
         wireTabs(doc);
+        wireHashChange(doc);
         wireSource(doc);
         wireSavedLists(doc);
         wireShare(doc);

--- a/web/src/test/js/cube.test.js
+++ b/web/src/test/js/cube.test.js
@@ -166,6 +166,60 @@ describe('renderPacks', () => {
     });
 });
 
+describe('deep-link hash activates the matching tab on in-page navigation', () => {
+    // wire() ran at require time and registered a hashchange listener on the
+    // window; here we stand up the tab markup and fire a hashchange to prove a
+    // /cube#preview deep-link (clicked while already on /cube) switches tabs.
+    // Append to a throwaway container (not innerHTML on body) so the shared
+    // zoom/lightbox overlays wire() created at require time survive.
+    let host;
+    afterEach(() => {
+        window.location.hash = '';
+        if (host && host.parentNode) host.parentNode.removeChild(host);
+        host = null;
+    });
+
+    function setUpTabs() {
+        host = document.createElement('div');
+        host.innerHTML =
+            '<button role="tab" data-tab="generate" aria-selected="true"></button>' +
+            '<button role="tab" data-tab="preview" aria-selected="false"></button>' +
+            '<button role="tab" data-tab="asfan" aria-selected="false"></button>' +
+            '<section data-panel="generate"></section>' +
+            '<section data-panel="preview" hidden></section>' +
+            '<section data-panel="asfan" hidden></section>';
+        document.body.appendChild(host);
+    }
+
+    test('a hashchange to #preview reveals the preview panel and selects its tab', () => {
+        setUpTabs();
+        window.location.hash = '#preview';
+        window.dispatchEvent(new window.Event('hashchange'));
+
+        expect(document.querySelector('[data-panel="preview"]').hidden).toBe(false);
+        expect(document.querySelector('[data-panel="generate"]').hidden).toBe(true);
+        expect(document.querySelector('[data-tab="preview"]').getAttribute('aria-selected')).toBe('true');
+    });
+
+    test('a hashchange to #asfan reveals the as-fan panel', () => {
+        setUpTabs();
+        window.location.hash = '#asfan';
+        window.dispatchEvent(new window.Event('hashchange'));
+
+        expect(document.querySelector('[data-panel="asfan"]').hidden).toBe(false);
+        expect(document.querySelector('[data-tab="asfan"]').getAttribute('aria-selected')).toBe('true');
+    });
+
+    test('an unknown hash leaves the tabs untouched', () => {
+        setUpTabs();
+        window.location.hash = '#nonsense';
+        window.dispatchEvent(new window.Event('hashchange'));
+
+        expect(document.querySelector('[data-panel="generate"]').hidden).toBe(false);
+        expect(document.querySelector('[data-panel="preview"]').hidden).toBe(true);
+    });
+});
+
 describe('manaSymbolUrls', () => {
     test('maps each {sym} to a Scryfall symbol SVG, stripping braces and slashes', () => {
         const urls = Cube.manaSymbolUrls('{1}{W/U}{R}');


### PR DESCRIPTION
## Bug

The navbar's **Magic** section has four deep-links:

| Link | Worked? |
|------|---------|
| `/cube` (Cube workshop) | ✅ |
| `/cube#asfan` (As-fan calculator) | ❌ |
| `/cube#preview` (Cube preview) | ❌ |
| `/cube#generate` (Pack generator) | ❌ |

`wireTabs` reads `location.hash` and activates the matching tab **only once, on load**. So a deep-link works when you land on `/cube` fresh from another page, but clicking one **while already on `/cube`** — e.g. straight from the navbar dropdown — only changes the URL hash (same document, no reload). Nothing re-activates the tab, so three of the four links look dead.

## Fix

Add a `hashchange` listener (`wireHashChange`) that re-runs the hash→tab activation whenever the hash changes. It's registered from `wire()` unconditionally, so it's live regardless of `wireTabs`' early return when no tabs are present. Unknown hashes are ignored (existing `tabIdFromHash` guard).

JS-only change — no markup change needed; the navbar hrefs already map to valid tab ids.

## Tests

Added jest cases: a `hashchange` to `#preview` / `#asfan` reveals the right panel and selects its tab, and an unknown hash leaves the tabs untouched. (Cleanup uses a throwaway container so the shared zoom/lightbox overlays created at require time survive.) Full suite: **673 passing**.

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs

---
_Generated by [Claude Code](https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs)_