### PR TITLE
Add a web single-card lookup (Card lookup tab)

### DIFF
--- a/web/src/main/kotlin/web/configuration/WebSecurityConfig.kt
+++ b/web/src/main/kotlin/web/configuration/WebSecurityConfig.kt
@@ -25,7 +25,7 @@ class WebSecurityConfig {
                     // shared cube (/cube/c/**) are public; the saved-lists and
                     // share-create APIs are deliberately NOT listed here so they
                     // fall through to anyRequest().authenticated().
-                    "/cube", "/cube/c/**", "/cube/api/asfan", "/cube/api/preview", "/cube/api/generate", "/cube/api/diff",
+                    "/cube", "/cube/c/**", "/cube/api/asfan", "/cube/api/preview", "/cube/api/generate", "/cube/api/diff", "/cube/api/card",
                     "/sitemap.xml", "/robots.txt",
                     // Service worker for web push must be reachable
                     // unauthenticated — the browser registers it on

--- a/web/src/main/kotlin/web/controller/CubeController.kt
+++ b/web/src/main/kotlin/web/controller/CubeController.kt
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.ResponseBody
 import web.service.AnalyticsView
 import web.service.CardView
 import web.service.CategoryAsFan
+import web.service.CardLookupView
 import web.service.CategoryGroup
 import web.service.CubeResult
 import web.service.DiffLineView
@@ -122,6 +123,14 @@ class CubeController(
         @RequestBody request: CubeListGenerateRequest,
     ): ResponseEntity<CubeGenerateResponse> =
         generateResponse(cubeWebService.generateList(request.list, request.packs, request.packSize, request.balanced))
+
+    @GetMapping("/api/card", produces = ["application/json"])
+    @ResponseBody
+    fun card(@RequestParam("name") name: String): ResponseEntity<CubeCardResponse> =
+        when (val result = cubeWebService.card(name)) {
+            is CubeResult.Success -> ResponseEntity.ok(CubeCardResponse(true, null, result.value))
+            is CubeResult.Failure -> ResponseEntity.badRequest().body(CubeCardResponse(false, result.error, null))
+        }
 
     @PostMapping("/api/diff", consumes = ["application/json"], produces = ["application/json"])
     @ResponseBody
@@ -246,6 +255,8 @@ data class ShareCubeRequest(val name: String = "", val cards: String = "")
 data class ShareCubeResponse(val token: String, val url: String, val name: String)
 
 data class CubeListPreviewRequest(val list: String = "", val packSize: Int = 15)
+
+data class CubeCardResponse(val ok: Boolean, val error: String?, val card: CardLookupView?)
 
 data class CubeDiffRequest(val listA: String = "", val listB: String = "")
 

--- a/web/src/main/kotlin/web/service/CubeWebService.kt
+++ b/web/src/main/kotlin/web/service/CubeWebService.kt
@@ -11,6 +11,7 @@ import common.mtg.CubeDiff
 import common.mtg.MtgNames
 import common.mtg.MtgColor
 import common.mtg.PackGenerator
+import common.mtg.Rarity
 import org.springframework.stereotype.Service
 import java.io.IOException
 import java.net.URI
@@ -43,6 +44,52 @@ class CubeWebService {
         } catch (e: IllegalArgumentException) {
             CubeResult.error(e.message ?: "Invalid as-fan inputs.")
         }
+
+    /**
+     * Looks a single card up by (fuzzy) name via Scryfall's `/cards/named`,
+     * for the web card-lookup tool — the website twin of `/cube card`.
+     */
+    fun card(name: String): CubeResult<CardLookupView> {
+        val trimmed = name.trim()
+        if (trimmed.isEmpty()) return CubeResult.error("Enter a card name to look up.")
+        val url = "$NAMED_ENDPOINT?fuzzy=" + URLEncoder.encode(trimmed, StandardCharsets.UTF_8)
+        return try {
+            val response = http.send(
+                HttpRequest.newBuilder(URI.create(url))
+                    .header("User-Agent", "tobybot-web/1.0")
+                    .header("Accept", "application/json")
+                    .timeout(Duration.ofSeconds(10))
+                    .GET()
+                    .build(),
+                HttpResponse.BodyHandlers.ofString(),
+            )
+            when (response.statusCode()) {
+                200 -> cardOf(jackson.readTree(response.body()))
+                    ?.let { CubeResult.ok(lookupView(it)) }
+                    ?: CubeResult.error("Scryfall returned an unexpected card.")
+                404 -> CubeResult.error("No card found matching “$trimmed”.")
+                else -> CubeResult.error("Scryfall returned ${response.statusCode()}.")
+            }
+        } catch (e: IOException) {
+            CubeResult.error("Could not reach Scryfall: ${e.message}")
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            CubeResult.error("Request interrupted.")
+        }
+    }
+
+    /** Maps a resolved card to the lookup view, resolving rarity + colours for display. */
+    internal fun lookupView(sc: ScryfallCard): CardLookupView = CardLookupView(
+        name = sc.card.name,
+        imageUrl = sc.imageUrl,
+        imageUrlLarge = sc.imageUrlLarge,
+        imageUrlBack = sc.imageUrlBack,
+        typeLine = sc.card.typeLine,
+        manaValue = sc.card.manaValue,
+        manaCost = sc.card.manaCost,
+        rarity = sc.card.rarity?.let { Rarity.parse(it).displayName },
+        colors = MtgColor.entries.filter { it in sc.card.colors }.map { it.displayName },
+    )
 
     /**
      * Compares two pasted card lists by name (the [CubeDiff] maths) — added,
@@ -210,26 +257,29 @@ class CubeWebService {
     fun parseScryfall(root: JsonNode): List<ScryfallCard> {
         val data = root.path("data")
         if (!data.isArray) return emptyList()
-        return data.mapNotNull { node ->
-            val name = node.path("name").asText("").takeIf { it.isNotBlank() } ?: return@mapNotNull null
-            val identity = node.path("color_identity").mapNotNull { it.asText(null) }
-            val typeLine = node.path("type_line").asText("")
-            ScryfallCard(
-                card = CubeCard(
-                    name = name,
-                    colors = MtgColor.parse(identity),
-                    isLand = CubeCard.isLandType(typeLine),
-                    typeLine = typeLine,
-                    manaValue = node.path("cmc").asDouble(0.0),
-                    rarity = node.path("rarity").asText("").takeIf { it.isNotBlank() },
-                    manaCost = manaCostOf(node),
-                ),
-                imageUrl = imageOf(node, "small"),
-                imageUrlLarge = imageOf(node, "normal"),
-                imageUrlBack = backImageOf(node),
+        return data.mapNotNull { cardOf(it) }
+    }
+
+    /** Maps one Scryfall card object to a [ScryfallCard], or null if it has no name. */
+    fun cardOf(node: JsonNode): ScryfallCard? {
+        val name = node.path("name").asText("").takeIf { it.isNotBlank() } ?: return null
+        val identity = node.path("color_identity").mapNotNull { it.asText(null) }
+        val typeLine = node.path("type_line").asText("")
+        return ScryfallCard(
+            card = CubeCard(
+                name = name,
+                colors = MtgColor.parse(identity),
+                isLand = CubeCard.isLandType(typeLine),
+                typeLine = typeLine,
+                manaValue = node.path("cmc").asDouble(0.0),
+                rarity = node.path("rarity").asText("").takeIf { it.isNotBlank() },
                 manaCost = manaCostOf(node),
-            )
-        }
+            ),
+            imageUrl = imageOf(node, "small"),
+            imageUrlLarge = imageOf(node, "normal"),
+            imageUrlBack = backImageOf(node),
+            manaCost = manaCostOf(node),
+        )
     }
 
     /**
@@ -423,6 +473,7 @@ class CubeWebService {
     private companion object {
         const val SEARCH_ENDPOINT = "https://api.scryfall.com/cards/search"
         const val COLLECTION_ENDPOINT = "https://api.scryfall.com/cards/collection"
+        const val NAMED_ENDPOINT = "https://api.scryfall.com/cards/named"
         const val MAX_CARDS = 750
         const val MAX_PAGES = 10
         const val COLLECTION_BATCH = 75
@@ -508,6 +559,19 @@ data class AnalyticsView(
     val duplicates: List<DuplicateView>,
     val colorPairs: List<ColorPairView>,
     val colorPips: List<ColorPipView>,
+)
+
+/** A single card looked up by name: image plus its key facts. */
+data class CardLookupView(
+    val name: String,
+    val imageUrl: String?,
+    val imageUrlLarge: String?,
+    val imageUrlBack: String?,
+    val typeLine: String,
+    val manaValue: Double,
+    val manaCost: String?,
+    val rarity: String?,
+    val colors: List<String>,
 )
 
 /** One card's change between two compared lists (copy counts from → to). */

--- a/web/src/main/resources/static/css/cube.css
+++ b/web/src/main/resources/static/css/cube.css
@@ -1197,6 +1197,53 @@ details[open] > .cube-section-summary .cube-collapse-chevron {
     }
 }
 
+/* Single-card lookup: image beside its facts. */
+.cube-cardlookup-wrap[hidden] {
+    display: none;
+}
+
+.cube-cardlookup {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-4);
+    margin-top: var(--space-3);
+    align-items: start;
+}
+
+.cube-cardlookup-img {
+    width: 240px;
+    max-width: 100%;
+    border-radius: 10px;
+    border: 1px solid var(--border);
+}
+
+.cube-cardlookup-facts {
+    flex: 1;
+    min-width: 200px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.cube-cardlookup-facts h3 {
+    margin: 0 0 var(--space-1);
+    color: var(--heading);
+}
+
+.cube-cardlookup-fact {
+    margin: 0;
+    font-size: 0.9rem;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex-wrap: wrap;
+}
+
+.cube-cardlookup-link {
+    align-self: start;
+    margin-top: var(--space-2);
+}
+
 @media (max-width: 600px) {
     .cube-hero h1 {
         font-size: 1.7rem;

--- a/web/src/main/resources/static/js/cube.js
+++ b/web/src/main/resources/static/js/cube.js
@@ -7,10 +7,10 @@
 (function (root) {
     'use strict';
 
-    const TABS = ['generate', 'preview', 'asfan', 'compare'];
+    const TABS = ['generate', 'preview', 'asfan', 'compare', 'card'];
 
     // Tools that work off their own inputs, not the shared "Your cube" source.
-    const NO_SHARED_SOURCE = ['asfan', 'compare'];
+    const NO_SHARED_SOURCE = ['asfan', 'compare', 'card'];
 
     // Colour-pie palette for swatches/bars. Tuned to read on the dark
     // dashboard background while staying recognisably W/U/B/R/G + gold
@@ -362,6 +362,77 @@
             rowEl.appendChild(value);
             container.appendChild(rowEl);
         });
+        return container;
+    }
+
+    /** GET URL for the single-card lookup. */
+    function cardUrl(name) {
+        return '/cube/api/card?name=' + encodeURIComponent(name);
+    }
+
+    /** Renders a looked-up card: its (large) image beside a list of facts. */
+    function renderCardLookup(container, card) {
+        container.replaceChildren();
+        const wrap = document.createElement('div');
+        wrap.className = 'cube-cardlookup';
+
+        const big = card.imageUrlLarge || card.imageUrl;
+        if (big) {
+            const img = document.createElement('img');
+            img.className = 'cube-cardlookup-img';
+            img.src = big;
+            img.alt = card.name;
+            wrap.appendChild(img);
+        }
+
+        const facts = document.createElement('div');
+        facts.className = 'cube-cardlookup-facts';
+        const h = document.createElement('h3');
+        h.textContent = card.name;
+        facts.appendChild(h);
+
+        function fact(label, value) {
+            if (value == null || value === '') return;
+            const p = document.createElement('p');
+            p.className = 'cube-cardlookup-fact';
+            const b = document.createElement('strong');
+            b.textContent = label + ' ';
+            p.appendChild(b);
+            p.appendChild(document.createTextNode(String(value)));
+            facts.appendChild(p);
+        }
+
+        fact('Type', card.typeLine);
+        const symbols = manaSymbolUrls(card.manaCost);
+        if (symbols.length) {
+            const p = document.createElement('p');
+            p.className = 'cube-cardlookup-fact';
+            const b = document.createElement('strong');
+            b.textContent = 'Mana cost ';
+            p.appendChild(b);
+            symbols.forEach(function (s) {
+                const sym = document.createElement('img');
+                sym.className = 'cube-mana-symbol';
+                sym.src = s.url;
+                sym.alt = s.symbol;
+                p.appendChild(sym);
+            });
+            facts.appendChild(p);
+        }
+        fact('Mana value', card.manaValue);
+        fact('Rarity', card.rarity);
+        fact('Colour identity', (card.colors && card.colors.length) ? card.colors.join(', ') : 'Colourless');
+
+        const link = document.createElement('a');
+        link.className = 'btn btn-secondary cube-cardlookup-link';
+        link.href = scryfallCardUrl(card.name);
+        link.target = '_blank';
+        link.rel = 'noopener';
+        link.textContent = 'View on Scryfall ↗';
+        facts.appendChild(link);
+
+        wrap.appendChild(facts);
+        container.appendChild(wrap);
         return container;
     }
 
@@ -1012,6 +1083,30 @@
         textarea.addEventListener('blur', function () { setTimeout(close, 150); });
     }
 
+    function wireCardLookup(doc) {
+        const form = q(doc, '[data-form="card"]');
+        if (!form) return;
+        const status = statusFor(doc, 'card');
+        const result = q(doc, '[data-result="card"]');
+        form.addEventListener('submit', function (e) {
+            e.preventDefault();
+            const name = (new FormData(form).get('name') || '').trim();
+            if (!name) { setStatus(status, 'Enter a card name.'); return; }
+            setStatus(status, 'Looking up…');
+            hide(result);
+            withBusy(form, true);
+            getJson(cardUrl(name))
+                .then(function (json) {
+                    if (!json.ok) { setStatus(status, json.error || 'No card found.'); return; }
+                    setStatus(status, '');
+                    renderCardLookup(result, json.card);
+                    show(result);
+                })
+                .catch(function () { setStatus(status, 'Something went wrong. Try again.'); })
+                .then(function () { withBusy(form, false); });
+        });
+    }
+
     function wireCompare(doc) {
         const form = q(doc, '[data-form="compare"]');
         if (!form) return;
@@ -1414,6 +1509,7 @@
         wireExamples(doc);
         wireAsFan(doc);
         wireCompare(doc);
+        wireCardLookup(doc);
         wirePreview(doc);
         wireGenerate(doc);
         wireCardFlip(doc);
@@ -1450,6 +1546,8 @@
         samplePackRequest: samplePackRequest,
         renderDistribution: renderDistribution,
         renderDiff: renderDiff,
+        cardUrl: cardUrl,
+        renderCardLookup: renderCardLookup,
         renderManaCurve: renderManaCurve,
         renderTypeBreakdown: renderTypeBreakdown,
         renderRarity: renderRarity,

--- a/web/src/main/resources/templates/cube.html
+++ b/web/src/main/resources/templates/cube.html
@@ -147,6 +147,12 @@
                 <span class="cube-tab-label">Compare</span>
                 <span class="cube-tab-sub">Diff two lists</span>
             </button>
+            <button type="button" id="tab-card" class="cube-tab" role="tab"
+                    data-tab="card" aria-controls="panel-card" aria-selected="false" tabindex="-1">
+                <span class="cube-tab-icon" aria-hidden="true">🔍</span>
+                <span class="cube-tab-label">Card lookup</span>
+                <span class="cube-tab-sub">Find one card</span>
+            </button>
         </div>
 
         <!-- Generate -->
@@ -285,6 +291,23 @@
             </form>
             <p class="cube-status" data-status="compare" aria-live="polite"></p>
             <div class="cube-diff" data-result="compare" hidden></div>
+        </section>
+
+        <!-- Card lookup -->
+        <section id="panel-card" class="cube-panel" role="tabpanel" aria-labelledby="tab-card"
+                 data-panel="card" hidden>
+            <p class="cube-panel-intro">
+                Look up any Magic card by name and see its image and details — the website twin of
+                the <code>/cube card</code> Discord command.
+            </p>
+            <form class="cube-form" data-form="card" autocomplete="off">
+                <label>Card name
+                    <input type="text" name="name" placeholder="e.g. Lightning Bolt" autocomplete="off" required>
+                </label>
+                <button type="submit" class="btn cube-submit">Look up</button>
+            </form>
+            <p class="cube-status" data-status="card" aria-live="polite"></p>
+            <div class="cube-cardlookup-wrap" data-result="card" hidden></div>
         </section>
     </div>
 </main>

--- a/web/src/test/js/cube.test.js
+++ b/web/src/test/js/cube.test.js
@@ -66,6 +66,7 @@ describe('tabIdFromHash', () => {
         expect(Cube.tabIdFromHash('#preview')).toBe('preview');
         expect(Cube.tabIdFromHash('#asfan')).toBe('asfan');
         expect(Cube.tabIdFromHash('#compare')).toBe('compare');
+        expect(Cube.tabIdFromHash('#card')).toBe('card');
     });
 
     test('returns null for anything else', () => {
@@ -383,6 +384,37 @@ describe('deep-link hash activates the matching tab on in-page navigation', () =
         window.location.hash = '#preview';
         window.dispatchEvent(new window.Event('hashchange'));
         expect(source.hidden).toBe(false);
+    });
+});
+
+describe('card lookup (cardUrl / renderCardLookup)', () => {
+    test('cardUrl encodes the name', () => {
+        expect(Cube.cardUrl('Urza, Lord High Artificer')).toBe('/cube/api/card?name=' + encodeURIComponent('Urza, Lord High Artificer'));
+    });
+
+    test('renderCardLookup shows the large image, facts, mana symbols and a Scryfall link', () => {
+        const container = document.createElement('div');
+        Cube.renderCardLookup(container, {
+            name: 'Ragavan, Nimble Pilferer',
+            imageUrl: 's.jpg', imageUrlLarge: 'n.jpg',
+            typeLine: 'Legendary Creature — Monkey Pirate',
+            manaValue: 1, manaCost: '{R}', rarity: 'Mythic', colors: ['Red'],
+        });
+        expect(container.querySelector('.cube-cardlookup-img').getAttribute('src')).toBe('n.jpg');
+        expect(container.querySelector('h3').textContent).toBe('Ragavan, Nimble Pilferer');
+        const text = container.querySelector('.cube-cardlookup-facts').textContent;
+        expect(text).toContain('Legendary Creature — Monkey Pirate');
+        expect(text).toContain('Mythic');
+        expect(text).toContain('Red');
+        // The mana cost renders as a Scryfall symbol image.
+        expect(container.querySelector('.cube-mana-symbol').getAttribute('src')).toBe('https://svgs.scryfall.io/card-symbols/R.svg');
+        expect(container.querySelector('.cube-cardlookup-link').getAttribute('href')).toBe(Cube.scryfallCardUrl('Ragavan, Nimble Pilferer'));
+    });
+
+    test('renderCardLookup describes a colourless card', () => {
+        const container = document.createElement('div');
+        Cube.renderCardLookup(container, { name: 'Sol Ring', imageUrlLarge: 'n.jpg', typeLine: 'Artifact', manaValue: 1, manaCost: '{1}', rarity: null, colors: [] });
+        expect(container.querySelector('.cube-cardlookup-facts').textContent).toContain('Colourless');
     });
 });
 

--- a/web/src/test/kotlin/web/controller/CubeControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/CubeControllerTest.kt
@@ -16,6 +16,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.ui.Model
 import web.service.AnalyticsView
+import web.service.CardLookupView
 import web.service.CardView
 import web.service.CategoryAsFan
 import web.service.CategoryGroup
@@ -135,6 +136,25 @@ class CubeControllerTest {
         // The cube report flows through the response.
         assertEquals(1.5, response.body!!.analytics!!.averageManaValue)
         assertEquals("Creature", response.body!!.analytics!!.types.first().type)
+    }
+
+    @Test
+    fun `card returns 200 with the looked-up card`() {
+        every { service.card("Ragavan") } returns CubeResult.ok(
+            CardLookupView("Ragavan, Nimble Pilferer", "s.jpg", "n.jpg", null, "Legendary Creature", 1.0, "{R}", "Mythic", listOf("Red"))
+        )
+        val response = controller.card("Ragavan")
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertTrue(response.body!!.ok)
+        assertEquals("Ragavan, Nimble Pilferer", response.body!!.card!!.name)
+    }
+
+    @Test
+    fun `card returns 400 when nothing matches`() {
+        every { service.card(any()) } returns CubeResult.error("No card found matching “zzz”.")
+        val response = controller.card("zzz")
+        assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+        assertFalse(response.body!!.ok)
     }
 
     @Test

--- a/web/src/test/kotlin/web/service/CubeWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/CubeWebServiceTest.kt
@@ -56,6 +56,24 @@ class CubeWebServiceTest {
         assertEquals(1, pips["Red"])
     }
 
+    // --- card lookup ---------------------------------------------------
+
+    @Test
+    fun `cardOf and lookupView resolve a single named card's facts`() {
+        val node = mapper.readTree(
+            """{"name":"Ragavan, Nimble Pilferer","color_identity":["R"],
+               "type_line":"Legendary Creature — Monkey Pirate","cmc":1.0,"mana_cost":"{R}","rarity":"mythic",
+               "image_uris":{"small":"s.jpg","normal":"n.jpg"}}"""
+        )
+        val view = service.lookupView(service.cardOf(node)!!)
+        assertEquals("Ragavan, Nimble Pilferer", view.name)
+        assertEquals("n.jpg", view.imageUrlLarge)
+        assertEquals("{R}", view.manaCost)
+        assertEquals("Mythic", view.rarity)
+        assertEquals(listOf("Red"), view.colors)
+        assertEquals("Legendary Creature — Monkey Pirate", view.typeLine)
+    }
+
     // --- diff (compare two lists) --------------------------------------
 
     @Test


### PR DESCRIPTION
## Why

Closes the last web/Discord gap — gives **`/cube card`** a website equivalent. (Rebased onto `main` now that #641 is merged.)

## What changed

- New **"Card lookup"** tab: type a card name → its **image beside its facts** (type, mana cost as Scryfall symbols, mana value, rarity, colour identity) + a *View on Scryfall* link.
- **`CubeWebService.card(name)`** — fuzzy lookup via Scryfall `/cards/named?fuzzy=`. The per-node mapping is factored into a reusable **`cardOf()`** (now also used by `parseScryfall`) plus a `lookupView()` that resolves rarity/colours to display strings.
- **`GET /cube/api/card`** (added to the security `permitAll`, like the other cube APIs).
- `cube.js`: `cardUrl` + `renderCardLookup` + `wireCardLookup`; `card` joins `TABS` and `NO_SHARED_SOURCE` (its own input, not the shared "Your cube" source). `cube.css` for the image-beside-facts layout.

## Tests

- web: `CubeWebService` `cardOf` + `lookupView` mapping; `CubeController` `card` endpoint (200 + 400).
- jest: `cardUrl` encoding, `renderCardLookup` (image / facts / mana symbols / Scryfall link, colourless case), and the `#card` tab hash.
- `:web:test`, `:web:koverVerify`, jest (707) and stylelint pass.

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs