### PR TITLE
Add card rulings lookup to the MTG tools (Discord + web)

### DIFF
--- a/common/src/main/kotlin/common/mtg/CardRulings.kt
+++ b/common/src/main/kotlin/common/mtg/CardRulings.kt
@@ -1,0 +1,21 @@
+package common.mtg
+
+/**
+ * A card's official rulings (Scryfall `/cards/:id/rulings`) — the clarifying
+ * notes the rules team publishes for tricky interactions. A pure value type
+ * shared by the bot's `/cube rulings` command and the web card-lookup tool,
+ * both of which fetch from Scryfall (over their own HTTP clients) and map the
+ * JSON into this. Presentation-only — no maths depend on it.
+ *
+ * [rulings] is empty when the card exists but has no published rulings, which
+ * each surface presents as a friendly "no rulings yet" state rather than an
+ * error.
+ */
+data class CardRulings(
+    val cardName: String,
+    val scryfallUri: String?,
+    val rulings: List<Ruling>,
+) {
+    /** One published ruling: when it was published (ISO date) and the note itself. */
+    data class Ruling(val publishedAt: String, val comment: String)
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeCommand.kt
@@ -68,7 +68,8 @@ class CubeCommand @Autowired constructor(
             SUB_GENERATE -> launchHandling(ctx) { handleGenerate(ctx, requestingUserDto) }
             SUB_SAVED -> launchHandling(ctx) { handleSaved(ctx, requestingUserDto, deleteDelay) }
             SUB_CARD -> launchHandling(ctx) { handleCard(ctx, deleteDelay) }
-            else -> reply(ctx, CubeEmbeds.errorEmbed("Pick a subcommand: asfan, preview, generate, saved or card."), deleteDelay)
+            SUB_RULINGS -> launchHandling(ctx) { handleRulings(ctx, deleteDelay) }
+            else -> reply(ctx, CubeEmbeds.errorEmbed("Pick a subcommand: asfan, preview, generate, saved, card or rulings."), deleteDelay)
         }
     }
 
@@ -257,6 +258,19 @@ class CubeCommand @Autowired constructor(
         }
     }
 
+    /** Looks up a single card's official rulings on Scryfall. */
+    private suspend fun handleRulings(ctx: CommandContext, deleteDelay: Int) {
+        val name = ctx.event.stringOption(OPT_NAME)?.trim()
+        if (name.isNullOrEmpty()) {
+            reply(ctx, CubeEmbeds.errorEmbed("Give me a card `name` to look up rulings for."), deleteDelay)
+            return
+        }
+        when (val rulings = fetcher.fetchRulings(name)) {
+            null -> reply(ctx, CubeEmbeds.errorEmbed("Couldn't find a card named `$name`."), deleteDelay)
+            else -> reply(ctx, CubeEmbeds.rulingsEmbed(rulings), deleteDelay)
+        }
+    }
+
     private fun reply(ctx: CommandContext, embed: MessageEmbed, deleteDelay: Int) {
         ctx.event.hook.sendMessageEmbeds(embed).queue(invokeDeleteOnMessageResponse(deleteDelay))
     }
@@ -293,6 +307,8 @@ class CubeCommand @Autowired constructor(
         SubcommandData(SUB_SAVED, "List the cubes you've saved on the website."),
         SubcommandData(SUB_CARD, "Look up a single Magic card by name.")
             .addOptions(OptionData(OptionType.STRING, OPT_NAME, "The card's name (e.g. Lightning Bolt).", true)),
+        SubcommandData(SUB_RULINGS, "Look up a Magic card's official rulings by name.")
+            .addOptions(OptionData(OptionType.STRING, OPT_NAME, "The card's name (e.g. Doubling Season).", true)),
     )
 
     companion object {
@@ -301,6 +317,7 @@ class CubeCommand @Autowired constructor(
         const val SUB_GENERATE = "generate"
         const val SUB_SAVED = "saved"
         const val SUB_CARD = "card"
+        const val SUB_RULINGS = "rulings"
 
         const val OPT_TOTAL = "total"
         const val OPT_NAME = "name"

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
@@ -2,6 +2,7 @@ package bot.toby.command.commands.mtg
 
 import common.discord.embed
 import common.discord.field
+import common.mtg.CardRulings
 import common.mtg.CardCategory
 import common.mtg.CardListParser
 import common.mtg.CubeAnalytics
@@ -224,6 +225,51 @@ internal object CubeEmbeds {
         card.priceEur?.let { add("€$it") }
         card.priceTix?.let { add("$it tix") }
     }.takeIf { it.isNotEmpty() }?.joinToString(" · ")
+
+    /**
+     * The official rulings panel for `/cube rulings`: each ruling as a
+     * `> date — comment` block, oldest first, trimmed to stay within an embed
+     * description. Shows a friendly empty state when the card has no rulings.
+     */
+    fun rulingsEmbed(rulings: CardRulings): MessageEmbed = embed(color = OK_COLOR) {
+        setAuthor(AUTHOR)
+        setTitle("${rulings.cardName} — rulings")
+        rulings.scryfallUri?.let { setUrl(it) }
+        if (rulings.rulings.isEmpty()) {
+            setDescription("No official rulings have been published for this card.")
+            return@embed
+        }
+        setDescription(rulingsBlock(rulings.rulings))
+        setFooter("${rulings.rulings.size} ruling${if (rulings.rulings.size == 1) "" else "s"} · source: Scryfall")
+    }
+
+    /**
+     * Joins rulings into one description, each headed by its date, dropping
+     * any that would overflow the embed description cap (so a heavily-ruled
+     * card like a planeswalker doesn't blow the 4096-char limit).
+     */
+    fun rulingsBlock(rulings: List<CardRulings.Ruling>): String {
+        val out = StringBuilder()
+        var shown = 0
+        for (r in rulings) {
+            val head = r.publishedAt.takeIf { it.isNotBlank() }?.let { "**$it**\n" }.orEmpty()
+            val entry = "$head${r.comment}"
+            // +2 for the blank line between entries.
+            if (out.length + entry.length + 2 > RULINGS_LIMIT) break
+            if (out.isNotEmpty()) out.append("\n\n")
+            out.append(entry)
+            shown++
+        }
+        if (shown < rulings.size) {
+            val more = "\n\n…and ${rulings.size - shown} more (see Scryfall)."
+            if (out.length + more.length <= RULINGS_DESC_CAP) out.append(more)
+        }
+        return out.toString()
+    }
+
+    /** Leave headroom under Discord's 4096-char description cap for the "…and N more" line. */
+    private const val RULINGS_LIMIT = 3800
+    private const val RULINGS_DESC_CAP = 4096
 
     /** Mana value without a trailing `.0` (whole numbers are the norm). */
     private fun formatMv(mv: Double): String =

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcher.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcher.kt
@@ -5,6 +5,7 @@ import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import common.logging.DiscordLogger
+import common.mtg.CardRulings
 import common.mtg.CubeCard
 import common.mtg.MtgColor
 import io.ktor.client.HttpClient
@@ -181,6 +182,55 @@ class ScryfallCubeFetcher @Autowired constructor(
             null
         }
     }
+
+    /**
+     * Resolves a card by (fuzzy) name and fetches its official rulings in two
+     * steps: `/cards/named?fuzzy=` to find the card (and its `rulings_uri`),
+     * then a GET of that uri. Returns null when no card matches or Scryfall is
+     * unreachable; a [CardRulings] with an empty list when the card exists but
+     * has no published rulings. Suspends on [Dispatchers.IO].
+     */
+    suspend fun fetchRulings(name: String): CardRulings? = withContext(dispatcher) {
+        val trimmed = name.trim()
+        if (trimmed.isEmpty()) return@withContext null
+        val namedUrl = "$NAMED_ENDPOINT?fuzzy=" + URLEncoder.encode(trimmed, StandardCharsets.UTF_8)
+        try {
+            val cardResp = client.get(namedUrl) {
+                header(HttpHeaders.Accept, "application/json")
+                timeout { requestTimeoutMillis = TIMEOUT_MS }
+            }
+            if (cardResp.status.value != 200) return@withContext null
+            val card = JsonParser.parseString(cardResp.bodyAsText()).asJsonObject
+            val cardName = card.get("name")?.asString?.takeIf { it.isNotBlank() } ?: return@withContext null
+            val scryfallUri = card.get("scryfall_uri")?.asString
+            val rulingsUri = card.get("rulings_uri")?.asString
+                ?: return@withContext CardRulings(cardName, scryfallUri, emptyList())
+
+            val rulingsResp = client.get(rulingsUri) {
+                header(HttpHeaders.Accept, "application/json")
+                timeout { requestTimeoutMillis = TIMEOUT_MS }
+            }
+            val rulings = if (rulingsResp.status.value == 200) {
+                parseRulings(JsonParser.parseString(rulingsResp.bodyAsText()).asJsonObject)
+            } else {
+                emptyList()
+            }
+            CardRulings(cardName, scryfallUri, rulings)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.error("Scryfall rulings lookup failed for '$trimmed': $e")
+            null
+        }
+    }
+
+    /** Maps a Scryfall `/rulings` JSON tree into [CardRulings.Ruling]s, oldest first as returned. */
+    fun parseRulings(root: JsonObject): List<CardRulings.Ruling> =
+        root.getAsJsonArray("data")?.mapNotNull { element ->
+            val obj = element.asJsonObject
+            val comment = obj.get("comment")?.asString?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+            CardRulings.Ruling(obj.get("published_at")?.asString.orEmpty(), comment)
+        } ?: emptyList()
 
     /** One `/cards/collection` POST for up to 75 names. */
     private suspend fun fetchCollectionBatch(chunk: List<String>): BatchResult {

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeCommandTest.kt
@@ -482,12 +482,44 @@ class CubeCommandTest : CommandTest {
     }
 
     @Test
-    fun `exposes the five subcommands with their options`() {
+    fun `rulings looks the name up and replies with a rulings panel`() {
+        val slot = slot<MessageEmbed>()
+        every { event.hook.sendMessageEmbeds(capture(slot), *anyVararg()) } returns webhookMessageCreateAction
+        every { event.subcommandName } returns CubeCommand.SUB_RULINGS
+        every { event.getOption(CubeCommand.OPT_NAME) } returns strOpt("Doubling Season")
+        coEvery { fetcher.fetchRulings("Doubling Season") } returns common.mtg.CardRulings(
+            "Doubling Season", "https://scryfall.com/card",
+            listOf(common.mtg.CardRulings.Ruling("2021-03-19", "Tokens are doubled.")),
+        )
+
+        run()
+
+        assertEquals("Doubling Season — rulings", slot.captured.title)
+        assertTrue(slot.captured.description!!.contains("Tokens are doubled."))
+    }
+
+    @Test
+    fun `rulings reports when the name doesn't resolve`() {
+        val slot = slot<MessageEmbed>()
+        every { event.hook.sendMessageEmbeds(capture(slot), *anyVararg()) } returns webhookMessageCreateAction
+        every { event.subcommandName } returns CubeCommand.SUB_RULINGS
+        every { event.getOption(CubeCommand.OPT_NAME) } returns strOpt("Notacard")
+        coEvery { fetcher.fetchRulings(any()) } returns null
+
+        run()
+
+        assertEquals("Couldn't build that cube", slot.captured.title)
+        assertTrue(slot.captured.description!!.contains("Notacard"))
+    }
+
+    @Test
+    fun `exposes the six subcommands with their options`() {
         assertEquals("cube", command.name)
         val subs = command.subCommands.associateBy { it.name }
-        assertEquals(setOf("asfan", "preview", "generate", "saved", "card"), subs.keys)
+        assertEquals(setOf("asfan", "preview", "generate", "saved", "card", "rulings"), subs.keys)
         assertEquals(OptionType.STRING, subs.getValue("card").options.first { it.name == "name" }.type)
         assertTrue(subs.getValue("card").options.first { it.name == "name" }.isRequired)
+        assertTrue(subs.getValue("rulings").options.first { it.name == "name" }.isRequired)
 
         val asfan = subs.getValue("asfan").options
         assertEquals(OptionType.INTEGER, asfan.first { it.name == "total" }.type)

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeEmbedsTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeEmbedsTest.kt
@@ -239,6 +239,44 @@ class CubeEmbedsTest {
     }
 
     @Test
+    fun `rulingsEmbed lists each ruling with its date, linking to Scryfall`() {
+        val rulings = common.mtg.CardRulings(
+            cardName = "Doubling Season",
+            scryfallUri = "https://scryfall.com/card/dd",
+            rulings = listOf(
+                common.mtg.CardRulings.Ruling("2021-03-19", "Tokens are doubled."),
+                common.mtg.CardRulings.Ruling("2022-01-01", "Counters are doubled too."),
+            ),
+        )
+        val embed = CubeEmbeds.rulingsEmbed(rulings)
+        assertEquals("Doubling Season — rulings", embed.title)
+        assertEquals("https://scryfall.com/card/dd", embed.url)
+        val desc = embed.description!!
+        assertTrue(desc.contains("Tokens are doubled."))
+        assertTrue(desc.contains("Counters are doubled too."))
+        assertTrue(desc.contains("2021-03-19"))
+        assertTrue(embed.footer!!.text!!.contains("2 rulings"))
+    }
+
+    @Test
+    fun `rulingsEmbed shows an empty state when the card has no rulings`() {
+        val rulings = common.mtg.CardRulings("Plains", "https://scryfall.com/p", emptyList())
+        val embed = CubeEmbeds.rulingsEmbed(rulings)
+        assertTrue(embed.description!!.contains("No official rulings"))
+        assertNull(embed.footer)
+    }
+
+    @Test
+    fun `rulingsBlock drops overflow rulings and notes how many were hidden`() {
+        // 60 long rulings can't all fit under the description cap — the block
+        // must stop early and append an "…and N more" pointer.
+        val many = (1..60).map { common.mtg.CardRulings.Ruling("2020-01-0$it", "x".repeat(200)) }
+        val block = CubeEmbeds.rulingsBlock(many)
+        assertTrue(block.length <= 4096, "block exceeded the embed description cap: ${block.length}")
+        assertTrue(block.contains("more (see Scryfall)"), "expected an overflow pointer: $block")
+    }
+
+    @Test
     fun `packsFile lists each card, appending its image link when present`() {
         val packs = listOf(
             listOf(

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcherTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcherTest.kt
@@ -310,6 +310,101 @@ class ScryfallCubeFetcherTest {
         assertNull(fetcherWith(MockEngine { throw IOException("down") }).fetchNamed("Bolt"))
     }
 
+    // --- rulings -------------------------------------------------------
+
+    @Test
+    fun `parseRulings maps the data array, skipping blank comments`() {
+        val rulings = fetcher.parseRulings(
+            obj("""{"data":[
+              {"published_at":"2021-03-19","comment":"First."},
+              {"published_at":"2022-02-02","comment":""},
+              {"comment":"No date."}
+            ]}""")
+        )
+        assertEquals(2, rulings.size)
+        assertEquals("2021-03-19", rulings[0].publishedAt)
+        assertEquals("First.", rulings[0].comment)
+        assertEquals("", rulings[1].publishedAt) // missing date → blank
+        assertEquals("No date.", rulings[1].comment)
+    }
+
+    @Test
+    fun `parseRulings tolerates a missing data array`() {
+        assertTrue(fetcher.parseRulings(obj("""{"object":"error"}""")).isEmpty())
+    }
+
+    @Test
+    fun `fetchRulings resolves the card then its rulings`() = runBlocking {
+        val engine = MockEngine { request ->
+            if (request.url.toString().contains("/rulings")) {
+                respond(
+                    """{"data":[{"published_at":"2021-03-19","comment":"It works like this."}]}""",
+                    HttpStatusCode.OK, jsonHeaders,
+                )
+            } else {
+                respond(
+                    """{"name":"Doubling Season","scryfall_uri":"https://scryfall.com/card",
+                       "rulings_uri":"https://api.scryfall.com/cards/abc/rulings"}""",
+                    HttpStatusCode.OK, jsonHeaders,
+                )
+            }
+        }
+        val rulings = fetcherWith(engine).fetchRulings("doubling season")
+        assertEquals("Doubling Season", rulings?.cardName)
+        assertEquals("https://scryfall.com/card", rulings?.scryfallUri)
+        assertEquals(1, rulings?.rulings?.size)
+        assertEquals("It works like this.", rulings?.rulings?.first()?.comment)
+        // Two calls: the fuzzy named lookup, then the rulings uri.
+        assertEquals(2, engine.requestHistory.size)
+    }
+
+    @Test
+    fun `fetchRulings returns an empty list when the card has no rulings`() = runBlocking {
+        val engine = MockEngine { request ->
+            if (request.url.toString().contains("/rulings")) {
+                respond("""{"data":[]}""", HttpStatusCode.OK, jsonHeaders)
+            } else {
+                respond(
+                    """{"name":"Plains","scryfall_uri":"https://scryfall.com/p","rulings_uri":"https://api.scryfall.com/cards/p/rulings"}""",
+                    HttpStatusCode.OK, jsonHeaders,
+                )
+            }
+        }
+        val rulings = fetcherWith(engine).fetchRulings("Plains")
+        assertEquals("Plains", rulings?.cardName)
+        assertTrue(rulings!!.rulings.isEmpty())
+    }
+
+    @Test
+    fun `fetchRulings returns null when no card matches (404)`() = runBlocking {
+        val rulings = fetcherWith(MockEngine { respondError(HttpStatusCode.NotFound) }).fetchRulings("zzznotacard")
+        assertNull(rulings)
+    }
+
+    @Test
+    fun `fetchRulings returns null for a blank name without calling the network`() = runBlocking {
+        val engine = MockEngine { respond("{}", HttpStatusCode.OK, jsonHeaders) }
+        assertNull(fetcherWith(engine).fetchRulings("   "))
+        assertEquals(0, engine.requestHistory.size)
+    }
+
+    @Test
+    fun `fetchRulings yields no rulings when the rulings call errors but the card resolved`() = runBlocking {
+        val engine = MockEngine { request ->
+            if (request.url.toString().contains("/rulings")) {
+                respondError(HttpStatusCode.InternalServerError)
+            } else {
+                respond(
+                    """{"name":"Bolt","scryfall_uri":"u","rulings_uri":"https://api.scryfall.com/cards/b/rulings"}""",
+                    HttpStatusCode.OK, jsonHeaders,
+                )
+            }
+        }
+        val rulings = fetcherWith(engine).fetchRulings("Bolt")
+        assertEquals("Bolt", rulings?.cardName)
+        assertTrue(rulings!!.rulings.isEmpty())
+    }
+
     // --- fetch ---------------------------------------------------------
 
     @Test

--- a/web/src/main/kotlin/web/configuration/WebSecurityConfig.kt
+++ b/web/src/main/kotlin/web/configuration/WebSecurityConfig.kt
@@ -25,7 +25,7 @@ class WebSecurityConfig {
                     // shared cube (/cube/c/**) are public; the saved-lists and
                     // share-create APIs are deliberately NOT listed here so they
                     // fall through to anyRequest().authenticated().
-                    "/cube", "/cube/c/**", "/cube/api/asfan", "/cube/api/preview", "/cube/api/generate", "/cube/api/diff", "/cube/api/card",
+                    "/cube", "/cube/c/**", "/cube/api/asfan", "/cube/api/preview", "/cube/api/generate", "/cube/api/diff", "/cube/api/card", "/cube/api/rulings",
                     "/sitemap.xml", "/robots.txt",
                     // Service worker for web push must be reachable
                     // unauthenticated — the browser registers it on

--- a/web/src/main/kotlin/web/controller/CubeController.kt
+++ b/web/src/main/kotlin/web/controller/CubeController.kt
@@ -24,6 +24,7 @@ import web.service.CategoryGroup
 import web.service.CubeResult
 import web.service.DiffLineView
 import web.service.CubeWebService
+import web.service.RulingView
 import web.service.GenerateData
 import web.service.PreviewData
 import web.util.discordIdOrNull
@@ -130,6 +131,17 @@ class CubeController(
         when (val result = cubeWebService.card(name)) {
             is CubeResult.Success -> ResponseEntity.ok(CubeCardResponse(true, null, result.value))
             is CubeResult.Failure -> ResponseEntity.badRequest().body(CubeCardResponse(false, result.error, null))
+        }
+
+    @GetMapping("/api/rulings", produces = ["application/json"])
+    @ResponseBody
+    fun rulings(@RequestParam("name") name: String): ResponseEntity<CubeRulingsResponse> =
+        when (val result = cubeWebService.rulings(name)) {
+            is CubeResult.Success -> ResponseEntity.ok(
+                CubeRulingsResponse(true, null, result.value.name, result.value.scryfallUri, result.value.rulings)
+            )
+            is CubeResult.Failure ->
+                ResponseEntity.badRequest().body(CubeRulingsResponse(false, result.error, null, null, emptyList()))
         }
 
     @PostMapping("/api/diff", consumes = ["application/json"], produces = ["application/json"])
@@ -257,6 +269,14 @@ data class ShareCubeResponse(val token: String, val url: String, val name: Strin
 data class CubeListPreviewRequest(val list: String = "", val packSize: Int = 15)
 
 data class CubeCardResponse(val ok: Boolean, val error: String?, val card: CardLookupView?)
+
+data class CubeRulingsResponse(
+    val ok: Boolean,
+    val error: String?,
+    val name: String?,
+    val scryfallUri: String?,
+    val rulings: List<RulingView>,
+)
 
 data class CubeDiffRequest(val listA: String = "", val listB: String = "")
 

--- a/web/src/main/kotlin/web/service/CubeWebService.kt
+++ b/web/src/main/kotlin/web/service/CubeWebService.kt
@@ -78,6 +78,73 @@ class CubeWebService {
         }
     }
 
+    /**
+     * Looks a card up by (fuzzy) name and fetches its official rulings — the
+     * website twin of `/cube rulings`. Two calls: `/cards/named` to resolve the
+     * card (and its `rulings_uri`), then a GET of that uri. A resolved card
+     * with no rulings is a success with an empty list, not an error.
+     */
+    fun rulings(name: String): CubeResult<RulingsView> {
+        val trimmed = name.trim()
+        if (trimmed.isEmpty()) return CubeResult.error("Enter a card name to look up rulings.")
+        val url = "$NAMED_ENDPOINT?fuzzy=" + URLEncoder.encode(trimmed, StandardCharsets.UTF_8)
+        return try {
+            val response = scryfallGet(url)
+            when (response.statusCode()) {
+                200 -> {
+                    val card = jackson.readTree(response.body())
+                    val cardName = card.path("name").asText("").takeIf { it.isNotBlank() }
+                        ?: return CubeResult.error("Scryfall returned an unexpected card.")
+                    val scryfallUri = card.path("scryfall_uri").asText("").takeIf { it.isNotBlank() }
+                    val rulingsUri = card.path("rulings_uri").asText("").takeIf { it.isNotBlank() }
+                    val rulings = rulingsUri?.let { fetchRulings(it) } ?: emptyList()
+                    CubeResult.ok(RulingsView(cardName, scryfallUri, rulings))
+                }
+                404 -> CubeResult.error("No card found matching “$trimmed”.")
+                else -> CubeResult.error("Scryfall returned ${response.statusCode()}.")
+            }
+        } catch (e: IOException) {
+            CubeResult.error("Could not reach Scryfall: ${e.message}")
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            CubeResult.error("Request interrupted.")
+        }
+    }
+
+    /** GETs and parses a `rulings_uri`; an unreachable/non-200 rulings call yields no rulings. */
+    private fun fetchRulings(rulingsUri: String): List<RulingView> =
+        try {
+            val response = scryfallGet(rulingsUri)
+            if (response.statusCode() == 200) rulingsOf(jackson.readTree(response.body())) else emptyList()
+        } catch (e: IOException) {
+            emptyList()
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            emptyList()
+        }
+
+    /** Maps a Scryfall `/rulings` JSON tree into ruling views, skipping blank comments. */
+    fun rulingsOf(root: JsonNode): List<RulingView> {
+        val data = root.path("data")
+        if (!data.isArray) return emptyList()
+        return data.mapNotNull { node ->
+            val comment = node.path("comment").asText("").takeIf { it.isNotBlank() } ?: return@mapNotNull null
+            RulingView(node.path("published_at").asText(""), comment)
+        }
+    }
+
+    /** A short GET against Scryfall with the standard headers and timeout. */
+    private fun scryfallGet(url: String): HttpResponse<String> =
+        http.send(
+            HttpRequest.newBuilder(URI.create(url))
+                .header("User-Agent", "tobybot-web/1.0")
+                .header("Accept", "application/json")
+                .timeout(Duration.ofSeconds(10))
+                .GET()
+                .build(),
+            HttpResponse.BodyHandlers.ofString(),
+        )
+
     /** Maps a resolved card to the lookup view, resolving rarity + colours for display. */
     internal fun lookupView(sc: ScryfallCard): CardLookupView = CardLookupView(
         name = sc.card.name,
@@ -627,6 +694,16 @@ data class CardLookupView(
     /** Play formats this card is currently legal in, display-cased, in [CubeCard.FORMATS] order. */
     val legalFormats: List<String> = emptyList(),
 )
+
+/** A card's official rulings, looked up by name: the card, its Scryfall page, and the notes. */
+data class RulingsView(
+    val name: String,
+    val scryfallUri: String?,
+    val rulings: List<RulingView>,
+)
+
+/** One published ruling: the ISO publish date and the note text. */
+data class RulingView(val publishedAt: String, val comment: String)
 
 /** One card's change between two compared lists (copy counts from → to). */
 data class DiffLineView(val name: String, val from: Int, val to: Int)

--- a/web/src/main/resources/static/css/cube.css
+++ b/web/src/main/resources/static/css/cube.css
@@ -1110,6 +1110,48 @@ details[open] > .cube-section-summary .cube-collapse-chevron {
     letter-spacing: 0.04em;
 }
 
+/* Official rulings, loaded on demand under the card lookup. */
+.cube-rulings {
+    margin-top: var(--space-3);
+}
+
+.cube-rulings-h {
+    margin: 0 0 var(--space-2);
+    color: var(--heading);
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.cube-rulings-empty {
+    margin: 0;
+    color: var(--text-muted);
+    font-size: 0.9rem;
+}
+
+.cube-rulings-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+}
+
+.cube-ruling {
+    padding: var(--space-2);
+    border-left: 3px solid var(--border);
+    background: var(--surface-2, rgba(255, 255, 255, 0.03));
+    font-size: 0.9rem;
+}
+
+.cube-ruling-date {
+    display: block;
+    margin-bottom: 2px;
+    color: var(--text-muted);
+    font-size: 0.78rem;
+}
+
 /* Total cube value (sum of priced cards), shown under the analytics breakdown,
    with a currency switch sitting alongside it. */
 .cube-total-value-row {

--- a/web/src/main/resources/static/js/cube.js
+++ b/web/src/main/resources/static/js/cube.js
@@ -405,6 +405,11 @@
         return '/cube/api/card?name=' + encodeURIComponent(name);
     }
 
+    /** GET URL for a card's official rulings. */
+    function rulingsUrl(name) {
+        return '/cube/api/rulings?name=' + encodeURIComponent(name);
+    }
+
     /**
      * A card's market prices as a compact one-liner ("$1.50 · €1.20 · 0.03 tix"),
      * present currencies only, or '' when Scryfall has no price for it. Pure.
@@ -488,8 +493,60 @@
         link.textContent = 'View on Scryfall ↗';
         facts.appendChild(link);
 
+        // On-demand rulings: a button that fetches /cube/api/rulings for this
+        // card and renders them into the box below (wired in wireCardLookup).
+        const rulingsBtn = document.createElement('button');
+        rulingsBtn.type = 'button';
+        rulingsBtn.className = 'btn btn-secondary cube-rulings-btn';
+        rulingsBtn.setAttribute('data-load-rulings', '');
+        rulingsBtn.setAttribute('data-card-name', card.name);
+        rulingsBtn.textContent = 'Show rulings';
+        facts.appendChild(rulingsBtn);
+
         wrap.appendChild(facts);
         container.appendChild(wrap);
+
+        const rulingsBox = document.createElement('div');
+        rulingsBox.className = 'cube-rulings';
+        rulingsBox.setAttribute('data-rulings-result', '');
+        rulingsBox.hidden = true;
+        container.appendChild(rulingsBox);
+        return container;
+    }
+
+    /** Renders a card's official rulings (date + note each), or a friendly empty state. */
+    function renderRulings(container, data) {
+        container.replaceChildren();
+        const h = document.createElement('h4');
+        h.className = 'cube-rulings-h';
+        h.textContent = 'Rulings';
+        container.appendChild(h);
+        const rulings = (data && data.rulings) || [];
+        if (!rulings.length) {
+            const p = document.createElement('p');
+            p.className = 'cube-rulings-empty';
+            p.textContent = 'No official rulings have been published for this card.';
+            container.appendChild(p);
+            return container;
+        }
+        const ul = document.createElement('ul');
+        ul.className = 'cube-rulings-list';
+        rulings.forEach(function (r) {
+            const li = document.createElement('li');
+            li.className = 'cube-ruling';
+            if (r.publishedAt) {
+                const date = document.createElement('span');
+                date.className = 'cube-ruling-date';
+                date.textContent = r.publishedAt;
+                li.appendChild(date);
+            }
+            const text = document.createElement('span');
+            text.className = 'cube-ruling-text';
+            text.textContent = r.comment;
+            li.appendChild(text);
+            ul.appendChild(li);
+        });
+        container.appendChild(ul);
         return container;
     }
 
@@ -1145,6 +1202,27 @@
         if (!form) return;
         const status = statusFor(doc, 'card');
         const result = q(doc, '[data-result="card"]');
+
+        // Delegated so it survives each re-render of the lookup result: the
+        // "Show rulings" button fetches that card's rulings on demand.
+        result.addEventListener('click', function (e) {
+            const btn = e.target.closest && e.target.closest('[data-load-rulings]');
+            if (!btn) return;
+            const name = btn.getAttribute('data-card-name');
+            const box = result.querySelector('[data-rulings-result]');
+            if (!name || !box) return;
+            btn.disabled = true;
+            btn.textContent = 'Loading rulings…';
+            getJson(rulingsUrl(name))
+                .then(function (json) {
+                    if (!json.ok) { btn.disabled = false; btn.textContent = json.error || 'No rulings found.'; return; }
+                    renderRulings(box, json);
+                    box.hidden = false;
+                    btn.hidden = true;
+                })
+                .catch(function () { btn.disabled = false; btn.textContent = 'Show rulings'; });
+        });
+
         form.addEventListener('submit', function (e) {
             e.preventDefault();
             const name = (new FormData(form).get('name') || '').trim();
@@ -1616,9 +1694,11 @@
         renderDistribution: renderDistribution,
         renderDiff: renderDiff,
         cardUrl: cardUrl,
+        rulingsUrl: rulingsUrl,
         priceLine: priceLine,
         totalValueText: totalValueText,
         renderCardLookup: renderCardLookup,
+        renderRulings: renderRulings,
         renderTotalValue: renderTotalValue,
         renderManaCurve: renderManaCurve,
         renderTypeBreakdown: renderTypeBreakdown,

--- a/web/src/test/js/cube.test.js
+++ b/web/src/test/js/cube.test.js
@@ -439,6 +439,46 @@ describe('card lookup (cardUrl / renderCardLookup)', () => {
         expect(text).not.toContain('Price');
         expect(text).not.toContain('Legal');
     });
+
+    test('renderCardLookup includes a Show rulings button carrying the card name, and a hidden box', () => {
+        const container = document.createElement('div');
+        Cube.renderCardLookup(container, { name: 'Doubling Season', imageUrlLarge: 'n.jpg', typeLine: 'Enchantment', manaValue: 5, rarity: 'Rare', colors: ['Green'] });
+        const btn = container.querySelector('[data-load-rulings]');
+        expect(btn).not.toBeNull();
+        expect(btn.getAttribute('data-card-name')).toBe('Doubling Season');
+        const box = container.querySelector('[data-rulings-result]');
+        expect(box).not.toBeNull();
+        expect(box.hidden).toBe(true);
+    });
+});
+
+describe('rulings (rulingsUrl / renderRulings)', () => {
+    test('rulingsUrl encodes the name', () => {
+        expect(Cube.rulingsUrl('Urza, Lord High Artificer'))
+            .toBe('/cube/api/rulings?name=' + encodeURIComponent('Urza, Lord High Artificer'));
+    });
+
+    test('renderRulings lists each ruling with its date', () => {
+        const container = document.createElement('div');
+        Cube.renderRulings(container, {
+            rulings: [
+                { publishedAt: '2021-03-19', comment: 'Tokens are doubled.' },
+                { publishedAt: '2022-01-01', comment: 'Counters too.' },
+            ],
+        });
+        expect(container.querySelector('.cube-rulings-h').textContent).toBe('Rulings');
+        const items = container.querySelectorAll('.cube-ruling');
+        expect(items).toHaveLength(2);
+        expect(items[0].querySelector('.cube-ruling-date').textContent).toBe('2021-03-19');
+        expect(items[0].querySelector('.cube-ruling-text').textContent).toBe('Tokens are doubled.');
+    });
+
+    test('renderRulings shows an empty state when there are none', () => {
+        const container = document.createElement('div');
+        Cube.renderRulings(container, { rulings: [] });
+        expect(container.querySelector('.cube-rulings-empty').textContent).toContain('No official rulings');
+        expect(container.querySelectorAll('.cube-ruling')).toHaveLength(0);
+    });
 });
 
 describe('priceLine (pure)', () => {

--- a/web/src/test/kotlin/web/controller/CubeControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/CubeControllerTest.kt
@@ -31,6 +31,8 @@ import web.service.DuplicateView
 import web.service.GenerateData
 import web.service.PreviewData
 import web.service.RarityCountView
+import web.service.RulingView
+import web.service.RulingsView
 import web.service.TypeCountView
 import java.time.Instant
 
@@ -155,6 +157,31 @@ class CubeControllerTest {
         val response = controller.card("zzz")
         assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
         assertFalse(response.body!!.ok)
+    }
+
+    @Test
+    fun `rulings returns 200 with the looked-up rulings`() {
+        every { service.rulings("Doubling Season") } returns CubeResult.ok(
+            RulingsView(
+                "Doubling Season", "https://scryfall.com/card",
+                listOf(RulingView("2021-03-19", "If two replacement effects apply, you choose the order.")),
+            )
+        )
+        val response = controller.rulings("Doubling Season")
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertTrue(response.body!!.ok)
+        assertEquals("Doubling Season", response.body!!.name)
+        assertEquals(1, response.body!!.rulings.size)
+        assertEquals("2021-03-19", response.body!!.rulings.first().publishedAt)
+    }
+
+    @Test
+    fun `rulings returns 400 when nothing matches`() {
+        every { service.rulings(any()) } returns CubeResult.error("No card found matching “zzz”.")
+        val response = controller.rulings("zzz")
+        assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+        assertFalse(response.body!!.ok)
+        assertTrue(response.body!!.rulings.isEmpty())
     }
 
     @Test

--- a/web/src/test/kotlin/web/service/CubeWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/CubeWebServiceTest.kt
@@ -122,6 +122,36 @@ class CubeWebServiceTest {
         assertEquals("1.25", parsed.toView().priceUsd) // surfaced on the grid tile
     }
 
+    // --- rulings -------------------------------------------------------
+
+    @Test
+    fun `rulingsOf maps the data array, skipping blank comments`() {
+        val root = mapper.readTree(
+            """{"data":[
+              {"published_at":"2021-03-19","comment":"First ruling."},
+              {"published_at":"2022-01-01","comment":""},
+              {"published_at":"2023-06-06","comment":"Third ruling."}
+            ]}"""
+        )
+        val rulings = service.rulingsOf(root)
+        assertEquals(2, rulings.size)
+        assertEquals("2021-03-19", rulings.first().publishedAt)
+        assertEquals("First ruling.", rulings.first().comment)
+        assertEquals("Third ruling.", rulings[1].comment)
+    }
+
+    @Test
+    fun `rulingsOf tolerates a missing or non-array data field`() {
+        assertTrue(service.rulingsOf(mapper.readTree("""{"object":"error"}""")).isEmpty())
+        assertTrue(service.rulingsOf(mapper.readTree("""{"data":{}}""")).isEmpty())
+    }
+
+    @Test
+    fun `rulings rejects a blank name without hitting the network`() {
+        val result = assertInstanceOf(CubeResult.Failure::class.java, service.rulings("  "))
+        assertTrue(result.error.contains("card name"))
+    }
+
     // --- diff (compare two lists) --------------------------------------
 
     @Test


### PR DESCRIPTION
Rounds out the "card bot" feature set: look up a Magic card's **official rulings** (the rules team's clarifications for tricky interactions) on both Discord and the web — the last of the three hot features picked earlier (prices ✅, legality ✅, rulings — this PR).

## What's new

**Shared domain (`common`)**
- `CardRulings` value type — card name, Scryfall URI, and the list of `Ruling(publishedAt, comment)`. An empty list means "card exists, no rulings yet" (a friendly state, not an error).

**Discord — `/cube rulings name:`**
- `ScryfallCubeFetcher.fetchRulings` resolves the card by fuzzy name, then GETs its `rulings_uri`.
- `CubeEmbeds.rulingsEmbed` renders each ruling with its date, links to the card's Scryfall page, trims overflow to stay under the embed description cap (with an "…and N more" pointer), and shows an empty state for unruled cards.

**Web — card-lookup tab**
- `CubeWebService.rulings` + `GET /cube/api/rulings` (added to the public allow-list).
- The card-lookup result gains an on-demand **Show rulings** button that fetches and renders the dated notes inline (no extra call unless asked).

## Testing
- `common`: exercised via the fetcher/service tests.
- Discord: `parseRulings`, `fetchRulings` (two-step happy path, no-rulings, 404, blank name, rulings-call error), `rulingsEmbed` + `rulingsBlock` overflow trim, `/cube rulings` command (success + not-found), subcommand registration.
- Web: `rulingsOf` parsing, blank-name guard, controller 200/400.
- jest: `rulingsUrl`, `renderRulings` (list + empty), card-lookup rulings button.
- stylelint + `:common:` / `:web:` / `:discord-bot:` kover gates all green; full jest suite (721) passing.

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs

---
_Generated by [Claude Code](https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs)_