### PR TITLE
Group the Magic settings into their own admin section

### DIFF
--- a/web/src/main/resources/templates/moderation/settings.html
+++ b/web/src/main/resources/templates/moderation/settings.html
@@ -37,6 +37,7 @@
                     <p class="settings-nav-heading">Server</p>
                     <a href="#settings-section-server-features" class="settings-nav-link">Server features</a>
                     <a href="#settings-section-messages" class="settings-nav-link">Messages &amp; leaderboards</a>
+                    <a href="#settings-section-magic" class="settings-nav-link">Magic: The Gathering</a>
                 </div>
                 <div class="settings-nav-group">
                     <p class="settings-nav-heading">Economy</p>
@@ -122,42 +123,6 @@
                 <details id="settings-section-messages" class="config-section">
                     <summary>Messages &amp; leaderboards</summary>
                     <div class="config-grid">
-                        <!-- Opt-out: inline [[card]] lookups are on unless explicitly
-                             set to "false", so a null/absent value reads as Enabled. -->
-                        <div class="config-row" data-key="CARD_MENTIONS">
-                            <label>Inline [[card]] Magic lookups</label>
-                            <select th:disabled="${!isOwner}">
-                                <option value="true"
-                                        th:selected="${overview.config['CARD_MENTIONS'] == null or overview.config['CARD_MENTIONS'] == 'true'}">
-                                    Enabled
-                                </option>
-                                <option value="false"
-                                        th:selected="${overview.config['CARD_MENTIONS'] == 'false'}">
-                                    Disabled
-                                </option>
-                            </select>
-                            <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                        </div>
-                        <!-- Currency the /cube preview's "cube value" total is shown in.
-                             Null/absent reads as USD. -->
-                        <div class="config-row" data-key="CUBE_CURRENCY">
-                            <label>Cube value currency</label>
-                            <select th:disabled="${!isOwner}">
-                                <option value="usd"
-                                        th:selected="${overview.config['CUBE_CURRENCY'] == null or overview.config['CUBE_CURRENCY'] == 'usd'}">
-                                    US Dollars ($)
-                                </option>
-                                <option value="eur"
-                                        th:selected="${overview.config['CUBE_CURRENCY'] == 'eur'}">
-                                    Euros (€)
-                                </option>
-                                <option value="tix"
-                                        th:selected="${overview.config['CUBE_CURRENCY'] == 'tix'}">
-                                    MTGO Tix
-                                </option>
-                            </select>
-                            <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                        </div>
                         <div class="config-row" data-key="DELETE_DELAY">
                             <label>Message delete delay (seconds)</label>
                             <input type="number" min="0" max="600"
@@ -229,6 +194,48 @@
                                 <button type="submit" class="btn config-create-channel-btn"
                                         th:disabled="${!isOwner}">Create</button>
                             </form>
+                        </div>
+                    </div>
+                </details>
+
+                <details id="settings-section-magic" class="config-section">
+                    <summary>Magic: The Gathering</summary>
+                    <div class="config-grid">
+                        <!-- Opt-out: inline [[card]] lookups are on unless explicitly
+                             set to "false", so a null/absent value reads as Enabled. -->
+                        <div class="config-row" data-key="CARD_MENTIONS">
+                            <label>Inline [[card]] Magic lookups</label>
+                            <select th:disabled="${!isOwner}">
+                                <option value="true"
+                                        th:selected="${overview.config['CARD_MENTIONS'] == null or overview.config['CARD_MENTIONS'] == 'true'}">
+                                    Enabled
+                                </option>
+                                <option value="false"
+                                        th:selected="${overview.config['CARD_MENTIONS'] == 'false'}">
+                                    Disabled
+                                </option>
+                            </select>
+                            <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                        </div>
+                        <!-- Currency the /cube preview's "cube value" total is shown in.
+                             Null/absent reads as USD. -->
+                        <div class="config-row" data-key="CUBE_CURRENCY">
+                            <label>Cube value currency</label>
+                            <select th:disabled="${!isOwner}">
+                                <option value="usd"
+                                        th:selected="${overview.config['CUBE_CURRENCY'] == null or overview.config['CUBE_CURRENCY'] == 'usd'}">
+                                    US Dollars ($)
+                                </option>
+                                <option value="eur"
+                                        th:selected="${overview.config['CUBE_CURRENCY'] == 'eur'}">
+                                    Euros (€)
+                                </option>
+                                <option value="tix"
+                                        th:selected="${overview.config['CUBE_CURRENCY'] == 'tix'}">
+                                    MTGO Tix
+                                </option>
+                            </select>
+                            <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                         </div>
                     </div>
                 </details>

--- a/web/src/test/kotlin/web/template/ModerationTemplateRowsTest.kt
+++ b/web/src/test/kotlin/web/template/ModerationTemplateRowsTest.kt
@@ -230,6 +230,32 @@ class ModerationTemplateRowsTest {
     }
 
     @Test
+    fun `settings template has a dedicated Magic section holding both Magic config keys`() {
+        // The two Magic keys (inline [[card]] lookups + cube value currency)
+        // used to be buried in the generic "Messages & leaderboards" section.
+        // They now live in their own <details><summary>Magic: The Gathering</summary>
+        // block — mirroring how each game gets its own section — so they're
+        // grouped and discoverable.
+        val start = settingsHtml.indexOf("<summary>Magic: The Gathering</summary>")
+        assertTrue(start >= 0, "expected a <details><summary>Magic: The Gathering</summary> section")
+        val sectionEnd = settingsHtml.indexOf("</details>", start)
+        assertTrue(sectionEnd > start, "Magic section not terminated")
+        val sectionHtml = settingsHtml.substring(start, sectionEnd)
+        for (key in listOf("CARD_MENTIONS", "CUBE_CURRENCY")) {
+            assertTrue(
+                sectionHtml.contains("data-key=\"$key\""),
+                "$key should live inside the Magic: The Gathering section",
+            )
+        }
+        // The section is reachable from the sticky left-rail nav, like every
+        // other section (the rail anchor must match the section id).
+        assertTrue(
+            settingsHtml.contains("href=\"#settings-section-magic\""),
+            "expected a left-rail link to #settings-section-magic",
+        )
+    }
+
+    @Test
     fun `settings template groups sections under server economy and casino pillars`() {
         // The three top-level <h2 class="config-pillar"> headers anchor
         // the visual grouping of the otherwise-flat accordion sections.


### PR DESCRIPTION
The two Magic config keys were buried in the generic **"Messages & leaderboards"** section of the moderation settings page, mixed in with delete-delay and leaderboard config. This gives Magic its own home.

## What changed
- New **"Magic: The Gathering"** collapsible `<details>` section under the **Server** pillar, holding both Magic keys:
  - `CARD_MENTIONS` — inline `[[card]]` lookups toggle
  - `CUBE_CURRENCY` — cube value currency
- A matching left-rail nav link (`#settings-section-magic`) so it's reachable from the sticky section rail, like every other section.
- The keys are removed from "Messages & leaderboards" (which now holds just delete-delay + leaderboard config).

This mirrors how each casino game (Poker, Blackjack, Jackpot) gets its own section, and stays discoverable through the config search. It's proportionate for two keys today and easy to grow into a full page later if Magic config expands.

## Notes
- Pure template move — no Kotlin/JS logic changed (the section rail and config search both work off the DOM, so the new section is picked up automatically).
- A `ModerationTemplateRowsTest` case pins both keys to the new section and the rail anchor to its id, so a future refactor can't silently scatter them. The existing bidirectional enum-vs-template guard still covers presence.

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs

---
_Generated by [Claude Code](https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs)_