### PR TITLE
Add /cube card &lt;name&gt; single-card lookup

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeCommand.kt
@@ -63,7 +63,8 @@ class CubeCommand @Autowired constructor(
             SUB_PREVIEW -> launchHandling(ctx) { handlePreview(ctx, requestingUserDto, deleteDelay) }
             SUB_GENERATE -> launchHandling(ctx) { handleGenerate(ctx, requestingUserDto) }
             SUB_SAVED -> launchHandling(ctx) { handleSaved(ctx, requestingUserDto, deleteDelay) }
-            else -> reply(ctx, CubeEmbeds.errorEmbed("Pick a subcommand: asfan, preview, generate or saved."), deleteDelay)
+            SUB_CARD -> launchHandling(ctx) { handleCard(ctx, deleteDelay) }
+            else -> reply(ctx, CubeEmbeds.errorEmbed("Pick a subcommand: asfan, preview, generate, saved or card."), deleteDelay)
         }
     }
 
@@ -221,6 +222,26 @@ class CubeCommand @Autowired constructor(
         reply(ctx, CubeEmbeds.savedCubesEmbed(saved), deleteDelay)
     }
 
+    /** Looks up a single card by name on Scryfall and shows its image + facts. */
+    private suspend fun handleCard(ctx: CommandContext, deleteDelay: Int) {
+        val name = ctx.event.stringOption(OPT_NAME)?.trim()
+        if (name.isNullOrEmpty()) {
+            reply(ctx, CubeEmbeds.errorEmbed("Give me a card `name` to look up."), deleteDelay)
+            return
+        }
+        when (val res = fetcher.fetchByNames(listOf(MtgNames.requestName(name)))) {
+            is ScryfallCubeFetcher.Result.Failure ->
+                reply(ctx, CubeEmbeds.errorEmbed("Couldn't find a card named `$name`."), deleteDelay)
+            is ScryfallCubeFetcher.Result.Success -> {
+                // Prefer the card whose full/face name matches what was typed.
+                val card = res.cards.firstOrNull { MtgNames.matchKeys(it.name).contains(MtgNames.lookupKey(name)) }
+                    ?: res.cards.firstOrNull()
+                if (card == null) reply(ctx, CubeEmbeds.errorEmbed("Couldn't find a card named `$name`."), deleteDelay)
+                else reply(ctx, CubeEmbeds.cardEmbed(card), deleteDelay)
+            }
+        }
+    }
+
     private fun reply(ctx: CommandContext, embed: MessageEmbed, deleteDelay: Int) {
         ctx.event.hook.sendMessageEmbeds(embed).queue(invokeDeleteOnMessageResponse(deleteDelay))
     }
@@ -255,6 +276,8 @@ class CubeCommand @Autowired constructor(
                 OptionData(OptionType.BOOLEAN, OPT_BALANCED, "Level colours/lands across packs (default true).", false),
             ),
         SubcommandData(SUB_SAVED, "List the cubes you've saved on the website."),
+        SubcommandData(SUB_CARD, "Look up a single Magic card by name.")
+            .addOptions(OptionData(OptionType.STRING, OPT_NAME, "The card's name (e.g. Lightning Bolt).", true)),
     )
 
     companion object {
@@ -262,8 +285,10 @@ class CubeCommand @Autowired constructor(
         const val SUB_PREVIEW = "preview"
         const val SUB_GENERATE = "generate"
         const val SUB_SAVED = "saved"
+        const val SUB_CARD = "card"
 
         const val OPT_TOTAL = "total"
+        const val OPT_NAME = "name"
         const val OPT_CUBE_SIZE = "cube-size"
         const val OPT_PACK_SIZE = "pack-size"
         const val OPT_QUERY = "query"

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
@@ -6,6 +6,8 @@ import common.mtg.CardCategory
 import common.mtg.CardListParser
 import common.mtg.CubeAnalytics
 import common.mtg.CubeCard
+import common.mtg.MtgColor
+import common.mtg.Rarity
 import database.dto.user.CubeListDto
 import net.dv8tion.jda.api.entities.MessageEmbed
 import java.awt.Color
@@ -166,6 +168,27 @@ internal object CubeEmbeds {
         setTitle("Couldn't build that cube")
         setDescription(message)
     }
+
+    /** A single-card panel for `/cube card`: image plus its key facts. */
+    fun cardEmbed(card: CubeCard): MessageEmbed = embed(color = OK_COLOR) {
+        setAuthor(AUTHOR)
+        setTitle(card.name)
+        card.imageUrl?.let { setImage(it) }
+        val colours = if (card.colors.isEmpty()) "Colourless"
+        else MtgColor.entries.filter { it in card.colors }.joinToString(", ") { it.displayName }
+        setDescription(
+            buildList {
+                if (card.typeLine.isNotBlank()) add("**Type** · ${card.typeLine}")
+                add("**Mana value** · ${formatMv(card.manaValue)}")
+                card.rarity?.let { add("**Rarity** · ${Rarity.parse(it).displayName}") }
+                add("**Colour identity** · $colours")
+            }.joinToString("\n")
+        )
+    }
+
+    /** Mana value without a trailing `.0` (whole numbers are the norm). */
+    private fun formatMv(mv: Double): String =
+        if (mv % 1.0 == 0.0) mv.toInt().toString() else format(mv)
 
     /** A `category — count (as-fan)` table, in colour-pie order, present buckets only. */
     private fun distributionTable(

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeCommandTest.kt
@@ -424,11 +424,45 @@ class CubeCommandTest : CommandTest {
         assertTrue(slot.captured.description!!.contains("haven't saved any"))
     }
 
+    // --- card lookup ---------------------------------------------------
+
     @Test
-    fun `exposes the four subcommands with their options`() {
+    fun `card looks the name up and replies with a card panel`() {
+        val slot = slot<MessageEmbed>()
+        every { event.hook.sendMessageEmbeds(capture(slot), *anyVararg()) } returns webhookMessageCreateAction
+        every { event.subcommandName } returns CubeCommand.SUB_CARD
+        every { event.getOption(CubeCommand.OPT_NAME) } returns strOpt("Lightning Bolt")
+        coEvery { fetcher.fetchByNames(listOf("Lightning Bolt")) } returns ScryfallCubeFetcher.Result.Success(
+            listOf(CubeCard("Lightning Bolt", setOf(MtgColor.RED), typeLine = "Instant", manaValue = 1.0, rarity = "common")),
+        )
+
+        run()
+
+        assertEquals("Lightning Bolt", slot.captured.title)
+        assertTrue(slot.captured.description!!.contains("Instant"))
+    }
+
+    @Test
+    fun `card reports when the name doesn't resolve`() {
+        val slot = slot<MessageEmbed>()
+        every { event.hook.sendMessageEmbeds(capture(slot), *anyVararg()) } returns webhookMessageCreateAction
+        every { event.subcommandName } returns CubeCommand.SUB_CARD
+        every { event.getOption(CubeCommand.OPT_NAME) } returns strOpt("Notacard")
+        coEvery { fetcher.fetchByNames(any()) } returns ScryfallCubeFetcher.Result.Failure("none")
+
+        run()
+
+        assertEquals("Couldn't build that cube", slot.captured.title)
+        assertTrue(slot.captured.description!!.contains("Notacard"))
+    }
+
+    @Test
+    fun `exposes the five subcommands with their options`() {
         assertEquals("cube", command.name)
         val subs = command.subCommands.associateBy { it.name }
-        assertEquals(setOf("asfan", "preview", "generate", "saved"), subs.keys)
+        assertEquals(setOf("asfan", "preview", "generate", "saved", "card"), subs.keys)
+        assertEquals(OptionType.STRING, subs.getValue("card").options.first { it.name == "name" }.type)
+        assertTrue(subs.getValue("card").options.first { it.name == "name" }.isRequired)
 
         val asfan = subs.getValue("asfan").options
         assertEquals(OptionType.INTEGER, asfan.first { it.name == "total" }.type)

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeEmbedsTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeEmbedsTest.kt
@@ -79,6 +79,35 @@ class CubeEmbedsTest {
     }
 
     @Test
+    fun `cardEmbed shows the card's image and key facts`() {
+        val card = CubeCard(
+            name = "Ragavan, Nimble Pilferer",
+            colors = setOf(MtgColor.RED),
+            typeLine = "Legendary Creature — Monkey Pirate",
+            manaValue = 1.0,
+            imageUrl = "https://img/ragavan.jpg",
+            rarity = "mythic",
+        )
+        val embed = CubeEmbeds.cardEmbed(card)
+
+        assertEquals("Ragavan, Nimble Pilferer", embed.title)
+        assertEquals("https://img/ragavan.jpg", embed.image?.url)
+        val desc = embed.description!!
+        assertTrue(desc.contains("Legendary Creature — Monkey Pirate"))
+        assertTrue(desc.contains("Mana value** · 1"), "MV without trailing .0: $desc")
+        assertTrue(desc.contains("Rarity** · Mythic"))
+        assertTrue(desc.contains("Colour identity** · Red"))
+    }
+
+    @Test
+    fun `cardEmbed describes a colourless card and omits rarity when unknown`() {
+        val card = CubeCard(name = "Sol Ring", typeLine = "Artifact", manaValue = 1.0)
+        val desc = CubeEmbeds.cardEmbed(card).description!!
+        assertTrue(desc.contains("Colour identity** · Colourless"))
+        assertFalse(desc.contains("Rarity"))
+    }
+
+    @Test
     fun `packsFile lists each card, appending its image link when present`() {
         val packs = listOf(
             listOf(


### PR DESCRIPTION
## Why

Third of the four adjacent features. A quick Discord lookup for a single Magic card — mirrors the `/dnd` utility pattern, reusing the cube Scryfall stack. Branches off `main`, independent of the web PRs (#638/#639).

## What changed

- **`/cube card name:<…>`** — resolves the name via `ScryfallCubeFetcher.fetchByNames` and replies with a **`cardEmbed`** panel: the card image plus type, mana value, rarity, and colour identity. Uses `MtgNames` front-face matching to pick the card whose name matches what was typed (so `Lightning Bolt` and DFC `A // B` names both land), with a clear "couldn't find" fallback.
- New `CubeEmbeds.cardEmbed(card)`; new `SUB_CARD`/`OPT_NAME`; dispatched through the existing IO-launch helper.

(The literal mana-cost symbols are intentionally left for a follow-up — `CubeCard.manaCost` lands in #638; here we show the mana **value**.)

## Tests

`CubeEmbedsTest`: `cardEmbed` facts + image, the colourless / rarity-omitted case. `CubeCommandTest`: the lookup happy path, the not-found error, and the now-**five**-subcommand surface. `:discord-bot:test` + `:discord-bot:koverVerify` pass.

Last from the shortlist: cube diff / compare.

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs

---
_Generated by [Claude Code](https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs)_