### PR TITLE
Add copy / download of the cube list on the web preview

### DIFF
--- a/web/src/main/resources/static/js/cube.js
+++ b/web/src/main/resources/static/js/cube.js
@@ -89,6 +89,25 @@
         }).join('\n\n') + '\n';
     }
 
+    /**
+     * The cube's cards as "<count> <name>" lines, from the de-duped preview
+     * groups (count is the copies in the pool, so "10 Forest"). A
+     * re-importable decklist — the read side of CardListParser.
+     */
+    function groupsToList(groups) {
+        const lines = [];
+        (groups || []).forEach(function (g) {
+            (g.cards || []).forEach(function (c) {
+                lines.push((c.count && c.count > 1 ? c.count : 1) + ' ' + c.name);
+            });
+        });
+        return lines;
+    }
+
+    function cubeListText(groups) {
+        return groupsToList(groups).join('\n') + '\n';
+    }
+
     function asfanUrl(p) {
         const q = new URLSearchParams({ total: p.total, cubeSize: p.cubeSize, packSize: p.packSize });
         return '/cube/api/asfan?' + q.toString();
@@ -968,6 +987,37 @@
         const curve = q(doc, '[data-curve="preview"]');
         const types = q(doc, '[data-types="preview"]');
         const rarity = q(doc, '[data-rarity="preview"]');
+        const actions = q(doc, '[data-actions="preview"]');
+        const copyBtn = q(doc, '[data-copy="preview"]');
+        const downloadBtn = q(doc, '[data-download="preview"]');
+        let lastGroups = [];
+
+        if (copyBtn) {
+            const label = copyBtn.textContent;
+            copyBtn.addEventListener('click', function () {
+                if (!lastGroups.length) return;
+                const text = cubeListText(lastGroups);
+                if (root.navigator && root.navigator.clipboard) {
+                    root.navigator.clipboard.writeText(text).then(
+                        function () { copyBtn.textContent = '✓ Copied'; root.setTimeout(function () { copyBtn.textContent = label; }, 2000); },
+                        function () { /* clipboard blocked — the download still works */ }
+                    );
+                }
+            });
+        }
+        if (downloadBtn) {
+            downloadBtn.addEventListener('click', function () {
+                if (!lastGroups.length) return;
+                const blob = new Blob([cubeListText(lastGroups)], { type: 'text/plain' });
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = 'cube.txt';
+                a.click();
+                URL.revokeObjectURL(url);
+            });
+        }
+
         form.addEventListener('submit', function (e) {
             e.preventDefault();
             const packSize = new FormData(form).get('packSize');
@@ -975,7 +1025,7 @@
             const err = sourceError(src);
             if (err) { setStatus(status, err); return; }
             setStatus(status, src.mode === 'list' ? 'Resolving your list…' : 'Fetching cards from Scryfall…');
-            hide(groups); hide(notFound); hide(dupes); hide(breakdown);
+            hide(groups); hide(notFound); hide(dupes); hide(breakdown); hide(actions);
             withBusy(form, true);
             setSpinner(doc, 'preview', true);
             const request = src.mode === 'list'
@@ -988,6 +1038,8 @@
                     hide(empty);
                     renderGroups(groups, json.groups);
                     show(groups);
+                    lastGroups = json.groups || [];
+                    show(actions);
                     renderNotFound(notFound, json.notFound);
                     renderAnalytics(json.analytics, { dupes: dupes, breakdown: breakdown, avgMv: avgMv, curve: curve, types: types, rarity: rarity });
                 })
@@ -1264,6 +1316,8 @@
         splitQuantityPrefix: splitQuantityPrefix,
         applyCardChoice: applyCardChoice,
         packsToText: packsToText,
+        groupsToList: groupsToList,
+        cubeListText: cubeListText,
         asfanUrl: asfanUrl,
         previewUrl: previewUrl,
         generateUrl: generateUrl,

--- a/web/src/main/resources/templates/cube.html
+++ b/web/src/main/resources/templates/cube.html
@@ -203,6 +203,10 @@
             <p class="cube-empty" data-empty="preview">Choose your cards above, then hit <strong>Preview balance</strong>.</p>
             <p class="cube-notfound" data-notfound="preview" hidden></p>
             <p class="cube-dup-warning" data-duplicates="preview" hidden></p>
+            <div class="cube-result-actions" data-actions="preview" hidden>
+                <button type="button" class="btn btn-secondary" data-copy="preview">⧉ Copy card list</button>
+                <button type="button" class="btn btn-secondary" data-download="preview">⬇ Download cube (.txt)</button>
+            </div>
             <div class="cube-groups" data-result="preview" hidden></div>
             <details class="cube-breakdown" data-breakdown="preview-analytics" hidden>
                 <summary>Show mana curve, types &amp; rarity</summary>

--- a/web/src/test/js/cube.test.js
+++ b/web/src/test/js/cube.test.js
@@ -385,6 +385,28 @@ describe('deep-link hash activates the matching tab on in-page navigation', () =
     });
 });
 
+describe('cube list export (groupsToList / cubeListText)', () => {
+    const groups = [
+        { category: 'Red', count: 2, asFan: 2, cards: [{ name: 'Lightning Bolt', count: 1 }, { name: 'Shock', count: 1 }] },
+        { category: 'Land', count: 10, asFan: 5, cards: [{ name: 'Forest', count: 10 }] },
+    ];
+
+    test('groupsToList emits one "<count> <name>" line per de-duped card', () => {
+        expect(Cube.groupsToList(groups)).toEqual(['1 Lightning Bolt', '1 Shock', '10 Forest']);
+    });
+
+    test('groupsToList defaults a missing/oneish count to 1 and tolerates empties', () => {
+        expect(Cube.groupsToList([{ cards: [{ name: 'Sol Ring' }] }])).toEqual(['1 Sol Ring']);
+        expect(Cube.groupsToList([])).toEqual([]);
+        expect(Cube.groupsToList(null)).toEqual([]);
+        expect(Cube.groupsToList([{ category: 'Empty' }])).toEqual([]);
+    });
+
+    test('cubeListText joins the lines with a trailing newline (re-importable by the parser)', () => {
+        expect(Cube.cubeListText(groups)).toBe('1 Lightning Bolt\n1 Shock\n10 Forest\n');
+    });
+});
+
 describe('cube report analytics renderers', () => {
     test('renderManaCurve draws one scaled bar per bucket', () => {
         const container = document.createElement('div');


### PR DESCRIPTION
## Why

PR 4 of 4 (final). The preview shows you a cube's cards — this lets you get them back out: **⧉ Copy card list** and **⬇ Download cube (.txt)**, the read side of the paste-a-list flow.

(Rebased onto `main` now that #636 is merged.)

## What changed (JS/HTML only)

- `cube.js`: `groupsToList(groups)` → `"<count> <name>"` lines from the de-duped preview groups (so a 10-of basic exports as `10 Forest`); `cubeListText` joins with a trailing newline — a **re-importable** decklist that round-trips through `CardListParser`. Copy (clipboard, transient "✓ Copied" label) and download (Blob → `cube.txt`) wired into `wirePreview`, mirroring the generate pack download. Both exported for jest.
- `cube.html`: the actions row in the preview panel, reusing the existing `.cube-result-actions` styling (no new CSS).

## Tests

jest covers `groupsToList` (counts, missing-count default, empty/null tolerance) and `cubeListText` (trailing newline). 72 cube tests / full jest suite pass; stylelint clean. No Kotlin change.

This completes the four-PR cube-analytics plan (#634 core, #635 Discord report, #636 web report, this).

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs