### PR TITLE
Richer, configurable card lookups: oracle text, DFC backs, opt-out toggle

### DIFF
--- a/common/src/main/kotlin/common/mtg/CubeCard.kt
+++ b/common/src/main/kotlin/common/mtg/CubeCard.kt
@@ -65,6 +65,17 @@ data class CubeCard(
      * colour balance — so this stays a dumb value type.
      */
     val manaCost: String? = null,
+    /**
+     * The card's rules text (Scryfall `oracle_text`), or null. Presentation-
+     * only — shown on a card lookup / `[[mention]]`, ignored by the maths.
+     * For a double-faced card both faces are combined.
+     */
+    val oracleText: String? = null,
+    /**
+     * The back-face image for a double-faced card (Scryfall second face
+     * `image_uris.normal`), or null for single-faced cards. Presentation-only.
+     */
+    val imageUrlBack: String? = null,
 ) {
     /** Which as-fan bucket this card falls into. Lands first, then by colour count. */
     val category: CardCategory

--- a/database/src/main/kotlin/database/dto/guild/ConfigDto.kt
+++ b/database/src/main/kotlin/database/dto/guild/ConfigDto.kt
@@ -33,6 +33,9 @@ class ConfigDto(
         VOLUME("DEFAULT_VOLUME"),
         MOVE("DEFAULT_MOVE_CHANNEL"),
         DELETE_DELAY("DELETE_MESSAGE_DELAY"),
+        // Inline [[card]] Magic lookups. Opt-out: enabled unless explicitly
+        // set to "false" for the guild.
+        CARD_MENTIONS("CARD_MENTIONS"),
         LEADERBOARD_CHANNEL("LEADERBOARD_CHANNEL"),
         // Per-guild UTC hour (0-23) at which MonthlyLeaderboardJob posts the
         // monthly leaderboard on the 1st of the month. Defaults to 12 (noon

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
@@ -186,19 +186,25 @@ internal object CubeEmbeds {
         card.imageUrl?.let { setImage(it) }
         val colours = if (card.colors.isEmpty()) "Colourless"
         else MtgColor.entries.filter { it in card.colors }.joinToString(", ") { it.displayName }
-        setDescription(
-            buildList {
-                if (card.typeLine.isNotBlank()) add("**Type** · ${card.typeLine}")
-                add("**Mana value** · ${formatMv(card.manaValue)}")
-                card.rarity?.let { add("**Rarity** · ${Rarity.parse(it).displayName}") }
-                add("**Colour identity** · $colours")
-            }.joinToString("\n")
-        )
+        val facts = buildList {
+            if (card.typeLine.isNotBlank()) add("**Type** · ${card.typeLine}")
+            add("**Mana value** · ${formatMv(card.manaValue)}")
+            card.rarity?.let { add("**Rarity** · ${Rarity.parse(it).displayName}") }
+            add("**Colour identity** · $colours")
+        }.joinToString("\n")
+        val oracle = card.oracleText?.let { "\n\n${oracleBlock(it)}" }.orEmpty()
+        setDescription(facts + oracle)
     }
 
     /** Mana value without a trailing `.0` (whole numbers are the norm). */
     private fun formatMv(mv: Double): String =
         if (mv % 1.0 == 0.0) mv.toInt().toString() else format(mv)
+
+    /** Oracle rules text, trimmed to stay well within an embed description. */
+    fun oracleBlock(oracleText: String): String =
+        if (oracleText.length <= ORACLE_LIMIT) oracleText else oracleText.take(ORACLE_LIMIT).trimEnd() + "…"
+
+    private const val ORACLE_LIMIT = 1500
 
     /** A `category — count (as-fan)` table, in colour-pie order, present buckets only. */
     private fun distributionTable(

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcher.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcher.kt
@@ -230,7 +230,32 @@ class ScryfallCubeFetcher @Autowired constructor(
             imageUrl = imageUrl(card),
             rarity = card.get("rarity")?.asString?.takeIf { it.isNotBlank() },
             manaCost = manaCost(card),
+            oracleText = oracleText(card),
+            imageUrlBack = backImageUrl(card),
         )
+    }
+
+    /**
+     * The card's rules text, or null. Single-faced cards carry `oracle_text`
+     * directly; double-faced cards put it on each face, so both are combined
+     * with their face names.
+     */
+    fun oracleText(card: JsonObject): String? {
+        card.get("oracle_text")?.asString?.takeIf { it.isNotBlank() }?.let { return it }
+        val faces = card.getAsJsonArray("card_faces") ?: return null
+        val parts = faces.mapNotNull { face ->
+            val obj = face.asJsonObject
+            val text = obj.get("oracle_text")?.asString?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+            obj.get("name")?.asString?.let { "**$it**\n$text" } ?: text
+        }
+        return parts.joinToString("\n\n").takeIf { it.isNotBlank() }
+    }
+
+    /** The back-face `normal` image for a double-faced card, or null. */
+    fun backImageUrl(card: JsonObject): String? {
+        val faces = card.getAsJsonArray("card_faces") ?: return null
+        if (faces.size() < 2) return null
+        return faces[1].asJsonObject.getAsJsonObject("image_uris")?.get("normal")?.asString?.takeIf { it.isNotBlank() }
     }
 
     /**

--- a/discord-bot/src/main/kotlin/bot/toby/handler/CardMentionListener.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/handler/CardMentionListener.kt
@@ -1,11 +1,14 @@
 package bot.toby.handler
 
+import bot.toby.command.commands.mtg.CubeEmbeds
 import bot.toby.command.commands.mtg.ScryfallCubeFetcher
 import common.discord.embed
 import common.logging.DiscordLogger
 import common.mtg.CubeCard
 import common.mtg.MtgColor
 import common.mtg.Rarity
+import database.dto.guild.ConfigDto
+import database.service.guild.ConfigService
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -19,18 +22,19 @@ import java.awt.Color
 
 /**
  * Inline Magic card lookups: when a message contains `[[Card Name]]` markers,
- * resolve each on Scryfall and reply with the card images. This is the
- * feature most MTG Discord communities install a bot for — it works in any
- * channel with no slash command.
+ * resolve each on Scryfall and reply with the card images, rules text and a
+ * back face for double-faced cards. This is the feature most MTG communities
+ * install a bot for — it works in any channel with no slash command.
  *
- * Resolution is fuzzy (handles partial/approximate names), capped per message
- * so a wall of brackets can't spam the channel, and runs on [Dispatchers.IO]
- * so the gateway thread is never blocked. Names that don't resolve are
- * silently skipped.
+ * Resolution is fuzzy (handles partial names), capped per message so a wall
+ * of brackets can't spam the channel, and runs on [Dispatchers.IO]. A guild
+ * can turn it off via the [ConfigDto.Configurations.CARD_MENTIONS] config
+ * (opt-out: on unless explicitly set to "false").
  */
 @Service
 class CardMentionListener @Autowired constructor(
     private val fetcher: ScryfallCubeFetcher,
+    private val configService: ConfigService,
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : ListenerAdapter() {
 
@@ -38,29 +42,45 @@ class CardMentionListener @Autowired constructor(
 
     override fun onMessageReceived(event: MessageReceivedEvent) {
         if (event.author.isBot || event.isWebhookMessage) return
+        if (event.isFromGuild && !mentionsEnabled(event.guild.idLong)) return
         val names = cardMentions(event.message.contentRaw)
         if (names.isEmpty()) return
         CoroutineScope(dispatcher).launch {
             runCatching {
-                val embeds = names.mapNotNull { name -> fetcher.fetchNamed(name)?.let(::cardEmbed) }
+                val embeds = names.mapNotNull { fetcher.fetchNamed(it) }
+                    .flatMap(::cardEmbeds)
+                    .take(MAX_EMBEDS)
                 if (embeds.isNotEmpty()) event.channel.sendMessageEmbeds(embeds).queue()
             }.onFailure { logger.error("Card-mention lookup failed: $it") }
         }
     }
 
-    /** A compact card panel: the image plus a one-line set of facts. */
-    private fun cardEmbed(card: CubeCard): MessageEmbed = embed(color = GOLD) {
-        setTitle(card.name)
-        card.imageUrl?.let { setImage(it) }
+    /** False only when the guild has explicitly disabled card mentions. */
+    private fun mentionsEnabled(guildId: Long): Boolean =
+        configService.getConfigByName(ConfigDto.Configurations.CARD_MENTIONS.configValue, guildId.toString())
+            ?.value?.lowercase() != "false"
+
+    /** The front-face panel, plus a back-face image embed for a double-faced card. */
+    private fun cardEmbeds(card: CubeCard): List<MessageEmbed> {
         val colours = if (card.colors.isEmpty()) "Colourless"
         else MtgColor.entries.filter { it in card.colors }.joinToString(", ") { it.displayName }
-        setDescription(
-            buildList {
+        val front = embed(color = GOLD) {
+            setTitle(card.name)
+            card.imageUrl?.let { setImage(it) }
+            val facts = buildList {
                 if (card.typeLine.isNotBlank()) add("**Type** · ${card.typeLine}")
                 card.rarity?.let { add("**Rarity** · ${Rarity.parse(it).displayName}") }
                 add("**Colour identity** · $colours")
             }.joinToString("\n")
-        )
+            setDescription(facts + (card.oracleText?.let { "\n\n${CubeEmbeds.oracleBlock(it)}" }.orEmpty()))
+        }
+        val back = card.imageUrlBack?.let { url ->
+            embed(color = GOLD) {
+                setTitle("${card.name} (back)")
+                setImage(url)
+            }
+        }
+        return listOfNotNull(front, back)
     }
 
     companion object {
@@ -70,6 +90,9 @@ class CardMentionListener @Autowired constructor(
 
         /** Max cards resolved from one message, so a bracket-wall can't spam. */
         const val MAX_CARDS = 5
+
+        /** Discord caps a message at 10 embeds (a DFC contributes two). */
+        const val MAX_EMBEDS = 10
 
         /** The distinct, non-blank `[[name]]` mentions in a message, capped at [MAX_CARDS]. */
         fun cardMentions(content: String): List<String> =

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeEmbedsTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeEmbedsTest.kt
@@ -134,6 +134,7 @@ class CubeEmbedsTest {
             manaValue = 1.0,
             imageUrl = "https://img/ragavan.jpg",
             rarity = "mythic",
+            oracleText = "Whenever Ragavan deals combat damage, create a Treasure.",
         )
         val embed = CubeEmbeds.cardEmbed(card)
 
@@ -144,6 +145,7 @@ class CubeEmbedsTest {
         assertTrue(desc.contains("Mana value** · 1"), "MV without trailing .0: $desc")
         assertTrue(desc.contains("Rarity** · Mythic"))
         assertTrue(desc.contains("Colour identity** · Red"))
+        assertTrue(desc.contains("create a Treasure"), "oracle text shown: $desc")
     }
 
     @Test

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcherTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcherTest.kt
@@ -125,6 +125,26 @@ class ScryfallCubeFetcherTest {
     }
 
     @Test
+    fun `parseCard reads oracle text and the back-face image`() {
+        val single = fetcher.parseCard(
+            obj("""{"name":"Bolt","color_identity":["R"],"type_line":"Instant","oracle_text":"Deals 3 damage."}""")
+        )!!
+        assertEquals("Deals 3 damage.", single.oracleText)
+        assertEquals(null, single.imageUrlBack)
+
+        val dfc = fetcher.parseCard(
+            obj("""{"name":"Delver // Aberration","color_identity":["U"],"type_line":"Creature","oracle_text":"",
+               "card_faces":[
+                 {"name":"Delver of Secrets","oracle_text":"Look at the top card.","image_uris":{"normal":"front.jpg"}},
+                 {"name":"Insectile Aberration","oracle_text":"Flying.","image_uris":{"normal":"back.jpg"}}]}""")
+        )!!
+        // Both faces' text combined, each headed by its face name.
+        assertTrue(dfc.oracleText!!.contains("Look at the top card."))
+        assertTrue(dfc.oracleText!!.contains("Insectile Aberration"))
+        assertEquals("back.jpg", dfc.imageUrlBack)
+    }
+
+    @Test
     fun `parseCard treats a card with no colour identity as colourless`() {
         val card = fetcher.parseCard(obj("""{"name":"Sol Ring","color_identity":[],"type_line":"Artifact"}"""))!!
         assertEquals(CardCategory.COLORLESS, card.category)

--- a/discord-bot/src/test/kotlin/bot/toby/handler/CardMentionListenerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/handler/CardMentionListenerTest.kt
@@ -3,6 +3,8 @@ package bot.toby.handler
 import bot.toby.command.commands.mtg.ScryfallCubeFetcher
 import common.mtg.CubeCard
 import common.mtg.MtgColor
+import database.dto.guild.ConfigDto
+import database.service.guild.ConfigService
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -12,22 +14,26 @@ import kotlinx.coroutines.Dispatchers
 import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class CardMentionListenerTest {
 
     private lateinit var fetcher: ScryfallCubeFetcher
+    private lateinit var configService: ConfigService
     private lateinit var listener: CardMentionListener
     private lateinit var event: MessageReceivedEvent
 
     @BeforeEach
     fun setUp() {
         fetcher = mockk()
-        listener = CardMentionListener(fetcher, Dispatchers.Unconfined)
+        configService = mockk(relaxed = true) // null config → feature enabled (opt-out)
+        listener = CardMentionListener(fetcher, configService, Dispatchers.Unconfined)
         event = mockk(relaxed = true)
         every { event.author.isBot } returns false
         every { event.isWebhookMessage } returns false
+        every { event.isFromGuild } returns false // most tests don't need a guild config
     }
 
     private fun message(content: String) = every { event.message.contentRaw } returns content
@@ -90,5 +96,55 @@ class CardMentionListenerTest {
         coEvery { fetcher.fetchNamed("Notacard") } returns null
         listener.onMessageReceived(event)
         verify(exactly = 0) { event.channel.sendMessageEmbeds(any<Collection<MessageEmbed>>()) }
+    }
+
+    @Test
+    fun `a card-mention embed includes the oracle rules text`() {
+        message("[[Lightning Bolt]]")
+        coEvery { fetcher.fetchNamed("Lightning Bolt") } returns CubeCard(
+            "Lightning Bolt", setOf(MtgColor.RED), typeLine = "Instant", manaValue = 1.0,
+            imageUrl = "https://img/bolt.jpg", rarity = "common", oracleText = "Lightning Bolt deals 3 damage to any target.",
+        )
+
+        listener.onMessageReceived(event)
+
+        val captured = mutableListOf<Collection<MessageEmbed>>()
+        verify { event.channel.sendMessageEmbeds(capture(captured)) }
+        val embeds = captured.first().toList()
+        assertEquals(1, embeds.size)
+        assertTrue(embeds[0].description!!.contains("deals 3 damage"))
+    }
+
+    @Test
+    fun `a double-faced card mention adds a second embed for the back face`() {
+        message("[[Delver of Secrets]]")
+        coEvery { fetcher.fetchNamed("Delver of Secrets") } returns CubeCard(
+            "Delver of Secrets // Insectile Aberration", setOf(MtgColor.BLUE), typeLine = "Creature",
+            manaValue = 1.0, imageUrl = "https://img/front.jpg", imageUrlBack = "https://img/back.jpg",
+        )
+
+        listener.onMessageReceived(event)
+
+        val captured = mutableListOf<Collection<MessageEmbed>>()
+        verify { event.channel.sendMessageEmbeds(capture(captured)) }
+        val embeds = captured.first().toList()
+        assertEquals(2, embeds.size)
+        assertEquals("https://img/front.jpg", embeds[0].image?.url)
+        assertTrue(embeds[1].title!!.contains("(back)"))
+        assertEquals("https://img/back.jpg", embeds[1].image?.url)
+    }
+
+    @Test
+    fun `a guild that turned card mentions off gets no lookup`() {
+        every { event.isFromGuild } returns true
+        every { event.guild.idLong } returns 123L
+        every {
+            configService.getConfigByName(ConfigDto.Configurations.CARD_MENTIONS.configValue, "123")
+        } returns mockk { every { value } returns "false" }
+        message("[[Lightning Bolt]]")
+
+        listener.onMessageReceived(event)
+
+        coVerify(exactly = 0) { fetcher.fetchNamed(any()) }
     }
 }

--- a/web/src/main/kotlin/web/service/CubeWebService.kt
+++ b/web/src/main/kotlin/web/service/CubeWebService.kt
@@ -89,6 +89,7 @@ class CubeWebService {
         manaCost = sc.card.manaCost,
         rarity = sc.card.rarity?.let { Rarity.parse(it).displayName },
         colors = MtgColor.entries.filter { it in sc.card.colors }.map { it.displayName },
+        oracleText = sc.card.oracleText,
     )
 
     /**
@@ -275,6 +276,8 @@ class CubeWebService {
                 manaValue = node.path("cmc").asDouble(0.0),
                 rarity = node.path("rarity").asText("").takeIf { it.isNotBlank() },
                 manaCost = manaCostOf(node),
+                oracleText = oracleTextOf(node),
+                imageUrlBack = backImageOf(node),
             ),
             imageUrl = imageOf(node, "small"),
             imageUrlLarge = imageOf(node, "normal"),
@@ -324,6 +327,22 @@ class CubeWebService {
             faces[0].path("mana_cost").asText("").takeIf { it.isNotBlank() }?.let { return it }
         }
         return null
+    }
+
+    /**
+     * The card's rules text, or null. Single-faced cards carry `oracle_text`
+     * directly; double-faced cards put it on each face, combined with the
+     * face names.
+     */
+    private fun oracleTextOf(node: JsonNode): String? {
+        node.path("oracle_text").asText("").takeIf { it.isNotBlank() }?.let { return it }
+        val faces = node.path("card_faces")
+        if (!faces.isArray) return null
+        val parts = faces.mapNotNull { face ->
+            val text = face.path("oracle_text").asText("").takeIf { it.isNotBlank() } ?: return@mapNotNull null
+            face.path("name").asText("").takeIf { it.isNotBlank() }?.let { "$it\n$text" } ?: text
+        }
+        return parts.joinToString("\n\n").takeIf { it.isNotBlank() }
     }
 
     private fun fetchPool(query: String): CubeResult<List<ScryfallCard>> {
@@ -580,6 +599,7 @@ data class CardLookupView(
     val manaCost: String?,
     val rarity: String?,
     val colors: List<String>,
+    val oracleText: String? = null,
 )
 
 /** One card's change between two compared lists (copy counts from → to). */

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -817,7 +817,8 @@ class ModerationWebService(
                 }
                 id
             }
-            ConfigDto.Configurations.ACTIVITY_TRACKING -> {
+            ConfigDto.Configurations.ACTIVITY_TRACKING,
+            ConfigDto.Configurations.CARD_MENTIONS -> {
                 val v = rawValue.trim().lowercase()
                 if (v != "true" && v != "false") return "Value must be true or false."
                 v

--- a/web/src/main/resources/static/css/cube.css
+++ b/web/src/main/resources/static/css/cube.css
@@ -1239,6 +1239,17 @@ details[open] > .cube-section-summary .cube-collapse-chevron {
     flex-wrap: wrap;
 }
 
+.cube-cardlookup-oracle {
+    margin: var(--space-2) 0 0;
+    padding: var(--space-2) var(--space-3);
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    font-size: 0.88rem;
+    line-height: 1.45;
+    white-space: pre-wrap;
+}
+
 .cube-cardlookup-link {
     align-self: start;
     margin-top: var(--space-2);

--- a/web/src/main/resources/static/js/cube.js
+++ b/web/src/main/resources/static/js/cube.js
@@ -423,6 +423,14 @@
         fact('Rarity', card.rarity);
         fact('Colour identity', (card.colors && card.colors.length) ? card.colors.join(', ') : 'Colourless');
 
+        if (card.oracleText) {
+            const oracle = document.createElement('p');
+            oracle.className = 'cube-cardlookup-oracle';
+            // Oracle text carries real newlines (and DFC face breaks); keep them.
+            oracle.textContent = card.oracleText;
+            facts.appendChild(oracle);
+        }
+
         const link = document.createElement('a');
         link.className = 'btn btn-secondary cube-cardlookup-link';
         link.href = scryfallCardUrl(card.name);

--- a/web/src/main/resources/templates/moderation/settings.html
+++ b/web/src/main/resources/templates/moderation/settings.html
@@ -122,6 +122,22 @@
                 <details id="settings-section-messages" class="config-section">
                     <summary>Messages &amp; leaderboards</summary>
                     <div class="config-grid">
+                        <!-- Opt-out: inline [[card]] lookups are on unless explicitly
+                             set to "false", so a null/absent value reads as Enabled. -->
+                        <div class="config-row" data-key="CARD_MENTIONS">
+                            <label>Inline [[card]] Magic lookups</label>
+                            <select th:disabled="${!isOwner}">
+                                <option value="true"
+                                        th:selected="${overview.config['CARD_MENTIONS'] == null or overview.config['CARD_MENTIONS'] == 'true'}">
+                                    Enabled
+                                </option>
+                                <option value="false"
+                                        th:selected="${overview.config['CARD_MENTIONS'] == 'false'}">
+                                    Disabled
+                                </option>
+                            </select>
+                            <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                        </div>
                         <div class="config-row" data-key="DELETE_DELAY">
                             <label>Message delete delay (seconds)</label>
                             <input type="number" min="0" max="600"

--- a/web/src/test/js/cube.test.js
+++ b/web/src/test/js/cube.test.js
@@ -399,6 +399,7 @@ describe('card lookup (cardUrl / renderCardLookup)', () => {
             imageUrl: 's.jpg', imageUrlLarge: 'n.jpg',
             typeLine: 'Legendary Creature — Monkey Pirate',
             manaValue: 1, manaCost: '{R}', rarity: 'Mythic', colors: ['Red'],
+            oracleText: 'Whenever Ragavan deals combat damage, create a Treasure.',
         });
         expect(container.querySelector('.cube-cardlookup-img').getAttribute('src')).toBe('n.jpg');
         expect(container.querySelector('h3').textContent).toBe('Ragavan, Nimble Pilferer');
@@ -406,6 +407,7 @@ describe('card lookup (cardUrl / renderCardLookup)', () => {
         expect(text).toContain('Legendary Creature — Monkey Pirate');
         expect(text).toContain('Mythic');
         expect(text).toContain('Red');
+        expect(container.querySelector('.cube-cardlookup-oracle').textContent).toContain('create a Treasure');
         // The mana cost renders as a Scryfall symbol image.
         expect(container.querySelector('.cube-mana-symbol').getAttribute('src')).toBe('https://svgs.scryfall.io/card-symbols/R.svg');
         expect(container.querySelector('.cube-cardlookup-link').getAttribute('href')).toBe(Cube.scryfallCardUrl('Ragavan, Nimble Pilferer'));

--- a/web/src/test/kotlin/web/service/CubeWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/CubeWebServiceTest.kt
@@ -63,6 +63,7 @@ class CubeWebServiceTest {
         val node = mapper.readTree(
             """{"name":"Ragavan, Nimble Pilferer","color_identity":["R"],
                "type_line":"Legendary Creature — Monkey Pirate","cmc":1.0,"mana_cost":"{R}","rarity":"mythic",
+               "oracle_text":"Whenever Ragavan deals combat damage, create a Treasure.",
                "image_uris":{"small":"s.jpg","normal":"n.jpg"}}"""
         )
         val view = service.lookupView(service.cardOf(node)!!)
@@ -72,6 +73,7 @@ class CubeWebServiceTest {
         assertEquals("Mythic", view.rarity)
         assertEquals(listOf("Red"), view.colors)
         assertEquals("Legendary Creature — Monkey Pirate", view.typeLine)
+        assertTrue(view.oracleText!!.contains("create a Treasure"))
     }
 
     // --- diff (compare two lists) --------------------------------------


### PR DESCRIPTION
## Why

The three follow-ons you picked, building on the `[[card]]` mentions (#645):

1. **Richer card panels** — oracle (rules) text on every card surface.
2. **Per-server `[[card]]` toggle** — opt-out for servers that don't want it.
4. **DFC back faces** in chat mentions.

## What changed

**Oracle text (#1)** — `CubeCard` gains `oracleText` (double-faced cards' faces combined with their names). Both Scryfall parsers (`ScryfallCubeFetcher.parseCard`, web `CubeWebService.cardOf`) read `oracle_text`. Shown on inline `[[mentions]]`, `/cube card` (`CubeEmbeds.cardEmbed`), and the web **Card lookup** tab (`renderCardLookup`, in a pre-wrapped block) — turning "image + facts" into a full readout. Trimmed to stay within Discord's embed limits.

**DFC backs in chat (#4)** — `CubeCard` gains `imageUrlBack` (parsed from the second face). A `[[mention]]` of a double-faced card now posts a **second embed** with the back image. Total embeds per message capped at 10 (Discord's limit).

**Per-server toggle (#2)** — a new `CARD_MENTIONS` config key (**opt-out**: enabled unless explicitly `"false"`). `CardMentionListener` checks it per guild; `ModerationWebService.updateConfig` validates true/false; a row is added to the moderation **settings** page (default Enabled), satisfying the template-rows guard test.

## Tests

- common/discord: `parseCard` oracle + back image (single & DFC), `cardOf`/`lookupView` oracle.
- Discord: `CubeEmbeds.cardEmbed` oracle; `CardMentionListener` — oracle in the embed, a DFC's second back embed, and the disabled-guild gate (no lookup).
- web: `lookupView` oracle; jest `renderCardLookup` oracle block.
- `:common:test` `:discord-bot:test` `:web:test`, all kover gates, jest (**708**) and stylelint pass.

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs

---
_Generated by [Claude Code](https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs)_