### PR TITLE
Feature the MTG cube workshop on the homepage

### DIFF
--- a/web/src/main/resources/templates/home.html
+++ b/web/src/main/resources/templates/home.html
@@ -251,6 +251,14 @@
         <h2 id="tabletop-title">Sundries that earn their keep</h2>
     </header>
     <div class="feature-grid">
+        <a class="feature-card" href="/cube" data-reveal>
+            <div class="feature-icon">&#127183;</div>
+            <h3>MTG cube workshop</h3>
+            <p>Build a balanced Magic: The Gathering draft from a Scryfall search or your own list &mdash;
+                preview its colour, curve, type &amp; rarity balance, deal randomised packs, compare two
+                lists, or look up any card. Save &amp; share cubes when signed in.</p>
+            <span class="feature-card-tag">New</span>
+        </a>
         <a class="feature-card" href="/dnd" data-reveal>
             <div class="feature-icon">&#127922;</div>
             <h3>D&amp;D lookups</h3>

--- a/web/src/test/kotlin/web/static/HomeFeatureCardsTemplateTest.kt
+++ b/web/src/test/kotlin/web/static/HomeFeatureCardsTemplateTest.kt
@@ -128,6 +128,33 @@ class HomeFeatureCardsTemplateTest {
     }
 
     @Test
+    fun `magic cube card is present in the tabletop and tools section`() {
+        // The MTG cube workshop (/cube) is a substantial tool — workshop,
+        // the cube report, compare, card lookup — but was only reachable
+        // from the navbar. Pin a discoverable feature card next to the
+        // D&D / Utilities cluster it belongs with.
+        assertTrue(
+            html.contains("<h3>MTG cube workshop</h3>"),
+            "home.html must include an `<h3>MTG cube workshop</h3>` feature-card heading " +
+                "so the Magic cube tooling is discoverable from the landing page."
+        )
+        assertTrue(
+            html.contains("href=\"/cube\""),
+            "the MTG cube feature-card must link to `/cube` — the cube workshop page."
+        )
+        val tabletopMarker = html.indexOf(">Tabletop &amp; Tools<")
+        val ctaMarker = html.indexOf("Ready to add")
+        val cubeMarker = html.indexOf("<h3>MTG cube workshop</h3>")
+        check(tabletopMarker >= 0) { "expected a `>Tabletop &amp; Tools<` section eyebrow on home.html" }
+        check(ctaMarker >= 0) { "expected the final CTA on home.html" }
+        assertTrue(
+            cubeMarker in (tabletopMarker + 1) until ctaMarker,
+            "the MTG cube card must sit inside the Tabletop & Tools section, " +
+                "grouped with D&D lookups and Utilities."
+        )
+    }
+
+    @Test
     fun `how-it-works step 1 mentions the in-Discord install wizard`() {
         // PR #534 shipped the /install wizard. The "How it works"
         // first step used to imply admins set everything via slash


### PR DESCRIPTION
## Why

The `/cube` tooling grew into a substantial feature — the workshop, the cube report (curve / types / rarity / colour-pair / pip balance), Compare, and card lookup — but was only reachable from the navbar, invisible from the landing page.

## What changed

- A **"MTG cube workshop"** feature card in the homepage's **Tabletop & Tools** section (next to D&D lookups and Utilities), linking to `/cube`, with a "New" tag — matching the existing card style.
- A `HomeFeatureCardsTemplateTest` case pinning it (heading present, links to `/cube`, and sits inside the Tabletop & Tools section), following the same convention that already guards the Achievements / Notifications / Welcome / Profile cards.

Template + test only. `:web:test` passes.

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs

---
_Generated by [Claude Code](https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs)_