### PR TITLE
Add card prices, format legality and cube value to the MTG tools

### DIFF
--- a/common/src/main/kotlin/common/mtg/CubeAnalytics.kt
+++ b/common/src/main/kotlin/common/mtg/CubeAnalytics.kt
@@ -30,6 +30,9 @@ object CubeAnalytics {
     /** Coloured mana pips of one colour across the whole cube (the true colour weight). */
     data class ColorPipCount(val color: String, val count: Int)
 
+    /** The cube's summed market value in one [MtgCurrency]. */
+    data class TotalValue(val currency: MtgCurrency, val amount: Double)
+
     /** The whole report, assembled once so the surfaces render identical numbers. */
     data class Analytics(
         val curve: List<ManaCurveBucket>,
@@ -40,9 +43,13 @@ object CubeAnalytics {
         val duplicates: List<Duplicate>,
         val colorPairs: List<ColorPairCount>,
         val colorPips: List<ColorPipCount>,
-        /** Sum of the priced cards' USD value, or null when none are priced. */
-        val totalValueUsd: Double?,
-    )
+        /** Summed market value per currency, present only for currencies something in the pool is priced in. */
+        val totalValues: List<TotalValue>,
+    ) {
+        /** The cube's total value in [currency], or null when nothing in the pool is priced in it. */
+        fun totalValueIn(currency: MtgCurrency): Double? =
+            totalValues.firstOrNull { it.currency == currency }?.amount
+    }
 
     /** The highest mana-value bucket; everything at or above it folds into "7+". */
     const val CURVE_TOP = 7
@@ -72,12 +79,21 @@ object CubeAnalytics {
         duplicates = duplicates(cards),
         colorPairs = colorPairs(cards),
         colorPips = colorPips(cards),
-        totalValueUsd = totalValueUsd(cards),
+        totalValues = totalValues(cards),
     )
 
-    /** Sum of the priced cards' USD value, or null when none of the pool is priced. */
-    fun totalValueUsd(cards: List<CubeCard>): Double? =
-        cards.mapNotNull { it.priceUsd?.toDoubleOrNull() }.takeIf { it.isNotEmpty() }?.sum()
+    /**
+     * The cube's summed market value in each [MtgCurrency], in enum order,
+     * including only currencies at least one card in the pool is priced in
+     * (so a cube with no MTGO prices simply omits the tix total).
+     */
+    fun totalValues(cards: List<CubeCard>): List<TotalValue> =
+        MtgCurrency.entries.mapNotNull { currency ->
+            cards.mapNotNull { it.price(currency)?.toDoubleOrNull() }
+                .takeIf { it.isNotEmpty() }
+                ?.sum()
+                ?.let { TotalValue(currency, it) }
+        }
 
     /**
      * Two-colour cards grouped by guild, in guild order, present pairs only —

--- a/common/src/main/kotlin/common/mtg/CubeAnalytics.kt
+++ b/common/src/main/kotlin/common/mtg/CubeAnalytics.kt
@@ -40,6 +40,8 @@ object CubeAnalytics {
         val duplicates: List<Duplicate>,
         val colorPairs: List<ColorPairCount>,
         val colorPips: List<ColorPipCount>,
+        /** Sum of the priced cards' USD value, or null when none are priced. */
+        val totalValueUsd: Double?,
     )
 
     /** The highest mana-value bucket; everything at or above it folds into "7+". */
@@ -70,7 +72,12 @@ object CubeAnalytics {
         duplicates = duplicates(cards),
         colorPairs = colorPairs(cards),
         colorPips = colorPips(cards),
+        totalValueUsd = totalValueUsd(cards),
     )
+
+    /** Sum of the priced cards' USD value, or null when none of the pool is priced. */
+    fun totalValueUsd(cards: List<CubeCard>): Double? =
+        cards.mapNotNull { it.priceUsd?.toDoubleOrNull() }.takeIf { it.isNotEmpty() }?.sum()
 
     /**
      * Two-colour cards grouped by guild, in guild order, present pairs only —

--- a/common/src/main/kotlin/common/mtg/CubeCard.kt
+++ b/common/src/main/kotlin/common/mtg/CubeCard.kt
@@ -96,6 +96,13 @@ data class CubeCard(
             else -> CardCategory.ofColor(colors.first())
         }
 
+    /** This card's raw price string in [currency] (e.g. "1.50"), or null when unpriced. */
+    fun price(currency: MtgCurrency): String? = when (currency) {
+        MtgCurrency.USD -> priceUsd
+        MtgCurrency.EUR -> priceEur
+        MtgCurrency.TIX -> priceTix
+    }
+
     companion object {
         /**
          * Play formats surfaced on a card panel, as `scryfall key to Display`,

--- a/common/src/main/kotlin/common/mtg/CubeCard.kt
+++ b/common/src/main/kotlin/common/mtg/CubeCard.kt
@@ -76,6 +76,16 @@ data class CubeCard(
      * `image_uris.normal`), or null for single-faced cards. Presentation-only.
      */
     val imageUrlBack: String? = null,
+    /** Scryfall market prices (raw strings, e.g. "1.50"), or null when unpriced. Presentation-only. */
+    val priceUsd: String? = null,
+    val priceEur: String? = null,
+    val priceTix: String? = null,
+    /**
+     * The play formats this card is currently legal in (Scryfall `legalities`
+     * entries with status "legal"), display-cased, in [CubeCard.FORMATS] order.
+     * Presentation-only.
+     */
+    val legalFormats: List<String> = emptyList(),
 ) {
     /** Which as-fan bucket this card falls into. Lands first, then by colour count. */
     val category: CardCategory
@@ -87,6 +97,25 @@ data class CubeCard(
         }
 
     companion object {
+        /**
+         * Play formats surfaced on a card panel, as `scryfall key to Display`,
+         * in the order shown. Both parsers map Scryfall `legalities` through
+         * this so the bot and web list the same formats consistently.
+         */
+        val FORMATS: List<Pair<String, String>> = listOf(
+            "standard" to "Standard",
+            "pioneer" to "Pioneer",
+            "modern" to "Modern",
+            "legacy" to "Legacy",
+            "vintage" to "Vintage",
+            "pauper" to "Pauper",
+            "commander" to "Commander",
+        )
+
+        /** The display-cased formats this card is legal in, from a Scryfall `legalities` map (key→status). */
+        fun legalFormatsOf(statusByFormat: (String) -> String?): List<String> =
+            FORMATS.filter { (key, _) -> statusByFormat(key) == "legal" }.map { it.second }
+
         /**
          * Whether a Scryfall `type_line` denotes a land, judged by the
          * **front face** only. A modal/transform card's combined type line

--- a/common/src/main/kotlin/common/mtg/MtgCurrency.kt
+++ b/common/src/main/kotlin/common/mtg/MtgCurrency.kt
@@ -1,0 +1,25 @@
+package common.mtg
+
+/**
+ * The market currencies Scryfall prices cards in. [code] matches the key in
+ * Scryfall's `prices` object (and the `CubeCard` price field it maps to);
+ * [symbol] / [suffix] format an amount (`$1.50`, `€1.50`, `1.50 tix`).
+ * Shared so the bot's "cube value" field, the web toggle, and the per-guild
+ * `CUBE_CURRENCY` config all agree on the same set and spelling.
+ */
+enum class MtgCurrency(val code: String, val display: String, val symbol: String, val suffix: String) {
+    USD("usd", "USD", "$", ""),
+    EUR("eur", "EUR", "€", ""),
+    TIX("tix", "Tix", "", " tix");
+
+    companion object {
+        /** The currency used when a guild hasn't picked one. */
+        val DEFAULT: MtgCurrency = USD
+
+        /** Resolves a stored config value (a [code] or [display]) to a currency, or null. */
+        fun fromCode(value: String?): MtgCurrency? {
+            val v = value?.trim() ?: return null
+            return entries.firstOrNull { it.code.equals(v, ignoreCase = true) || it.display.equals(v, ignoreCase = true) }
+        }
+    }
+}

--- a/common/src/test/kotlin/common/mtg/CubeAnalyticsTest.kt
+++ b/common/src/test/kotlin/common/mtg/CubeAnalyticsTest.kt
@@ -14,6 +14,8 @@ class CubeAnalyticsTest {
         colors: Set<MtgColor> = emptySet(),
         manaCost: String? = null,
         priceUsd: String? = null,
+        priceEur: String? = null,
+        priceTix: String? = null,
     ) = CubeCard(
         name = name,
         colors = colors,
@@ -23,6 +25,8 @@ class CubeAnalyticsTest {
         rarity = rarity,
         manaCost = manaCost,
         priceUsd = priceUsd,
+        priceEur = priceEur,
+        priceTix = priceTix,
     )
 
     // --- mana curve ----------------------------------------------------
@@ -210,24 +214,42 @@ class CubeAnalyticsTest {
         assertEquals(listOf("White", "Red", "Green"), CubeAnalytics.colorPips(pool).map { it.color })
     }
 
-    // --- total value ---------------------------------------------------
+    // --- total value (per currency) ------------------------------------
 
     @Test
-    fun `totalValueUsd sums priced cards and ignores unpriced or unparseable ones`() {
+    fun `totalValues sums each currency, ignoring unpriced or unparseable cards`() {
         val pool = listOf(
-            card("A", priceUsd = "1.50"),
-            card("B", priceUsd = "2.25"),
+            card("A", priceUsd = "1.50", priceEur = "1.20", priceTix = "0.03"),
+            card("B", priceUsd = "2.25", priceEur = "2.00"),
             card("C", priceUsd = null),      // unpriced — ignored
             card("D", priceUsd = ""),        // blank — ignored
             card("E", priceUsd = "n/a"),     // not a number — ignored
         )
-        assertEquals(3.75, CubeAnalytics.totalValueUsd(pool)!!, 1e-9)
+        val totals = CubeAnalytics.totalValues(pool).associate { it.currency to it.amount }
+        assertEquals(3.75, totals[MtgCurrency.USD]!!, 1e-9)
+        assertEquals(3.20, totals[MtgCurrency.EUR]!!, 1e-9)
+        assertEquals(0.03, totals[MtgCurrency.TIX]!!, 1e-9)
     }
 
     @Test
-    fun `totalValueUsd is null when nothing in the pool is priced`() {
+    fun `totalValues lists currencies in enum order, omitting unpriced currencies`() {
+        // Only EUR is priced here, so USD and Tix are absent entirely.
+        val pool = listOf(card("A", priceEur = "5.00"))
+        val totals = CubeAnalytics.totalValues(pool)
+        assertEquals(listOf(MtgCurrency.EUR), totals.map { it.currency })
+    }
+
+    @Test
+    fun `totalValues is empty when nothing in the pool is priced`() {
         val pool = listOf(card("A"), card("B", priceUsd = ""))
-        assertEquals(null, CubeAnalytics.totalValueUsd(pool))
+        assertTrue(CubeAnalytics.totalValues(pool).isEmpty())
+    }
+
+    @Test
+    fun `Analytics totalValueIn resolves a currency or returns null`() {
+        val a = CubeAnalytics.analyze(listOf(card("A", priceUsd = "4.00")), packSize = 1)
+        assertEquals(4.00, a.totalValueIn(MtgCurrency.USD)!!, 1e-9)
+        assertEquals(null, a.totalValueIn(MtgCurrency.EUR))
     }
 
     // --- analyze (aggregate) -------------------------------------------
@@ -245,16 +267,18 @@ class CubeAnalyticsTest {
         assertEquals(1.5, a.averageManaValue, 1e-9)
         assertEquals(setOf("Creature", "Instant", "Land"), a.types.map { it.type.displayName }.toSet())
         assertTrue(a.duplicates.isEmpty())
-        assertEquals(null, a.totalValueUsd) // none of these cards carry a price
+        assertTrue(a.totalValues.isEmpty()) // none of these cards carry a price
     }
 
     @Test
-    fun `analyze carries the total USD value when cards are priced`() {
+    fun `analyze carries the per-currency totals when cards are priced`() {
         val pool = listOf(
-            card("Bolt", "Instant", 1.0, priceUsd = "2.00"),
-            card("Bear", "Creature — Bear", 2.0, priceUsd = "0.50"),
+            card("Bolt", "Instant", 1.0, priceUsd = "2.00", priceEur = "1.50"),
+            card("Bear", "Creature — Bear", 2.0, priceUsd = "0.50", priceEur = "0.40"),
         )
-        assertEquals(2.50, CubeAnalytics.analyze(pool, packSize = 2).totalValueUsd!!, 1e-9)
+        val a = CubeAnalytics.analyze(pool, packSize = 2)
+        assertEquals(2.50, a.totalValueIn(MtgCurrency.USD)!!, 1e-9)
+        assertEquals(1.90, a.totalValueIn(MtgCurrency.EUR)!!, 1e-9)
     }
 
     @Test
@@ -269,6 +293,6 @@ class CubeAnalyticsTest {
         assertTrue(a.colorPips.isEmpty())
         assertEquals(8, a.curve.size) // still the eight empty buckets
         assertTrue(a.curve.all { it.count == 0 })
-        assertEquals(null, a.totalValueUsd)
+        assertTrue(a.totalValues.isEmpty())
     }
 }

--- a/common/src/test/kotlin/common/mtg/CubeAnalyticsTest.kt
+++ b/common/src/test/kotlin/common/mtg/CubeAnalyticsTest.kt
@@ -13,6 +13,7 @@ class CubeAnalyticsTest {
         rarity: String? = "common",
         colors: Set<MtgColor> = emptySet(),
         manaCost: String? = null,
+        priceUsd: String? = null,
     ) = CubeCard(
         name = name,
         colors = colors,
@@ -21,6 +22,7 @@ class CubeAnalyticsTest {
         manaValue = manaValue,
         rarity = rarity,
         manaCost = manaCost,
+        priceUsd = priceUsd,
     )
 
     // --- mana curve ----------------------------------------------------
@@ -208,6 +210,26 @@ class CubeAnalyticsTest {
         assertEquals(listOf("White", "Red", "Green"), CubeAnalytics.colorPips(pool).map { it.color })
     }
 
+    // --- total value ---------------------------------------------------
+
+    @Test
+    fun `totalValueUsd sums priced cards and ignores unpriced or unparseable ones`() {
+        val pool = listOf(
+            card("A", priceUsd = "1.50"),
+            card("B", priceUsd = "2.25"),
+            card("C", priceUsd = null),      // unpriced — ignored
+            card("D", priceUsd = ""),        // blank — ignored
+            card("E", priceUsd = "n/a"),     // not a number — ignored
+        )
+        assertEquals(3.75, CubeAnalytics.totalValueUsd(pool)!!, 1e-9)
+    }
+
+    @Test
+    fun `totalValueUsd is null when nothing in the pool is priced`() {
+        val pool = listOf(card("A"), card("B", priceUsd = ""))
+        assertEquals(null, CubeAnalytics.totalValueUsd(pool))
+    }
+
     // --- analyze (aggregate) -------------------------------------------
 
     @Test
@@ -223,6 +245,16 @@ class CubeAnalyticsTest {
         assertEquals(1.5, a.averageManaValue, 1e-9)
         assertEquals(setOf("Creature", "Instant", "Land"), a.types.map { it.type.displayName }.toSet())
         assertTrue(a.duplicates.isEmpty())
+        assertEquals(null, a.totalValueUsd) // none of these cards carry a price
+    }
+
+    @Test
+    fun `analyze carries the total USD value when cards are priced`() {
+        val pool = listOf(
+            card("Bolt", "Instant", 1.0, priceUsd = "2.00"),
+            card("Bear", "Creature — Bear", 2.0, priceUsd = "0.50"),
+        )
+        assertEquals(2.50, CubeAnalytics.analyze(pool, packSize = 2).totalValueUsd!!, 1e-9)
     }
 
     @Test
@@ -237,5 +269,6 @@ class CubeAnalyticsTest {
         assertTrue(a.colorPips.isEmpty())
         assertEquals(8, a.curve.size) // still the eight empty buckets
         assertTrue(a.curve.all { it.count == 0 })
+        assertEquals(null, a.totalValueUsd)
     }
 }

--- a/common/src/test/kotlin/common/mtg/CubeCardTest.kt
+++ b/common/src/test/kotlin/common/mtg/CubeCardTest.kt
@@ -83,6 +83,18 @@ class CubeCardTest {
     }
 
     @Test
+    fun `price returns the field for each currency`() {
+        val card = CubeCard(name = "X", priceUsd = "1.50", priceEur = "1.20", priceTix = "0.03")
+        assertEquals("1.50", card.price(MtgCurrency.USD))
+        assertEquals("1.20", card.price(MtgCurrency.EUR))
+        assertEquals("0.03", card.price(MtgCurrency.TIX))
+        val bare = CubeCard(name = "Y")
+        assertEquals(null, bare.price(MtgCurrency.USD))
+        assertEquals(null, bare.price(MtgCurrency.EUR))
+        assertEquals(null, bare.price(MtgCurrency.TIX))
+    }
+
+    @Test
     fun `legalFormatsOf keeps only legal formats, display-cased, in FORMATS order`() {
         val status = mapOf(
             "standard" to "not_legal",

--- a/common/src/test/kotlin/common/mtg/CubeCardTest.kt
+++ b/common/src/test/kotlin/common/mtg/CubeCardTest.kt
@@ -63,6 +63,46 @@ class CubeCardTest {
     }
 
     @Test
+    fun `prices and legalFormats default empty and round-trip when set`() {
+        val plain = CubeCard(name = "Placeholder")
+        assertEquals(null, plain.priceUsd)
+        assertEquals(null, plain.priceEur)
+        assertEquals(null, plain.priceTix)
+        assertTrue(plain.legalFormats.isEmpty())
+        val card = CubeCard(
+            name = "Ragavan",
+            priceUsd = "60.00",
+            priceEur = "55.50",
+            priceTix = "12.0",
+            legalFormats = listOf("Modern", "Legacy"),
+        )
+        assertEquals("60.00", card.priceUsd)
+        assertEquals("55.50", card.priceEur)
+        assertEquals("12.0", card.priceTix)
+        assertEquals(listOf("Modern", "Legacy"), card.legalFormats)
+    }
+
+    @Test
+    fun `legalFormatsOf keeps only legal formats, display-cased, in FORMATS order`() {
+        val status = mapOf(
+            "standard" to "not_legal",
+            "modern" to "legal",
+            "legacy" to "legal",
+            "vintage" to "restricted",
+            "commander" to "legal",
+            "pauper" to "banned",
+        )
+        // FORMATS order is standard, pioneer, modern, legacy, vintage, pauper, commander.
+        assertEquals(listOf("Modern", "Legacy", "Commander"), CubeCard.legalFormatsOf { status[it] })
+    }
+
+    @Test
+    fun `legalFormatsOf is empty when nothing is legal or the map is unknown`() {
+        assertTrue(CubeCard.legalFormatsOf { null }.isEmpty())
+        assertTrue(CubeCard.legalFormatsOf { "banned" }.isEmpty())
+    }
+
+    @Test
     fun `mono-coloured card maps to its colour bucket`() {
         assertEquals(
             CardCategory.RED,

--- a/common/src/test/kotlin/common/mtg/MtgCurrencyTest.kt
+++ b/common/src/test/kotlin/common/mtg/MtgCurrencyTest.kt
@@ -1,0 +1,37 @@
+package common.mtg
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class MtgCurrencyTest {
+
+    @Test
+    fun `default currency is USD`() {
+        assertEquals(MtgCurrency.USD, MtgCurrency.DEFAULT)
+    }
+
+    @Test
+    fun `fromCode resolves a code or display name, case-insensitively`() {
+        assertEquals(MtgCurrency.USD, MtgCurrency.fromCode("usd"))
+        assertEquals(MtgCurrency.EUR, MtgCurrency.fromCode("EUR"))
+        assertEquals(MtgCurrency.TIX, MtgCurrency.fromCode("  Tix  "))
+        // Display names resolve too, so a stored "USD" reads back.
+        assertEquals(MtgCurrency.USD, MtgCurrency.fromCode("USD"))
+    }
+
+    @Test
+    fun `fromCode returns null for unknown, blank or null input`() {
+        assertNull(MtgCurrency.fromCode("gbp"))
+        assertNull(MtgCurrency.fromCode(""))
+        assertNull(MtgCurrency.fromCode(null))
+    }
+
+    @Test
+    fun `symbol and suffix format each currency distinctly`() {
+        assertEquals("$", MtgCurrency.USD.symbol)
+        assertEquals("", MtgCurrency.USD.suffix)
+        assertEquals("€", MtgCurrency.EUR.symbol)
+        assertEquals(" tix", MtgCurrency.TIX.suffix)
+    }
+}

--- a/database/src/main/kotlin/database/dto/guild/ConfigDto.kt
+++ b/database/src/main/kotlin/database/dto/guild/ConfigDto.kt
@@ -36,6 +36,10 @@ class ConfigDto(
         // Inline [[card]] Magic lookups. Opt-out: enabled unless explicitly
         // set to "false" for the guild.
         CARD_MENTIONS("CARD_MENTIONS"),
+        // Currency the /cube preview's "cube value" total is reported in.
+        // One of "usd", "eur" or "tix" (see common.mtg.MtgCurrency). Defaults
+        // to USD when unset or unrecognised.
+        CUBE_CURRENCY("CUBE_CURRENCY"),
         LEADERBOARD_CHANNEL("LEADERBOARD_CHANNEL"),
         // Per-guild UTC hour (0-23) at which MonthlyLeaderboardJob posts the
         // monthly leaderboard on the 1st of the month. Defaults to 12 (noon

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeCommand.kt
@@ -7,11 +7,14 @@ import common.mtg.AsFan
 import common.mtg.CardListParser
 import common.mtg.CubeAnalytics
 import common.mtg.CubeCard
+import common.mtg.MtgCurrency
 import common.mtg.MtgNames
 import common.mtg.PackGenerator
 import core.command.Command.Companion.invokeDeleteOnMessageResponse
 import core.command.CommandContext
+import database.dto.guild.ConfigDto
 import database.dto.user.UserDto
+import database.service.guild.ConfigService
 import database.service.user.CubeListService
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -47,6 +50,7 @@ import kotlin.random.Random
 class CubeCommand @Autowired constructor(
     private val fetcher: ScryfallCubeFetcher,
     private val cubeListService: CubeListService,
+    private val configService: ConfigService,
     // Mirrors the /dnd command: IO-bound subcommands run on this dispatcher
     // (tests pass Dispatchers.Unconfined so the launched work resolves
     // synchronously).
@@ -144,6 +148,16 @@ class CubeCommand @Autowired constructor(
         }
     }
 
+    /**
+     * The currency this guild's "cube value" is reported in — its
+     * [ConfigDto.Configurations.CUBE_CURRENCY] config, or [MtgCurrency.DEFAULT]
+     * (USD) when unset or unrecognised.
+     */
+    private fun currencyFor(ctx: CommandContext): MtgCurrency =
+        MtgCurrency.fromCode(
+            configService.getConfigByName(ConfigDto.Configurations.CUBE_CURRENCY.configValue, ctx.guild.id)?.value
+        ) ?: MtgCurrency.DEFAULT
+
     /** A user-facing note when the pool was truncated to the Scryfall fetch ceiling. */
     private fun capNote(capped: Boolean): String? =
         if (capped) "Matched more than ${ScryfallCubeFetcher.DEFAULT_MAX_CARDS} cards; only the first ${ScryfallCubeFetcher.DEFAULT_MAX_CARDS} were used."
@@ -177,6 +191,7 @@ class CubeCommand @Autowired constructor(
                     analytics = CubeAnalytics.analyze(pool, packSize),
                     notFound = resolved.notFound,
                     note = resolved.note,
+                    currency = currencyFor(ctx),
                 )
                 reply(ctx, embed, deleteDelay)
             }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
@@ -7,6 +7,7 @@ import common.mtg.CardListParser
 import common.mtg.CubeAnalytics
 import common.mtg.CubeCard
 import common.mtg.MtgColor
+import common.mtg.MtgCurrency
 import common.mtg.Rarity
 import database.dto.user.CubeListDto
 import net.dv8tion.jda.api.entities.MessageEmbed
@@ -51,6 +52,7 @@ internal object CubeEmbeds {
         analytics: CubeAnalytics.Analytics,
         notFound: List<String> = emptyList(),
         note: String? = null,
+        currency: MtgCurrency = MtgCurrency.DEFAULT,
     ): MessageEmbed = embed(color = OK_COLOR) {
         setAuthor(AUTHOR)
         setTitle("Cube preview")
@@ -65,7 +67,7 @@ internal object CubeEmbeds {
         field("Rarity", rarityTable(analytics.rarities), inline = false)
         if (analytics.colorPairs.isNotEmpty()) field("Colour pairs", pairTable(analytics.colorPairs), inline = false)
         if (analytics.colorPips.isNotEmpty()) field("Colour pips", pipTable(analytics.colorPips), inline = false)
-        analytics.totalValueUsd?.let { field("Cube value", "≈ $${format(it)} (priced cards, USD)", inline = false) }
+        cubeValue(analytics, currency)?.let { field("Cube value", it, inline = false) }
         addDuplicatesField(analytics.duplicates)
         addNotFoundField(notFound)
     }
@@ -197,6 +199,20 @@ internal object CubeEmbeds {
         }.joinToString("\n")
         val oracle = card.oracleText?.let { "\n\n${oracleBlock(it)}" }.orEmpty()
         setDescription(facts + oracle)
+    }
+
+    /**
+     * The cube's total value line in the requested [currency]
+     * (`≈ $123.45 (priced cards, USD)`), falling back to the first currency
+     * anything in the pool is priced in when the chosen one has no prices, or
+     * null when nothing in the pool is priced at all.
+     */
+    fun cubeValue(analytics: CubeAnalytics.Analytics, currency: MtgCurrency): String? {
+        val total = analytics.totalValueIn(currency)?.let { currency to it }
+            ?: analytics.totalValues.firstOrNull()?.let { it.currency to it.amount }
+            ?: return null
+        val (cur, amount) = total
+        return "≈ ${cur.symbol}${format(amount)}${cur.suffix} (priced cards, ${cur.display})"
     }
 
     /**

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
@@ -65,6 +65,7 @@ internal object CubeEmbeds {
         field("Rarity", rarityTable(analytics.rarities), inline = false)
         if (analytics.colorPairs.isNotEmpty()) field("Colour pairs", pairTable(analytics.colorPairs), inline = false)
         if (analytics.colorPips.isNotEmpty()) field("Colour pips", pipTable(analytics.colorPips), inline = false)
+        analytics.totalValueUsd?.let { field("Cube value", "≈ $${format(it)} (priced cards, USD)", inline = false) }
         addDuplicatesField(analytics.duplicates)
         addNotFoundField(notFound)
     }
@@ -191,10 +192,22 @@ internal object CubeEmbeds {
             add("**Mana value** · ${formatMv(card.manaValue)}")
             card.rarity?.let { add("**Rarity** · ${Rarity.parse(it).displayName}") }
             add("**Colour identity** · $colours")
+            priceLine(card)?.let { add("**Price** · $it") }
+            if (card.legalFormats.isNotEmpty()) add("**Legal** · ${card.legalFormats.joinToString(", ")}")
         }.joinToString("\n")
         val oracle = card.oracleText?.let { "\n\n${oracleBlock(it)}" }.orEmpty()
         setDescription(facts + oracle)
     }
+
+    /**
+     * The card's market prices as a compact one-liner (`$1.50 · €1.20 · 0.03 tix`),
+     * present currencies only, or null when Scryfall has no price for it.
+     */
+    fun priceLine(card: CubeCard): String? = buildList {
+        card.priceUsd?.let { add("$$it") }
+        card.priceEur?.let { add("€$it") }
+        card.priceTix?.let { add("$it tix") }
+    }.takeIf { it.isNotEmpty() }?.joinToString(" · ")
 
     /** Mana value without a trailing `.0` (whole numbers are the norm). */
     private fun formatMv(mv: Double): String =

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcher.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcher.kt
@@ -232,8 +232,18 @@ class ScryfallCubeFetcher @Autowired constructor(
             manaCost = manaCost(card),
             oracleText = oracleText(card),
             imageUrlBack = backImageUrl(card),
+            priceUsd = price(card, "usd"),
+            priceEur = price(card, "eur"),
+            priceTix = price(card, "tix"),
+            legalFormats = CubeCard.legalFormatsOf { fmt ->
+                card.getAsJsonObject("legalities")?.get(fmt)?.asString
+            },
         )
     }
+
+    /** A Scryfall `prices` entry (e.g. "usd"), or null when absent/blank. */
+    fun price(card: JsonObject, key: String): String? =
+        card.getAsJsonObject("prices")?.get(key)?.takeIf { !it.isJsonNull }?.asString?.takeIf { it.isNotBlank() }
 
     /**
      * The card's rules text, or null. Single-faced cards carry `oracle_text`

--- a/discord-bot/src/main/kotlin/bot/toby/handler/CardMentionListener.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/handler/CardMentionListener.kt
@@ -71,6 +71,8 @@ class CardMentionListener @Autowired constructor(
                 if (card.typeLine.isNotBlank()) add("**Type** · ${card.typeLine}")
                 card.rarity?.let { add("**Rarity** · ${Rarity.parse(it).displayName}") }
                 add("**Colour identity** · $colours")
+                CubeEmbeds.priceLine(card)?.let { add("**Price** · $it") }
+                if (card.legalFormats.isNotEmpty()) add("**Legal** · ${card.legalFormats.joinToString(", ")}")
             }.joinToString("\n")
             setDescription(facts + (card.oracleText?.let { "\n\n${CubeEmbeds.oracleBlock(it)}" }.orEmpty()))
         }

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeCommandTest.kt
@@ -32,6 +32,7 @@ class CubeCommandTest : CommandTest {
 
     private lateinit var fetcher: ScryfallCubeFetcher
     private lateinit var cubeListService: CubeListService
+    private lateinit var configService: database.service.guild.ConfigService
     private lateinit var command: CubeCommand
 
     @BeforeEach
@@ -39,8 +40,9 @@ class CubeCommandTest : CommandTest {
         setUpCommonMocks()
         fetcher = mockk()
         cubeListService = mockk(relaxed = true)
+        configService = mockk(relaxed = true) // null config → USD default
         // Unconfined so the launched IO coroutine resolves synchronously in tests.
-        command = CubeCommand(fetcher, cubeListService, Dispatchers.Unconfined)
+        command = CubeCommand(fetcher, cubeListService, configService, Dispatchers.Unconfined)
         every { requestingUserDto.discordId } returns 100L
         every { webhookMessageCreateAction.addFiles(any<FileUpload>()) } returns webhookMessageCreateAction
         every { webhookMessageCreateAction.queue() } just runs
@@ -106,6 +108,29 @@ class CubeCommandTest : CommandTest {
         // The cube report is wired in: the analytics fields ride along.
         assertTrue(slot.captured.fields.any { it.name == "Card types" })
         coVerify(exactly = 1) { fetcher.fetch(any(), any()) }
+    }
+
+    @Test
+    fun `preview reports the cube value in the guild's configured currency`() {
+        val slot = slot<MessageEmbed>()
+        every { event.hook.sendMessageEmbeds(capture(slot), *anyVararg()) } returns webhookMessageCreateAction
+        every { event.subcommandName } returns CubeCommand.SUB_PREVIEW
+        every { event.getOption(CubeCommand.OPT_QUERY) } returns strOpt("set:vow")
+        every { event.getOption(CubeCommand.OPT_PACK_SIZE) } returns null
+        // Guild has CUBE_CURRENCY = eur (guild id "1" from CommandTest mocks).
+        every {
+            configService.getConfigByName("CUBE_CURRENCY", "1")
+        } returns mockk { every { value } returns "eur" }
+        val priced = listOf(
+            CubeCard("Bolt", setOf(MtgColor.RED), priceUsd = "2.00", priceEur = "1.50"),
+            CubeCard("Bear", setOf(MtgColor.GREEN), priceUsd = "0.50", priceEur = "0.40"),
+        )
+        coEvery { fetcher.fetch(any(), any()) } returns ScryfallCubeFetcher.Result.Success(priced)
+
+        run()
+
+        val value = slot.captured.fields.first { it.name == "Cube value" }.value!!
+        assertTrue(value.contains("€1.90"), "expected EUR total, got: $value")
     }
 
     @Test

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeEmbedsTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeEmbedsTest.kt
@@ -23,16 +23,23 @@ class CubeEmbedsTest {
         colors: Set<MtgColor> = emptySet(),
         manaCost: String? = null,
         priceUsd: String? = null,
-    ) = CubeCard(name = name, colors = colors, isLand = land, typeLine = typeLine, manaValue = mv, rarity = rarity, manaCost = manaCost, priceUsd = priceUsd)
-
-    private fun preview(pool: List<CubeCard>, packSize: Int = 5) = CubeEmbeds.previewEmbed(
-        query = "test",
-        poolSize = pool.size,
-        packSize = packSize,
-        counts = AsFan.categoryCounts(pool),
-        distribution = AsFan.distribution(pool, packSize),
-        analytics = CubeAnalytics.analyze(pool, packSize),
+        priceEur: String? = null,
+        priceTix: String? = null,
+    ) = CubeCard(
+        name = name, colors = colors, isLand = land, typeLine = typeLine, manaValue = mv, rarity = rarity,
+        manaCost = manaCost, priceUsd = priceUsd, priceEur = priceEur, priceTix = priceTix,
     )
+
+    private fun preview(pool: List<CubeCard>, packSize: Int = 5, currency: common.mtg.MtgCurrency = common.mtg.MtgCurrency.USD) =
+        CubeEmbeds.previewEmbed(
+            query = "test",
+            poolSize = pool.size,
+            packSize = packSize,
+            counts = AsFan.categoryCounts(pool),
+            distribution = AsFan.distribution(pool, packSize),
+            analytics = CubeAnalytics.analyze(pool, packSize),
+            currency = currency,
+        )
 
     private fun field(embed: net.dv8tion.jda.api.entities.MessageEmbed, name: String) =
         embed.fields.firstOrNull { it.name == name }
@@ -191,16 +198,44 @@ class CubeEmbedsTest {
     }
 
     @Test
-    fun `previewEmbed shows the cube's total USD value only when cards are priced`() {
+    fun `previewEmbed shows the cube's total value only when cards are priced`() {
         val priced = listOf(
             card("Bolt", "Instant", 1.0, "common", priceUsd = "2.00"),
             card("Bear", "Creature — Bear", 2.0, "common", priceUsd = "0.50"),
         )
         val value = field(preview(priced), "Cube value")
         assertNotNull(value)
-        assertTrue(value!!.value!!.contains("2.50"), "total value: ${value.value}")
+        assertTrue(value!!.value!!.contains("$2.50"), "total value: ${value.value}")
+        assertTrue(value.value!!.contains("USD"))
 
         assertNull(field(preview(listOf(card("Token", "Token", 0.0, null))), "Cube value"))
+    }
+
+    @Test
+    fun `previewEmbed reports the cube value in the requested currency`() {
+        val priced = listOf(
+            card("Bolt", "Instant", 1.0, "common", priceUsd = "2.00", priceEur = "1.50", priceTix = "0.10"),
+            card("Bear", "Creature — Bear", 2.0, "common", priceUsd = "0.50", priceEur = "0.40", priceTix = "0.02"),
+        )
+        val eur = field(preview(priced, currency = common.mtg.MtgCurrency.EUR), "Cube value")!!.value!!
+        assertTrue(eur.contains("€1.90"), "EUR total: $eur")
+        assertTrue(eur.contains("EUR"))
+
+        val tix = field(preview(priced, currency = common.mtg.MtgCurrency.TIX), "Cube value")!!.value!!
+        assertTrue(tix.contains("0.12 tix"), "Tix total: $tix")
+    }
+
+    @Test
+    fun `cubeValue falls back to an available currency when the chosen one is unpriced`() {
+        // Only USD prices exist, but the guild's default is EUR: show USD rather than nothing.
+        val analytics = CubeAnalytics.analyze(listOf(card("Bolt", "Instant", 1.0, "common", priceUsd = "3.00")), 1)
+        val line = CubeEmbeds.cubeValue(analytics, common.mtg.MtgCurrency.EUR)
+        assertNotNull(line)
+        assertTrue(line!!.contains("$3.00"), "fallback line: $line")
+        assertTrue(line.contains("USD"))
+
+        // Nothing priced at all → no line regardless of currency.
+        assertNull(CubeEmbeds.cubeValue(CubeAnalytics.analyze(listOf(card("Token", "Token", 0.0, null)), 1), common.mtg.MtgCurrency.USD))
     }
 
     @Test

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeEmbedsTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeEmbedsTest.kt
@@ -22,7 +22,8 @@ class CubeEmbedsTest {
         land: Boolean = false,
         colors: Set<MtgColor> = emptySet(),
         manaCost: String? = null,
-    ) = CubeCard(name = name, colors = colors, isLand = land, typeLine = typeLine, manaValue = mv, rarity = rarity, manaCost = manaCost)
+        priceUsd: String? = null,
+    ) = CubeCard(name = name, colors = colors, isLand = land, typeLine = typeLine, manaValue = mv, rarity = rarity, manaCost = manaCost, priceUsd = priceUsd)
 
     private fun preview(pool: List<CubeCard>, packSize: Int = 5) = CubeEmbeds.previewEmbed(
         query = "test",
@@ -154,6 +155,52 @@ class CubeEmbedsTest {
         val desc = CubeEmbeds.cardEmbed(card).description!!
         assertTrue(desc.contains("Colour identity** · Colourless"))
         assertFalse(desc.contains("Rarity"))
+    }
+
+    @Test
+    fun `cardEmbed shows price and legality when present, omits them otherwise`() {
+        val priced = CubeCard(
+            name = "Ragavan, Nimble Pilferer",
+            colors = setOf(MtgColor.RED),
+            typeLine = "Legendary Creature — Monkey Pirate",
+            manaValue = 1.0,
+            rarity = "mythic",
+            priceUsd = "60.00",
+            priceEur = "55.50",
+            priceTix = "12.00",
+            legalFormats = listOf("Modern", "Legacy"),
+        )
+        val desc = CubeEmbeds.cardEmbed(priced).description!!
+        assertTrue(desc.contains("Price** · \$60.00 · €55.50 · 12.00 tix"), "price line: $desc")
+        assertTrue(desc.contains("Legal** · Modern, Legacy"), "legal line: $desc")
+
+        val bare = CubeCard(name = "Token", typeLine = "Token", manaValue = 0.0)
+        val bareDesc = CubeEmbeds.cardEmbed(bare).description!!
+        assertFalse(bareDesc.contains("Price"))
+        assertFalse(bareDesc.contains("Legal"))
+    }
+
+    @Test
+    fun `priceLine joins present currencies only and is null when unpriced`() {
+        assertEquals("\$1.50", CubeEmbeds.priceLine(CubeCard(name = "A", priceUsd = "1.50")))
+        assertEquals(
+            "\$1.50 · €1.20 · 0.03 tix",
+            CubeEmbeds.priceLine(CubeCard(name = "B", priceUsd = "1.50", priceEur = "1.20", priceTix = "0.03")),
+        )
+        assertNull(CubeEmbeds.priceLine(CubeCard(name = "C")))
+    }
+
+    @Test
+    fun `previewEmbed shows the cube's total USD value only when cards are priced`() {
+        val priced = listOf(
+            card("Bolt", "Instant", 1.0, "common", priceUsd = "2.00"),
+            card("Bear", "Creature — Bear", 2.0, "common", priceUsd = "0.50"),
+        )
+        val value = field(preview(priced), "Cube value")
+        assertNotNull(value)
+        assertTrue(value!!.value!!.contains("2.50"), "total value: ${value.value}")
+
+        assertNull(field(preview(listOf(card("Token", "Token", 0.0, null))), "Cube value"))
     }
 
     @Test

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcherTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcherTest.kt
@@ -145,6 +145,35 @@ class ScryfallCubeFetcherTest {
     }
 
     @Test
+    fun `parseCard reads prices, treating a JSON null or absent price as null`() {
+        val priced = fetcher.parseCard(
+            obj("""{"name":"Ragavan","color_identity":["R"],"type_line":"Legendary Creature",
+               "prices":{"usd":"60.00","eur":null,"tix":"12.00"}}""")
+        )!!
+        assertEquals("60.00", priced.priceUsd)
+        assertEquals(null, priced.priceEur) // a JSON null price → null, not "null"
+        assertEquals("12.00", priced.priceTix)
+
+        val unpriced = fetcher.parseCard(obj("""{"name":"Token","color_identity":[],"type_line":"Token"}"""))!!
+        assertEquals(null, unpriced.priceUsd)
+        assertEquals(null, unpriced.priceEur)
+        assertEquals(null, unpriced.priceTix)
+    }
+
+    @Test
+    fun `parseCard reads the legal formats from Scryfall legalities, in FORMATS order`() {
+        val card = fetcher.parseCard(
+            obj("""{"name":"Ragavan","color_identity":["R"],"type_line":"Legendary Creature",
+               "legalities":{"standard":"not_legal","pioneer":"not_legal","modern":"legal","legacy":"legal",
+                 "vintage":"legal","pauper":"not_legal","commander":"legal"}}""")
+        )!!
+        assertEquals(listOf("Modern", "Legacy", "Vintage", "Commander"), card.legalFormats)
+
+        val noLegalities = fetcher.parseCard(obj("""{"name":"Token","color_identity":[],"type_line":"Token"}"""))!!
+        assertTrue(noLegalities.legalFormats.isEmpty())
+    }
+
+    @Test
     fun `parseCard treats a card with no colour identity as colourless`() {
         val card = fetcher.parseCard(obj("""{"name":"Sol Ring","color_identity":[],"type_line":"Artifact"}"""))!!
         assertEquals(CardCategory.COLORLESS, card.category)

--- a/discord-bot/src/test/kotlin/bot/toby/handler/CardMentionListenerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/handler/CardMentionListenerTest.kt
@@ -116,6 +116,24 @@ class CardMentionListenerTest {
     }
 
     @Test
+    fun `a card-mention embed includes the price and legal formats when present`() {
+        message("[[Ragavan]]")
+        coEvery { fetcher.fetchNamed("Ragavan") } returns CubeCard(
+            "Ragavan, Nimble Pilferer", setOf(MtgColor.RED), typeLine = "Legendary Creature — Monkey Pirate",
+            manaValue = 1.0, imageUrl = "https://img/ragavan.jpg", rarity = "mythic",
+            priceUsd = "60.00", priceTix = "12.00", legalFormats = listOf("Modern", "Legacy"),
+        )
+
+        listener.onMessageReceived(event)
+
+        val captured = mutableListOf<Collection<MessageEmbed>>()
+        verify { event.channel.sendMessageEmbeds(capture(captured)) }
+        val desc = captured.first().toList().first().description!!
+        assertTrue(desc.contains("Price** · \$60.00 · 12.00 tix"), "price line: $desc")
+        assertTrue(desc.contains("Legal** · Modern, Legacy"), "legal line: $desc")
+    }
+
+    @Test
     fun `a double-faced card mention adds a second embed for the back face`() {
         message("[[Delver of Secrets]]")
         coEvery { fetcher.fetchNamed("Delver of Secrets") } returns CubeCard(

--- a/web/src/main/kotlin/web/service/CubeWebService.kt
+++ b/web/src/main/kotlin/web/service/CubeWebService.kt
@@ -178,7 +178,7 @@ class CubeWebService {
             duplicates = a.duplicates.map { DuplicateView(it.name, it.count) },
             colorPairs = a.colorPairs.map { ColorPairView(it.pair, it.count) },
             colorPips = a.colorPips.map { ColorPipView(it.color, it.count) },
-            totalValueUsd = a.totalValueUsd,
+            totalValues = a.totalValues.map { TotalValueView(it.currency.code, it.currency.display, it.amount) },
         )
     }
 
@@ -601,9 +601,12 @@ data class AnalyticsView(
     val duplicates: List<DuplicateView>,
     val colorPairs: List<ColorPairView>,
     val colorPips: List<ColorPipView>,
-    /** Total USD value of the priced cards in the pool, or null when none are priced. */
-    val totalValueUsd: Double? = null,
+    /** Cube market value per currency (code, display name, amount), present currencies only. */
+    val totalValues: List<TotalValueView> = emptyList(),
 )
+
+/** One currency's summed cube value: Scryfall code ("usd"), display ("USD"), amount. */
+data class TotalValueView(val currency: String, val display: String, val amount: Double)
 
 /** A single card looked up by name: image plus its key facts. */
 data class CardLookupView(

--- a/web/src/main/kotlin/web/service/CubeWebService.kt
+++ b/web/src/main/kotlin/web/service/CubeWebService.kt
@@ -90,6 +90,10 @@ class CubeWebService {
         rarity = sc.card.rarity?.let { Rarity.parse(it).displayName },
         colors = MtgColor.entries.filter { it in sc.card.colors }.map { it.displayName },
         oracleText = sc.card.oracleText,
+        priceUsd = sc.card.priceUsd,
+        priceEur = sc.card.priceEur,
+        priceTix = sc.card.priceTix,
+        legalFormats = sc.card.legalFormats,
     )
 
     /**
@@ -174,6 +178,7 @@ class CubeWebService {
             duplicates = a.duplicates.map { DuplicateView(it.name, it.count) },
             colorPairs = a.colorPairs.map { ColorPairView(it.pair, it.count) },
             colorPips = a.colorPips.map { ColorPipView(it.color, it.count) },
+            totalValueUsd = a.totalValueUsd,
         )
     }
 
@@ -278,6 +283,10 @@ class CubeWebService {
                 manaCost = manaCostOf(node),
                 oracleText = oracleTextOf(node),
                 imageUrlBack = backImageOf(node),
+                priceUsd = priceOf(node, "usd"),
+                priceEur = priceOf(node, "eur"),
+                priceTix = priceOf(node, "tix"),
+                legalFormats = CubeCard.legalFormatsOf { node.path("legalities").path(it).asText(null) },
             ),
             imageUrl = imageOf(node, "small"),
             imageUrlLarge = imageOf(node, "normal"),
@@ -328,6 +337,10 @@ class CubeWebService {
         }
         return null
     }
+
+    /** A Scryfall `prices` entry (e.g. "usd"), or null when absent/blank. */
+    private fun priceOf(node: JsonNode, key: String): String? =
+        node.path("prices").path(key).asText("").takeIf { it.isNotBlank() }
 
     /**
      * The card's rules text, or null. Single-faced cards carry `oracle_text`
@@ -528,7 +541,7 @@ data class ScryfallCard(
     val manaCost: String? = null,
 ) {
     fun toView(): CardView =
-        CardView(card.name, imageUrl, imageUrlLarge, card.typeLine, card.manaValue, manaCost, imageUrlBack)
+        CardView(card.name, imageUrl, imageUrlLarge, card.typeLine, card.manaValue, manaCost, imageUrlBack, priceUsd = card.priceUsd)
 }
 
 /**
@@ -547,6 +560,8 @@ data class CardView(
     val manaCost: String? = null,
     val imageUrlBack: String? = null,
     val count: Int = 1,
+    /** Scryfall USD market price (raw string, e.g. "1.50"), or null when unpriced. */
+    val priceUsd: String? = null,
 )
 
 /** A colour/land bucket plus the actual cards it contains. */
@@ -586,6 +601,8 @@ data class AnalyticsView(
     val duplicates: List<DuplicateView>,
     val colorPairs: List<ColorPairView>,
     val colorPips: List<ColorPipView>,
+    /** Total USD value of the priced cards in the pool, or null when none are priced. */
+    val totalValueUsd: Double? = null,
 )
 
 /** A single card looked up by name: image plus its key facts. */
@@ -600,6 +617,12 @@ data class CardLookupView(
     val rarity: String?,
     val colors: List<String>,
     val oracleText: String? = null,
+    /** Scryfall market prices (raw strings), or null when unpriced. */
+    val priceUsd: String? = null,
+    val priceEur: String? = null,
+    val priceTix: String? = null,
+    /** Play formats this card is currently legal in, display-cased, in [CubeCard.FORMATS] order. */
+    val legalFormats: List<String> = emptyList(),
 )
 
 /** One card's change between two compared lists (copy counts from → to). */

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -823,6 +823,12 @@ class ModerationWebService(
                 if (v != "true" && v != "false") return "Value must be true or false."
                 v
             }
+            ConfigDto.Configurations.CUBE_CURRENCY -> {
+                // The /cube preview's "cube value" currency. Normalise to the
+                // MtgCurrency code so the bot reads it back cleanly.
+                common.mtg.MtgCurrency.fromCode(rawValue)?.code
+                    ?: return "Value must be one of usd, eur or tix."
+            }
             ConfigDto.Configurations.ACTIVITY_TRACKING_NOTIFIED ->
                 return "This flag is managed automatically and cannot be edited."
             ConfigDto.Configurations.JACKPOT_LOSS_TRIBUTE_PCT -> {

--- a/web/src/main/resources/static/css/cube.css
+++ b/web/src/main/resources/static/css/cube.css
@@ -1110,12 +1110,25 @@ details[open] > .cube-section-summary .cube-collapse-chevron {
     letter-spacing: 0.04em;
 }
 
-/* Total cube value (sum of priced cards), shown under the analytics breakdown. */
+/* Total cube value (sum of priced cards), shown under the analytics breakdown,
+   with a currency switch sitting alongside it. */
+.cube-total-value-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-2);
+    margin-top: var(--space-2);
+}
+
 .cube-total-value {
-    margin: var(--space-2) 0 0;
+    margin: 0;
     color: var(--heading);
     font-size: 0.9rem;
     font-weight: 600;
+}
+
+.cube-total-currency select {
+    font-size: 0.85rem;
 }
 
 /* Singleton-violation warning (non-basic duplicates), matching .cube-notfound. */

--- a/web/src/main/resources/static/css/cube.css
+++ b/web/src/main/resources/static/css/cube.css
@@ -1110,6 +1110,14 @@ details[open] > .cube-section-summary .cube-collapse-chevron {
     letter-spacing: 0.04em;
 }
 
+/* Total cube value (sum of priced cards), shown under the analytics breakdown. */
+.cube-total-value {
+    margin: var(--space-2) 0 0;
+    color: var(--heading);
+    font-size: 0.9rem;
+    font-weight: 600;
+}
+
 /* Singleton-violation warning (non-basic duplicates), matching .cube-notfound. */
 .cube-dup-warning {
     margin: var(--space-2) 0 0;

--- a/web/src/main/resources/static/js/cube.js
+++ b/web/src/main/resources/static/js/cube.js
@@ -334,7 +334,16 @@
         if (els.rarity) renderRarity(els.rarity, analytics.rarities || []);
         if (els.pairs) renderColorPairs(els.pairs, analytics.colorPairs || []);
         if (els.pips) renderColorPips(els.pips, analytics.colorPips || []);
+        renderTotalValue(els.value, analytics.totalValueUsd);
         show(els.breakdown);
+    }
+
+    /** "≈ $123.45 in priced cards (USD)" — hidden when nothing in the pool is priced. */
+    function renderTotalValue(el, totalValueUsd) {
+        if (!el) return;
+        if (totalValueUsd == null) { el.hidden = true; el.textContent = ''; return; }
+        el.textContent = '≈ $' + Number(totalValueUsd).toFixed(2) + ' in priced cards (USD)';
+        el.hidden = false;
     }
 
     /** As-fan bars only (the secondary "balance" view under a generate). */
@@ -368,6 +377,18 @@
     /** GET URL for the single-card lookup. */
     function cardUrl(name) {
         return '/cube/api/card?name=' + encodeURIComponent(name);
+    }
+
+    /**
+     * A card's market prices as a compact one-liner ("$1.50 · €1.20 · 0.03 tix"),
+     * present currencies only, or '' when Scryfall has no price for it. Pure.
+     */
+    function priceLine(card) {
+        const parts = [];
+        if (card.priceUsd) parts.push('$' + card.priceUsd);
+        if (card.priceEur) parts.push('€' + card.priceEur);
+        if (card.priceTix) parts.push(card.priceTix + ' tix');
+        return parts.join(' · ');
     }
 
     /** Renders a looked-up card: its (large) image beside a list of facts. */
@@ -422,6 +443,8 @@
         fact('Mana value', card.manaValue);
         fact('Rarity', card.rarity);
         fact('Colour identity', (card.colors && card.colors.length) ? card.colors.join(', ') : 'Colourless');
+        fact('Price', priceLine(card));
+        fact('Legal', (card.legalFormats && card.legalFormats.length) ? card.legalFormats.join(', ') : '');
 
         if (card.oracleText) {
             const oracle = document.createElement('p');
@@ -1193,6 +1216,7 @@
         const rarity = q(doc, '[data-rarity="preview"]');
         const pairs = q(doc, '[data-pairs="preview"]');
         const pips = q(doc, '[data-pips="preview"]');
+        const value = q(doc, '[data-value="preview"]');
         const actions = q(doc, '[data-actions="preview"]');
         const copyBtn = q(doc, '[data-copy="preview"]');
         const downloadBtn = q(doc, '[data-download="preview"]');
@@ -1269,7 +1293,7 @@
                     lastGroups = json.groups || [];
                     show(actions);
                     renderNotFound(notFound, json.notFound);
-                    renderAnalytics(json.analytics, { dupes: dupes, breakdown: breakdown, avgMv: avgMv, curve: curve, types: types, rarity: rarity, pairs: pairs, pips: pips });
+                    renderAnalytics(json.analytics, { dupes: dupes, breakdown: breakdown, avgMv: avgMv, curve: curve, types: types, rarity: rarity, pairs: pairs, pips: pips, value: value });
                 })
                 .catch(function () { setStatus(status, 'Something went wrong. Try again.'); })
                 .then(function () { withBusy(form, false); setSpinner(doc, 'preview', false); });
@@ -1555,7 +1579,9 @@
         renderDistribution: renderDistribution,
         renderDiff: renderDiff,
         cardUrl: cardUrl,
+        priceLine: priceLine,
         renderCardLookup: renderCardLookup,
+        renderTotalValue: renderTotalValue,
         renderManaCurve: renderManaCurve,
         renderTypeBreakdown: renderTypeBreakdown,
         renderRarity: renderRarity,

--- a/web/src/main/resources/static/js/cube.js
+++ b/web/src/main/resources/static/js/cube.js
@@ -334,15 +334,41 @@
         if (els.rarity) renderRarity(els.rarity, analytics.rarities || []);
         if (els.pairs) renderColorPairs(els.pairs, analytics.colorPairs || []);
         if (els.pips) renderColorPips(els.pips, analytics.colorPips || []);
-        renderTotalValue(els.value, analytics.totalValueUsd);
+        const totals = analytics.totalValues || [];
+        const code = (els.valueCurrency && els.valueCurrency.value) || 'usd';
+        renderTotalValue(els.value, totals, code);
+        // Only offer the currency switch when something in the pool is priced.
+        if (els.valueCurrency) els.valueCurrency.hidden = totals.length === 0;
         show(els.breakdown);
     }
 
-    /** "≈ $123.45 in priced cards (USD)" — hidden when nothing in the pool is priced. */
-    function renderTotalValue(el, totalValueUsd) {
+    // Market currencies, mirroring common.mtg.MtgCurrency. The `code` matches
+    // the AnalyticsView total-value entries and the currency-toggle option
+    // values; symbol/suffix format an amount ($1.50 / €1.50 / 1.50 tix).
+    const CURRENCIES = [
+        { code: 'usd', display: 'USD', symbol: '$', suffix: '' },
+        { code: 'eur', display: 'EUR', symbol: '€', suffix: '' },
+        { code: 'tix', display: 'Tix', symbol: '', suffix: ' tix' },
+    ];
+
+    function currencyMeta(code) {
+        return CURRENCIES.filter(function (c) { return c.code === code; })[0] || CURRENCIES[0];
+    }
+
+    /** The total-value line for [code] from a totals list, or '' when nothing is priced in it. Pure. */
+    function totalValueText(totalValues, code) {
+        const match = (totalValues || []).filter(function (t) { return t.currency === code; })[0];
+        if (!match) return '';
+        const m = currencyMeta(code);
+        return '≈ ' + m.symbol + Number(match.amount).toFixed(2) + m.suffix + ' in priced cards (' + m.display + ')';
+    }
+
+    /** Renders the cube's total value in the [code] currency; hides when nothing is priced in it. */
+    function renderTotalValue(el, totalValues, code) {
         if (!el) return;
-        if (totalValueUsd == null) { el.hidden = true; el.textContent = ''; return; }
-        el.textContent = '≈ $' + Number(totalValueUsd).toFixed(2) + ' in priced cards (USD)';
+        const text = totalValueText(totalValues, code);
+        if (!text) { el.hidden = true; el.textContent = ''; return; }
+        el.textContent = text;
         el.hidden = false;
     }
 
@@ -1217,7 +1243,17 @@
         const pairs = q(doc, '[data-pairs="preview"]');
         const pips = q(doc, '[data-pips="preview"]');
         const value = q(doc, '[data-value="preview"]');
+        const valueCurrency = q(doc, '[data-value-currency="preview"]');
         const actions = q(doc, '[data-actions="preview"]');
+        let lastTotalValues = [];
+
+        // Switching currency re-renders the total line from the cached totals —
+        // no refetch, since every currency's total is already in the payload.
+        if (valueCurrency) {
+            valueCurrency.addEventListener('change', function () {
+                renderTotalValue(value, lastTotalValues, valueCurrency.value);
+            });
+        }
         const copyBtn = q(doc, '[data-copy="preview"]');
         const downloadBtn = q(doc, '[data-download="preview"]');
         const sampleBtn = q(doc, '[data-sample-pack="preview"]');
@@ -1293,7 +1329,8 @@
                     lastGroups = json.groups || [];
                     show(actions);
                     renderNotFound(notFound, json.notFound);
-                    renderAnalytics(json.analytics, { dupes: dupes, breakdown: breakdown, avgMv: avgMv, curve: curve, types: types, rarity: rarity, pairs: pairs, pips: pips, value: value });
+                    lastTotalValues = (json.analytics && json.analytics.totalValues) || [];
+                    renderAnalytics(json.analytics, { dupes: dupes, breakdown: breakdown, avgMv: avgMv, curve: curve, types: types, rarity: rarity, pairs: pairs, pips: pips, value: value, valueCurrency: valueCurrency });
                 })
                 .catch(function () { setStatus(status, 'Something went wrong. Try again.'); })
                 .then(function () { withBusy(form, false); setSpinner(doc, 'preview', false); });
@@ -1580,6 +1617,7 @@
         renderDiff: renderDiff,
         cardUrl: cardUrl,
         priceLine: priceLine,
+        totalValueText: totalValueText,
         renderCardLookup: renderCardLookup,
         renderTotalValue: renderTotalValue,
         renderManaCurve: renderManaCurve,

--- a/web/src/main/resources/templates/cube.html
+++ b/web/src/main/resources/templates/cube.html
@@ -236,6 +236,7 @@
                     <div class="cube-dist" data-pairs="preview"></div>
                     <h4 class="cube-analytics-h">Colour balance (mana pips)</h4>
                     <div class="cube-dist" data-pips="preview"></div>
+                    <p class="cube-total-value" data-value="preview" hidden></p>
                 </div>
             </details>
         </section>

--- a/web/src/main/resources/templates/cube.html
+++ b/web/src/main/resources/templates/cube.html
@@ -236,7 +236,17 @@
                     <div class="cube-dist" data-pairs="preview"></div>
                     <h4 class="cube-analytics-h">Colour balance (mana pips)</h4>
                     <div class="cube-dist" data-pips="preview"></div>
-                    <p class="cube-total-value" data-value="preview" hidden></p>
+                    <div class="cube-total-value-row">
+                        <p class="cube-total-value" data-value="preview" hidden></p>
+                        <label class="cube-total-currency">
+                            <span class="sr-only">Cube value currency</span>
+                            <select data-value-currency="preview" hidden>
+                                <option value="usd">USD ($)</option>
+                                <option value="eur">EUR (€)</option>
+                                <option value="tix">MTGO Tix</option>
+                            </select>
+                        </label>
+                    </div>
                 </div>
             </details>
         </section>

--- a/web/src/main/resources/templates/moderation/settings.html
+++ b/web/src/main/resources/templates/moderation/settings.html
@@ -138,6 +138,26 @@
                             </select>
                             <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                         </div>
+                        <!-- Currency the /cube preview's "cube value" total is shown in.
+                             Null/absent reads as USD. -->
+                        <div class="config-row" data-key="CUBE_CURRENCY">
+                            <label>Cube value currency</label>
+                            <select th:disabled="${!isOwner}">
+                                <option value="usd"
+                                        th:selected="${overview.config['CUBE_CURRENCY'] == null or overview.config['CUBE_CURRENCY'] == 'usd'}">
+                                    US Dollars ($)
+                                </option>
+                                <option value="eur"
+                                        th:selected="${overview.config['CUBE_CURRENCY'] == 'eur'}">
+                                    Euros (€)
+                                </option>
+                                <option value="tix"
+                                        th:selected="${overview.config['CUBE_CURRENCY'] == 'tix'}">
+                                    MTGO Tix
+                                </option>
+                            </select>
+                            <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                        </div>
                         <div class="config-row" data-key="DELETE_DELAY">
                             <label>Message delete delay (seconds)</label>
                             <input type="number" min="0" max="600"

--- a/web/src/test/js/cube.test.js
+++ b/web/src/test/js/cube.test.js
@@ -418,6 +418,56 @@ describe('card lookup (cardUrl / renderCardLookup)', () => {
         Cube.renderCardLookup(container, { name: 'Sol Ring', imageUrlLarge: 'n.jpg', typeLine: 'Artifact', manaValue: 1, manaCost: '{1}', rarity: null, colors: [] });
         expect(container.querySelector('.cube-cardlookup-facts').textContent).toContain('Colourless');
     });
+
+    test('renderCardLookup shows price and legal formats when present', () => {
+        const container = document.createElement('div');
+        Cube.renderCardLookup(container, {
+            name: 'Ragavan, Nimble Pilferer', imageUrlLarge: 'n.jpg', typeLine: 'Legendary Creature',
+            manaValue: 1, manaCost: '{R}', rarity: 'Mythic', colors: ['Red'],
+            priceUsd: '60.00', priceEur: '55.50', priceTix: '12.00',
+            legalFormats: ['Modern', 'Legacy'],
+        });
+        const text = container.querySelector('.cube-cardlookup-facts').textContent;
+        expect(text).toContain('$60.00 · €55.50 · 12.00 tix');
+        expect(text).toContain('Modern, Legacy');
+    });
+
+    test('renderCardLookup omits price and legal lines when the card has neither', () => {
+        const container = document.createElement('div');
+        Cube.renderCardLookup(container, { name: 'Token', imageUrlLarge: 'n.jpg', typeLine: 'Token', manaValue: 0, rarity: null, colors: [] });
+        const text = container.querySelector('.cube-cardlookup-facts').textContent;
+        expect(text).not.toContain('Price');
+        expect(text).not.toContain('Legal');
+    });
+});
+
+describe('priceLine (pure)', () => {
+    test('joins present currencies only', () => {
+        expect(Cube.priceLine({ priceUsd: '1.50' })).toBe('$1.50');
+        expect(Cube.priceLine({ priceUsd: '1.50', priceEur: '1.20', priceTix: '0.03' })).toBe('$1.50 · €1.20 · 0.03 tix');
+        expect(Cube.priceLine({ priceEur: '1.20' })).toBe('€1.20');
+    });
+
+    test('is empty when the card has no prices', () => {
+        expect(Cube.priceLine({})).toBe('');
+    });
+});
+
+describe('renderTotalValue', () => {
+    test('shows the rounded USD total and reveals the element', () => {
+        const el = document.createElement('p');
+        el.hidden = true;
+        Cube.renderTotalValue(el, 123.456);
+        expect(el.hidden).toBe(false);
+        expect(el.textContent).toBe('≈ $123.46 in priced cards (USD)');
+    });
+
+    test('hides the element when nothing is priced (null)', () => {
+        const el = document.createElement('p');
+        Cube.renderTotalValue(el, null);
+        expect(el.hidden).toBe(true);
+        expect(el.textContent).toBe('');
+    });
 });
 
 describe('renderDiff (compare two lists)', () => {
@@ -577,6 +627,8 @@ describe('cube report analytics renderers', () => {
         const rarity = document.createElement('div');
         const pairs = document.createElement('div');
         const pips = document.createElement('div');
+        const value = document.createElement('p');
+        value.hidden = true;
         Cube.renderAnalytics(
             {
                 curve: [{ label: '0', count: 1 }, { label: '1', count: 2 }],
@@ -587,8 +639,9 @@ describe('cube report analytics renderers', () => {
                 duplicates: [{ name: 'Sol Ring', count: 2 }],
                 colorPairs: [{ pair: 'Azorius (WU)', count: 4 }],
                 colorPips: [{ color: 'White', count: 6 }],
+                totalValueUsd: 42.5,
             },
-            { dupes: dupes, breakdown: breakdown, avgMv: avgMv, curve: curve, types: types, rarity: rarity, pairs: pairs, pips: pips },
+            { dupes: dupes, breakdown: breakdown, avgMv: avgMv, curve: curve, types: types, rarity: rarity, pairs: pairs, pips: pips, value: value },
         );
         expect(breakdown.hidden).toBe(false);
         expect(avgMv.textContent).toContain('Average mana value 2.50');
@@ -599,6 +652,8 @@ describe('cube report analytics renderers', () => {
         expect(pairs.querySelector('.cube-bar-label').textContent).toBe('Azorius (WU)');
         expect(pips.querySelector('.cube-bar-label').textContent).toBe('White');
         expect(dupes.hidden).toBe(false);
+        expect(value.hidden).toBe(false);
+        expect(value.textContent).toContain('$42.50');
     });
 
     test('renderAnalytics tolerates a missing payload and an all-land pool', () => {

--- a/web/src/test/js/cube.test.js
+++ b/web/src/test/js/cube.test.js
@@ -453,20 +453,47 @@ describe('priceLine (pure)', () => {
     });
 });
 
-describe('renderTotalValue', () => {
-    test('shows the rounded USD total and reveals the element', () => {
-        const el = document.createElement('p');
-        el.hidden = true;
-        Cube.renderTotalValue(el, 123.456);
-        expect(el.hidden).toBe(false);
-        expect(el.textContent).toBe('≈ $123.46 in priced cards (USD)');
+describe('totalValueText (pure, per currency)', () => {
+    const totals = [
+        { currency: 'usd', display: 'USD', amount: 123.456 },
+        { currency: 'eur', display: 'EUR', amount: 100 },
+        { currency: 'tix', display: 'Tix', amount: 4.2 },
+    ];
+
+    test('formats the chosen currency with its symbol/suffix', () => {
+        expect(Cube.totalValueText(totals, 'usd')).toBe('≈ $123.46 in priced cards (USD)');
+        expect(Cube.totalValueText(totals, 'eur')).toBe('≈ €100.00 in priced cards (EUR)');
+        expect(Cube.totalValueText(totals, 'tix')).toBe('≈ 4.20 tix in priced cards (Tix)');
     });
 
-    test('hides the element when nothing is priced (null)', () => {
+    test('is empty when the chosen currency has no total', () => {
+        expect(Cube.totalValueText([{ currency: 'usd', display: 'USD', amount: 1 }], 'eur')).toBe('');
+        expect(Cube.totalValueText([], 'usd')).toBe('');
+    });
+});
+
+describe('renderTotalValue', () => {
+    const totals = [{ currency: 'usd', display: 'USD', amount: 123.456 }, { currency: 'eur', display: 'EUR', amount: 99 }];
+
+    test('shows the rounded total for the chosen currency and reveals the element', () => {
         const el = document.createElement('p');
-        Cube.renderTotalValue(el, null);
+        el.hidden = true;
+        Cube.renderTotalValue(el, totals, 'usd');
+        expect(el.hidden).toBe(false);
+        expect(el.textContent).toBe('≈ $123.46 in priced cards (USD)');
+
+        Cube.renderTotalValue(el, totals, 'eur');
+        expect(el.textContent).toBe('≈ €99.00 in priced cards (EUR)');
+    });
+
+    test('hides the element when the chosen currency is unpriced or totals are empty', () => {
+        const el = document.createElement('p');
+        Cube.renderTotalValue(el, totals, 'tix'); // not in the totals
         expect(el.hidden).toBe(true);
         expect(el.textContent).toBe('');
+
+        Cube.renderTotalValue(el, [], 'usd');
+        expect(el.hidden).toBe(true);
     });
 });
 
@@ -629,6 +656,9 @@ describe('cube report analytics renderers', () => {
         const pips = document.createElement('div');
         const value = document.createElement('p');
         value.hidden = true;
+        const valueCurrency = document.createElement('select');
+        valueCurrency.innerHTML = '<option value="usd">USD</option><option value="eur">EUR</option>';
+        valueCurrency.hidden = true;
         Cube.renderAnalytics(
             {
                 curve: [{ label: '0', count: 1 }, { label: '1', count: 2 }],
@@ -639,9 +669,9 @@ describe('cube report analytics renderers', () => {
                 duplicates: [{ name: 'Sol Ring', count: 2 }],
                 colorPairs: [{ pair: 'Azorius (WU)', count: 4 }],
                 colorPips: [{ color: 'White', count: 6 }],
-                totalValueUsd: 42.5,
+                totalValues: [{ currency: 'usd', display: 'USD', amount: 42.5 }, { currency: 'eur', display: 'EUR', amount: 38 }],
             },
-            { dupes: dupes, breakdown: breakdown, avgMv: avgMv, curve: curve, types: types, rarity: rarity, pairs: pairs, pips: pips, value: value },
+            { dupes: dupes, breakdown: breakdown, avgMv: avgMv, curve: curve, types: types, rarity: rarity, pairs: pairs, pips: pips, value: value, valueCurrency: valueCurrency },
         );
         expect(breakdown.hidden).toBe(false);
         expect(avgMv.textContent).toContain('Average mana value 2.50');
@@ -652,8 +682,21 @@ describe('cube report analytics renderers', () => {
         expect(pairs.querySelector('.cube-bar-label').textContent).toBe('Azorius (WU)');
         expect(pips.querySelector('.cube-bar-label').textContent).toBe('White');
         expect(dupes.hidden).toBe(false);
+        // Total value renders in the select's currency (USD), and the switch is revealed.
         expect(value.hidden).toBe(false);
         expect(value.textContent).toContain('$42.50');
+        expect(valueCurrency.hidden).toBe(false);
+    });
+
+    test('renderAnalytics hides the currency switch when nothing is priced', () => {
+        const value = document.createElement('p');
+        const valueCurrency = document.createElement('select');
+        Cube.renderAnalytics(
+            { curve: [], averageManaValue: 0, nonLandCount: 0, types: [], rarities: [], duplicates: [], totalValues: [] },
+            { dupes: document.createElement('p'), breakdown: document.createElement('details'), value: value, valueCurrency: valueCurrency },
+        );
+        expect(value.hidden).toBe(true);
+        expect(valueCurrency.hidden).toBe(true);
     });
 
     test('renderAnalytics tolerates a missing payload and an all-land pool', () => {

--- a/web/src/test/kotlin/web/service/CubeWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/CubeWebServiceTest.kt
@@ -57,15 +57,18 @@ class CubeWebServiceTest {
     }
 
     @Test
-    fun `analyticsView carries the total USD value, null when nothing is priced`() {
+    fun `analyticsView carries per-currency totals, empty when nothing is priced`() {
         val priced = listOf(
-            CubeCard("Bolt", setOf(MtgColor.RED), typeLine = "Instant", manaValue = 1.0, priceUsd = "2.50"),
-            CubeCard("Bear", setOf(MtgColor.GREEN), typeLine = "Creature", manaValue = 2.0, priceUsd = "0.50"),
+            CubeCard("Bolt", setOf(MtgColor.RED), typeLine = "Instant", manaValue = 1.0, priceUsd = "2.50", priceEur = "2.00"),
+            CubeCard("Bear", setOf(MtgColor.GREEN), typeLine = "Creature", manaValue = 2.0, priceUsd = "0.50", priceEur = "0.40"),
         )
-        assertEquals(3.0, service.analyticsView(priced, packSize = 2).totalValueUsd!!, 1e-9)
+        val totals = service.analyticsView(priced, packSize = 2).totalValues.associate { it.currency to it }
+        assertEquals(3.0, totals["usd"]!!.amount, 1e-9)
+        assertEquals("USD", totals["usd"]!!.display)
+        assertEquals(2.4, totals["eur"]!!.amount, 1e-9)
 
         val unpriced = listOf(CubeCard("Token", typeLine = "Token"))
-        assertEquals(null, service.analyticsView(unpriced, packSize = 1).totalValueUsd)
+        assertTrue(service.analyticsView(unpriced, packSize = 1).totalValues.isEmpty())
     }
 
     // --- card lookup ---------------------------------------------------

--- a/web/src/test/kotlin/web/service/CubeWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/CubeWebServiceTest.kt
@@ -56,6 +56,18 @@ class CubeWebServiceTest {
         assertEquals(1, pips["Red"])
     }
 
+    @Test
+    fun `analyticsView carries the total USD value, null when nothing is priced`() {
+        val priced = listOf(
+            CubeCard("Bolt", setOf(MtgColor.RED), typeLine = "Instant", manaValue = 1.0, priceUsd = "2.50"),
+            CubeCard("Bear", setOf(MtgColor.GREEN), typeLine = "Creature", manaValue = 2.0, priceUsd = "0.50"),
+        )
+        assertEquals(3.0, service.analyticsView(priced, packSize = 2).totalValueUsd!!, 1e-9)
+
+        val unpriced = listOf(CubeCard("Token", typeLine = "Token"))
+        assertEquals(null, service.analyticsView(unpriced, packSize = 1).totalValueUsd)
+    }
+
     // --- card lookup ---------------------------------------------------
 
     @Test
@@ -64,6 +76,8 @@ class CubeWebServiceTest {
             """{"name":"Ragavan, Nimble Pilferer","color_identity":["R"],
                "type_line":"Legendary Creature — Monkey Pirate","cmc":1.0,"mana_cost":"{R}","rarity":"mythic",
                "oracle_text":"Whenever Ragavan deals combat damage, create a Treasure.",
+               "prices":{"usd":"60.00","eur":"55.50","tix":"12.00"},
+               "legalities":{"standard":"not_legal","modern":"legal","legacy":"legal","vintage":"legal","commander":"legal","pauper":"not_legal","pioneer":"not_legal"},
                "image_uris":{"small":"s.jpg","normal":"n.jpg"}}"""
         )
         val view = service.lookupView(service.cardOf(node)!!)
@@ -74,6 +88,35 @@ class CubeWebServiceTest {
         assertEquals(listOf("Red"), view.colors)
         assertEquals("Legendary Creature — Monkey Pirate", view.typeLine)
         assertTrue(view.oracleText!!.contains("create a Treasure"))
+        assertEquals("60.00", view.priceUsd)
+        assertEquals("55.50", view.priceEur)
+        assertEquals("12.00", view.priceTix)
+        assertEquals(listOf("Modern", "Legacy", "Vintage", "Commander"), view.legalFormats)
+    }
+
+    @Test
+    fun `cardOf leaves prices null and legalFormats empty when Scryfall omits them`() {
+        val node = mapper.readTree(
+            """{"name":"Token","color_identity":[],"type_line":"Token"}"""
+        )
+        val card = service.cardOf(node)!!.card
+        assertEquals(null, card.priceUsd)
+        assertEquals(null, card.priceEur)
+        assertEquals(null, card.priceTix)
+        assertTrue(card.legalFormats.isEmpty())
+    }
+
+    @Test
+    fun `parseScryfall reads prices onto the card and the tile shows the USD price`() {
+        val root = mapper.readTree(
+            """{"data":[{"name":"Bolt","color_identity":["R"],"type_line":"Instant","cmc":1.0,
+               "prices":{"usd":"1.25","eur":null,"tix":"0.03"}}]}"""
+        )
+        val parsed = service.parseScryfall(root).first()
+        assertEquals("1.25", parsed.card.priceUsd)
+        assertEquals(null, parsed.card.priceEur) // a JSON null price stays null
+        assertEquals("0.03", parsed.card.priceTix)
+        assertEquals("1.25", parsed.toView().priceUsd) // surfaced on the grid tile
     }
 
     // --- diff (compare two lists) --------------------------------------

--- a/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
@@ -281,6 +281,22 @@ class ModerationWebServiceTest {
     }
 
     @Test
+    fun `updateConfig accepts a known CUBE_CURRENCY and normalises it to a code`() {
+        mockMember(ownerId, isOwner = true)
+        val key = ConfigDto.Configurations.CUBE_CURRENCY
+
+        assertNull(service.updateConfig(ownerId, guildId, key, "usd"))
+        assertNull(service.updateConfig(ownerId, guildId, key, "EUR")) // case-insensitive
+        assertNull(service.updateConfig(ownerId, guildId, key, "USD")) // display name resolves too
+        // Persisted as the normalised MtgCurrency code.
+        verify { configService.upsertConfig(key.configValue, "usd", guildId.toString()) }
+        verify { configService.upsertConfig(key.configValue, "eur", guildId.toString()) }
+
+        assertNotNull(service.updateConfig(ownerId, guildId, key, "gbp"))
+        assertNotNull(service.updateConfig(ownerId, guildId, key, ""))
+    }
+
+    @Test
     fun `updateConfig accepts per-guild cron HOUR keys in 0 to 23 and rejects others`() {
         mockMember(ownerId, isOwner = true)
         val keys = listOf(


### PR DESCRIPTION
Surfaces Scryfall **market prices** (USD / EUR / MTGO tix) and current **format legality** across every Magic card surface, plus a cube-wide **total value** — three of the most-requested "card bot" features, which broadens install appeal for trading/deckbuilding communities.

## What's new

**Shared domain (`common`)**
- `CubeCard` gains `priceUsd` / `priceEur` / `priceTix` and a `legalFormats` list, with a shared `FORMATS` map + `legalFormatsOf {}` helper so the bot and web parsers list the same formats in the same order.
- `CubeAnalytics` gains `totalValueUsd` — the summed USD value of priced cards in a pool (null when none are priced).

**Discord**
- `ScryfallCubeFetcher.parseCard` reads `prices` (treating a JSON `null` price as null) and `legalities`.
- `/cube card` and inline `[[mention]]` embeds show a compact price line (`$1.50 · €1.20 · 0.03 tix`) and the legal formats.
- The cube preview shows the pool's total USD value.

**Web**
- `CubeWebService` threads prices + legality onto the card-lookup view and the total value onto the analytics view; grid tiles carry the USD price.
- The card-lookup panel shows price + legality; the preview breakdown shows the cube's total value (new `.cube-total-value` element/style).

## Testing
- `common`: prices/legality round-trip + `legalFormatsOf` ordering; `totalValueUsd` aggregation and `analyze` wiring.
- web service: `cardOf`/`lookupView` prices+legality, `analyticsView` total value, tile price.
- jest: `priceLine`, `renderTotalValue`, `renderCardLookup` price/legality, `renderAnalytics` total value.
- Discord: `CubeEmbeds` price/legality/value, `ScryfallCubeFetcher` price/legality parsing, `CardMentionListener` price+legality line.
- stylelint + `:common:`, `:web:`, `:discord-bot:` kover gates all green.

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs

---
_Generated by [Claude Code](https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs)_