### PR TITLE
Harden the cube feature after an audit pass

### DIFF
--- a/common/src/test/kotlin/common/mtg/CardTypeTest.kt
+++ b/common/src/test/kotlin/common/mtg/CardTypeTest.kt
@@ -46,6 +46,13 @@ class CardTypeTest {
     fun `unknown or empty type lines fall through to Other`() {
         assertEquals(CardType.OTHER, CardType.of(""))
         assertEquals(CardType.OTHER, CardType.of("Tribal — Goblin"))
+        assertEquals(CardType.OTHER, CardType.of("Kindred — Goblin")) // the renamed "Tribal"
         assertEquals(CardType.OTHER, CardType.of("Plane — Mirrodin"))
+    }
+
+    @Test
+    fun `a Kindred card with a real body still classifies by that body`() {
+        assertEquals(CardType.CREATURE, CardType.of("Kindred Creature — Elf"))
+        assertEquals(CardType.INSTANT, CardType.of("Kindred Instant — Arcane"))
     }
 }

--- a/common/src/test/kotlin/common/mtg/CubeAnalyticsTest.kt
+++ b/common/src/test/kotlin/common/mtg/CubeAnalyticsTest.kt
@@ -158,13 +158,15 @@ class CubeAnalyticsTest {
             card("Teferi", colors = setOf(MtgColor.WHITE, MtgColor.BLUE)),
             card("Dovin", colors = setOf(MtgColor.WHITE, MtgColor.BLUE)),
             card("Hadana", colors = setOf(MtgColor.GREEN, MtgColor.BLUE)), // Simic
+            // A dual land counts toward its pair — it's fixing for that archetype.
+            card("Hallowed Fountain", typeLine = "Land — Plains Island", colors = setOf(MtgColor.WHITE, MtgColor.BLUE)),
             card("Bolt", colors = setOf(MtgColor.RED)), // mono — ignored
             card("Niv", colors = MtgColor.entries.toSet()), // 5c — ignored
         )
         val pairs = CubeAnalytics.colorPairs(pool)
         // Codes are WUBRG-canonical, so Simic {G,U} renders as "UG".
         assertEquals(listOf("Azorius (WU)", "Simic (UG)"), pairs.map { it.pair }) // guild order
-        assertEquals(2, pairs.first { it.pair.startsWith("Azorius") }.count)
+        assertEquals(3, pairs.first { it.pair.startsWith("Azorius") }.count) // 2 spells + the dual land
     }
 
     // --- colour pips ---------------------------------------------------
@@ -181,10 +183,23 @@ class CubeAnalyticsTest {
         )
         val pips = CubeAnalytics.colorPips(pool).associate { it.color to it.count }
         assertEquals(3, pips["White"]) // WW + hybrid W
-        assertEquals(2, pips["Blue"]) // B's U + hybrid U
+        assertEquals(2, pips["Blue"]) // U from card B + U from the hybrid
         assertEquals(1, pips["Black"])
         assertEquals(1, pips["Red"])
         assertEquals(null, pips["Green"]) // absent → not listed
+    }
+
+    @Test
+    fun `colorPips ignores generic, colourless, snow, variable and two-brid generic`() {
+        val pool = listOf(
+            card("Genericish", manaCost = "{2}{C}{S}{X}{W}"), // only the W is a coloured pip
+            card("Twobrid", manaCost = "{2/W}{2/U}"),         // two-brid → the W and U halves count
+        )
+        val pips = CubeAnalytics.colorPips(pool).associate { it.color to it.count }
+        assertEquals(2, pips["White"]) // {W} + {2/W}
+        assertEquals(1, pips["Blue"]) // {2/U}
+        assertEquals(null, pips["Black"])
+        assertEquals(null, pips["Green"])
     }
 
     @Test

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeEmbedsTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeEmbedsTest.kt
@@ -76,6 +76,26 @@ class CubeEmbedsTest {
     }
 
     @Test
+    fun `previewEmbed stays within Discord's 25-field limit when fully loaded`() {
+        // A pool that fires every conditional field: curve, types, rarity,
+        // colour pairs, colour pips, duplicates — plus a notFound list.
+        val pool = listOf(
+            card("Teferi", "Creature", 3.0, "rare", colors = setOf(MtgColor.WHITE, MtgColor.BLUE), manaCost = "{1}{W}{U}"),
+            card("Teferi", "Creature", 3.0, "rare", colors = setOf(MtgColor.WHITE, MtgColor.BLUE), manaCost = "{1}{W}{U}"),
+            card("Bolt", "Instant", 1.0, "common", colors = setOf(MtgColor.RED), manaCost = "{R}"),
+            card("Forest", "Basic Land — Forest", 0.0, "common", land = true),
+        )
+        val embed = CubeEmbeds.previewEmbed(
+            query = "q", poolSize = pool.size, packSize = 5,
+            counts = AsFan.categoryCounts(pool), distribution = AsFan.distribution(pool, 5),
+            analytics = CubeAnalytics.analyze(pool, 5), notFound = listOf("Missing One"),
+        )
+        assertTrue(embed.fields.size <= 25, "previewEmbed emitted ${embed.fields.size} fields (Discord caps at 25)")
+        assertTrue(embed.fields.any { it.name == "Colour pairs" })
+        assertTrue(embed.fields.any { it.name == "Colour pips" })
+    }
+
+    @Test
     fun `previewEmbed shows a duplicates field only when a non-basic repeats`() {
         val singleton = listOf(
             card("Sol Ring", "Artifact", 1.0, "uncommon"),

--- a/web/src/main/kotlin/web/service/CubeWebService.kt
+++ b/web/src/main/kotlin/web/service/CubeWebService.kt
@@ -96,6 +96,7 @@ class CubeWebService {
      * removed and count-changed cards. Pure: no Scryfall, so it's instant.
      */
     fun diff(listA: String, listB: String): CubeResult<DiffData> {
+        if (listA.length > MAX_LIST_LENGTH || listB.length > MAX_LIST_LENGTH) return CubeResult.error(TOO_LARGE)
         val a = CardListParser.parse(listA)
         val b = CardListParser.parse(listB)
         if (a.isEmpty() && b.isEmpty()) return CubeResult.error("Paste a card list into both sides to compare.")
@@ -388,6 +389,7 @@ class CubeWebService {
      * don't resolve are reported in [ResolvedPool.notFound].
      */
     private fun resolveList(text: String): CubeResult<ResolvedPool> {
+        if (text.length > MAX_LIST_LENGTH) return CubeResult.error(TOO_LARGE)
         val entries = parseList(text)
         if (entries.isEmpty()) return CubeResult.error("Paste at least one card name, one per line.")
 
@@ -477,6 +479,12 @@ class CubeWebService {
         const val MAX_CARDS = 750
         const val MAX_PAGES = 10
         const val COLLECTION_BATCH = 75
+
+        // Bound pasted-list text on the compute endpoints (preview / generate /
+        // diff) the way the controller already bounds saved/shared text, so an
+        // unauthenticated POST can't force a huge parse/allocation.
+        const val MAX_LIST_LENGTH = 100_000
+        const val TOO_LARGE = "That list is too large (max 100,000 characters)."
     }
 }
 

--- a/web/src/test/js/cube.test.js
+++ b/web/src/test/js/cube.test.js
@@ -627,6 +627,12 @@ describe('manaSymbolUrls', () => {
         expect(Cube.manaSymbolUrls(null)).toEqual([]);
         expect(Cube.manaSymbolUrls('')).toEqual([]);
     });
+
+    test('ignores an unterminated brace rather than throwing', () => {
+        expect(Cube.manaSymbolUrls('{R')).toEqual([]); // no closing brace → no match
+        // A trailing unterminated token is dropped; the valid ones still parse.
+        expect(Cube.manaSymbolUrls('{W}{U}{B').map((u) => u.symbol)).toEqual(['{W}', '{U}']);
+    });
 });
 
 describe('cardTile enrichments (via renderGroups)', () => {

--- a/web/src/test/kotlin/web/service/CubeWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/CubeWebServiceTest.kt
@@ -94,6 +94,15 @@ class CubeWebServiceTest {
         assertInstanceOf(CubeResult.Failure::class.java, service.diff("", "   "))
     }
 
+    @Test
+    fun `diff and previewList reject an oversized list without parsing it`() {
+        val huge = "a\n".repeat(60_000) // > 100k chars
+        val diff = service.diff(huge, "Bolt") as CubeResult.Failure
+        assertTrue(diff.error.contains("too large"))
+        val preview = service.previewList(huge, 15) as CubeResult.Failure
+        assertTrue(preview.error.contains("too large"))
+    }
+
     // --- asFan ---------------------------------------------------------
 
     @Test


### PR DESCRIPTION
## Why

A read-only audit of the whole cube feature (shared domain, web, Discord) for bugs and missing tests. **No correctness bugs were found** — the algorithms (`CubeAnalytics`, `CubeDiff`, `CardType`, `Rarity`, pack/as-fan maths) all check out. The one real gap was a missing input bound; the rest is edge-case coverage worth pinning.

## What changed

**Fix — DoS hardening**
- The compute POST endpoints — `previewList`, `generateList`, **and** `/api/diff` — accepted **unbounded** list text, unlike save/share which cap at 100k chars (`MAX_CARDS_LENGTH`, added in #624). An unauthenticated POST could force a huge parse/allocation. Added a shared `MAX_LIST_LENGTH` (100k) guard in `CubeWebService` that rejects oversized input *before* parsing. (The audit flagged `/api/diff`; the gap actually spanned all three compute endpoints, so I closed it consistently.)

**Tests (lock in audit-verified behaviour)**
- `previewEmbed` stays within Discord's **25-field** limit when fully loaded (all conditional report fields + notFound).
- `manaSymbolUrls` tolerates unterminated braces (`{R`, `{W}{U}{B`).
- `colorPips` ignores generic / colourless `{C}` / snow `{S}` / variable `{X}` / two-brid-generic (`{2/W}` counts only the W).
- `colorPairs` counts a **dual land** toward its guild.
- `CardType` handles `Kindred` (alone → OTHER; `Kindred Creature` → CREATURE).
- Corrected a misleading comment in the pip test.

**Verified as non-issues** (audit flagged, already sound): `renderCardLookup` is null-safe for colours; `handleCard` already has happy/not-found tests; web⇄Discord mana-cost parsing is consistent; `/cube/api/**` POSTs are CSRF-exempt; all JS DOM writes use `textContent` (no XSS); HTTP calls have 10s timeouts.

## Verification

`:common:test` `:web:test` `:discord-bot:test`, all three kover gates, jest (**709**) and stylelint pass.

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs

---
_Generated by [Claude Code](https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs)_