### PR TITLE
Add "open a sample pack" to the web cube preview

### DIFF
--- a/common/src/main/kotlin/common/mtg/CubeAnalytics.kt
+++ b/common/src/main/kotlin/common/mtg/CubeAnalytics.kt
@@ -24,6 +24,12 @@ object CubeAnalytics {
     /** A non-basic card name appearing more than once (a singleton violation). */
     data class Duplicate(val name: String, val count: Int)
 
+    /** Count of two-colour cards supporting a guild, e.g. "Azorius (WU)". */
+    data class ColorPairCount(val pair: String, val count: Int)
+
+    /** Coloured mana pips of one colour across the whole cube (the true colour weight). */
+    data class ColorPipCount(val color: String, val count: Int)
+
     /** The whole report, assembled once so the surfaces render identical numbers. */
     data class Analytics(
         val curve: List<ManaCurveBucket>,
@@ -32,10 +38,28 @@ object CubeAnalytics {
         val types: List<TypeCount>,
         val rarities: List<RarityCount>,
         val duplicates: List<Duplicate>,
+        val colorPairs: List<ColorPairCount>,
+        val colorPips: List<ColorPipCount>,
     )
 
     /** The highest mana-value bucket; everything at or above it folds into "7+". */
     const val CURVE_TOP = 7
+
+    /** The ten guilds, in allied-then-enemy order, for the colour-pair breakdown. */
+    private val GUILDS: List<Pair<Set<MtgColor>, String>> = listOf(
+        setOf(MtgColor.WHITE, MtgColor.BLUE) to "Azorius",
+        setOf(MtgColor.BLUE, MtgColor.BLACK) to "Dimir",
+        setOf(MtgColor.BLACK, MtgColor.RED) to "Rakdos",
+        setOf(MtgColor.RED, MtgColor.GREEN) to "Gruul",
+        setOf(MtgColor.GREEN, MtgColor.WHITE) to "Selesnya",
+        setOf(MtgColor.WHITE, MtgColor.BLACK) to "Orzhov",
+        setOf(MtgColor.BLUE, MtgColor.RED) to "Izzet",
+        setOf(MtgColor.BLACK, MtgColor.GREEN) to "Golgari",
+        setOf(MtgColor.RED, MtgColor.WHITE) to "Boros",
+        setOf(MtgColor.GREEN, MtgColor.BLUE) to "Simic",
+    )
+
+    private val PIP = Regex("\\{([^}]+)\\}")
 
     fun analyze(cards: List<CubeCard>, packSize: Int): Analytics = Analytics(
         curve = manaCurve(cards),
@@ -44,7 +68,47 @@ object CubeAnalytics {
         types = typeCounts(cards, packSize),
         rarities = rarityCounts(cards, packSize),
         duplicates = duplicates(cards),
+        colorPairs = colorPairs(cards),
+        colorPips = colorPips(cards),
     )
+
+    /**
+     * Two-colour cards grouped by guild, in guild order, present pairs only —
+     * how well each two-colour archetype is supported. Includes dual lands
+     * (they're fixing for that pair).
+     */
+    fun colorPairs(cards: List<CubeCard>): List<ColorPairCount> {
+        val twoColor = cards.filter { it.colors.size == 2 }
+        return GUILDS.mapNotNull { (set, name) ->
+            val count = twoColor.count { it.colors == set }
+            if (count > 0) ColorPairCount("$name (${pairCode(set)})", count) else null
+        }
+    }
+
+    /** The WUBRG-ordered symbol code for a colour set, e.g. {W,U} → "WU". */
+    private fun pairCode(colors: Set<MtgColor>): String =
+        MtgColor.entries.filter { it in colors }.joinToString("") { it.symbol.toString() }
+
+    /**
+     * Coloured mana pips per colour across every card's mana cost — the cube's
+     * true colour weight, which card counts alone miss. Hybrid pips ({W/U})
+     * count toward both colours; generic/Phyrexian/colourless symbols are
+     * ignored. WUBRG order, present colours only.
+     */
+    fun colorPips(cards: List<CubeCard>): List<ColorPipCount> {
+        val counts = linkedMapOf<MtgColor, Int>()
+        cards.forEach { card ->
+            val cost = card.manaCost ?: return@forEach
+            PIP.findAll(cost).forEach { match ->
+                match.groupValues[1].forEach { ch ->
+                    MtgColor.fromSymbol(ch)?.let { counts[it] = (counts[it] ?: 0) + 1 }
+                }
+            }
+        }
+        return MtgColor.entries
+            .filter { counts[it] != null }
+            .map { ColorPipCount(it.displayName, counts.getValue(it)) }
+    }
 
     /**
      * The mana curve of the nonland cards: always all eight buckets

--- a/common/src/main/kotlin/common/mtg/CubeCard.kt
+++ b/common/src/main/kotlin/common/mtg/CubeCard.kt
@@ -59,6 +59,12 @@ data class CubeCard(
      * to a [Rarity] — so this stays a dumb value type, like [imageUrl].
      */
     val rarity: String? = null,
+    /**
+     * Raw Scryfall `mana_cost` string (e.g. `{1}{W}{W}`), or null. Kept raw —
+     * [common.mtg.CubeAnalytics] counts its colour pips for the pip-weighted
+     * colour balance — so this stays a dumb value type.
+     */
+    val manaCost: String? = null,
 ) {
     /** Which as-fan bucket this card falls into. Lands first, then by colour count. */
     val category: CardCategory

--- a/common/src/test/kotlin/common/mtg/CubeAnalyticsTest.kt
+++ b/common/src/test/kotlin/common/mtg/CubeAnalyticsTest.kt
@@ -11,12 +11,16 @@ class CubeAnalyticsTest {
         typeLine: String = "Creature",
         manaValue: Double = 1.0,
         rarity: String? = "common",
+        colors: Set<MtgColor> = emptySet(),
+        manaCost: String? = null,
     ) = CubeCard(
         name = name,
+        colors = colors,
         isLand = CubeCard.isLandType(typeLine),
         typeLine = typeLine,
         manaValue = manaValue,
         rarity = rarity,
+        manaCost = manaCost,
     )
 
     // --- mana curve ----------------------------------------------------
@@ -146,6 +150,49 @@ class CubeAnalyticsTest {
         assertTrue(CubeAnalytics.duplicates(pool).isEmpty())
     }
 
+    // --- colour pairs (guilds) -----------------------------------------
+
+    @Test
+    fun `colorPairs counts two-colour cards by guild, in guild order, present only`() {
+        val pool = listOf(
+            card("Teferi", colors = setOf(MtgColor.WHITE, MtgColor.BLUE)),
+            card("Dovin", colors = setOf(MtgColor.WHITE, MtgColor.BLUE)),
+            card("Hadana", colors = setOf(MtgColor.GREEN, MtgColor.BLUE)), // Simic
+            card("Bolt", colors = setOf(MtgColor.RED)), // mono — ignored
+            card("Niv", colors = MtgColor.entries.toSet()), // 5c — ignored
+        )
+        val pairs = CubeAnalytics.colorPairs(pool)
+        // Codes are WUBRG-canonical, so Simic {G,U} renders as "UG".
+        assertEquals(listOf("Azorius (WU)", "Simic (UG)"), pairs.map { it.pair }) // guild order
+        assertEquals(2, pairs.first { it.pair.startsWith("Azorius") }.count)
+    }
+
+    // --- colour pips ---------------------------------------------------
+
+    @Test
+    fun `colorPips counts coloured pips from mana costs, hybrid counts both`() {
+        val pool = listOf(
+            card("A", manaCost = "{1}{W}{W}"),       // W,W
+            card("B", manaCost = "{U}{B}"),          // U,B
+            card("C", manaCost = "{W/U}"),           // hybrid → W and U
+            card("D", manaCost = "{2}{R/P}"),        // Phyrexian red → R (generic/P ignored)
+            card("E", manaCost = null),              // no cost — skipped
+            card("Forest", typeLine = "Basic Land — Forest", manaCost = ""), // no pips
+        )
+        val pips = CubeAnalytics.colorPips(pool).associate { it.color to it.count }
+        assertEquals(3, pips["White"]) // WW + hybrid W
+        assertEquals(2, pips["Blue"]) // B's U + hybrid U
+        assertEquals(1, pips["Black"])
+        assertEquals(1, pips["Red"])
+        assertEquals(null, pips["Green"]) // absent → not listed
+    }
+
+    @Test
+    fun `colorPips lists colours in WUBRG order`() {
+        val pool = listOf(card("X", manaCost = "{G}{R}{W}"))
+        assertEquals(listOf("White", "Red", "Green"), CubeAnalytics.colorPips(pool).map { it.color })
+    }
+
     // --- analyze (aggregate) -------------------------------------------
 
     @Test
@@ -171,6 +218,8 @@ class CubeAnalyticsTest {
         assertTrue(a.types.isEmpty())
         assertTrue(a.rarities.isEmpty())
         assertTrue(a.duplicates.isEmpty())
+        assertTrue(a.colorPairs.isEmpty())
+        assertTrue(a.colorPips.isEmpty())
         assertEquals(8, a.curve.size) // still the eight empty buckets
         assertTrue(a.curve.all { it.count == 0 })
     }

--- a/common/src/test/kotlin/common/mtg/CubeCardTest.kt
+++ b/common/src/test/kotlin/common/mtg/CubeCardTest.kt
@@ -53,9 +53,13 @@ class CubeCardTest {
     }
 
     @Test
-    fun `rarity defaults to null and round-trips when set`() {
-        assertEquals(null, CubeCard(name = "Placeholder").rarity)
-        assertEquals("mythic", CubeCard(name = "Ragavan", rarity = "mythic").rarity)
+    fun `rarity and manaCost default to null and round-trip when set`() {
+        val plain = CubeCard(name = "Placeholder")
+        assertEquals(null, plain.rarity)
+        assertEquals(null, plain.manaCost)
+        val ragavan = CubeCard(name = "Ragavan", rarity = "mythic", manaCost = "{R}")
+        assertEquals("mythic", ragavan.rarity)
+        assertEquals("{R}", ragavan.manaCost)
     }
 
     @Test

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
@@ -61,6 +61,8 @@ internal object CubeEmbeds {
         if (analytics.nonLandCount > 0) field("Mana curve", curveLine(analytics), inline = false)
         field("Card types", typeTable(analytics.types), inline = false)
         field("Rarity", rarityTable(analytics.rarities), inline = false)
+        if (analytics.colorPairs.isNotEmpty()) field("Colour pairs", pairTable(analytics.colorPairs), inline = false)
+        if (analytics.colorPips.isNotEmpty()) field("Colour pips", pipTable(analytics.colorPips), inline = false)
         addDuplicatesField(analytics.duplicates)
         addNotFoundField(notFound)
     }
@@ -130,6 +132,14 @@ internal object CubeEmbeds {
     private fun rarityTable(rarities: List<CubeAnalytics.RarityCount>): String =
         rarities.joinToString("\n") { "${it.rarity.displayName} — ${it.count} (${format(it.asFan)}/pack)" }
             .ifEmpty { "—" }
+
+    /** A `guild — count` table for the two-colour cards. */
+    private fun pairTable(pairs: List<CubeAnalytics.ColorPairCount>): String =
+        pairs.joinToString("\n") { "${it.pair} — ${it.count}" }
+
+    /** Coloured mana pips as a compact one-liner: `White 42 · Blue 38 · …`. */
+    private fun pipTable(pips: List<CubeAnalytics.ColorPipCount>): String =
+        pips.joinToString(" · ") { "${it.color} ${it.count}" }
 
     /** Keep the saved-cube listing under Discord's 4096-char description cap. */
     private const val SAVED_LIST_LIMIT = 25

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcher.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcher.kt
@@ -205,7 +205,21 @@ class ScryfallCubeFetcher @Autowired constructor(
             manaValue = manaValue,
             imageUrl = imageUrl(card),
             rarity = card.get("rarity")?.asString?.takeIf { it.isNotBlank() },
+            manaCost = manaCost(card),
         )
+    }
+
+    /**
+     * The card's `mana_cost`, or null. Single-faced cards carry it directly;
+     * double-faced cards put it on the first face.
+     */
+    fun manaCost(card: JsonObject): String? {
+        fun costOf(obj: JsonObject?): String? =
+            obj?.get("mana_cost")?.asString?.takeIf { it.isNotBlank() }
+
+        costOf(card)?.let { return it }
+        val firstFace = card.getAsJsonArray("card_faces")?.firstOrNull()?.asJsonObject
+        return costOf(firstFace)
     }
 
     /**

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeEmbedsTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeEmbedsTest.kt
@@ -14,8 +14,15 @@ import java.nio.charset.StandardCharsets
 
 class CubeEmbedsTest {
 
-    private fun card(name: String, typeLine: String, mv: Double, rarity: String?, land: Boolean = false) =
-        CubeCard(name = name, isLand = land, typeLine = typeLine, manaValue = mv, rarity = rarity)
+    private fun card(
+        name: String,
+        typeLine: String,
+        mv: Double,
+        rarity: String?,
+        land: Boolean = false,
+        colors: Set<MtgColor> = emptySet(),
+        manaCost: String? = null,
+    ) = CubeCard(name = name, colors = colors, isLand = land, typeLine = typeLine, manaValue = mv, rarity = rarity, manaCost = manaCost)
 
     private fun preview(pool: List<CubeCard>, packSize: Int = 5) = CubeEmbeds.previewEmbed(
         query = "test",
@@ -46,6 +53,26 @@ class CubeEmbedsTest {
         assertTrue(types!!.value!!.contains("Creature — 2"))
         assertTrue(types.value!!.contains("Land — 1"))
         assertTrue(field(embed, "Rarity")!!.value!!.contains("Common — 3"))
+    }
+
+    @Test
+    fun `previewEmbed adds colour-pair and pip fields when the cube has multicolour cards`() {
+        val pool = listOf(
+            card("Teferi", "Creature", 3.0, "rare", colors = setOf(MtgColor.WHITE, MtgColor.BLUE), manaCost = "{1}{W}{U}"),
+            card("Dovin", "Creature", 3.0, "rare", colors = setOf(MtgColor.WHITE, MtgColor.BLUE), manaCost = "{2}{W}{U}"),
+            card("Bolt", "Instant", 1.0, "common", colors = setOf(MtgColor.RED), manaCost = "{R}"),
+        )
+        val embed = preview(pool)
+        assertTrue(field(embed, "Colour pairs")!!.value!!.contains("Azorius (WU) — 2"))
+        assertTrue(field(embed, "Colour pips")!!.value!!.contains("White 2"))
+    }
+
+    @Test
+    fun `previewEmbed omits the colour-pair and pip fields for a colourless or costless cube`() {
+        val pool = listOf(card("Sol Ring", "Artifact", 1.0, "uncommon"))
+        val embed = preview(pool)
+        assertNull(field(embed, "Colour pairs"))
+        assertNull(field(embed, "Colour pips"))
     }
 
     @Test

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcherTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcherTest.kt
@@ -112,6 +112,19 @@ class ScryfallCubeFetcherTest {
     }
 
     @Test
+    fun `parseCard reads the mana cost, single-faced and from the front of a DFC`() {
+        val single = fetcher.parseCard(
+            obj("""{"name":"Bolt","color_identity":["R"],"type_line":"Instant","mana_cost":"{R}"}""")
+        )!!
+        assertEquals("{R}", single.manaCost)
+        val dfc = fetcher.parseCard(
+            obj("""{"name":"Huntmaster // Ravager","color_identity":["R","G"],"type_line":"Creature","mana_cost":"",
+               "card_faces":[{"mana_cost":"{2}{R}{G}"},{"mana_cost":""}]}""")
+        )!!
+        assertEquals("{2}{R}{G}", dfc.manaCost)
+    }
+
+    @Test
     fun `parseCard treats a card with no colour identity as colourless`() {
         val card = fetcher.parseCard(obj("""{"name":"Sol Ring","color_identity":[],"type_line":"Artifact"}"""))!!
         assertEquals(CardCategory.COLORLESS, card.category)

--- a/web/src/main/kotlin/web/service/CubeWebService.kt
+++ b/web/src/main/kotlin/web/service/CubeWebService.kt
@@ -107,6 +107,8 @@ class CubeWebService {
             types = a.types.map { TypeCountView(it.type.displayName, it.count, it.asFan) },
             rarities = a.rarities.map { RarityCountView(it.rarity.displayName, it.count, it.asFan) },
             duplicates = a.duplicates.map { DuplicateView(it.name, it.count) },
+            colorPairs = a.colorPairs.map { ColorPairView(it.pair, it.count) },
+            colorPips = a.colorPips.map { ColorPipView(it.color, it.count) },
         )
     }
 
@@ -204,6 +206,7 @@ class CubeWebService {
                     typeLine = typeLine,
                     manaValue = node.path("cmc").asDouble(0.0),
                     rarity = node.path("rarity").asText("").takeIf { it.isNotBlank() },
+                    manaCost = manaCostOf(node),
                 ),
                 imageUrl = imageOf(node, "small"),
                 imageUrlLarge = imageOf(node, "normal"),
@@ -478,6 +481,8 @@ data class CurveBucketView(val label: String, val count: Int)
 data class TypeCountView(val type: String, val count: Int, val asFan: Double)
 data class RarityCountView(val rarity: String, val count: Int, val asFan: Double)
 data class DuplicateView(val name: String, val count: Int)
+data class ColorPairView(val pair: String, val count: Int)
+data class ColorPipView(val color: String, val count: Int)
 data class AnalyticsView(
     val curve: List<CurveBucketView>,
     val averageManaValue: Double,
@@ -485,6 +490,8 @@ data class AnalyticsView(
     val types: List<TypeCountView>,
     val rarities: List<RarityCountView>,
     val duplicates: List<DuplicateView>,
+    val colorPairs: List<ColorPairView>,
+    val colorPips: List<ColorPipView>,
 )
 
 data class PreviewData(

--- a/web/src/main/resources/static/js/cube.js
+++ b/web/src/main/resources/static/js/cube.js
@@ -270,6 +270,26 @@
         return container;
     }
 
+    /** The two-colour guild breakdown (archetype support). */
+    function renderColorPairs(container, pairs) {
+        container.replaceChildren();
+        const max = pairs.reduce(function (m, p) { return Math.max(m, p.count); }, 0);
+        pairs.forEach(function (p) {
+            container.appendChild(statRow(p.pair, String(p.count), max > 0 ? p.count / max : 0, NEUTRAL_BAR));
+        });
+        return container;
+    }
+
+    /** The pip-weighted colour balance, each bar tinted with its colour swatch. */
+    function renderColorPips(container, pips) {
+        container.replaceChildren();
+        const max = pips.reduce(function (m, p) { return Math.max(m, p.count); }, 0);
+        pips.forEach(function (p) {
+            container.appendChild(statRow(p.color, String(p.count), max > 0 ? p.count / max : 0, categoryColor(p.color)));
+        });
+        return container;
+    }
+
     /** A singleton-violation warning; hidden when the cube has no non-basic duplicates. */
     function renderDuplicates(el, duplicates) {
         if (!el) return;
@@ -296,6 +316,8 @@
         if (els.curve) renderManaCurve(els.curve, analytics.curve || []);
         if (els.types) renderTypeBreakdown(els.types, analytics.types || []);
         if (els.rarity) renderRarity(els.rarity, analytics.rarities || []);
+        if (els.pairs) renderColorPairs(els.pairs, analytics.colorPairs || []);
+        if (els.pips) renderColorPips(els.pips, analytics.colorPips || []);
         show(els.breakdown);
     }
 
@@ -987,6 +1009,8 @@
         const curve = q(doc, '[data-curve="preview"]');
         const types = q(doc, '[data-types="preview"]');
         const rarity = q(doc, '[data-rarity="preview"]');
+        const pairs = q(doc, '[data-pairs="preview"]');
+        const pips = q(doc, '[data-pips="preview"]');
         const actions = q(doc, '[data-actions="preview"]');
         const copyBtn = q(doc, '[data-copy="preview"]');
         const downloadBtn = q(doc, '[data-download="preview"]');
@@ -1041,7 +1065,7 @@
                     lastGroups = json.groups || [];
                     show(actions);
                     renderNotFound(notFound, json.notFound);
-                    renderAnalytics(json.analytics, { dupes: dupes, breakdown: breakdown, avgMv: avgMv, curve: curve, types: types, rarity: rarity });
+                    renderAnalytics(json.analytics, { dupes: dupes, breakdown: breakdown, avgMv: avgMv, curve: curve, types: types, rarity: rarity, pairs: pairs, pips: pips });
                 })
                 .catch(function () { setStatus(status, 'Something went wrong. Try again.'); })
                 .then(function () { withBusy(form, false); setSpinner(doc, 'preview', false); });
@@ -1325,6 +1349,8 @@
         renderManaCurve: renderManaCurve,
         renderTypeBreakdown: renderTypeBreakdown,
         renderRarity: renderRarity,
+        renderColorPairs: renderColorPairs,
+        renderColorPips: renderColorPips,
         renderDuplicates: renderDuplicates,
         renderAnalytics: renderAnalytics,
         renderGroups: renderGroups,

--- a/web/src/main/resources/static/js/cube.js
+++ b/web/src/main/resources/static/js/cube.js
@@ -129,6 +129,19 @@
     }
 
     /**
+     * The request to deal ONE balanced pack from a preview's source — reuses
+     * the generate endpoint (packs=1). GET for a Scryfall search, POST for a
+     * pasted list. Pure so it's unit-testable.
+     */
+    function samplePackRequest(src, packSize) {
+        const ps = Number(packSize) || 15;
+        if (src.mode === 'list') {
+            return { method: 'POST', url: '/cube/api/generate', body: { list: src.list, packs: 1, packSize: ps, balanced: true } };
+        }
+        return { method: 'GET', url: generateUrl({ query: src.query, packs: 1, packSize: ps, balanced: true }) };
+    }
+
+    /**
      * A card as a thumbnail tile linking to its Scryfall page. Falls back
      * to a captioned placeholder box when Scryfall has no image for it.
      * Images lazy-load so a 500-card preview doesn't fetch everything at once.
@@ -1014,6 +1027,8 @@
         const actions = q(doc, '[data-actions="preview"]');
         const copyBtn = q(doc, '[data-copy="preview"]');
         const downloadBtn = q(doc, '[data-download="preview"]');
+        const sampleBtn = q(doc, '[data-sample-pack="preview"]');
+        const sample = q(doc, '[data-sample="preview"]');
         let lastGroups = [];
 
         if (copyBtn) {
@@ -1042,6 +1057,26 @@
             });
         }
 
+        if (sampleBtn) {
+            sampleBtn.addEventListener('click', function () {
+                const src = activeSource(doc);
+                const srcErr = sourceError(src);
+                if (srcErr) { setStatus(status, srcErr); return; }
+                const req = samplePackRequest(src, new FormData(form).get('packSize'));
+                sampleBtn.disabled = true;
+                if (sample) hide(sample);
+                const pending = req.method === 'POST' ? postJson(req.url, req.body) : getJson(req.url);
+                pending
+                    .then(function (json) {
+                        if (!json.ok) { setStatus(status, json.error || 'Could not deal a pack.'); return; }
+                        renderPacks(sample, json.packs);
+                        show(sample);
+                    })
+                    .catch(function () { setStatus(status, 'Something went wrong. Try again.'); })
+                    .then(function () { sampleBtn.disabled = false; });
+            });
+        }
+
         form.addEventListener('submit', function (e) {
             e.preventDefault();
             const packSize = new FormData(form).get('packSize');
@@ -1049,7 +1084,7 @@
             const err = sourceError(src);
             if (err) { setStatus(status, err); return; }
             setStatus(status, src.mode === 'list' ? 'Resolving your list…' : 'Fetching cards from Scryfall…');
-            hide(groups); hide(notFound); hide(dupes); hide(breakdown); hide(actions);
+            hide(groups); hide(notFound); hide(dupes); hide(breakdown); hide(actions); hide(sample);
             withBusy(form, true);
             setSpinner(doc, 'preview', true);
             const request = src.mode === 'list'
@@ -1345,6 +1380,7 @@
         asfanUrl: asfanUrl,
         previewUrl: previewUrl,
         generateUrl: generateUrl,
+        samplePackRequest: samplePackRequest,
         renderDistribution: renderDistribution,
         renderManaCurve: renderManaCurve,
         renderTypeBreakdown: renderTypeBreakdown,

--- a/web/src/main/resources/templates/cube.html
+++ b/web/src/main/resources/templates/cube.html
@@ -218,6 +218,10 @@
                     <div class="cube-dist" data-types="preview"></div>
                     <h4 class="cube-analytics-h">Rarity</h4>
                     <div class="cube-dist" data-rarity="preview"></div>
+                    <h4 class="cube-analytics-h">Colour pairs (two-colour archetypes)</h4>
+                    <div class="cube-dist" data-pairs="preview"></div>
+                    <h4 class="cube-analytics-h">Colour balance (mana pips)</h4>
+                    <div class="cube-dist" data-pips="preview"></div>
                 </div>
             </details>
         </section>

--- a/web/src/main/resources/templates/cube.html
+++ b/web/src/main/resources/templates/cube.html
@@ -204,9 +204,11 @@
             <p class="cube-notfound" data-notfound="preview" hidden></p>
             <p class="cube-dup-warning" data-duplicates="preview" hidden></p>
             <div class="cube-result-actions" data-actions="preview" hidden>
+                <button type="button" class="btn btn-secondary" data-sample-pack="preview">🎴 Open a sample pack</button>
                 <button type="button" class="btn btn-secondary" data-copy="preview">⧉ Copy card list</button>
                 <button type="button" class="btn btn-secondary" data-download="preview">⬇ Download cube (.txt)</button>
             </div>
+            <div class="cube-packs" data-sample="preview" hidden></div>
             <div class="cube-groups" data-result="preview" hidden></div>
             <details class="cube-breakdown" data-breakdown="preview-analytics" hidden>
                 <summary>Show mana curve, types &amp; rarity</summary>

--- a/web/src/test/js/cube.test.js
+++ b/web/src/test/js/cube.test.js
@@ -446,6 +446,32 @@ describe('cube report analytics renderers', () => {
         expect(row.querySelector('.cube-bar-value').textContent).toBe('5.00 / pack · 90');
     });
 
+    test('renderColorPairs lists each guild with its count', () => {
+        const container = document.createElement('div');
+        Cube.renderColorPairs(container, [
+            { pair: 'Azorius (WU)', count: 12 },
+            { pair: 'Simic (GU)', count: 6 },
+        ]);
+        const rows = container.querySelectorAll('.cube-bar-row');
+        expect(rows).toHaveLength(2);
+        expect(rows[0].querySelector('.cube-bar-label').textContent).toBe('Azorius (WU)');
+        expect(rows[0].querySelector('.cube-bar-value').textContent).toBe('12');
+        expect(rows[0].querySelector('.cube-bar-fill').style.width).toBe('100%'); // tallest
+    });
+
+    test('renderColorPips tints each bar with its colour swatch', () => {
+        const container = document.createElement('div');
+        Cube.renderColorPips(container, [{ color: 'White', count: 40 }, { color: 'Blue', count: 20 }]);
+        const rows = container.querySelectorAll('.cube-bar-row');
+        expect(rows[0].querySelector('.cube-bar-label').textContent).toBe('White');
+        // The pip bar is tinted with the colour-pie swatch, not the neutral grey
+        // (jsdom reports the colour as rgb(...), so just assert it's set and not neutral).
+        const bg = rows[0].querySelector('.cube-bar-fill').style.background;
+        expect(bg).not.toBe('');
+        expect(bg).not.toBe('rgb(122, 122, 138)'); // NEUTRAL_BAR #7a7a8a
+        expect(rows[1].querySelector('.cube-bar-fill').style.width).toBe('50%');
+    });
+
     test('renderDuplicates warns on non-basic duplicates and hides when there are none', () => {
         const el = document.createElement('p');
         Cube.renderDuplicates(el, [{ name: 'Sol Ring', count: 2 }, { name: 'Mana Crypt', count: 3 }]);
@@ -467,6 +493,8 @@ describe('cube report analytics renderers', () => {
         const curve = document.createElement('div');
         const types = document.createElement('div');
         const rarity = document.createElement('div');
+        const pairs = document.createElement('div');
+        const pips = document.createElement('div');
         Cube.renderAnalytics(
             {
                 curve: [{ label: '0', count: 1 }, { label: '1', count: 2 }],
@@ -475,8 +503,10 @@ describe('cube report analytics renderers', () => {
                 types: [{ type: 'Creature', count: 2, asFan: 1.0 }],
                 rarities: [{ rarity: 'Rare', count: 1, asFan: 0.5 }],
                 duplicates: [{ name: 'Sol Ring', count: 2 }],
+                colorPairs: [{ pair: 'Azorius (WU)', count: 4 }],
+                colorPips: [{ color: 'White', count: 6 }],
             },
-            { dupes: dupes, breakdown: breakdown, avgMv: avgMv, curve: curve, types: types, rarity: rarity },
+            { dupes: dupes, breakdown: breakdown, avgMv: avgMv, curve: curve, types: types, rarity: rarity, pairs: pairs, pips: pips },
         );
         expect(breakdown.hidden).toBe(false);
         expect(avgMv.textContent).toContain('Average mana value 2.50');
@@ -484,6 +514,8 @@ describe('cube report analytics renderers', () => {
         expect(curve.querySelectorAll('.cube-bar-row')).toHaveLength(2);
         expect(types.querySelector('.cube-bar-label').textContent).toBe('Creature');
         expect(rarity.querySelector('.cube-bar-label').textContent).toBe('Rare');
+        expect(pairs.querySelector('.cube-bar-label').textContent).toBe('Azorius (WU)');
+        expect(pips.querySelector('.cube-bar-label').textContent).toBe('White');
         expect(dupes.hidden).toBe(false);
     });
 

--- a/web/src/test/js/cube.test.js
+++ b/web/src/test/js/cube.test.js
@@ -385,6 +385,27 @@ describe('deep-link hash activates the matching tab on in-page navigation', () =
     });
 });
 
+describe('samplePackRequest (open a sample pack from the preview source)', () => {
+    test('a Scryfall search becomes a GET to generate with packs=1', () => {
+        const req = Cube.samplePackRequest({ mode: 'search', query: 'cube:vintage' }, '15');
+        expect(req.method).toBe('GET');
+        expect(req.url).toBe(Cube.generateUrl({ query: 'cube:vintage', packs: 1, packSize: 15, balanced: true }));
+        expect(req.url).toContain('packs=1');
+    });
+
+    test('a pasted list becomes a POST body with packs=1', () => {
+        const req = Cube.samplePackRequest({ mode: 'list', list: '40 Bolt' }, '20');
+        expect(req.method).toBe('POST');
+        expect(req.url).toBe('/cube/api/generate');
+        expect(req.body).toEqual({ list: '40 Bolt', packs: 1, packSize: 20, balanced: true });
+    });
+
+    test('a missing/invalid pack size falls back to 15', () => {
+        expect(Cube.samplePackRequest({ mode: 'list', list: 'x' }, '').body.packSize).toBe(15);
+        expect(Cube.samplePackRequest({ mode: 'list', list: 'x' }, undefined).body.packSize).toBe(15);
+    });
+});
+
 describe('cube list export (groupsToList / cubeListText)', () => {
     const groups = [
         { category: 'Red', count: 2, asFan: 2, cards: [{ name: 'Lightning Bolt', count: 1 }, { name: 'Shock', count: 1 }] },

--- a/web/src/test/kotlin/web/controller/CubeControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/CubeControllerTest.kt
@@ -19,6 +19,8 @@ import web.service.AnalyticsView
 import web.service.CardView
 import web.service.CategoryAsFan
 import web.service.CategoryGroup
+import web.service.ColorPairView
+import web.service.ColorPipView
 import web.service.CubeResult
 import web.service.CubeWebService
 import web.service.CurveBucketView
@@ -55,6 +57,8 @@ class CubeControllerTest {
         types = types,
         rarities = listOf(RarityCountView("Common", 1, 0.5)),
         duplicates = duplicates,
+        colorPairs = listOf(ColorPairView("Azorius (WU)", 3)),
+        colorPips = listOf(ColorPipView("White", 5)),
     )
 
     @BeforeEach

--- a/web/src/test/kotlin/web/service/CubeWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/CubeWebServiceTest.kt
@@ -40,6 +40,22 @@ class CubeWebServiceTest {
         assertEquals(2, view.duplicates.first().count)
     }
 
+    @Test
+    fun `analyticsView maps colour pairs and pip-weighted balance`() {
+        val pool = listOf(
+            CubeCard("Teferi", setOf(MtgColor.WHITE, MtgColor.BLUE), typeLine = "Creature", manaValue = 3.0, manaCost = "{1}{W}{U}"),
+            CubeCard("Dovin", setOf(MtgColor.WHITE, MtgColor.BLUE), typeLine = "Creature", manaValue = 3.0, manaCost = "{2}{W}{U}"),
+            CubeCard("Bolt", setOf(MtgColor.RED), typeLine = "Instant", manaValue = 1.0, manaCost = "{R}"),
+        )
+        val view = service.analyticsView(pool, packSize = 3)
+        assertEquals(listOf("Azorius (WU)"), view.colorPairs.map { it.pair })
+        assertEquals(2, view.colorPairs.first().count)
+        val pips = view.colorPips.associate { it.color to it.count }
+        assertEquals(2, pips["White"]) // one W per Azorius card
+        assertEquals(2, pips["Blue"])
+        assertEquals(1, pips["Red"])
+    }
+
     // --- asFan ---------------------------------------------------------
 
     @Test
@@ -186,6 +202,7 @@ class CubeWebServiceTest {
         )
         val parsed = service.parseScryfall(root).first()
         assertEquals("{2}{R}{G}", parsed.manaCost) // falls back to the front face
+        assertEquals("{2}{R}{G}", parsed.card.manaCost) // …and is kept on the domain card too
         assertEquals("b-lg.jpg", parsed.imageUrlBack)
     }
 


### PR DESCRIPTION
## Why

Second of the four adjacent features. A one-click **🎴 Open a sample pack** on the preview deals a single balanced pack from the current cube — a quick feel for what drafting it looks like, without switching to Generate and configuring counts.

> **Stacked on #638** (`claude/cube-color-archetypes`) since both touch the preview panel / `wirePreview`. Base is that branch; I'll retarget to `main` once #638 merges.

## What changed (frontend only)

- `cube.js`: a pure, exported `samplePackRequest(src, packSize)` that builds the request to deal **one** pack by reusing the generate endpoint (`packs=1`) — GET for a Scryfall search, POST for a pasted list. `wirePreview` wires the button: deals the pack, renders it with the existing `renderPacks`, into a sample container that clears on the next preview.
- `cube.html`: the button in the preview actions row + a `data-sample="preview"` result container.

No backend change — it reuses `/cube/api/generate` and `renderPacks`.

## Tests

jest covers `samplePackRequest` (search → GET with `packs=1`, list → POST body, pack-size fallback to 15). 702 jest pass; stylelint clean.

Remaining from the shortlist: `/cube card` lookup (Discord) and cube diff/compare.

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs

---
_Generated by [Claude Code](https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs)_