### PR TITLE
Add the cube report to the Discord /cube preview embed

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeCommand.kt
@@ -5,6 +5,7 @@ import bot.toby.helpers.intOption
 import bot.toby.helpers.stringOption
 import common.mtg.AsFan
 import common.mtg.CardListParser
+import common.mtg.CubeAnalytics
 import common.mtg.CubeCard
 import common.mtg.MtgNames
 import common.mtg.PackGenerator
@@ -172,6 +173,7 @@ class CubeCommand @Autowired constructor(
                     packSize = packSize,
                     counts = AsFan.categoryCounts(pool),
                     distribution = AsFan.distribution(pool, packSize),
+                    analytics = CubeAnalytics.analyze(pool, packSize),
                     notFound = resolved.notFound,
                     note = resolved.note,
                 )

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
@@ -4,6 +4,7 @@ import common.discord.embed
 import common.discord.field
 import common.mtg.CardCategory
 import common.mtg.CardListParser
+import common.mtg.CubeAnalytics
 import common.mtg.CubeCard
 import database.dto.user.CubeListDto
 import net.dv8tion.jda.api.entities.MessageEmbed
@@ -38,13 +39,14 @@ internal object CubeEmbeds {
             field("Maths", "($typeCount ÷ $cubeSize) × $packSize = ${format(value)}", inline = false)
         }
 
-    /** As-fan breakdown of a whole fetched pool — no pack generation. */
+    /** As-fan breakdown of a whole fetched pool, plus the cube report — no pack generation. */
     fun previewEmbed(
         query: String,
         poolSize: Int,
         packSize: Int,
         counts: Map<CardCategory, Int>,
         distribution: Map<CardCategory, Double>,
+        analytics: CubeAnalytics.Analytics,
         notFound: List<String> = emptyList(),
         note: String? = null,
     ): MessageEmbed = embed(color = OK_COLOR) {
@@ -55,6 +57,11 @@ internal object CubeEmbeds {
                 note.orEmpty().let { if (it.isNotEmpty()) "\nℹ️ $it" else "" }
         )
         field("Distribution", distributionTable(counts, distribution), inline = false)
+        // The "cube report": curve (skipped for an all-land pool), types, rarity.
+        if (analytics.nonLandCount > 0) field("Mana curve", curveLine(analytics), inline = false)
+        field("Card types", typeTable(analytics.types), inline = false)
+        field("Rarity", rarityTable(analytics.rarities), inline = false)
+        addDuplicatesField(analytics.duplicates)
         addNotFoundField(notFound)
     }
 
@@ -90,14 +97,39 @@ internal object CubeEmbeds {
      */
     private fun net.dv8tion.jda.api.EmbedBuilder.addNotFoundField(notFound: List<String>) {
         if (notFound.isEmpty()) return
-        val joined = notFound.joinToString(", ")
-        val value = if (joined.length <= NOT_FOUND_LIMIT) {
-            joined
-        } else {
-            joined.take(NOT_FOUND_LIMIT).substringBeforeLast(", ") + " … (+more)"
-        }
-        field("⚠️ Couldn't find ${notFound.size}", value, inline = false)
+        field("⚠️ Couldn't find ${notFound.size}", truncateField(notFound.joinToString(", ")), inline = false)
     }
+
+    /**
+     * Lists non-basic cards that appear more than once — a singleton cube
+     * shouldn't have any — only when there are some, so a legal cube stays
+     * clean.
+     */
+    private fun net.dv8tion.jda.api.EmbedBuilder.addDuplicatesField(duplicates: List<CubeAnalytics.Duplicate>) {
+        if (duplicates.isEmpty()) return
+        val joined = duplicates.joinToString(", ") { "${it.name} ×${it.count}" }
+        field("⚠️ Duplicates ${duplicates.size}", truncateField(joined), inline = false)
+    }
+
+    /** Keeps a comma-joined field value under Discord's 1024-char field cap. */
+    private fun truncateField(joined: String): String =
+        if (joined.length <= NOT_FOUND_LIMIT) joined
+        else joined.take(NOT_FOUND_LIMIT).substringBeforeLast(", ") + " … (+more)"
+
+    /** Compact one-line mana curve plus the average mana value. */
+    private fun curveLine(analytics: CubeAnalytics.Analytics): String =
+        "`" + analytics.curve.joinToString(" ") { "${it.label}:${it.count}" } + "`" +
+            "  ·  avg MV ${format(analytics.averageManaValue)}"
+
+    /** A `type — count (as-fan)` table, in type order, present types only. */
+    private fun typeTable(types: List<CubeAnalytics.TypeCount>): String =
+        types.joinToString("\n") { "${it.type.displayName} — ${it.count} (${format(it.asFan)}/pack)" }
+            .ifEmpty { "—" }
+
+    /** A `rarity — count (as-fan)` table, common→mythic, present rarities only. */
+    private fun rarityTable(rarities: List<CubeAnalytics.RarityCount>): String =
+        rarities.joinToString("\n") { "${it.rarity.displayName} — ${it.count} (${format(it.asFan)}/pack)" }
+            .ifEmpty { "—" }
 
     /** Keep the saved-cube listing under Discord's 4096-char description cap. */
     private const val SAVED_LIST_LIMIT = 25

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeCommandTest.kt
@@ -103,6 +103,8 @@ class CubeCommandTest : CommandTest {
         run()
 
         assertEquals("Cube preview", slot.captured.title)
+        // The cube report is wired in: the analytics fields ride along.
+        assertTrue(slot.captured.fields.any { it.name == "Card types" })
         coVerify(exactly = 1) { fetcher.fetch(any(), any()) }
     }
 

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeEmbedsTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeEmbedsTest.kt
@@ -1,13 +1,82 @@
 package bot.toby.command.commands.mtg
 
+import common.mtg.AsFan
+import common.mtg.CubeAnalytics
 import common.mtg.CubeCard
 import common.mtg.MtgColor
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.nio.charset.StandardCharsets
 
 class CubeEmbedsTest {
+
+    private fun card(name: String, typeLine: String, mv: Double, rarity: String?, land: Boolean = false) =
+        CubeCard(name = name, isLand = land, typeLine = typeLine, manaValue = mv, rarity = rarity)
+
+    private fun preview(pool: List<CubeCard>, packSize: Int = 5) = CubeEmbeds.previewEmbed(
+        query = "test",
+        poolSize = pool.size,
+        packSize = packSize,
+        counts = AsFan.categoryCounts(pool),
+        distribution = AsFan.distribution(pool, packSize),
+        analytics = CubeAnalytics.analyze(pool, packSize),
+    )
+
+    private fun field(embed: net.dv8tion.jda.api.entities.MessageEmbed, name: String) =
+        embed.fields.firstOrNull { it.name == name }
+
+    @Test
+    fun `previewEmbed carries the curve, type and rarity report fields`() {
+        val pool = listOf(
+            card("Bolt", "Instant", 1.0, "common"),
+            card("Bear", "Creature — Bear", 2.0, "common"),
+            card("Drake", "Creature — Drake", 3.0, "uncommon"),
+            card("Forest", "Basic Land — Forest", 0.0, "common", land = true),
+        )
+        val embed = preview(pool)
+
+        assertNotNull(field(embed, "Mana curve"))
+        assertTrue(field(embed, "Mana curve")!!.value!!.contains("avg MV"))
+        val types = field(embed, "Card types")
+        assertNotNull(types)
+        assertTrue(types!!.value!!.contains("Creature — 2"))
+        assertTrue(types.value!!.contains("Land — 1"))
+        assertTrue(field(embed, "Rarity")!!.value!!.contains("Common — 3"))
+    }
+
+    @Test
+    fun `previewEmbed shows a duplicates field only when a non-basic repeats`() {
+        val singleton = listOf(
+            card("Sol Ring", "Artifact", 1.0, "uncommon"),
+            card("Forest", "Basic Land — Forest", 0.0, "common", land = true),
+            card("Forest", "Basic Land — Forest", 0.0, "common", land = true), // basics allowed
+        )
+        assertNull(field(preview(singleton), "⚠️ Duplicates 1"))
+
+        val withDupe = listOf(
+            card("Sol Ring", "Artifact", 1.0, "uncommon"),
+            card("Sol Ring", "Artifact", 1.0, "uncommon"),
+        )
+        val dupField = preview(withDupe).fields.firstOrNull { it.name!!.startsWith("⚠️ Duplicates") }
+        assertNotNull(dupField)
+        assertTrue(dupField!!.value!!.contains("Sol Ring ×2"))
+    }
+
+    @Test
+    fun `previewEmbed skips the mana curve for an all-land pool`() {
+        val pool = listOf(
+            card("Forest", "Basic Land — Forest", 0.0, "common", land = true),
+            card("Island", "Basic Land — Island", 0.0, "common", land = true),
+        )
+        val embed = preview(pool)
+        assertNull(field(embed, "Mana curve"))
+        // Types still render (both are lands).
+        assertEquals("Land — 2 (5.00/pack)", field(embed, "Card types")!!.value)
+    }
 
     @Test
     fun `packsFile lists each card, appending its image link when present`() {


### PR DESCRIPTION
## Why

PR 2 of 4. Surfaces the shared `CubeAnalytics` (from #634, now merged) on the Discord `/cube preview` embed.

## What changed

`CubeEmbeds.previewEmbed` gains an `analytics: CubeAnalytics.Analytics` param and renders, after the colour Distribution:
- **Mana curve** — compact one-liner `` `0:4 1:9 2:15 …` `` + `avg MV 2.84`; **skipped for an all-land pool**.
- **Card types** / **Rarity** — short `"Creature — 40 (4.20/pack)"` tables (present buckets only).
- **⚠️ Duplicates** — non-basic cards that repeat (`Sol Ring ×2`), shown **only when a singleton cube actually has some**.

Refactor: field-truncation moves out of `addNotFoundField` into a shared `truncateField` helper (reused by the duplicates field). `CubeCommand.handlePreview` computes `CubeAnalytics.analyze(pool, packSize)` and passes it in. Discord field/length caps respected.

## Tests

`CubeEmbedsTest`: curve/type/rarity fields present with expected content; duplicates field only when a non-basic repeats (basics allowed); curve skipped for an all-land pool. `CubeCommandTest`: the live preview embed carries the report. `:discord-bot:test` + `:discord-bot:koverVerify` pass.

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs