### PR TITLE
Add shared cube-analytics core (curve, types, rarity, duplicates)

### DIFF
--- a/common/src/main/kotlin/common/mtg/CardType.kt
+++ b/common/src/main/kotlin/common/mtg/CardType.kt
@@ -1,0 +1,55 @@
+package common.mtg
+
+/**
+ * The primary card type a cube-design report buckets cards by. Magic cards
+ * can carry several types at once ("Artifact Creature", "Enchantment —
+ * Saga"), so [of] picks a single dominant type by a fixed precedence rather
+ * than listing them all.
+ */
+enum class CardType(val displayName: String) {
+    CREATURE("Creature"),
+    INSTANT("Instant"),
+    SORCERY("Sorcery"),
+    ARTIFACT("Artifact"),
+    ENCHANTMENT("Enchantment"),
+    PLANESWALKER("Planeswalker"),
+    BATTLE("Battle"),
+    LAND("Land"),
+    OTHER("Other");
+
+    companion object {
+        /**
+         * Classifies a Scryfall `type_line` by its **front face** (everything
+         * before `//`, like [CubeCard.isLandType]) so a double-faced card is
+         * bucketed by what's drafted and cast. First match in this precedence
+         * wins:
+         *
+         *  1. **Land** — a land is fixing, not a spell, regardless of any other
+         *     types ("Artifact Land", or Dryad Arbor's "Land Creature"). Mirrors
+         *     [CubeCard.category], which buckets any land as LAND.
+         *  2. **Planeswalker** / **Battle** — distinct buckets that never
+         *     co-occur with Creature, checked first so they aren't swept into
+         *     Other.
+         *  3. **Creature** — so "Artifact Creature" / "Enchantment Creature"
+         *     count as creatures (the dominant gameplay role; a body matters
+         *     more than its supertypes for curve/role analysis).
+         *  4. **Instant** / **Sorcery** / **Enchantment** / **Artifact**.
+         *  5. **Other** — Tribal-only, Plane, Scheme, an empty type line, etc.
+         */
+        fun of(typeLine: String): CardType {
+            val front = typeLine.substringBefore("//")
+            fun has(word: String) = front.contains(word, ignoreCase = true)
+            return when {
+                has("Land") -> LAND
+                has("Planeswalker") -> PLANESWALKER
+                has("Battle") -> BATTLE
+                has("Creature") -> CREATURE
+                has("Instant") -> INSTANT
+                has("Sorcery") -> SORCERY
+                has("Enchantment") -> ENCHANTMENT
+                has("Artifact") -> ARTIFACT
+                else -> OTHER
+            }
+        }
+    }
+}

--- a/common/src/main/kotlin/common/mtg/CubeAnalytics.kt
+++ b/common/src/main/kotlin/common/mtg/CubeAnalytics.kt
@@ -1,0 +1,102 @@
+package common.mtg
+
+/**
+ * The "cube report": curve, card-type mix, rarity mix, average mana value,
+ * and singleton/duplicate detection over a card pool. Pure maths shared by
+ * the web tool and the Discord command (like [AsFan], which it delegates to
+ * for the per-pack numbers) so the two surfaces can't drift.
+ *
+ * Lands are excluded from the mana curve and the average — a land's mana
+ * value is 0 and would crush both — but they still appear in the type and
+ * rarity breakdowns.
+ */
+object CubeAnalytics {
+
+    /** Count of nonland cards at a mana value. [label] is "0".."6" or "7+". */
+    data class ManaCurveBucket(val label: String, val count: Int)
+
+    /** Count and as-fan-per-pack for a single [CardType]. */
+    data class TypeCount(val type: CardType, val count: Int, val asFan: Double)
+
+    /** Count and as-fan-per-pack for a single [Rarity]. */
+    data class RarityCount(val rarity: Rarity, val count: Int, val asFan: Double)
+
+    /** A non-basic card name appearing more than once (a singleton violation). */
+    data class Duplicate(val name: String, val count: Int)
+
+    /** The whole report, assembled once so the surfaces render identical numbers. */
+    data class Analytics(
+        val curve: List<ManaCurveBucket>,
+        val averageManaValue: Double,
+        val nonLandCount: Int,
+        val types: List<TypeCount>,
+        val rarities: List<RarityCount>,
+        val duplicates: List<Duplicate>,
+    )
+
+    /** The highest mana-value bucket; everything at or above it folds into "7+". */
+    const val CURVE_TOP = 7
+
+    fun analyze(cards: List<CubeCard>, packSize: Int): Analytics = Analytics(
+        curve = manaCurve(cards),
+        averageManaValue = averageManaValue(cards),
+        nonLandCount = cards.count { !it.isLand },
+        types = typeCounts(cards, packSize),
+        rarities = rarityCounts(cards, packSize),
+        duplicates = duplicates(cards),
+    )
+
+    /**
+     * The mana curve of the nonland cards: always all eight buckets
+     * (0..6, 7+) including empty ones, so a chart shows the full shape.
+     * Fractional mana values (un-cards) truncate toward the lower bucket.
+     */
+    fun manaCurve(cards: List<CubeCard>): List<ManaCurveBucket> {
+        val counts = IntArray(CURVE_TOP + 1)
+        cards.asSequence()
+            .filter { !it.isLand }
+            .forEach { counts[it.manaValue.toInt().coerceIn(0, CURVE_TOP)]++ }
+        return counts.mapIndexed { mv, count ->
+            ManaCurveBucket(if (mv == CURVE_TOP) "$CURVE_TOP+" else mv.toString(), count)
+        }
+    }
+
+    /** Mean mana value of the nonland cards, or 0.0 when there are none. */
+    fun averageManaValue(cards: List<CubeCard>): Double {
+        val nonland = cards.filter { !it.isLand }
+        if (nonland.isEmpty()) return 0.0
+        return nonland.sumOf { it.manaValue } / nonland.size
+    }
+
+    /** Count + as-fan per [CardType] present in the pool, in enum order. */
+    fun typeCounts(cards: List<CubeCard>, packSize: Int): List<TypeCount> {
+        if (cards.isEmpty()) return emptyList()
+        val counts = cards.groupingBy { CardType.of(it.typeLine) }.eachCount()
+        return CardType.entries
+            .filter { counts[it] != null }
+            .map { type -> TypeCount(type, counts.getValue(type), AsFan.value(counts.getValue(type), cards.size, packSize)) }
+    }
+
+    /** Count + as-fan per [Rarity] present in the pool, in enum order. */
+    fun rarityCounts(cards: List<CubeCard>, packSize: Int): List<RarityCount> {
+        if (cards.isEmpty()) return emptyList()
+        val counts = cards.groupingBy { Rarity.parse(it.rarity) }.eachCount()
+        return Rarity.entries
+            .filter { counts[it] != null }
+            .map { rarity -> RarityCount(rarity, counts.getValue(rarity), AsFan.value(counts.getValue(rarity), cards.size, packSize)) }
+    }
+
+    /**
+     * Non-basic card names appearing more than once — a singleton cube
+     * shouldn't have any. Basics (incl. Snow-Covered and Wastes) are allowed
+     * duplicates, told apart by their type line, not a name list. Sorted by
+     * count (most-duplicated first), then name.
+     */
+    fun duplicates(cards: List<CubeCard>): List<Duplicate> =
+        cards.asSequence()
+            .filterNot { CubeCard.isBasicType(it.typeLine) }
+            .groupingBy { it.name }.eachCount()
+            .filter { it.value > 1 }
+            .map { Duplicate(it.key, it.value) }
+            .sortedWith(compareByDescending<Duplicate> { it.count }.thenBy { it.name })
+}

--- a/common/src/main/kotlin/common/mtg/CubeCard.kt
+++ b/common/src/main/kotlin/common/mtg/CubeCard.kt
@@ -53,6 +53,12 @@ data class CubeCard(
      * it (the bot's pack list) can show it without a second lookup.
      */
     val imageUrl: String? = null,
+    /**
+     * Raw Scryfall `rarity` string (`common`/`uncommon`/`rare`/`mythic`/…),
+     * or null when unknown. Kept raw — [common.mtg.CubeAnalytics] resolves it
+     * to a [Rarity] — so this stays a dumb value type, like [imageUrl].
+     */
+    val rarity: String? = null,
 ) {
     /** Which as-fan bucket this card falls into. Lands first, then by colour count. */
     val category: CardCategory
@@ -75,5 +81,15 @@ data class CubeCard(
          */
         fun isLandType(typeLine: String): Boolean =
             typeLine.substringBefore("//").contains("Land", ignoreCase = true)
+
+        /**
+         * Whether a `type_line`'s **front face** is a basic land — the five
+         * basics, their Snow-Covered variants, and Wastes all carry "Basic"
+         * in their type ("Basic Land — Forest", "Basic Snow Land — Island",
+         * "Basic Land"). Used to allow duplicate basics in a singleton cube
+         * without a brittle name list.
+         */
+        fun isBasicType(typeLine: String): Boolean =
+            typeLine.substringBefore("//").contains("Basic", ignoreCase = true)
     }
 }

--- a/common/src/main/kotlin/common/mtg/Rarity.kt
+++ b/common/src/main/kotlin/common/mtg/Rarity.kt
@@ -1,0 +1,25 @@
+package common.mtg
+
+/**
+ * A card's printing rarity, for a cube's rarity-mix report. Scryfall's
+ * `rarity` string maps onto these; the handful of non-standard values
+ * (`special`, `bonus`) and anything unknown fold into [OTHER] so a report
+ * never crashes on a surprise value.
+ */
+enum class Rarity(val displayName: String) {
+    COMMON("Common"),
+    UNCOMMON("Uncommon"),
+    RARE("Rare"),
+    MYTHIC("Mythic"),
+    OTHER("Other");
+
+    companion object {
+        fun parse(raw: String?): Rarity = when (raw?.trim()?.lowercase()) {
+            "common" -> COMMON
+            "uncommon" -> UNCOMMON
+            "rare" -> RARE
+            "mythic" -> MYTHIC
+            else -> OTHER // "special", "bonus", null, or anything unexpected
+        }
+    }
+}

--- a/common/src/test/kotlin/common/mtg/CardTypeTest.kt
+++ b/common/src/test/kotlin/common/mtg/CardTypeTest.kt
@@ -1,0 +1,51 @@
+package common.mtg
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class CardTypeTest {
+
+    @Test
+    fun `classifies the plain types`() {
+        assertEquals(CardType.CREATURE, CardType.of("Creature — Goblin"))
+        assertEquals(CardType.INSTANT, CardType.of("Instant"))
+        assertEquals(CardType.SORCERY, CardType.of("Sorcery"))
+        assertEquals(CardType.ENCHANTMENT, CardType.of("Enchantment — Aura"))
+        assertEquals(CardType.ARTIFACT, CardType.of("Artifact — Equipment"))
+        assertEquals(CardType.PLANESWALKER, CardType.of("Legendary Planeswalker — Jace"))
+        assertEquals(CardType.BATTLE, CardType.of("Battle — Siege"))
+        assertEquals(CardType.LAND, CardType.of("Land"))
+    }
+
+    @Test
+    fun `a body wins over its supertypes`() {
+        assertEquals(CardType.CREATURE, CardType.of("Artifact Creature — Golem"))
+        assertEquals(CardType.CREATURE, CardType.of("Enchantment Creature — God"))
+    }
+
+    @Test
+    fun `any land is a land, even a land-creature or artifact land`() {
+        assertEquals(CardType.LAND, CardType.of("Land Creature — Forest Dryad")) // Dryad Arbor
+        assertEquals(CardType.LAND, CardType.of("Artifact Land"))
+    }
+
+    @Test
+    fun `classifies by the front face of a double-faced card`() {
+        // Legion's Landing: front is an enchantment, back is a land.
+        assertEquals(CardType.ENCHANTMENT, CardType.of("Legendary Enchantment // Legendary Land"))
+        // Westvale Abbey: front is a land.
+        assertEquals(CardType.LAND, CardType.of("Land // Creature — Demon"))
+    }
+
+    @Test
+    fun `enchantment beats artifact when both are present without a body`() {
+        assertEquals(CardType.ENCHANTMENT, CardType.of("Artifact Enchantment"))
+    }
+
+    @Test
+    fun `unknown or empty type lines fall through to Other`() {
+        assertEquals(CardType.OTHER, CardType.of(""))
+        assertEquals(CardType.OTHER, CardType.of("Tribal — Goblin"))
+        assertEquals(CardType.OTHER, CardType.of("Plane — Mirrodin"))
+    }
+}

--- a/common/src/test/kotlin/common/mtg/CubeAnalyticsTest.kt
+++ b/common/src/test/kotlin/common/mtg/CubeAnalyticsTest.kt
@@ -1,0 +1,177 @@
+package common.mtg
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class CubeAnalyticsTest {
+
+    private fun card(
+        name: String,
+        typeLine: String = "Creature",
+        manaValue: Double = 1.0,
+        rarity: String? = "common",
+    ) = CubeCard(
+        name = name,
+        isLand = CubeCard.isLandType(typeLine),
+        typeLine = typeLine,
+        manaValue = manaValue,
+        rarity = rarity,
+    )
+
+    // --- mana curve ----------------------------------------------------
+
+    @Test
+    fun `mana curve always emits all eight buckets, lands excluded`() {
+        val pool = listOf(
+            card("A", "Instant", 0.0),
+            card("B", "Creature", 2.0),
+            card("C", "Creature", 2.0),
+            card("Forest", "Basic Land — Forest", 0.0),
+        )
+        val curve = CubeAnalytics.manaCurve(pool)
+        assertEquals(listOf("0", "1", "2", "3", "4", "5", "6", "7+"), curve.map { it.label })
+        assertEquals(1, curve.first { it.label == "0" }.count) // the land at 0 is excluded → only the instant
+        assertEquals(2, curve.first { it.label == "2" }.count)
+        assertEquals(0, curve.first { it.label == "5" }.count)
+    }
+
+    @Test
+    fun `the top bucket gathers everything at or above seven`() {
+        val pool = listOf(
+            card("Seven", "Creature", 7.0),
+            card("Eight", "Creature", 8.0),
+            card("Twelve", "Creature", 12.0),
+            card("Six", "Creature", 6.0),
+        )
+        val curve = CubeAnalytics.manaCurve(pool)
+        assertEquals(3, curve.first { it.label == "7+" }.count)
+        assertEquals(1, curve.first { it.label == "6" }.count)
+    }
+
+    @Test
+    fun `fractional mana values truncate toward the lower bucket`() {
+        val pool = listOf(card("Half", "Instant", 0.5), card("ThreeAndHalf", "Instant", 3.5))
+        val curve = CubeAnalytics.manaCurve(pool)
+        assertEquals(1, curve.first { it.label == "0" }.count)
+        assertEquals(1, curve.first { it.label == "3" }.count)
+    }
+
+    // --- average mana value --------------------------------------------
+
+    @Test
+    fun `average mana value is the nonland mean`() {
+        val pool = listOf(
+            card("A", "Instant", 1.0),
+            card("B", "Creature", 3.0),
+            card("Forest", "Basic Land — Forest", 0.0),
+        )
+        assertEquals(2.0, CubeAnalytics.averageManaValue(pool), 1e-9)
+    }
+
+    @Test
+    fun `average mana value is zero for an all-land pool`() {
+        val pool = listOf(card("Forest", "Basic Land — Forest", 0.0), card("Island", "Basic Land — Island", 0.0))
+        assertEquals(0.0, CubeAnalytics.averageManaValue(pool), 1e-9)
+    }
+
+    // --- type breakdown ------------------------------------------------
+
+    @Test
+    fun `type counts bucket by dominant type with as-fan, in enum order`() {
+        val pool = listOf(
+            card("Bear", "Creature — Bear", 2.0),
+            card("Golem", "Artifact Creature — Golem", 4.0),
+            card("Bolt", "Instant", 1.0),
+            card("Sol Ring", "Artifact", 1.0),
+            card("Forest", "Basic Land — Forest", 0.0),
+        )
+        val types = CubeAnalytics.typeCounts(pool, packSize = 5)
+        assertEquals(listOf("Creature", "Instant", "Artifact", "Land"), types.map { it.type.displayName })
+        val creature = types.first { it.type == CardType.CREATURE }
+        assertEquals(2, creature.count)
+        // (2 / 5) * 5 = 2.0
+        assertEquals(2.0, creature.asFan, 1e-9)
+    }
+
+    @Test
+    fun `type counts on an empty pool is empty and never divides by zero`() {
+        assertTrue(CubeAnalytics.typeCounts(emptyList(), packSize = 15).isEmpty())
+    }
+
+    // --- rarity breakdown ----------------------------------------------
+
+    @Test
+    fun `rarity counts group by parsed rarity, unknowns into Other`() {
+        val pool = listOf(
+            card("A", rarity = "common"),
+            card("B", rarity = "common"),
+            card("C", rarity = "mythic"),
+            card("D", rarity = null),
+            card("E", rarity = "special"),
+        )
+        val rarities = CubeAnalytics.rarityCounts(pool, packSize = 5)
+        assertEquals(listOf("Common", "Mythic", "Other"), rarities.map { it.rarity.displayName })
+        assertEquals(2, rarities.first { it.rarity == Rarity.COMMON }.count)
+        assertEquals(2, rarities.first { it.rarity == Rarity.OTHER }.count) // null + special
+    }
+
+    // --- duplicates ----------------------------------------------------
+
+    @Test
+    fun `duplicates flag repeated non-basic cards, sorted by count then name`() {
+        val pool = listOf(
+            card("Sol Ring", "Artifact", 1.0),
+            card("Sol Ring", "Artifact", 1.0),
+            card("Mana Crypt", "Artifact", 0.0),
+            card("Mana Crypt", "Artifact", 0.0),
+            card("Mana Crypt", "Artifact", 0.0),
+            card("Lightning Bolt", "Instant", 1.0),
+        )
+        val dupes = CubeAnalytics.duplicates(pool)
+        assertEquals(listOf("Mana Crypt", "Sol Ring"), dupes.map { it.name }) // 3 before 2
+        assertEquals(3, dupes.first { it.name == "Mana Crypt" }.count)
+    }
+
+    @Test
+    fun `basics, snow-covered basics and wastes are allowed duplicates`() {
+        val pool = listOf(
+            card("Forest", "Basic Land — Forest", 0.0),
+            card("Forest", "Basic Land — Forest", 0.0),
+            card("Snow-Covered Island", "Basic Snow Land — Island", 0.0),
+            card("Snow-Covered Island", "Basic Snow Land — Island", 0.0),
+            card("Wastes", "Basic Land", 0.0),
+            card("Wastes", "Basic Land", 0.0),
+        )
+        assertTrue(CubeAnalytics.duplicates(pool).isEmpty())
+    }
+
+    // --- analyze (aggregate) -------------------------------------------
+
+    @Test
+    fun `analyze assembles every section and counts nonland cards`() {
+        val pool = listOf(
+            card("Bolt", "Instant", 1.0, "common"),
+            card("Bear", "Creature — Bear", 2.0, "common"),
+            card("Forest", "Basic Land — Forest", 0.0, "common"),
+        )
+        val a = CubeAnalytics.analyze(pool, packSize = 3)
+        assertEquals(8, a.curve.size)
+        assertEquals(2, a.nonLandCount)
+        assertEquals(1.5, a.averageManaValue, 1e-9)
+        assertEquals(setOf("Creature", "Instant", "Land"), a.types.map { it.type.displayName }.toSet())
+        assertTrue(a.duplicates.isEmpty())
+    }
+
+    @Test
+    fun `analyze on an empty pool does not throw`() {
+        val a = CubeAnalytics.analyze(emptyList(), packSize = 15)
+        assertEquals(0, a.nonLandCount)
+        assertEquals(0.0, a.averageManaValue, 1e-9)
+        assertTrue(a.types.isEmpty())
+        assertTrue(a.rarities.isEmpty())
+        assertTrue(a.duplicates.isEmpty())
+        assertEquals(8, a.curve.size) // still the eight empty buckets
+        assertTrue(a.curve.all { it.count == 0 })
+    }
+}

--- a/common/src/test/kotlin/common/mtg/CubeCardTest.kt
+++ b/common/src/test/kotlin/common/mtg/CubeCardTest.kt
@@ -37,6 +37,28 @@ class CubeCardTest {
     }
 
     @Test
+    fun `isBasicType recognises the basics, snow-covered basics and Wastes`() {
+        assertTrue(CubeCard.isBasicType("Basic Land — Forest"))
+        assertTrue(CubeCard.isBasicType("Basic Snow Land — Island"))
+        assertTrue(CubeCard.isBasicType("Basic Land")) // Wastes
+    }
+
+    @Test
+    fun `isBasicType is false for non-basic lands and spells`() {
+        assertFalse(CubeCard.isBasicType("Land — Mountain Plains")) // a dual is not basic
+        assertFalse(CubeCard.isBasicType("Legendary Land"))
+        assertFalse(CubeCard.isBasicType("Artifact"))
+        // Judged by the front face, like isLandType.
+        assertFalse(CubeCard.isBasicType("Legendary Enchantment // Basic Land"))
+    }
+
+    @Test
+    fun `rarity defaults to null and round-trips when set`() {
+        assertEquals(null, CubeCard(name = "Placeholder").rarity)
+        assertEquals("mythic", CubeCard(name = "Ragavan", rarity = "mythic").rarity)
+    }
+
+    @Test
     fun `mono-coloured card maps to its colour bucket`() {
         assertEquals(
             CardCategory.RED,

--- a/common/src/test/kotlin/common/mtg/RarityTest.kt
+++ b/common/src/test/kotlin/common/mtg/RarityTest.kt
@@ -1,0 +1,24 @@
+package common.mtg
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class RarityTest {
+
+    @Test
+    fun `maps the standard Scryfall rarities, case-insensitively`() {
+        assertEquals(Rarity.COMMON, Rarity.parse("common"))
+        assertEquals(Rarity.UNCOMMON, Rarity.parse("Uncommon"))
+        assertEquals(Rarity.RARE, Rarity.parse("RARE"))
+        assertEquals(Rarity.MYTHIC, Rarity.parse(" mythic "))
+    }
+
+    @Test
+    fun `special, bonus, unknown and null all fold into Other`() {
+        assertEquals(Rarity.OTHER, Rarity.parse("special"))
+        assertEquals(Rarity.OTHER, Rarity.parse("bonus"))
+        assertEquals(Rarity.OTHER, Rarity.parse("legendary"))
+        assertEquals(Rarity.OTHER, Rarity.parse(""))
+        assertEquals(Rarity.OTHER, Rarity.parse(null))
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcher.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcher.kt
@@ -204,6 +204,7 @@ class ScryfallCubeFetcher @Autowired constructor(
             typeLine = typeLine,
             manaValue = manaValue,
             imageUrl = imageUrl(card),
+            rarity = card.get("rarity")?.asString?.takeIf { it.isNotBlank() },
         )
     }
 

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcherTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcherTest.kt
@@ -102,6 +102,16 @@ class ScryfallCubeFetcherTest {
     }
 
     @Test
+    fun `parseCard reads the rarity, leaving it null when absent`() {
+        val withRarity = fetcher.parseCard(
+            obj("""{"name":"Ragavan","color_identity":["R"],"type_line":"Legendary Creature","rarity":"mythic"}""")
+        )!!
+        assertEquals("mythic", withRarity.rarity)
+        val without = fetcher.parseCard(obj("""{"name":"Token","color_identity":[],"type_line":"Token"}"""))!!
+        assertEquals(null, without.rarity)
+    }
+
+    @Test
     fun `parseCard treats a card with no colour identity as colourless`() {
         val card = fetcher.parseCard(obj("""{"name":"Sol Ring","color_identity":[],"type_line":"Artifact"}"""))!!
         assertEquals(CardCategory.COLORLESS, card.category)

--- a/web/src/main/kotlin/web/service/CubeWebService.kt
+++ b/web/src/main/kotlin/web/service/CubeWebService.kt
@@ -188,6 +188,7 @@ class CubeWebService {
                     isLand = CubeCard.isLandType(typeLine),
                     typeLine = typeLine,
                     manaValue = node.path("cmc").asDouble(0.0),
+                    rarity = node.path("rarity").asText("").takeIf { it.isNotBlank() },
                 ),
                 imageUrl = imageOf(node, "small"),
                 imageUrlLarge = imageOf(node, "normal"),

--- a/web/src/test/kotlin/web/service/CubeWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/CubeWebServiceTest.kt
@@ -174,6 +174,18 @@ class CubeWebServiceTest {
     }
 
     @Test
+    fun `parseScryfall reads the rarity, leaving it null when absent`() {
+        val withRarity = service.parseScryfall(
+            mapper.readTree("""{"data":[{"name":"Ragavan","color_identity":["R"],"type_line":"Legendary Creature","rarity":"mythic"}]}""")
+        ).first().card
+        assertEquals("mythic", withRarity.rarity)
+        val without = service.parseScryfall(
+            mapper.readTree("""{"data":[{"name":"Token","color_identity":[],"type_line":"Token"}]}""")
+        ).first().card
+        assertEquals(null, without.rarity)
+    }
+
+    @Test
     fun `parseScryfall yields null images when Scryfall has none`() {
         val root = mapper.readTree("""{"data":[{"name":"Imageless","color_identity":[],"type_line":"Token"}]}""")
         val parsed = service.parseScryfall(root).first()


### PR DESCRIPTION
## Why

Foundation PR (1 of 4) for a "cube report" — mana curve, card-type breakdown, rarity mix, average mana value, and singleton/duplicate detection — that the following PRs surface on the web and Discord `/cube preview`. Keeping the maths in one pure `common.mtg` module (delegating per-pack numbers to `AsFan`) means the two surfaces can't drift, the same discipline the existing colour distribution already uses.

**No behaviour change yet** — this only adds the shared core + the `rarity` field plumbing.

## What changed (`common/.../mtg/`)

- **`CardType.of(typeLine)`** — front-face (`substringBefore("//")`) classification with a fixed precedence: **Land** > **Planeswalker**/**Battle** > **Creature** > **Instant**/**Sorcery** > **Enchantment** > **Artifact** > **Other**. So "Artifact Creature" / "Enchantment Creature" read as creatures, and any land (incl. Dryad Arbor's "Land Creature") reads as a land — consistent with `CubeCard.category`/`isLandType`.
- **`Rarity.parse(raw)`** — Scryfall rarity → enum; `special`/`bonus`/null/unknown → `OTHER`.
- **`CubeAnalytics`** — `manaCurve` (nonland, always 8 buckets `0..7+`, fractional cmc truncates), `averageManaValue` (nonland mean, 0.0 when none), `typeCounts`/`rarityCounts` (count + as-fan, present buckets in enum order), `duplicates` (non-basic names with count > 1, sorted), and an `analyze(...)` aggregate. Every function guards an empty pool so `AsFan.value` never sees `cubeSize = 0`.
- **`CubeCard`** — trailing defaulted `rarity: String?` (raw, like `imageUrl`) + companion `isBasicType(typeLine)` (type-line check, not a name list — admits the 5 basics, Snow-Covered basics, Wastes).
- Both Scryfall parsers (`CubeWebService.parseScryfall`, `ScryfallCubeFetcher.parseCard`) now read `rarity`.

## Tests

New `CardTypeTest`, `RarityTest`, `CubeAnalyticsTest`; extended `CubeCardTest` (`isBasicType`, `rarity`) and both parser tests (rarity read). Covers the full CardType precedence (Artifact/Enchantment Creature, Dryad Arbor land-creature, DFC `//` front face, empty → OTHER), curve bucketing (fractional, 7/8 → "7+", lands excluded, all 8 buckets), average (all-land → 0.0), rarity folding, duplicate detection (basics/Snow-Covered/Wastes allowed, sort order), and empty-pool safety. `:common:test` + `:common:koverVerify` pass; web/discord parser tests pass.

First of four; next PRs surface this on the Discord embed and the web preview, plus a web export/copy.

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs

---
_Generated by [Claude Code](https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs)_