### PR TITLE
Make cube packs & preview groups collapsible for easier navigation

### DIFF
--- a/web/src/main/resources/static/css/cube.css
+++ b/web/src/main/resources/static/css/cube.css
@@ -733,6 +733,53 @@ button:disabled {
     border-bottom: 1px solid var(--border);
 }
 
+/* Collapsible pack / preview-group sections (native <details>). The summary
+   is the tap/click target; a chevron rotates to show the open state. */
+.cube-section-summary {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    cursor: pointer;
+    list-style: none;
+}
+
+.cube-section-summary::-webkit-details-marker {
+    display: none;
+}
+
+.cube-section-summary > .cube-group-head {
+    flex: 1;
+    margin-bottom: 0;
+}
+
+.cube-section-summary > h3 {
+    flex: 1;
+    margin: 0;
+}
+
+.cube-collapse-chevron {
+    flex: none;
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    line-height: 1;
+    transition: transform var(--dur-fast) var(--ease-out);
+}
+
+details[open] > .cube-section-summary .cube-collapse-chevron {
+    transform: rotate(90deg);
+}
+
+.cube-section-summary:hover .cube-collapse-chevron,
+.cube-section-summary:focus-visible .cube-collapse-chevron {
+    color: var(--mtg-gold);
+}
+
+.cube-collapse-bar {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: var(--space-2);
+}
+
 /* --- Card thumbnails (shared by packs + preview groups) ------------- */
 
 .cube-card-grid {
@@ -1015,7 +1062,7 @@ button:disabled {
     align-items: baseline;
     justify-content: space-between;
     gap: var(--space-2);
-    margin: 0 0 var(--space-2);
+    margin: 0;
     font-size: 0.95rem;
     color: var(--heading);
 }

--- a/web/src/main/resources/static/js/cube.js
+++ b/web/src/main/resources/static/js/cube.js
@@ -226,14 +226,50 @@
         return container;
     }
 
+    /** A chevron that rotates when its parent <details> is open. */
+    function collapseChevron() {
+        const c = document.createElement('span');
+        c.className = 'cube-collapse-chevron';
+        c.setAttribute('aria-hidden', 'true');
+        c.textContent = '▸';
+        return c;
+    }
+
+    /**
+     * A "Collapse all / Expand all" control for a result area full of
+     * collapsible <details> sections — makes a 24-pack deal navigable.
+     */
+    function collapseToggle(container) {
+        const bar = document.createElement('div');
+        bar.className = 'cube-collapse-bar';
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'cube-link-btn';
+        btn.setAttribute('data-collapse-all', '');
+        btn.textContent = 'Collapse all';
+        btn.addEventListener('click', function () {
+            const sections = container.querySelectorAll('details.cube-pack, details.cube-group');
+            const anyOpen = Array.prototype.some.call(sections, function (d) { return d.open; });
+            Array.prototype.forEach.call(sections, function (d) { d.open = !anyOpen; });
+            btn.textContent = anyOpen ? 'Expand all' : 'Collapse all';
+        });
+        bar.appendChild(btn);
+        return bar;
+    }
+
     /** The preview: each colour/land group with its as-fan AND its cards. */
     function renderGroups(container, groups) {
         container.replaceChildren();
+        if (groups.length > 1) container.appendChild(collapseToggle(container));
         const max = groups.reduce(function (m, g) { return Math.max(m, g.asFan); }, 0);
         groups.forEach(function (group) {
-            const block = document.createElement('section');
+            const block = document.createElement('details');
             block.className = 'cube-group';
+            block.open = true;
 
+            const summary = document.createElement('summary');
+            summary.className = 'cube-section-summary';
+            summary.appendChild(collapseChevron());
             const head = document.createElement('div');
             head.className = 'cube-group-head';
             const label = document.createElement('span');
@@ -249,7 +285,8 @@
             head.appendChild(label);
             head.appendChild(asFanBar(group.category, group.asFan, max));
             head.appendChild(value);
-            block.appendChild(head);
+            summary.appendChild(head);
+            block.appendChild(summary);
 
             const grid = document.createElement('div');
             grid.className = 'cube-card-grid';
@@ -264,16 +301,22 @@
 
     function renderPacks(container, packs) {
         container.replaceChildren();
+        if (packs.length > 1) container.appendChild(collapseToggle(container));
         packs.forEach(function (pack, i) {
-            const card = document.createElement('div');
+            const card = document.createElement('details');
             card.className = 'cube-pack';
+            card.open = true;
+            const summary = document.createElement('summary');
+            summary.className = 'cube-section-summary cube-pack-head';
+            summary.appendChild(collapseChevron());
             const heading = document.createElement('h3');
             heading.textContent = 'Pack ' + (i + 1);
             const count = document.createElement('span');
             count.className = 'cube-pack-count';
             count.textContent = pack.length + ' cards';
             heading.appendChild(count);
-            card.appendChild(heading);
+            summary.appendChild(heading);
+            card.appendChild(summary);
             const grid = document.createElement('div');
             grid.className = 'cube-card-grid';
             pack.forEach(function (c) {

--- a/web/src/test/js/cube.test.js
+++ b/web/src/test/js/cube.test.js
@@ -212,6 +212,109 @@ describe('collapsible result sections', () => {
         Cube.renderPacks(container, [[{ name: 'Bolt' }]]);
         expect(container.querySelector('[data-collapse-all]')).toBeNull();
     });
+
+    test('a single preview group also gets no collapse-all toggle', () => {
+        const container = document.createElement('div');
+        Cube.renderGroups(container, [
+            { category: 'Red', count: 1, asFan: 1, cards: [{ name: 'Bolt' }] },
+        ]);
+        expect(container.querySelector('[data-collapse-all]')).toBeNull();
+        expect(container.querySelectorAll('.cube-group')).toHaveLength(1);
+    });
+
+    test('each pack summary leads with an aria-hidden chevron', () => {
+        const container = document.createElement('div');
+        Cube.renderPacks(container, [[{ name: 'Bolt' }], [{ name: 'Forest' }]]);
+        const summary = container.querySelector('.cube-pack > summary');
+        const chevron = summary.firstChild;
+        expect(chevron.className).toBe('cube-collapse-chevron');
+        expect(chevron.getAttribute('aria-hidden')).toBe('true');
+    });
+
+    test('each group summary leads with a chevron, then the as-fan header', () => {
+        const container = document.createElement('div');
+        Cube.renderGroups(container, [
+            { category: 'Red', count: 2, asFan: 2, cards: [{ name: 'Bolt' }] },
+            { category: 'Land', count: 1, asFan: 0.5, cards: [{ name: 'Wastes' }] },
+        ]);
+        const summary = container.querySelector('.cube-group > summary');
+        expect(summary.firstChild.className).toBe('cube-collapse-chevron');
+        expect(summary.querySelector('.cube-group-head .cube-bar-value').textContent).toBe('2.00 / pack');
+    });
+
+    test('the collapse-all bar sits above the sections', () => {
+        const container = document.createElement('div');
+        Cube.renderPacks(container, [[{ name: 'Bolt' }], [{ name: 'Forest' }]]);
+        expect(container.firstChild.className).toBe('cube-collapse-bar');
+        expect(container.firstChild.querySelector('[data-collapse-all]')).not.toBeNull();
+    });
+
+    test("the card grid is a direct child of the <details>, so collapsing hides the cards", () => {
+        const container = document.createElement('div');
+        Cube.renderPacks(container, [[{ name: 'Bolt' }], [{ name: 'Forest' }]]);
+        const pack = container.querySelector('.cube-pack');
+        const grid = pack.querySelector('.cube-card-grid');
+        expect(grid.parentElement).toBe(pack); // sibling of <summary>, inside <details>
+        expect(grid.previousElementSibling.tagName).toBe('SUMMARY');
+    });
+
+    test('preview groups get their own working Collapse all toggle', () => {
+        const container = document.createElement('div');
+        Cube.renderGroups(container, [
+            { category: 'Red', count: 1, asFan: 1, cards: [{ name: 'Bolt' }] },
+            { category: 'Blue', count: 1, asFan: 1, cards: [{ name: 'Counterspell' }] },
+        ]);
+        const btn = container.querySelector('[data-collapse-all]');
+        expect(btn).not.toBeNull();
+        btn.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+        container.querySelectorAll('.cube-group').forEach((d) => expect(d.open).toBe(false));
+        expect(btn.textContent).toBe('Expand all');
+    });
+
+    test('Collapse all closes everything even from a mixed open/closed state', () => {
+        const container = document.createElement('div');
+        Cube.renderPacks(container, [[{ name: 'Bolt' }], [{ name: 'Forest' }], [{ name: 'Island' }]]);
+        const packs = container.querySelectorAll('.cube-pack');
+        packs[0].open = false; // one already collapsed, the rest open
+        const btn = container.querySelector('[data-collapse-all]');
+
+        btn.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+        // Any-open → collapse them all.
+        container.querySelectorAll('.cube-pack').forEach((d) => expect(d.open).toBe(false));
+        expect(btn.textContent).toBe('Expand all');
+
+        btn.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+        // None open → expand them all.
+        container.querySelectorAll('.cube-pack').forEach((d) => expect(d.open).toBe(true));
+        expect(btn.textContent).toBe('Collapse all');
+    });
+
+    test('the collapse-all button is a styled link-button carrying the data hook', () => {
+        const container = document.createElement('div');
+        Cube.renderPacks(container, [[{ name: 'Bolt' }], [{ name: 'Forest' }]]);
+        const btn = container.querySelector('[data-collapse-all]');
+        expect(btn.tagName).toBe('BUTTON');
+        expect(btn.getAttribute('type')).toBe('button');
+        expect(btn.className).toContain('cube-link-btn');
+    });
+
+    test('re-rendering replaces the sections and leaves exactly one toggle', () => {
+        const container = document.createElement('div');
+        Cube.renderPacks(container, [[{ name: 'Bolt' }], [{ name: 'Forest' }], [{ name: 'Island' }]]);
+        // Re-render with fewer packs (e.g. a new, smaller deal).
+        Cube.renderPacks(container, [[{ name: 'Swamp' }], [{ name: 'Plains' }]]);
+        expect(container.querySelectorAll('[data-collapse-all]')).toHaveLength(1);
+        expect(container.querySelectorAll('.cube-pack')).toHaveLength(2);
+        expect(container.querySelector('.cube-pack .cube-card-name').textContent).toBe('Swamp');
+    });
+
+    test('re-rendering down to a single section drops the toggle entirely', () => {
+        const container = document.createElement('div');
+        Cube.renderPacks(container, [[{ name: 'Bolt' }], [{ name: 'Forest' }]]);
+        expect(container.querySelector('[data-collapse-all]')).not.toBeNull();
+        Cube.renderPacks(container, [[{ name: 'Swamp' }]]);
+        expect(container.querySelector('[data-collapse-all]')).toBeNull();
+    });
 });
 
 describe('deep-link hash activates the matching tab on in-page navigation', () => {

--- a/web/src/test/js/cube.test.js
+++ b/web/src/test/js/cube.test.js
@@ -166,6 +166,54 @@ describe('renderPacks', () => {
     });
 });
 
+describe('collapsible result sections', () => {
+    test('packs render as open <details> with a summary, so they can be collapsed', () => {
+        const container = document.createElement('div');
+        Cube.renderPacks(container, [[{ name: 'Bolt' }], [{ name: 'Forest' }]]);
+        const pack = container.querySelector('.cube-pack');
+        expect(pack.tagName).toBe('DETAILS');
+        expect(pack.open).toBe(true);
+        expect(pack.querySelector('summary')).not.toBeNull();
+    });
+
+    test('preview groups render as open <details>', () => {
+        const container = document.createElement('div');
+        Cube.renderGroups(container, [
+            { category: 'Red', count: 1, asFan: 1, cards: [{ name: 'Bolt' }] },
+            { category: 'Land', count: 1, asFan: 0.5, cards: [{ name: 'Wastes' }] },
+        ]);
+        const group = container.querySelector('.cube-group');
+        expect(group.tagName).toBe('DETAILS');
+        expect(group.open).toBe(true);
+        // The header (with its as-fan) lives in the summary.
+        expect(group.querySelector('summary .cube-bar-value').textContent).toBe('1.00 / pack');
+    });
+
+    test('a multi-section deal gets a Collapse all / Expand all toggle', () => {
+        const container = document.createElement('div');
+        Cube.renderPacks(container, [[{ name: 'Bolt' }], [{ name: 'Forest' }], [{ name: 'Island' }]]);
+        const btn = container.querySelector('[data-collapse-all]');
+        expect(btn).not.toBeNull();
+        expect(btn.textContent).toBe('Collapse all');
+
+        btn.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+        let packs = container.querySelectorAll('.cube-pack');
+        packs.forEach((d) => expect(d.open).toBe(false));
+        expect(btn.textContent).toBe('Expand all');
+
+        btn.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+        packs = container.querySelectorAll('.cube-pack');
+        packs.forEach((d) => expect(d.open).toBe(true));
+        expect(btn.textContent).toBe('Collapse all');
+    });
+
+    test('a single section gets no collapse-all toggle', () => {
+        const container = document.createElement('div');
+        Cube.renderPacks(container, [[{ name: 'Bolt' }]]);
+        expect(container.querySelector('[data-collapse-all]')).toBeNull();
+    });
+});
+
 describe('deep-link hash activates the matching tab on in-page navigation', () => {
     // wire() ran at require time and registered a hashchange listener on the
     // window; here we stand up the tab markup and fire a hashchange to prove a


### PR DESCRIPTION
## Why

A 24-pack generate (or a big cube preview) is a very long scroll. There was no way to fold sections you'd already looked at.

## What changed

- Each **pack** and each **preview colour/land group** now renders as a native `<details open>` with its header in a `<summary>`. Tap/click the header to collapse it — keyboard- and screen-reader-friendly, with no JS state to manage. A small chevron rotates to show the open/closed state.
- Multi-section results get a **"Collapse all / Expand all"** control so a full draft folds/unfolds in one click.

Implementation notes:
- The group header keeps its grid layout (label / as-fan bar / value) by living in a `.cube-group-head` div inside the summary, so the existing mobile `grid-template-areas` are untouched; the chevron sits beside it via a flex summary.
- Collapsed `<details>` natively hide their card grid — no extra CSS — and the delegated hover-zoom / lightbox / flip handlers are unaffected.

## Tests

- jest: packs/groups render as open `<details>` with a `<summary>`; the multi-section toggle collapses then expands all sections and updates its label; a single section gets no toggle. Existing render tests pass unchanged (the `.cube-pack` / `.cube-group` / `h3` / `.cube-card-grid` / `.cube-bar-value` selectors are preserved). 678 tests pass; stylelint clean.

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs

---
_Generated by [Claude Code](https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs)_