### PR TITLE
Cube UX: hide the source on the As-fan tab; clearer saved-cube picker

### DIFF
--- a/web/src/main/resources/static/css/cube.css
+++ b/web/src/main/resources/static/css/cube.css
@@ -316,12 +316,26 @@
     color: var(--mtg-gold);
 }
 
+.cube-saved-block {
+    margin-top: var(--space-3);
+}
+
+.cube-saved-help {
+    margin: 0 0 var(--space-2);
+    font-size: 0.85rem;
+    line-height: 1.4;
+}
+
 .cube-saved {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
     gap: var(--space-2);
-    margin-top: var(--space-3);
+}
+
+.cube-saved-status {
+    display: block;
+    margin-top: var(--space-2);
 }
 
 .cube-saved-input {

--- a/web/src/main/resources/static/js/cube.js
+++ b/web/src/main/resources/static/js/cube.js
@@ -330,6 +330,12 @@
         doc.querySelectorAll('[data-panel]').forEach(function (panel) {
             panel.hidden = panel.getAttribute('data-panel') !== name;
         });
+        // The as-fan calculator works off manual numbers, so the shared "Your
+        // cube" source (and its cue) don't apply — hide them on that tab so the
+        // tool stands on its own.
+        doc.querySelectorAll('[data-needs-cube]').forEach(function (el) {
+            el.hidden = name === 'asfan';
+        });
     }
 
     function wireTabs(doc) {

--- a/web/src/main/resources/templates/cube.html
+++ b/web/src/main/resources/templates/cube.html
@@ -45,8 +45,9 @@
     </header>
 
     <div class="cube-shell">
-        <!-- Shared card source, used by Preview and Generate -->
-        <section class="cube-source-card">
+        <!-- Shared card source, used by Preview and Generate (hidden on the
+             standalone As-fan calculator via data-needs-cube). -->
+        <section class="cube-source-card" data-needs-cube>
             <div class="cube-source-head">
                 <h2>Your cube</h2>
                 <span class="cube-source-note">Used by Preview &amp; Generate</span>
@@ -92,13 +93,20 @@
                     <span class="cube-card-count" data-card-count aria-live="polite">0 cards</span>
                     <button type="button" class="cube-link-btn" data-clear-list>Clear</button>
                 </div>
-                <div class="cube-saved" th:if="${loggedIn}">
-                    <input type="text" class="cube-saved-input" data-saved-lists list="cube-saved-options"
-                           autocomplete="off" placeholder="Find a saved cube…" aria-label="Saved cubes">
-                    <datalist id="cube-saved-options" data-saved-options></datalist>
-                    <button type="button" class="btn btn-secondary" data-save-list>Save</button>
-                    <button type="button" class="btn btn-secondary" data-delete-list>Delete</button>
-                    <button type="button" class="btn btn-secondary" data-share-list>Share</button>
+                <div class="cube-saved-block" th:if="${loggedIn}">
+                    <p class="cube-saved-help muted" id="cube-saved-help">
+                        Pick a saved cube to load it, or type a name and <strong>Save</strong> to keep
+                        the list above. <strong>Delete</strong> / <strong>Share</strong> act on the named cube.
+                    </p>
+                    <div class="cube-saved">
+                        <input type="text" class="cube-saved-input" data-saved-lists list="cube-saved-options"
+                               autocomplete="off" placeholder="Saved cube name…" aria-label="Saved cube name"
+                               aria-describedby="cube-saved-help">
+                        <datalist id="cube-saved-options" data-saved-options></datalist>
+                        <button type="button" class="btn btn-secondary" data-save-list>Save</button>
+                        <button type="button" class="btn btn-secondary" data-delete-list>Delete</button>
+                        <button type="button" class="btn btn-secondary" data-share-list>Share</button>
+                    </div>
                     <span class="cube-saved-status muted" data-saved-status aria-live="polite"></span>
                 </div>
                 <p class="cube-saved-login muted" th:unless="${loggedIn}">
@@ -113,7 +121,7 @@
             </div>
         </section>
 
-        <p class="cube-tabs-hint" id="cube-tabs-hint">Then pick a tool:</p>
+        <p class="cube-tabs-hint" id="cube-tabs-hint" data-needs-cube>Then pick a tool:</p>
         <div class="cube-tabs segmented" role="tablist" aria-label="Cube tools" aria-describedby="cube-tabs-hint">
             <button type="button" id="tab-generate" class="cube-tab" role="tab"
                     data-tab="generate" aria-controls="panel-generate" aria-selected="true">

--- a/web/src/test/js/cube.test.js
+++ b/web/src/test/js/cube.test.js
@@ -182,6 +182,7 @@ describe('deep-link hash activates the matching tab on in-page navigation', () =
     function setUpTabs() {
         host = document.createElement('div');
         host.innerHTML =
+            '<section class="cube-source-card" data-needs-cube></section>' +
             '<button role="tab" data-tab="generate" aria-selected="true"></button>' +
             '<button role="tab" data-tab="preview" aria-selected="false"></button>' +
             '<button role="tab" data-tab="asfan" aria-selected="false"></button>' +
@@ -217,6 +218,19 @@ describe('deep-link hash activates the matching tab on in-page navigation', () =
 
         expect(document.querySelector('[data-panel="generate"]').hidden).toBe(false);
         expect(document.querySelector('[data-panel="preview"]').hidden).toBe(true);
+    });
+
+    test('the as-fan tab hides the standalone "Your cube" source; other tabs show it', () => {
+        setUpTabs();
+        const source = document.querySelector('[data-needs-cube]');
+
+        window.location.hash = '#asfan';
+        window.dispatchEvent(new window.Event('hashchange'));
+        expect(source.hidden).toBe(true);
+
+        window.location.hash = '#preview';
+        window.dispatchEvent(new window.Event('hashchange'));
+        expect(source.hidden).toBe(false);
     });
 });
 


### PR DESCRIPTION
## Usability pass on the `/cube` workshop page

Two intuitiveness fixes:

### 1. The As-fan calculator no longer shows the irrelevant "Your cube" source
The As-fan tab is a standalone calculator driven by manually-entered numbers (type count / cube size / pack size). But the big **"Your cube"** card — explicitly labelled *"Used by Preview & Generate"* — stayed pinned above it on every tab, so on As-fan it was misleading dead weight.

`activateTab` now toggles anything marked `data-needs-cube` (the source card **and** its "Then pick a tool" cue) off on the As-fan tab, so the calculator stands on its own. The source reappears — with the user's query/list intact — when they switch back to Generate/Preview. This runs through every entry point (tab click, `#asfan` deep-link, hash change).

### 2. Clearer logged-in saved-cube picker
The saved-cube control was a single input doing triple duty (load / name-to-save / delete-target) behind a vague *"Find a saved cube…"* placeholder. Now:
- a one-line explainer: *"Pick a saved cube to load it, or type a name and **Save** to keep the list above. **Delete** / **Share** act on the named cube."*
- a clearer **"Saved cube name…"** placeholder + `aria-describedby` wiring to the explainer.

## Tests
- jest: the hashchange suite now asserts the As-fan tab hides `data-needs-cube` and other tabs show it. 674 tests pass; stylelint clean.
- HTML/CSS-only otherwise; no Kotlin change.

I kept this to high-confidence wins. Happy to follow up on more (e.g. making the search/list source toggle a proper ARIA tablist, or a guided "step 1 → step 2" treatment) if you want to go further.

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs

---
_Generated by [Claude Code](https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs)_