### PR TITLE
Add the cube report to the web /cube preview

### DIFF
--- a/web/src/main/kotlin/web/controller/CubeController.kt
+++ b/web/src/main/kotlin/web/controller/CubeController.kt
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseBody
+import web.service.AnalyticsView
 import web.service.CardView
 import web.service.CategoryAsFan
 import web.service.CategoryGroup
@@ -124,10 +125,13 @@ class CubeController(
     private fun previewResponse(result: CubeResult<PreviewData>): ResponseEntity<CubePreviewResponse> =
         when (result) {
             is CubeResult.Success -> ResponseEntity.ok(
-                CubePreviewResponse(true, null, result.value.poolSize, result.value.groups, result.value.notFound, result.value.note)
+                CubePreviewResponse(
+                    true, null, result.value.poolSize, result.value.groups,
+                    result.value.analytics, result.value.notFound, result.value.note,
+                )
             )
             is CubeResult.Failure ->
-                ResponseEntity.badRequest().body(CubePreviewResponse(false, result.error, 0, emptyList(), emptyList(), null))
+                ResponseEntity.badRequest().body(CubePreviewResponse(false, result.error, 0, emptyList(), null, emptyList(), null))
         }
 
     private fun generateResponse(result: CubeResult<GenerateData>): ResponseEntity<CubeGenerateResponse> =
@@ -246,6 +250,7 @@ data class CubePreviewResponse(
     val error: String?,
     val poolSize: Int,
     val groups: List<CategoryGroup>,
+    val analytics: AnalyticsView? = null,
     val notFound: List<String> = emptyList(),
     val note: String? = null,
 )

--- a/web/src/main/kotlin/web/service/CubeWebService.kt
+++ b/web/src/main/kotlin/web/service/CubeWebService.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import common.mtg.AsFan
 import common.mtg.CardCategory
 import common.mtg.CardListParser
+import common.mtg.CubeAnalytics
 import common.mtg.CubeCard
 import common.mtg.MtgNames
 import common.mtg.MtgColor
@@ -91,9 +92,23 @@ class CubeWebService {
         poolSize = pool.size,
         packSize = packSize,
         groups = groups(pool, packSize),
+        analytics = analyticsView(pool.map { it.card }, packSize),
         notFound = notFound,
         note = note,
     )
+
+    /** The shared cube report, mapped to JSON-friendly views (enum → displayName). */
+    internal fun analyticsView(cards: List<CubeCard>, packSize: Int): AnalyticsView {
+        val a = CubeAnalytics.analyze(cards, packSize)
+        return AnalyticsView(
+            curve = a.curve.map { CurveBucketView(it.label, it.count) },
+            averageManaValue = a.averageManaValue,
+            nonLandCount = a.nonLandCount,
+            types = a.types.map { TypeCountView(it.type.displayName, it.count, it.asFan) },
+            rarities = a.rarities.map { RarityCountView(it.rarity.displayName, it.count, it.asFan) },
+            duplicates = a.duplicates.map { DuplicateView(it.name, it.count) },
+        )
+    }
 
     private fun buildGenerate(
         label: String,
@@ -458,11 +473,26 @@ data class ResolvedPool(
 /** Outcome of matching list entries to fetched cards: the pool + unresolved names. */
 data class MatchResult(val pool: List<ScryfallCard>, val notFound: List<String>)
 
+/** The "cube report" the preview renders: curve, types, rarity, averages, duplicates. */
+data class CurveBucketView(val label: String, val count: Int)
+data class TypeCountView(val type: String, val count: Int, val asFan: Double)
+data class RarityCountView(val rarity: String, val count: Int, val asFan: Double)
+data class DuplicateView(val name: String, val count: Int)
+data class AnalyticsView(
+    val curve: List<CurveBucketView>,
+    val averageManaValue: Double,
+    val nonLandCount: Int,
+    val types: List<TypeCountView>,
+    val rarities: List<RarityCountView>,
+    val duplicates: List<DuplicateView>,
+)
+
 data class PreviewData(
     val query: String,
     val poolSize: Int,
     val packSize: Int,
     val groups: List<CategoryGroup>,
+    val analytics: AnalyticsView,
     val notFound: List<String> = emptyList(),
     val note: String? = null,
 )

--- a/web/src/main/resources/static/css/cube.css
+++ b/web/src/main/resources/static/css/cube.css
@@ -1089,6 +1089,42 @@ details[open] > .cube-section-summary .cube-collapse-chevron {
     font-size: 0.9rem;
 }
 
+/* The cube report: average MV, mana curve, type and rarity breakdowns. */
+.cube-analytics {
+    display: grid;
+    gap: var(--space-2);
+    margin-top: var(--space-3);
+}
+
+.cube-avg-mv {
+    margin: 0;
+    color: var(--text-muted);
+    font-size: 0.9rem;
+}
+
+.cube-analytics-h {
+    margin: var(--space-2) 0 0;
+    color: var(--heading);
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+/* Singleton-violation warning (non-basic duplicates), matching .cube-notfound. */
+.cube-dup-warning {
+    margin: var(--space-2) 0 0;
+    padding: 8px 12px;
+    background: var(--warn-soft);
+    border: 1px solid var(--warn);
+    border-radius: var(--radius-sm);
+    color: var(--text);
+    font-size: 0.85rem;
+}
+
+.cube-dup-warning[hidden] {
+    display: none;
+}
+
 @media (max-width: 600px) {
     .cube-hero h1 {
         font-size: 1.7rem;

--- a/web/src/main/resources/static/js/cube.js
+++ b/web/src/main/resources/static/js/cube.js
@@ -185,17 +185,99 @@
         return a;
     }
 
-    function asFanBar(category, asFan, max) {
-        const color = categoryColor(category);
-        const pct = max > 0 ? Math.max(2, Math.round((asFan / max) * 100)) : 0;
+    // A neutral bar colour for analytics with no colour-pie meaning (curve,
+    // types, rarity), matching the categoryColor fallback.
+    const NEUTRAL_BAR = '#7a7a8a';
+
+    /** A length-scaled bar track from a 0..1 [ratio] in [color]. */
+    function barTrack(ratio, color) {
         const track = document.createElement('div');
         track.className = 'cube-bar-track';
         const fill = document.createElement('div');
         fill.className = 'cube-bar-fill';
-        fill.style.width = pct + '%';
+        fill.style.width = (ratio > 0 ? Math.max(2, Math.round(ratio * 100)) : 0) + '%';
         fill.style.background = color;
         track.appendChild(fill);
         return track;
+    }
+
+    function asFanBar(category, asFan, max) {
+        return barTrack(max > 0 ? asFan / max : 0, categoryColor(category));
+    }
+
+    /** A `label | bar | value` row (no colour swatch) for the analytics panels. */
+    function statRow(labelText, valueText, ratio, color) {
+        const rowEl = document.createElement('div');
+        rowEl.className = 'cube-bar-row';
+        const label = document.createElement('span');
+        label.className = 'cube-bar-label';
+        label.textContent = labelText;
+        const value = document.createElement('span');
+        value.className = 'cube-bar-value';
+        value.textContent = valueText;
+        rowEl.appendChild(label);
+        rowEl.appendChild(barTrack(ratio, color));
+        rowEl.appendChild(value);
+        return rowEl;
+    }
+
+    /** The mana curve: one bar per bucket ("0".."7+"), scaled to the tallest. */
+    function renderManaCurve(container, curve) {
+        container.replaceChildren();
+        const max = curve.reduce(function (m, b) { return Math.max(m, b.count); }, 0);
+        curve.forEach(function (b) {
+            container.appendChild(statRow(b.label, String(b.count), max > 0 ? b.count / max : 0, NEUTRAL_BAR));
+        });
+        return container;
+    }
+
+    /** The card-type breakdown: count + as-fan per type. */
+    function renderTypeBreakdown(container, types) {
+        container.replaceChildren();
+        const max = types.reduce(function (m, t) { return Math.max(m, t.asFan); }, 0);
+        types.forEach(function (t) {
+            container.appendChild(statRow(t.type, formatAsFan(t.asFan) + ' / pack · ' + t.count, max > 0 ? t.asFan / max : 0, NEUTRAL_BAR));
+        });
+        return container;
+    }
+
+    /** The rarity breakdown: count + as-fan per rarity. */
+    function renderRarity(container, rarities) {
+        container.replaceChildren();
+        const max = rarities.reduce(function (m, r) { return Math.max(m, r.asFan); }, 0);
+        rarities.forEach(function (r) {
+            container.appendChild(statRow(r.rarity, formatAsFan(r.asFan) + ' / pack · ' + r.count, max > 0 ? r.asFan / max : 0, NEUTRAL_BAR));
+        });
+        return container;
+    }
+
+    /** A singleton-violation warning; hidden when the cube has no non-basic duplicates. */
+    function renderDuplicates(el, duplicates) {
+        if (!el) return;
+        if (!duplicates || !duplicates.length) { el.hidden = true; el.textContent = ''; return; }
+        el.textContent = '⚠️ ' + duplicates.length + ' non-basic card' + (duplicates.length > 1 ? 's' : '') +
+            ' duplicated: ' + duplicates.map(function (d) { return d.name + ' ×' + d.count; }).join(', ');
+        el.hidden = false;
+    }
+
+    /**
+     * Renders the whole cube report into the preview panels (duplicates
+     * warning always-visible, the rest inside a collapsible). Tolerates a
+     * missing analytics payload (older responses) and any missing element.
+     */
+    function renderAnalytics(analytics, els) {
+        renderDuplicates(els.dupes, analytics && analytics.duplicates);
+        if (!analytics) { hide(els.breakdown); return; }
+        if (els.avgMv) {
+            els.avgMv.textContent = analytics.nonLandCount > 0
+                ? 'Average mana value ' + formatAsFan(analytics.averageManaValue) +
+                    ' over ' + analytics.nonLandCount + ' nonland card' + (analytics.nonLandCount > 1 ? 's' : '')
+                : 'No nonland cards.';
+        }
+        if (els.curve) renderManaCurve(els.curve, analytics.curve || []);
+        if (els.types) renderTypeBreakdown(els.types, analytics.types || []);
+        if (els.rarity) renderRarity(els.rarity, analytics.rarities || []);
+        show(els.breakdown);
     }
 
     /** As-fan bars only (the secondary "balance" view under a generate). */
@@ -880,6 +962,12 @@
         const empty = emptyFor(doc, 'preview');
         const groups = q(doc, '[data-result="preview"]');
         const notFound = q(doc, '[data-notfound="preview"]');
+        const dupes = q(doc, '[data-duplicates="preview"]');
+        const breakdown = q(doc, '[data-breakdown="preview-analytics"]');
+        const avgMv = q(doc, '[data-avg-mv="preview"]');
+        const curve = q(doc, '[data-curve="preview"]');
+        const types = q(doc, '[data-types="preview"]');
+        const rarity = q(doc, '[data-rarity="preview"]');
         form.addEventListener('submit', function (e) {
             e.preventDefault();
             const packSize = new FormData(form).get('packSize');
@@ -887,7 +975,7 @@
             const err = sourceError(src);
             if (err) { setStatus(status, err); return; }
             setStatus(status, src.mode === 'list' ? 'Resolving your list…' : 'Fetching cards from Scryfall…');
-            hide(groups); hide(notFound);
+            hide(groups); hide(notFound); hide(dupes); hide(breakdown);
             withBusy(form, true);
             setSpinner(doc, 'preview', true);
             const request = src.mode === 'list'
@@ -901,6 +989,7 @@
                     renderGroups(groups, json.groups);
                     show(groups);
                     renderNotFound(notFound, json.notFound);
+                    renderAnalytics(json.analytics, { dupes: dupes, breakdown: breakdown, avgMv: avgMv, curve: curve, types: types, rarity: rarity });
                 })
                 .catch(function () { setStatus(status, 'Something went wrong. Try again.'); })
                 .then(function () { withBusy(form, false); setSpinner(doc, 'preview', false); });
@@ -1179,6 +1268,11 @@
         previewUrl: previewUrl,
         generateUrl: generateUrl,
         renderDistribution: renderDistribution,
+        renderManaCurve: renderManaCurve,
+        renderTypeBreakdown: renderTypeBreakdown,
+        renderRarity: renderRarity,
+        renderDuplicates: renderDuplicates,
+        renderAnalytics: renderAnalytics,
         renderGroups: renderGroups,
         renderPacks: renderPacks,
     };

--- a/web/src/main/resources/templates/cube.html
+++ b/web/src/main/resources/templates/cube.html
@@ -202,7 +202,20 @@
             </div>
             <p class="cube-empty" data-empty="preview">Choose your cards above, then hit <strong>Preview balance</strong>.</p>
             <p class="cube-notfound" data-notfound="preview" hidden></p>
+            <p class="cube-dup-warning" data-duplicates="preview" hidden></p>
             <div class="cube-groups" data-result="preview" hidden></div>
+            <details class="cube-breakdown" data-breakdown="preview-analytics" hidden>
+                <summary>Show mana curve, types &amp; rarity</summary>
+                <div class="cube-analytics">
+                    <p class="cube-avg-mv" data-avg-mv="preview"></p>
+                    <h4 class="cube-analytics-h">Mana curve</h4>
+                    <div class="cube-dist" data-curve="preview"></div>
+                    <h4 class="cube-analytics-h">Card types</h4>
+                    <div class="cube-dist" data-types="preview"></div>
+                    <h4 class="cube-analytics-h">Rarity</h4>
+                    <div class="cube-dist" data-rarity="preview"></div>
+                </div>
+            </details>
         </section>
 
         <!-- As-fan calculator -->

--- a/web/src/test/js/cube.test.js
+++ b/web/src/test/js/cube.test.js
@@ -385,6 +385,102 @@ describe('deep-link hash activates the matching tab on in-page navigation', () =
     });
 });
 
+describe('cube report analytics renderers', () => {
+    test('renderManaCurve draws one scaled bar per bucket', () => {
+        const container = document.createElement('div');
+        Cube.renderManaCurve(container, [
+            { label: '0', count: 0 },
+            { label: '1', count: 10 },
+            { label: '2', count: 5 },
+            { label: '7+', count: 1 },
+        ]);
+        const rows = container.querySelectorAll('.cube-bar-row');
+        expect(rows).toHaveLength(4);
+        expect(rows[1].querySelector('.cube-bar-label').textContent).toBe('1');
+        expect(rows[1].querySelector('.cube-bar-value').textContent).toBe('10');
+        // Tallest bucket fills 100%, the empty one 0%.
+        expect(rows[1].querySelector('.cube-bar-fill').style.width).toBe('100%');
+        expect(rows[0].querySelector('.cube-bar-fill').style.width).toBe('0%');
+        expect(rows[3].querySelector('.cube-bar-label').textContent).toBe('7+');
+    });
+
+    test('renderTypeBreakdown shows the type, as-fan and count', () => {
+        const container = document.createElement('div');
+        Cube.renderTypeBreakdown(container, [
+            { type: 'Creature', count: 40, asFan: 4.2 },
+            { type: 'Instant', count: 12, asFan: 1.26 },
+        ]);
+        const rows = container.querySelectorAll('.cube-bar-row');
+        expect(rows[0].querySelector('.cube-bar-label').textContent).toBe('Creature');
+        expect(rows[0].querySelector('.cube-bar-value').textContent).toBe('4.20 / pack · 40');
+        expect(rows[0].querySelector('.cube-bar-fill').style.width).toBe('100%'); // tallest
+    });
+
+    test('renderRarity shows the rarity, as-fan and count', () => {
+        const container = document.createElement('div');
+        Cube.renderRarity(container, [{ rarity: 'Common', count: 90, asFan: 5.0 }]);
+        const row = container.querySelector('.cube-bar-row');
+        expect(row.querySelector('.cube-bar-label').textContent).toBe('Common');
+        expect(row.querySelector('.cube-bar-value').textContent).toBe('5.00 / pack · 90');
+    });
+
+    test('renderDuplicates warns on non-basic duplicates and hides when there are none', () => {
+        const el = document.createElement('p');
+        Cube.renderDuplicates(el, [{ name: 'Sol Ring', count: 2 }, { name: 'Mana Crypt', count: 3 }]);
+        expect(el.hidden).toBe(false);
+        expect(el.textContent).toContain('2 non-basic cards duplicated');
+        expect(el.textContent).toContain('Sol Ring ×2');
+        expect(el.textContent).toContain('Mana Crypt ×3');
+
+        Cube.renderDuplicates(el, []);
+        expect(el.hidden).toBe(true);
+        expect(el.textContent).toBe('');
+    });
+
+    test('renderAnalytics fills every panel and reveals the breakdown', () => {
+        const dupes = document.createElement('p');
+        const breakdown = document.createElement('details');
+        breakdown.hidden = true;
+        const avgMv = document.createElement('p');
+        const curve = document.createElement('div');
+        const types = document.createElement('div');
+        const rarity = document.createElement('div');
+        Cube.renderAnalytics(
+            {
+                curve: [{ label: '0', count: 1 }, { label: '1', count: 2 }],
+                averageManaValue: 2.5,
+                nonLandCount: 3,
+                types: [{ type: 'Creature', count: 2, asFan: 1.0 }],
+                rarities: [{ rarity: 'Rare', count: 1, asFan: 0.5 }],
+                duplicates: [{ name: 'Sol Ring', count: 2 }],
+            },
+            { dupes: dupes, breakdown: breakdown, avgMv: avgMv, curve: curve, types: types, rarity: rarity },
+        );
+        expect(breakdown.hidden).toBe(false);
+        expect(avgMv.textContent).toContain('Average mana value 2.50');
+        expect(avgMv.textContent).toContain('3 nonland cards');
+        expect(curve.querySelectorAll('.cube-bar-row')).toHaveLength(2);
+        expect(types.querySelector('.cube-bar-label').textContent).toBe('Creature');
+        expect(rarity.querySelector('.cube-bar-label').textContent).toBe('Rare');
+        expect(dupes.hidden).toBe(false);
+    });
+
+    test('renderAnalytics tolerates a missing payload and an all-land pool', () => {
+        const breakdown = document.createElement('details');
+        const dupes = document.createElement('p');
+        Cube.renderAnalytics(null, { dupes: dupes, breakdown: breakdown });
+        expect(breakdown.hidden).toBe(true);
+        expect(dupes.hidden).toBe(true);
+
+        const avgMv = document.createElement('p');
+        Cube.renderAnalytics(
+            { curve: [], averageManaValue: 0, nonLandCount: 0, types: [], rarities: [], duplicates: [] },
+            { dupes: dupes, breakdown: breakdown, avgMv: avgMv, curve: document.createElement('div'), types: document.createElement('div'), rarity: document.createElement('div') },
+        );
+        expect(avgMv.textContent).toBe('No nonland cards.');
+    });
+});
+
 describe('manaSymbolUrls', () => {
     test('maps each {sym} to a Scryfall symbol SVG, stripping braces and slashes', () => {
         const urls = Cube.manaSymbolUrls('{1}{W/U}{R}');

--- a/web/src/test/kotlin/web/controller/CubeControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/CubeControllerTest.kt
@@ -15,13 +15,18 @@ import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
 import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.ui.Model
+import web.service.AnalyticsView
 import web.service.CardView
 import web.service.CategoryAsFan
 import web.service.CategoryGroup
 import web.service.CubeResult
 import web.service.CubeWebService
+import web.service.CurveBucketView
+import web.service.DuplicateView
 import web.service.GenerateData
 import web.service.PreviewData
+import web.service.RarityCountView
+import web.service.TypeCountView
 import java.time.Instant
 
 class CubeControllerTest {
@@ -38,6 +43,19 @@ class CubeControllerTest {
         every { getAttribute<String>("username") } returns "matt"
     }
     private fun anon() = mockk<OAuth2User> { every { getAttribute<String>("id") } returns null }
+
+    /** A sample cube report for preview fixtures. */
+    private fun analytics(
+        types: List<TypeCountView> = listOf(TypeCountView("Creature", 1, 0.5)),
+        duplicates: List<DuplicateView> = emptyList(),
+    ) = AnalyticsView(
+        curve = listOf(CurveBucketView("0", 0), CurveBucketView("1", 1)),
+        averageManaValue = 1.5,
+        nonLandCount = 1,
+        types = types,
+        rarities = listOf(RarityCountView("Common", 1, 0.5)),
+        duplicates = duplicates,
+    )
 
     @BeforeEach
     fun setup() {
@@ -95,6 +113,7 @@ class CubeControllerTest {
                     ),
                 )
             ),
+            analytics = analytics(),
         )
         every { service.preview("set:vow", 15) } returns CubeResult.ok(data)
 
@@ -107,6 +126,9 @@ class CubeControllerTest {
         val cards = response.body!!.groups.first().cards
         assertEquals(listOf("Sigarda's Splendor", "Sungold Sentinel"), cards.map { it.name })
         assertEquals("https://img/sigarda.jpg", cards.first().imageUrl)
+        // The cube report flows through the response.
+        assertEquals(1.5, response.body!!.analytics!!.averageManaValue)
+        assertEquals("Creature", response.body!!.analytics!!.types.first().type)
     }
 
     @Test
@@ -159,6 +181,7 @@ class CubeControllerTest {
         val data = PreviewData(
             query = "your list", poolSize = 2, packSize = 15,
             groups = listOf(CategoryGroup("Red", 2, 2.0, listOf(CardView("Bolt", null, null, "Instant", 1.0)))),
+            analytics = analytics(),
             notFound = listOf("Definitely Not A Card"),
         )
         every { service.previewList("3 Bolt\nDefinitely Not A Card", 15) } returns CubeResult.ok(data)
@@ -193,6 +216,7 @@ class CubeControllerTest {
     fun `previewList passes a truncation note through to the response`() {
         val data = PreviewData(
             query = "your list", poolSize = 750, packSize = 15, groups = emptyList(),
+            analytics = analytics(),
             notFound = emptyList(), note = "Your list resolved to 900 cards; only the first 750 were used.",
         )
         every { service.previewList(any(), any()) } returns CubeResult.ok(data)

--- a/web/src/test/kotlin/web/service/CubeWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/CubeWebServiceTest.kt
@@ -14,6 +14,32 @@ class CubeWebServiceTest {
     private val service = CubeWebService()
     private val mapper = ObjectMapper()
 
+    // --- analyticsView (the cube report, mapped to JSON views) ---------
+
+    @Test
+    fun `analyticsView maps the shared report to display-name views`() {
+        val pool = listOf(
+            CubeCard("Bolt", setOf(MtgColor.RED), typeLine = "Instant", manaValue = 1.0, rarity = "common"),
+            CubeCard("Bear", setOf(MtgColor.GREEN), typeLine = "Creature — Bear", manaValue = 2.0, rarity = "common"),
+            CubeCard("Sol Ring", typeLine = "Artifact", manaValue = 1.0, rarity = "uncommon"),
+            CubeCard("Sol Ring", typeLine = "Artifact", manaValue = 1.0, rarity = "uncommon"),
+            CubeCard("Forest", isLand = true, typeLine = "Basic Land — Forest", rarity = "common"),
+            CubeCard("Forest", isLand = true, typeLine = "Basic Land — Forest", rarity = "common"),
+        )
+        val view = service.analyticsView(pool, packSize = 6)
+
+        assertEquals(8, view.curve.size) // always the 0..7+ buckets
+        assertEquals(listOf("0", "1", "2", "3", "4", "5", "6", "7+"), view.curve.map { it.label })
+        assertEquals(3, view.curve.first { it.label == "1" }.count) // Bolt + two Sol Rings
+        assertEquals(1, view.curve.first { it.label == "2" }.count) // Bear
+        assertEquals(4, view.nonLandCount)
+        assertEquals(setOf("Creature", "Instant", "Artifact", "Land"), view.types.map { it.type }.toSet())
+        assertEquals(setOf("Common", "Uncommon"), view.rarities.map { it.rarity }.toSet())
+        // Two Sol Rings = a non-basic duplicate; the basics are allowed.
+        assertEquals(listOf("Sol Ring"), view.duplicates.map { it.name })
+        assertEquals(2, view.duplicates.first().count)
+    }
+
     // --- asFan ---------------------------------------------------------
 
     @Test


### PR DESCRIPTION
## Why

PR 3 of 4. Surfaces the shared `CubeAnalytics` (from #634) on the **web** `/cube preview`. Branches off `main` (the core is merged), independent of the Discord PR (#635).

## What changed

- **Backend** — `CubeWebService` maps `CubeAnalytics.analyze` to a JSON-friendly `AnalyticsView` (curve / type / rarity / duplicate sub-views, enum → `displayName`), carried on `PreviewData`; `CubeController` threads it onto `CubePreviewResponse` (`null` on the failure branch).
- **Frontend** — the preview panel gains an always-visible **singleton/duplicate warning** above the card groups, plus a collapsible **"Show mana curve, types & rarity"** block: average mana value + length-scaled bars for the curve, card-type, and rarity breakdowns.
  - `cube.js`: factored a `barTrack` helper out of `asFanBar`; new `renderManaCurve` / `renderTypeBreakdown` / `renderRarity` / `renderDuplicates` / `renderAnalytics`, wired into `wirePreview` and exported. Tolerates a missing analytics payload and an all-land pool.
  - `cube.html` / `cube.css`: reuse the generate `.cube-breakdown` + `.cube-notfound` grammar.

Generate is unchanged.

## Tests

- Kotlin: `CubeWebServiceTest` covers `analyticsView` mapping (curve all-8-buckets, type/rarity display names, non-basic duplicate, basics allowed); `CubeControllerTest` asserts the report flows through the response.
- jest: each renderer + the orchestrator, including the missing-payload and all-land-pool paths.
- `:web:test`, `:web:koverVerify`, jest (**694**) and stylelint all pass.

Next: PR 4 — web export/copy of the cube list.

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs

---
_Generated by [Claude Code](https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs)_