### PR TITLE
Add a Compare tab: diff two card lists on the web

### DIFF
--- a/common/src/main/kotlin/common/mtg/CubeDiff.kt
+++ b/common/src/main/kotlin/common/mtg/CubeDiff.kt
@@ -1,0 +1,60 @@
+package common.mtg
+
+/**
+ * Compares two card lists by name — the read side of iterating a cube ("what
+ * changed between this version and the last?"). Pure name-level maths: no
+ * Scryfall, so it's instant and works on any pasted list or saved cube.
+ *
+ * Names are matched case-insensitively (via [MtgNames.lookupKey]); the
+ * display name keeps the spelling from whichever side has the card. Counts
+ * are summed per name, so a list with `3 Forest` then `7 Forest` is ten.
+ */
+object CubeDiff {
+
+    /** One card's change from list A to list B; [from]/[to] are its copy counts. */
+    data class Line(val name: String, val from: Int, val to: Int)
+
+    data class Diff(
+        val added: List<Line>,    // in B, not A (from == 0)
+        val removed: List<Line>,  // in A, not B (to == 0)
+        val changed: List<Line>,  // in both, count differs
+        val sizeA: Int,           // total cards in A
+        val sizeB: Int,           // total cards in B
+    )
+
+    fun diff(a: List<CardListParser.Entry>, b: List<CardListParser.Entry>): Diff {
+        val mapA = collapse(a)
+        val mapB = collapse(b)
+        val added = mutableListOf<Line>()
+        val removed = mutableListOf<Line>()
+        val changed = mutableListOf<Line>()
+        for (key in (mapA.keys + mapB.keys)) {
+            val from = mapA[key]?.second ?: 0
+            val to = mapB[key]?.second ?: 0
+            val name = mapB[key]?.first ?: mapA.getValue(key).first
+            when {
+                from == 0 -> added.add(Line(name, 0, to))
+                to == 0 -> removed.add(Line(name, from, 0))
+                from != to -> changed.add(Line(name, from, to))
+            }
+        }
+        return Diff(
+            added = added.sortedBy { it.name.lowercase() },
+            removed = removed.sortedBy { it.name.lowercase() },
+            changed = changed.sortedBy { it.name.lowercase() },
+            sizeA = mapA.values.sumOf { it.second },
+            sizeB = mapB.values.sumOf { it.second },
+        )
+    }
+
+    /** Collapses entries to a `lookupKey -> (displayName, totalCount)` map. */
+    private fun collapse(entries: List<CardListParser.Entry>): Map<String, Pair<String, Int>> {
+        val out = LinkedHashMap<String, Pair<String, Int>>()
+        for (entry in entries) {
+            val key = MtgNames.lookupKey(entry.name)
+            val existing = out[key]
+            out[key] = (existing?.first ?: entry.name) to ((existing?.second ?: 0) + entry.count)
+        }
+        return out
+    }
+}

--- a/common/src/test/kotlin/common/mtg/CubeDiffTest.kt
+++ b/common/src/test/kotlin/common/mtg/CubeDiffTest.kt
@@ -1,0 +1,66 @@
+package common.mtg
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class CubeDiffTest {
+
+    private fun entries(vararg lines: String) = CardListParser.parse(lines.joinToString("\n"))
+
+    @Test
+    fun `reports added, removed and changed cards`() {
+        val a = entries("Lightning Bolt", "Counterspell", "3 Forest")
+        val b = entries("Lightning Bolt", "Shock", "5 Forest")
+        val diff = CubeDiff.diff(a, b)
+
+        assertEquals(listOf("Shock"), diff.added.map { it.name })
+        assertEquals(0, diff.added.first().from)
+        assertEquals(1, diff.added.first().to)
+
+        assertEquals(listOf("Counterspell"), diff.removed.map { it.name })
+        assertEquals(1, diff.removed.first().from)
+
+        assertEquals(listOf("Forest"), diff.changed.map { it.name })
+        assertEquals(3, diff.changed.first().from)
+        assertEquals(5, diff.changed.first().to)
+    }
+
+    @Test
+    fun `an unchanged card appears in none of the buckets`() {
+        val diff = CubeDiff.diff(entries("Sol Ring"), entries("Sol Ring"))
+        assertTrue(diff.added.isEmpty())
+        assertTrue(diff.removed.isEmpty())
+        assertTrue(diff.changed.isEmpty())
+    }
+
+    @Test
+    fun `matching is case-insensitive and counts are summed per name`() {
+        val a = entries("lightning bolt", "2 Forest", "3 Forest") // 5 Forest total
+        val b = entries("Lightning Bolt", "5 forest")
+        val diff = CubeDiff.diff(a, b)
+        assertTrue(diff.added.isEmpty())
+        assertTrue(diff.removed.isEmpty())
+        assertTrue(diff.changed.isEmpty()) // bolt unchanged, forest 5 == 5
+    }
+
+    @Test
+    fun `reports the total size of each side`() {
+        val diff = CubeDiff.diff(entries("Bolt", "10 Forest"), entries("Bolt"))
+        assertEquals(11, diff.sizeA)
+        assertEquals(1, diff.sizeB)
+    }
+
+    @Test
+    fun `buckets are alphabetised`() {
+        val b = entries("Shock", "Ancestral Recall", "Mox Pearl")
+        val diff = CubeDiff.diff(emptyList(), b)
+        assertEquals(listOf("Ancestral Recall", "Mox Pearl", "Shock"), diff.added.map { it.name })
+    }
+
+    @Test
+    fun `diffing against an empty list reports everything as added or removed`() {
+        assertEquals(2, CubeDiff.diff(emptyList(), entries("A", "B")).added.size)
+        assertEquals(2, CubeDiff.diff(entries("A", "B"), emptyList()).removed.size)
+    }
+}

--- a/web/src/main/kotlin/web/configuration/WebSecurityConfig.kt
+++ b/web/src/main/kotlin/web/configuration/WebSecurityConfig.kt
@@ -25,7 +25,7 @@ class WebSecurityConfig {
                     // shared cube (/cube/c/**) are public; the saved-lists and
                     // share-create APIs are deliberately NOT listed here so they
                     // fall through to anyRequest().authenticated().
-                    "/cube", "/cube/c/**", "/cube/api/asfan", "/cube/api/preview", "/cube/api/generate",
+                    "/cube", "/cube/c/**", "/cube/api/asfan", "/cube/api/preview", "/cube/api/generate", "/cube/api/diff",
                     "/sitemap.xml", "/robots.txt",
                     // Service worker for web push must be reachable
                     // unauthenticated — the browser registers it on

--- a/web/src/main/kotlin/web/controller/CubeController.kt
+++ b/web/src/main/kotlin/web/controller/CubeController.kt
@@ -21,6 +21,7 @@ import web.service.CardView
 import web.service.CategoryAsFan
 import web.service.CategoryGroup
 import web.service.CubeResult
+import web.service.DiffLineView
 import web.service.CubeWebService
 import web.service.GenerateData
 import web.service.PreviewData
@@ -121,6 +122,20 @@ class CubeController(
         @RequestBody request: CubeListGenerateRequest,
     ): ResponseEntity<CubeGenerateResponse> =
         generateResponse(cubeWebService.generateList(request.list, request.packs, request.packSize, request.balanced))
+
+    @PostMapping("/api/diff", consumes = ["application/json"], produces = ["application/json"])
+    @ResponseBody
+    fun diff(@RequestBody request: CubeDiffRequest): ResponseEntity<CubeDiffResponse> =
+        when (val result = cubeWebService.diff(request.listA, request.listB)) {
+            is CubeResult.Success -> ResponseEntity.ok(
+                CubeDiffResponse(
+                    true, null, result.value.added, result.value.removed, result.value.changed,
+                    result.value.sizeA, result.value.sizeB,
+                )
+            )
+            is CubeResult.Failure ->
+                ResponseEntity.badRequest().body(CubeDiffResponse(false, result.error, emptyList(), emptyList(), emptyList(), 0, 0))
+        }
 
     private fun previewResponse(result: CubeResult<PreviewData>): ResponseEntity<CubePreviewResponse> =
         when (result) {
@@ -231,6 +246,18 @@ data class ShareCubeRequest(val name: String = "", val cards: String = "")
 data class ShareCubeResponse(val token: String, val url: String, val name: String)
 
 data class CubeListPreviewRequest(val list: String = "", val packSize: Int = 15)
+
+data class CubeDiffRequest(val listA: String = "", val listB: String = "")
+
+data class CubeDiffResponse(
+    val ok: Boolean,
+    val error: String?,
+    val added: List<DiffLineView>,
+    val removed: List<DiffLineView>,
+    val changed: List<DiffLineView>,
+    val sizeA: Int,
+    val sizeB: Int,
+)
 
 data class CubeListGenerateRequest(
     val list: String = "",

--- a/web/src/main/kotlin/web/service/CubeWebService.kt
+++ b/web/src/main/kotlin/web/service/CubeWebService.kt
@@ -7,6 +7,7 @@ import common.mtg.CardCategory
 import common.mtg.CardListParser
 import common.mtg.CubeAnalytics
 import common.mtg.CubeCard
+import common.mtg.CubeDiff
 import common.mtg.MtgNames
 import common.mtg.MtgColor
 import common.mtg.PackGenerator
@@ -42,6 +43,21 @@ class CubeWebService {
         } catch (e: IllegalArgumentException) {
             CubeResult.error(e.message ?: "Invalid as-fan inputs.")
         }
+
+    /**
+     * Compares two pasted card lists by name (the [CubeDiff] maths) — added,
+     * removed and count-changed cards. Pure: no Scryfall, so it's instant.
+     */
+    fun diff(listA: String, listB: String): CubeResult<DiffData> {
+        val a = CardListParser.parse(listA)
+        val b = CardListParser.parse(listB)
+        if (a.isEmpty() && b.isEmpty()) return CubeResult.error("Paste a card list into both sides to compare.")
+        val d = CubeDiff.diff(a, b)
+        fun lines(list: List<CubeDiff.Line>) = list.map { DiffLineView(it.name, it.from, it.to) }
+        return CubeResult.ok(
+            DiffData(lines(d.added), lines(d.removed), lines(d.changed), d.sizeA, d.sizeB)
+        )
+    }
 
     /** As-fan distribution of a Scryfall query's cards, no pack generation. */
     fun preview(query: String, packSize: Int): CubeResult<PreviewData> {
@@ -492,6 +508,18 @@ data class AnalyticsView(
     val duplicates: List<DuplicateView>,
     val colorPairs: List<ColorPairView>,
     val colorPips: List<ColorPipView>,
+)
+
+/** One card's change between two compared lists (copy counts from → to). */
+data class DiffLineView(val name: String, val from: Int, val to: Int)
+
+/** The outcome of comparing two card lists by name. */
+data class DiffData(
+    val added: List<DiffLineView>,
+    val removed: List<DiffLineView>,
+    val changed: List<DiffLineView>,
+    val sizeA: Int,
+    val sizeB: Int,
 )
 
 data class PreviewData(

--- a/web/src/main/resources/static/css/cube.css
+++ b/web/src/main/resources/static/css/cube.css
@@ -1125,6 +1125,78 @@ details[open] > .cube-section-summary .cube-collapse-chevron {
     display: none;
 }
 
+/* Compare two lists: side-by-side inputs and a Added/Removed/Changed diff. */
+.cube-compare-form {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--space-3);
+    align-items: start;
+}
+
+.cube-compare-col {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.cube-compare-form .cube-submit {
+    grid-column: 1 / -1;
+    justify-self: start;
+}
+
+.cube-diff {
+    display: grid;
+    gap: var(--space-3);
+    margin-top: var(--space-3);
+}
+
+.cube-diff[hidden] {
+    display: none;
+}
+
+.cube-diff-h {
+    margin: 0 0 var(--space-1);
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--heading);
+}
+
+.cube-diff-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    gap: 2px;
+}
+
+.cube-diff-line {
+    font-size: 0.85rem;
+    font-family: var(--font-mono, monospace);
+}
+
+.cube-diff-add {
+    color: #22c55e;
+}
+
+.cube-diff-remove {
+    color: #ef4444;
+}
+
+.cube-diff-change {
+    color: var(--mtg-gold);
+}
+
+.cube-diff-empty {
+    color: var(--text-muted);
+}
+
+@media (max-width: 600px) {
+    .cube-compare-form {
+        grid-template-columns: 1fr;
+    }
+}
+
 @media (max-width: 600px) {
     .cube-hero h1 {
         font-size: 1.7rem;

--- a/web/src/main/resources/static/js/cube.js
+++ b/web/src/main/resources/static/js/cube.js
@@ -7,7 +7,10 @@
 (function (root) {
     'use strict';
 
-    const TABS = ['generate', 'preview', 'asfan'];
+    const TABS = ['generate', 'preview', 'asfan', 'compare'];
+
+    // Tools that work off their own inputs, not the shared "Your cube" source.
+    const NO_SHARED_SOURCE = ['asfan', 'compare'];
 
     // Colour-pie palette for swatches/bars. Tuned to read on the dark
     // dashboard background while staying recognisably W/U/B/R/G + gold
@@ -362,6 +365,43 @@
         return container;
     }
 
+    /** Renders a cube diff: Added / Removed / Count-changed sections of card names. */
+    function renderDiff(container, data) {
+        container.replaceChildren();
+        function section(title, lines, sign) {
+            if (!lines || !lines.length) return;
+            const block = document.createElement('div');
+            block.className = 'cube-diff-group';
+            const h = document.createElement('h4');
+            h.className = 'cube-diff-h';
+            h.textContent = title + ' (' + lines.length + ')';
+            block.appendChild(h);
+            const ul = document.createElement('ul');
+            ul.className = 'cube-diff-list';
+            const prefix = sign === 'add' ? '+ ' : (sign === 'remove' ? '− ' : '~ ');
+            lines.forEach(function (line) {
+                const li = document.createElement('li');
+                li.className = 'cube-diff-line cube-diff-' + sign;
+                li.textContent = prefix + line.name +
+                    (sign === 'change' ? ' (' + line.from + ' → ' + line.to + ')' : '');
+                ul.appendChild(li);
+            });
+            block.appendChild(ul);
+            container.appendChild(block);
+        }
+        section('Added', data.added, 'add');
+        section('Removed', data.removed, 'remove');
+        section('Count changed', data.changed, 'change');
+        const total = (data.added || []).length + (data.removed || []).length + (data.changed || []).length;
+        if (total === 0) {
+            const p = document.createElement('p');
+            p.className = 'cube-diff-empty';
+            p.textContent = 'No differences — the two lists match.';
+            container.appendChild(p);
+        }
+        return container;
+    }
+
     /** A chevron that rotates when its parent <details> is open. */
     function collapseChevron() {
         const c = document.createElement('span');
@@ -509,11 +549,11 @@
         doc.querySelectorAll('[data-panel]').forEach(function (panel) {
             panel.hidden = panel.getAttribute('data-panel') !== name;
         });
-        // The as-fan calculator works off manual numbers, so the shared "Your
-        // cube" source (and its cue) don't apply — hide them on that tab so the
-        // tool stands on its own.
+        // Some tools (as-fan, compare) work off their own inputs, so the shared
+        // "Your cube" source (and its cue) don't apply — hide them there.
+        const usesSource = NO_SHARED_SOURCE.indexOf(name) < 0;
         doc.querySelectorAll('[data-needs-cube]').forEach(function (el) {
-            el.hidden = name === 'asfan';
+            el.hidden = !usesSource;
         });
     }
 
@@ -972,6 +1012,32 @@
         textarea.addEventListener('blur', function () { setTimeout(close, 150); });
     }
 
+    function wireCompare(doc) {
+        const form = q(doc, '[data-form="compare"]');
+        if (!form) return;
+        const status = statusFor(doc, 'compare');
+        const result = q(doc, '[data-result="compare"]');
+        form.addEventListener('submit', function (e) {
+            e.preventDefault();
+            const data = new FormData(form);
+            const listA = (data.get('listA') || '').trim();
+            const listB = (data.get('listB') || '').trim();
+            if (!listA && !listB) { setStatus(status, 'Paste a card list into both sides to compare.'); return; }
+            setStatus(status, 'Comparing…');
+            hide(result);
+            withBusy(form, true);
+            postJson('/cube/api/diff', { listA: listA, listB: listB })
+                .then(function (json) {
+                    if (!json.ok) { setStatus(status, json.error || 'Could not compare.'); return; }
+                    setStatus(status, 'List A: ' + json.sizeA + ' cards · List B: ' + json.sizeB + ' cards');
+                    renderDiff(result, json);
+                    show(result);
+                })
+                .catch(function () { setStatus(status, 'Something went wrong. Try again.'); })
+                .then(function () { withBusy(form, false); });
+        });
+    }
+
     function wireAsFan(doc) {
         const form = q(doc, '[data-form="asfan"]');
         if (!form) return;
@@ -1347,6 +1413,7 @@
         wireCopyQuery(doc);
         wireExamples(doc);
         wireAsFan(doc);
+        wireCompare(doc);
         wirePreview(doc);
         wireGenerate(doc);
         wireCardFlip(doc);
@@ -1382,6 +1449,7 @@
         generateUrl: generateUrl,
         samplePackRequest: samplePackRequest,
         renderDistribution: renderDistribution,
+        renderDiff: renderDiff,
         renderManaCurve: renderManaCurve,
         renderTypeBreakdown: renderTypeBreakdown,
         renderRarity: renderRarity,

--- a/web/src/main/resources/templates/cube.html
+++ b/web/src/main/resources/templates/cube.html
@@ -141,6 +141,12 @@
                 <span class="cube-tab-label">As-fan calculator</span>
                 <span class="cube-tab-sub">Quick maths</span>
             </button>
+            <button type="button" id="tab-compare" class="cube-tab" role="tab"
+                    data-tab="compare" aria-controls="panel-compare" aria-selected="false" tabindex="-1">
+                <span class="cube-tab-icon" aria-hidden="true">🔀</span>
+                <span class="cube-tab-label">Compare</span>
+                <span class="cube-tab-sub">Diff two lists</span>
+            </button>
         </div>
 
         <!-- Generate -->
@@ -257,6 +263,28 @@
                 </div>
                 <p class="cube-asfan-sentence" data-asfan-sentence></p>
             </div>
+        </section>
+
+        <!-- Compare two lists -->
+        <section id="panel-compare" class="cube-panel" role="tabpanel" aria-labelledby="tab-compare"
+                 data-panel="compare" hidden>
+            <p class="cube-panel-intro">
+                Paste two card lists to see what changed — handy for iterating a cube. Compares by
+                name (counts included), no Scryfall lookup needed.
+            </p>
+            <form class="cube-form cube-compare-form" data-form="compare" autocomplete="off">
+                <label class="cube-compare-col">List A (before)
+                    <textarea name="listA" rows="8" spellcheck="false"
+                              placeholder="One card per line:&#10;1 Lightning Bolt&#10;10 Forest"></textarea>
+                </label>
+                <label class="cube-compare-col">List B (after)
+                    <textarea name="listB" rows="8" spellcheck="false"
+                              placeholder="The new version of the list"></textarea>
+                </label>
+                <button type="submit" class="btn cube-submit">Compare</button>
+            </form>
+            <p class="cube-status" data-status="compare" aria-live="polite"></p>
+            <div class="cube-diff" data-result="compare" hidden></div>
         </section>
     </div>
 </main>

--- a/web/src/test/js/cube.test.js
+++ b/web/src/test/js/cube.test.js
@@ -61,10 +61,11 @@ describe('scryfallCardUrl', () => {
 });
 
 describe('tabIdFromHash', () => {
-    test('recognises the three tab hashes', () => {
+    test('recognises the tab hashes', () => {
         expect(Cube.tabIdFromHash('#generate')).toBe('generate');
         expect(Cube.tabIdFromHash('#preview')).toBe('preview');
         expect(Cube.tabIdFromHash('#asfan')).toBe('asfan');
+        expect(Cube.tabIdFromHash('#compare')).toBe('compare');
     });
 
     test('returns null for anything else', () => {
@@ -382,6 +383,32 @@ describe('deep-link hash activates the matching tab on in-page navigation', () =
         window.location.hash = '#preview';
         window.dispatchEvent(new window.Event('hashchange'));
         expect(source.hidden).toBe(false);
+    });
+});
+
+describe('renderDiff (compare two lists)', () => {
+    test('renders Added / Removed / Count-changed sections with prefixes', () => {
+        const container = document.createElement('div');
+        Cube.renderDiff(container, {
+            added: [{ name: 'Shock', from: 0, to: 1 }],
+            removed: [{ name: 'Counterspell', from: 1, to: 0 }],
+            changed: [{ name: 'Forest', from: 3, to: 5 }],
+            sizeA: 5, sizeB: 7,
+        });
+        expect(container.querySelectorAll('.cube-diff-group')).toHaveLength(3);
+        expect(container.querySelector('.cube-diff-add').textContent).toBe('+ Shock');
+        expect(container.querySelector('.cube-diff-remove').textContent).toBe('− Counterspell');
+        expect(container.querySelector('.cube-diff-change').textContent).toBe('~ Forest (3 → 5)');
+    });
+
+    test('omits empty sections and notes when the lists are identical', () => {
+        const onlyAdds = document.createElement('div');
+        Cube.renderDiff(onlyAdds, { added: [{ name: 'A', from: 0, to: 1 }], removed: [], changed: [], sizeA: 0, sizeB: 1 });
+        expect(onlyAdds.querySelectorAll('.cube-diff-group')).toHaveLength(1);
+
+        const same = document.createElement('div');
+        Cube.renderDiff(same, { added: [], removed: [], changed: [], sizeA: 1, sizeB: 1 });
+        expect(same.querySelector('.cube-diff-empty').textContent).toContain('No differences');
     });
 });
 

--- a/web/src/test/kotlin/web/controller/CubeControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/CubeControllerTest.kt
@@ -24,6 +24,8 @@ import web.service.ColorPipView
 import web.service.CubeResult
 import web.service.CubeWebService
 import web.service.CurveBucketView
+import web.service.DiffData
+import web.service.DiffLineView
 import web.service.DuplicateView
 import web.service.GenerateData
 import web.service.PreviewData
@@ -133,6 +135,32 @@ class CubeControllerTest {
         // The cube report flows through the response.
         assertEquals(1.5, response.body!!.analytics!!.averageManaValue)
         assertEquals("Creature", response.body!!.analytics!!.types.first().type)
+    }
+
+    @Test
+    fun `diff returns 200 with the comparison`() {
+        every { service.diff("A list", "B list") } returns CubeResult.ok(
+            DiffData(
+                added = listOf(DiffLineView("Shock", 0, 1)),
+                removed = emptyList(),
+                changed = listOf(DiffLineView("Forest", 3, 5)),
+                sizeA = 4, sizeB = 6,
+            )
+        )
+        val response = controller.diff(CubeDiffRequest("A list", "B list"))
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertTrue(response.body!!.ok)
+        assertEquals("Shock", response.body!!.added.first().name)
+        assertEquals(5, response.body!!.changed.first().to)
+        assertEquals(4, response.body!!.sizeA)
+    }
+
+    @Test
+    fun `diff returns 400 on failure`() {
+        every { service.diff(any(), any()) } returns CubeResult.error("Paste a card list into both sides to compare.")
+        val response = controller.diff(CubeDiffRequest("", ""))
+        assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+        assertFalse(response.body!!.ok)
     }
 
     @Test

--- a/web/src/test/kotlin/web/service/CubeWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/CubeWebServiceTest.kt
@@ -56,6 +56,26 @@ class CubeWebServiceTest {
         assertEquals(1, pips["Red"])
     }
 
+    // --- diff (compare two lists) --------------------------------------
+
+    @Test
+    fun `diff compares two pasted lists by name`() {
+        val result = service.diff("Bolt\nCounterspell\n3 Forest", "Bolt\nShock\n5 Forest")
+        val data = (result as CubeResult.Success<DiffData>).value
+        assertEquals(listOf("Shock"), data.added.map { it.name })
+        assertEquals(listOf("Counterspell"), data.removed.map { it.name })
+        assertEquals(listOf("Forest"), data.changed.map { it.name })
+        assertEquals(3, data.changed.first().from)
+        assertEquals(5, data.changed.first().to)
+        assertEquals(5, data.sizeA) // Bolt + Counterspell + 3 Forest
+        assertEquals(7, data.sizeB) // Bolt + Shock + 5 Forest
+    }
+
+    @Test
+    fun `diff rejects two empty lists`() {
+        assertInstanceOf(CubeResult.Failure::class.java, service.diff("", "   "))
+    }
+
     // --- asFan ---------------------------------------------------------
 
     @Test


### PR DESCRIPTION
## Why

Last of the four adjacent features — a **cube diff / compare** tool, the read side of *iterating* a cube ("what changed between this version and the last?").

## What changed

- **Shared `common.mtg.CubeDiff`** — pure name-level comparison: **added** (in B not A), **removed** (in A not B), **count-changed** (in both, different counts). Case-insensitive (`MtgNames.lookupKey`), counts summed per name, sorted. No Scryfall → instant.
- **Web** — `CubeWebService.diff` + `POST /cube/api/diff` (added to the security `permitAll` list; already CSRF-exempt under `/cube/api/**`). A new **"Compare"** tab with two list inputs (A "before" / B "after") and a colour-coded Added / Removed / Count-changed result. The tab joins as-fan in **not** using the shared "Your cube" source (new `NO_SHARED_SOURCE` set drives the source-hide).
- `cube.js`: `renderDiff` + `wireCompare`; `cube.css`: side-by-side inputs + diff colours; `cube.html`: the tab + panel.

## Tests

- common: `CubeDiff` — added/removed/changed, case-insensitivity + summed counts, sizes, alphabetisation, empty-side handling.
- web: `CubeWebService.diff` (compare + reject-two-empty), `CubeController` diff endpoint (200 + 400).
- jest: `renderDiff` (sections, prefixes, no-diff note) + the `#compare` tab hash.
- `:common:test` `:web:test`, kover gates, jest (**704**) and stylelint pass.

This completes the adjacent-feature set: colour/archetype (#638), sample pack (#639), `/cube card` (#640), and this. Next: a **web single-card lookup** (per your request, to give `/cube card` a website equivalent).

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs

---
_Generated by [Claude Code](https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs)_