### PR TITLE
Surface cube value on generate, per-card prices in pack files, and value extremes

### DIFF
--- a/common/src/main/kotlin/common/mtg/CubeAnalytics.kt
+++ b/common/src/main/kotlin/common/mtg/CubeAnalytics.kt
@@ -33,6 +33,12 @@ object CubeAnalytics {
     /** The cube's summed market value in one [MtgCurrency]. */
     data class TotalValue(val currency: MtgCurrency, val amount: Double)
 
+    /** A card paired with its price in some currency, for the value extremes. */
+    data class ValuedCard(val name: String, val amount: Double)
+
+    /** The priciest and cheapest priced cards in a pool, in a given currency. */
+    data class ValueExtremes(val currency: MtgCurrency, val mostValuable: ValuedCard, val leastValuable: ValuedCard)
+
     /** The whole report, assembled once so the surfaces render identical numbers. */
     data class Analytics(
         val curve: List<ManaCurveBucket>,
@@ -94,6 +100,18 @@ object CubeAnalytics {
                 ?.sum()
                 ?.let { TotalValue(currency, it) }
         }
+
+    /**
+     * The most- and least-valuable priced cards in the pool for [currency], or
+     * null when nothing is priced in it. Ties resolve to the first card seen.
+     * Unpriced cards (and cards with an unparseable price) are ignored.
+     */
+    fun valueExtremes(cards: List<CubeCard>, currency: MtgCurrency): ValueExtremes? {
+        val priced = cards.mapNotNull { card ->
+            card.price(currency)?.toDoubleOrNull()?.let { ValuedCard(card.name, it) }
+        }.takeIf { it.isNotEmpty() } ?: return null
+        return ValueExtremes(currency, priced.maxBy { it.amount }, priced.minBy { it.amount })
+    }
 
     /**
      * Two-colour cards grouped by guild, in guild order, present pairs only —

--- a/common/src/test/kotlin/common/mtg/CubeAnalyticsTest.kt
+++ b/common/src/test/kotlin/common/mtg/CubeAnalyticsTest.kt
@@ -246,6 +246,31 @@ class CubeAnalyticsTest {
     }
 
     @Test
+    fun `valueExtremes finds the priciest and cheapest priced card in a currency`() {
+        val pool = listOf(
+            card("Cheap", priceUsd = "0.25", priceEur = "0.20"),
+            card("Pricey", priceUsd = "60.00", priceEur = "55.00"),
+            card("Mid", priceUsd = "3.00", priceEur = "2.50"),
+            card("Unpriced", priceUsd = null),
+        )
+        val usd = CubeAnalytics.valueExtremes(pool, MtgCurrency.USD)!!
+        assertEquals(MtgCurrency.USD, usd.currency)
+        assertEquals("Pricey", usd.mostValuable.name)
+        assertEquals(60.00, usd.mostValuable.amount, 1e-9)
+        assertEquals("Cheap", usd.leastValuable.name)
+        assertEquals(0.25, usd.leastValuable.amount, 1e-9)
+        // Resolves independently per currency.
+        assertEquals("Pricey", CubeAnalytics.valueExtremes(pool, MtgCurrency.EUR)!!.mostValuable.name)
+    }
+
+    @Test
+    fun `valueExtremes is null when nothing is priced in that currency`() {
+        val pool = listOf(card("A", priceUsd = "1.00"))
+        assertEquals(null, CubeAnalytics.valueExtremes(pool, MtgCurrency.EUR))
+        assertEquals(null, CubeAnalytics.valueExtremes(emptyList(), MtgCurrency.USD))
+    }
+
+    @Test
     fun `Analytics totalValueIn resolves a currency or returns null`() {
         val a = CubeAnalytics.analyze(listOf(card("A", priceUsd = "4.00")), packSize = 1)
         assertEquals(4.00, a.totalValueIn(MtgCurrency.USD)!!, 1e-9)

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeCommand.kt
@@ -183,6 +183,7 @@ class CubeCommand @Autowired constructor(
             is PoolResult.Failed -> reply(ctx, CubeEmbeds.errorEmbed(resolved.message), deleteDelay)
             is PoolResult.Ready -> {
                 val pool = resolved.pool
+                val currency = currencyFor(ctx)
                 val embed = CubeEmbeds.previewEmbed(
                     query = resolved.label,
                     poolSize = pool.size,
@@ -192,7 +193,8 @@ class CubeCommand @Autowired constructor(
                     analytics = CubeAnalytics.analyze(pool, packSize),
                     notFound = resolved.notFound,
                     note = resolved.note,
-                    currency = currencyFor(ctx),
+                    currency = currency,
+                    valueExtremes = CubeAnalytics.valueExtremes(pool, currency),
                 )
                 reply(ctx, embed, deleteDelay)
             }
@@ -212,6 +214,7 @@ class CubeCommand @Autowired constructor(
                     is PackGenerator.Result.Failure -> ctx.event.hook.sendMessageEmbeds(CubeEmbeds.errorEmbed(packs.reason)).queue()
                     is PackGenerator.Result.Success -> {
                         val selected = packs.value.cards
+                        val currency = currencyFor(ctx)
                         val embed = CubeEmbeds.generateEmbed(
                             query = resolved.label,
                             poolSize = pool.size,
@@ -223,8 +226,9 @@ class CubeCommand @Autowired constructor(
                             distribution = AsFan.distribution(selected, packSize),
                             notFound = resolved.notFound,
                             note = resolved.note,
+                            currency = currency,
                         )
-                        val file = FileUpload.fromData(CubeEmbeds.packsFile(packs.value.packs), ATTACHMENT_NAME)
+                        val file = FileUpload.fromData(CubeEmbeds.packsFile(packs.value.packs, currency), ATTACHMENT_NAME)
                         ctx.event.hook.sendMessageEmbeds(embed).addFiles(file).queue()
                     }
                 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
@@ -54,6 +54,7 @@ internal object CubeEmbeds {
         notFound: List<String> = emptyList(),
         note: String? = null,
         currency: MtgCurrency = MtgCurrency.DEFAULT,
+        valueExtremes: CubeAnalytics.ValueExtremes? = null,
     ): MessageEmbed = embed(color = OK_COLOR) {
         setAuthor(AUTHOR)
         setTitle("Cube preview")
@@ -69,6 +70,7 @@ internal object CubeEmbeds {
         if (analytics.colorPairs.isNotEmpty()) field("Colour pairs", pairTable(analytics.colorPairs), inline = false)
         if (analytics.colorPips.isNotEmpty()) field("Colour pips", pipTable(analytics.colorPips), inline = false)
         cubeValue(analytics, currency)?.let { field("Cube value", it, inline = false) }
+        valueExtremes?.let { field("Top & bottom value", valueExtremesBlock(it), inline = false) }
         addDuplicatesField(analytics.duplicates)
         addNotFoundField(notFound)
     }
@@ -85,6 +87,7 @@ internal object CubeEmbeds {
         distribution: Map<CardCategory, Double>,
         notFound: List<String> = emptyList(),
         note: String? = null,
+        currency: MtgCurrency = MtgCurrency.DEFAULT,
     ): MessageEmbed = embed(color = OK_COLOR) {
         setAuthor(AUTHOR)
         setTitle("Generated $packCount packs of $packSize")
@@ -94,6 +97,8 @@ internal object CubeEmbeds {
                 note.orEmpty().let { if (it.isNotEmpty()) "\nℹ️ $it" else "" }
         )
         field("As-fan per pack", distributionTable(counts, distribution), inline = false)
+        // Total value of the cards actually dealt into the packs.
+        valueLine(CubeAnalytics.totalValues(selected), currency)?.let { field("Packs value", it, inline = false) }
         addNotFoundField(notFound)
         setFooter("Full pack lists attached as a text file.")
     }
@@ -208,12 +213,27 @@ internal object CubeEmbeds {
      * anything in the pool is priced in when the chosen one has no prices, or
      * null when nothing in the pool is priced at all.
      */
-    fun cubeValue(analytics: CubeAnalytics.Analytics, currency: MtgCurrency): String? {
-        val total = analytics.totalValueIn(currency)?.let { currency to it }
-            ?: analytics.totalValues.firstOrNull()?.let { it.currency to it.amount }
+    fun cubeValue(analytics: CubeAnalytics.Analytics, currency: MtgCurrency): String? =
+        valueLine(analytics.totalValues, currency)
+
+    /**
+     * A `≈ $123.45 (priced cards, USD)` line from a per-currency total list,
+     * preferring [currency] but falling back to the first currency anything is
+     * priced in, or null when nothing is priced at all.
+     */
+    fun valueLine(totalValues: List<CubeAnalytics.TotalValue>, currency: MtgCurrency): String? {
+        val total = totalValues.firstOrNull { it.currency == currency }?.let { currency to it.amount }
+            ?: totalValues.firstOrNull()?.let { it.currency to it.amount }
             ?: return null
         val (cur, amount) = total
         return "≈ ${cur.symbol}${format(amount)}${cur.suffix} (priced cards, ${cur.display})"
+    }
+
+    /** A two-line "most / least valuable card" block in the extremes' currency. */
+    fun valueExtremesBlock(ext: CubeAnalytics.ValueExtremes): String {
+        fun line(v: CubeAnalytics.ValuedCard) =
+            "${v.name} (${ext.currency.symbol}${format(v.amount)}${ext.currency.suffix})"
+        return "**Most:** ${line(ext.mostValuable)}\n**Least:** ${line(ext.leastValuable)}"
     }
 
     /**
@@ -297,12 +317,17 @@ internal object CubeEmbeds {
      * far past what fits in an embed, so the full lists ride along as an
      * attachment.
      */
-    fun packsFile(packs: List<List<CubeCard>>): ByteArray = buildString {
+    fun packsFile(packs: List<List<CubeCard>>, currency: MtgCurrency = MtgCurrency.DEFAULT): ByteArray = buildString {
         packs.forEachIndexed { i, pack ->
-            appendLine("== Pack ${i + 1} (${pack.size} cards) ==")
+            val priced = pack.mapNotNull { it.price(currency)?.toDoubleOrNull() }
+            val packTotal = priced.takeIf { it.isNotEmpty() }
+                ?.let { " — ≈ ${currency.symbol}${format(it.sum())}${currency.suffix}" }
+                .orEmpty()
+            appendLine("== Pack ${i + 1} (${pack.size} cards)$packTotal ==")
             pack.forEach { card ->
+                val price = card.price(currency)?.let { " (${currency.symbol}$it${currency.suffix})" }.orEmpty()
                 val image = card.imageUrl?.let { " — $it" }.orEmpty()
-                appendLine("  ${card.name}$image")
+                appendLine("  ${card.name}$price$image")
             }
             appendLine()
         }

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeCommandTest.kt
@@ -167,6 +167,50 @@ class CubeCommandTest : CommandTest {
     }
 
     @Test
+    fun `generate reports the packs value in the guild's configured currency`() {
+        val slot = slot<MessageEmbed>()
+        every { event.hook.sendMessageEmbeds(capture(slot), *anyVararg()) } returns webhookMessageCreateAction
+        every { event.subcommandName } returns CubeCommand.SUB_GENERATE
+        every { event.getOption(CubeCommand.OPT_QUERY) } returns strOpt("cube:vintage")
+        every { event.getOption(CubeCommand.OPT_PACKS) } returns intOpt(1)
+        every { event.getOption(CubeCommand.OPT_PACK_SIZE) } returns intOpt(2)
+        every { event.getOption(CubeCommand.OPT_BALANCED) } returns boolOpt(false)
+        every { configService.getConfigByName("CUBE_CURRENCY", "1") } returns mockk { every { value } returns "eur" }
+        coEvery { fetcher.fetch(any(), any()) } returns ScryfallCubeFetcher.Result.Success(
+            listOf(
+                CubeCard("Bolt", setOf(MtgColor.RED), priceUsd = "2.00", priceEur = "1.50"),
+                CubeCard("Bear", setOf(MtgColor.GREEN), priceUsd = "0.50", priceEur = "0.40"),
+            ),
+        )
+
+        run()
+
+        val value = slot.captured.fields.first { it.name == "Packs value" }.value!!
+        assertTrue(value.contains("€1.90"), "expected EUR packs value, got: $value")
+    }
+
+    @Test
+    fun `preview reports the most and least valuable cards`() {
+        val slot = slot<MessageEmbed>()
+        every { event.hook.sendMessageEmbeds(capture(slot), *anyVararg()) } returns webhookMessageCreateAction
+        every { event.subcommandName } returns CubeCommand.SUB_PREVIEW
+        every { event.getOption(CubeCommand.OPT_QUERY) } returns strOpt("set:vow")
+        every { event.getOption(CubeCommand.OPT_PACK_SIZE) } returns null
+        coEvery { fetcher.fetch(any(), any()) } returns ScryfallCubeFetcher.Result.Success(
+            listOf(
+                CubeCard("Pricey", setOf(MtgColor.RED), priceUsd = "60.00"),
+                CubeCard("Cheap", setOf(MtgColor.BLUE), priceUsd = "0.25"),
+            ),
+        )
+
+        run()
+
+        val value = slot.captured.fields.first { it.name == "Top & bottom value" }.value!!
+        assertTrue(value.contains("Pricey ($60.00)"), value)
+        assertTrue(value.contains("Cheap ($0.25)"), value)
+    }
+
+    @Test
     fun `generate reports when the pool is too small`() {
         val slot = slot<MessageEmbed>()
         every { event.hook.sendMessageEmbeds(capture(slot), *anyVararg()) } returns webhookMessageCreateAction

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeEmbedsTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeEmbedsTest.kt
@@ -239,6 +239,55 @@ class CubeEmbedsTest {
     }
 
     @Test
+    fun `previewEmbed shows the most and least valuable cards when given extremes`() {
+        val pool = listOf(
+            card("Pricey", "Creature", 4.0, "mythic", priceUsd = "60.00"),
+            card("Cheap", "Instant", 1.0, "common", priceUsd = "0.25"),
+        )
+        val extremes = CubeAnalytics.valueExtremes(pool, common.mtg.MtgCurrency.USD)
+        val embed = CubeEmbeds.previewEmbed(
+            query = "q", poolSize = pool.size, packSize = 2,
+            counts = AsFan.categoryCounts(pool), distribution = AsFan.distribution(pool, 2),
+            analytics = CubeAnalytics.analyze(pool, 2), valueExtremes = extremes,
+        )
+        val value = field(embed, "Top & bottom value")!!.value!!
+        assertTrue(value.contains("Pricey ($60.00)"), "most: $value")
+        assertTrue(value.contains("Cheap ($0.25)"), "least: $value")
+    }
+
+    @Test
+    fun `previewEmbed omits the extremes field when none are given`() {
+        assertNull(field(preview(listOf(card("Bolt", "Instant", 1.0, "common"))), "Top & bottom value"))
+    }
+
+    @Test
+    fun `valueExtremesBlock formats most and least in the extremes currency`() {
+        val ext = CubeAnalytics.ValueExtremes(
+            common.mtg.MtgCurrency.EUR,
+            CubeAnalytics.ValuedCard("Big", 55.5),
+            CubeAnalytics.ValuedCard("Small", 0.4),
+        )
+        val block = CubeEmbeds.valueExtremesBlock(ext)
+        assertTrue(block.contains("Big (€55.50)"), block)
+        assertTrue(block.contains("Small (€0.40)"), block)
+    }
+
+    @Test
+    fun `generateEmbed shows the packs value in the chosen currency`() {
+        val selected = listOf(
+            CubeCard("Bolt", setOf(MtgColor.RED), priceUsd = "2.00", priceEur = "1.50"),
+            CubeCard("Bear", setOf(MtgColor.GREEN), priceUsd = "0.50", priceEur = "0.40"),
+        )
+        val embed = CubeEmbeds.generateEmbed(
+            query = "q", poolSize = 10, packCount = 1, packSize = 2, balanced = true,
+            selected = selected, counts = AsFan.categoryCounts(selected),
+            distribution = AsFan.distribution(selected, 2), currency = common.mtg.MtgCurrency.EUR,
+        )
+        val value = field(embed, "Packs value")!!.value!!
+        assertTrue(value.contains("€1.90"), "packs value: $value")
+    }
+
+    @Test
     fun `rulingsEmbed lists each ruling with its date, linking to Scryfall`() {
         val rulings = common.mtg.CardRulings(
             cardName = "Doubling Season",
@@ -291,5 +340,30 @@ class CubeEmbedsTest {
         // A card with no image is just its name — no trailing dash.
         assertTrue(text.contains("  Forest\n"))
         assertFalse(text.contains("Forest —"))
+    }
+
+    @Test
+    fun `packsFile includes per-card prices and a per-pack total in the chosen currency`() {
+        val packs = listOf(
+            listOf(
+                CubeCard("Lightning Bolt", setOf(MtgColor.RED), imageUrl = "https://img/bolt.jpg", priceUsd = "2.00", priceEur = "1.50"),
+                CubeCard("Forest", isLand = true, priceUsd = "0.10", priceEur = "0.08"),
+            ),
+        )
+        val text = String(CubeEmbeds.packsFile(packs, common.mtg.MtgCurrency.EUR), StandardCharsets.UTF_8)
+
+        // Pack header carries the EUR total (1.50 + 0.08).
+        assertTrue(text.contains("== Pack 1 (2 cards) — ≈ €1.58 =="), "header: $text")
+        // Each card shows its EUR price before the image link.
+        assertTrue(text.contains("  Lightning Bolt (€1.50) — https://img/bolt.jpg"), "bolt line: $text")
+        assertTrue(text.contains("  Forest (€0.08)"), "forest line: $text")
+    }
+
+    @Test
+    fun `packsFile omits prices and the pack total when nothing is priced`() {
+        val packs = listOf(listOf(CubeCard("Forest", isLand = true)))
+        val text = String(CubeEmbeds.packsFile(packs), StandardCharsets.UTF_8)
+        assertTrue(text.contains("== Pack 1 (1 cards) =="), text) // no " — ≈ " total
+        assertFalse(text.contains("≈"))
     }
 }

--- a/web/src/main/kotlin/web/service/CubeWebService.kt
+++ b/web/src/main/kotlin/web/service/CubeWebService.kt
@@ -8,6 +8,7 @@ import common.mtg.CardListParser
 import common.mtg.CubeAnalytics
 import common.mtg.CubeCard
 import common.mtg.CubeDiff
+import common.mtg.MtgCurrency
 import common.mtg.MtgNames
 import common.mtg.MtgColor
 import common.mtg.PackGenerator
@@ -246,6 +247,18 @@ class CubeWebService {
             colorPairs = a.colorPairs.map { ColorPairView(it.pair, it.count) },
             colorPips = a.colorPips.map { ColorPipView(it.color, it.count) },
             totalValues = a.totalValues.map { TotalValueView(it.currency.code, it.currency.display, it.amount) },
+            valueExtremes = MtgCurrency.entries.mapNotNull { currency ->
+                CubeAnalytics.valueExtremes(cards, currency)?.let {
+                    ValueExtremesView(
+                        currency = currency.code,
+                        display = currency.display,
+                        mostName = it.mostValuable.name,
+                        mostAmount = it.mostValuable.amount,
+                        leastName = it.leastValuable.name,
+                        leastAmount = it.leastValuable.amount,
+                    )
+                }
+            },
         )
     }
 
@@ -670,10 +683,22 @@ data class AnalyticsView(
     val colorPips: List<ColorPipView>,
     /** Cube market value per currency (code, display name, amount), present currencies only. */
     val totalValues: List<TotalValueView> = emptyList(),
+    /** Most/least valuable card per currency, present currencies only. */
+    val valueExtremes: List<ValueExtremesView> = emptyList(),
 )
 
 /** One currency's summed cube value: Scryfall code ("usd"), display ("USD"), amount. */
 data class TotalValueView(val currency: String, val display: String, val amount: Double)
+
+/** The priciest and cheapest priced card in one currency. */
+data class ValueExtremesView(
+    val currency: String,
+    val display: String,
+    val mostName: String,
+    val mostAmount: Double,
+    val leastName: String,
+    val leastAmount: Double,
+)
 
 /** A single card looked up by name: image plus its key facts. */
 data class CardLookupView(

--- a/web/src/main/resources/static/css/cube.css
+++ b/web/src/main/resources/static/css/cube.css
@@ -1173,6 +1173,25 @@ details[open] > .cube-section-summary .cube-collapse-chevron {
     font-size: 0.85rem;
 }
 
+/* Most/least valuable cards, under the cube value (same currency as the switch). */
+.cube-extremes {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    margin-top: var(--space-2);
+    font-size: 0.85rem;
+}
+
+.cube-extreme-label {
+    display: inline-block;
+    min-width: 8.5em;
+    color: var(--text-muted);
+}
+
+.cube-extreme-card {
+    color: var(--heading);
+}
+
 /* Singleton-violation warning (non-basic duplicates), matching .cube-notfound. */
 .cube-dup-warning {
     margin: var(--space-2) 0 0;

--- a/web/src/main/resources/static/js/cube.js
+++ b/web/src/main/resources/static/js/cube.js
@@ -337,6 +337,7 @@
         const totals = analytics.totalValues || [];
         const code = (els.valueCurrency && els.valueCurrency.value) || 'usd';
         renderTotalValue(els.value, totals, code);
+        renderValueExtremes(els.extremes, analytics.valueExtremes || [], code);
         // Only offer the currency switch when something in the pool is priced.
         if (els.valueCurrency) els.valueCurrency.hidden = totals.length === 0;
         show(els.breakdown);
@@ -369,6 +370,36 @@
         const text = totalValueText(totalValues, code);
         if (!text) { el.hidden = true; el.textContent = ''; return; }
         el.textContent = text;
+        el.hidden = false;
+    }
+
+    /** Formats one currency amount, e.g. "$1.50" / "1.50 tix". Pure. */
+    function formatMoney(amount, code) {
+        const m = currencyMeta(code);
+        return m.symbol + Number(amount).toFixed(2) + m.suffix;
+    }
+
+    /** Renders the most/least valuable cards in [code] as two rows; hides when none priced. */
+    function renderValueExtremes(el, valueExtremes, code) {
+        if (!el) return;
+        const match = (valueExtremes || []).filter(function (e) { return e.currency === code; })[0];
+        if (!match) { el.hidden = true; el.replaceChildren(); return; }
+        el.replaceChildren();
+        function row(label, name, amount) {
+            const div = document.createElement('div');
+            div.className = 'cube-extreme';
+            const tag = document.createElement('span');
+            tag.className = 'cube-extreme-label';
+            tag.textContent = label;
+            const card = document.createElement('span');
+            card.className = 'cube-extreme-card';
+            card.textContent = name + ' (' + formatMoney(amount, code) + ')';
+            div.appendChild(tag);
+            div.appendChild(card);
+            return div;
+        }
+        el.appendChild(row('Most valuable', match.mostName, match.mostAmount));
+        el.appendChild(row('Least valuable', match.leastName, match.leastAmount));
         el.hidden = false;
     }
 
@@ -1321,15 +1352,18 @@
         const pairs = q(doc, '[data-pairs="preview"]');
         const pips = q(doc, '[data-pips="preview"]');
         const value = q(doc, '[data-value="preview"]');
+        const extremes = q(doc, '[data-value-extremes="preview"]');
         const valueCurrency = q(doc, '[data-value-currency="preview"]');
         const actions = q(doc, '[data-actions="preview"]');
         let lastTotalValues = [];
+        let lastValueExtremes = [];
 
-        // Switching currency re-renders the total line from the cached totals —
-        // no refetch, since every currency's total is already in the payload.
+        // Switching currency re-renders the value lines from the cached payload —
+        // no refetch, since every currency's totals/extremes are already present.
         if (valueCurrency) {
             valueCurrency.addEventListener('change', function () {
                 renderTotalValue(value, lastTotalValues, valueCurrency.value);
+                renderValueExtremes(extremes, lastValueExtremes, valueCurrency.value);
             });
         }
         const copyBtn = q(doc, '[data-copy="preview"]');
@@ -1408,7 +1442,8 @@
                     show(actions);
                     renderNotFound(notFound, json.notFound);
                     lastTotalValues = (json.analytics && json.analytics.totalValues) || [];
-                    renderAnalytics(json.analytics, { dupes: dupes, breakdown: breakdown, avgMv: avgMv, curve: curve, types: types, rarity: rarity, pairs: pairs, pips: pips, value: value, valueCurrency: valueCurrency });
+                    lastValueExtremes = (json.analytics && json.analytics.valueExtremes) || [];
+                    renderAnalytics(json.analytics, { dupes: dupes, breakdown: breakdown, avgMv: avgMv, curve: curve, types: types, rarity: rarity, pairs: pairs, pips: pips, value: value, extremes: extremes, valueCurrency: valueCurrency });
                 })
                 .catch(function () { setStatus(status, 'Something went wrong. Try again.'); })
                 .then(function () { withBusy(form, false); setSpinner(doc, 'preview', false); });
@@ -1697,9 +1732,11 @@
         rulingsUrl: rulingsUrl,
         priceLine: priceLine,
         totalValueText: totalValueText,
+        formatMoney: formatMoney,
         renderCardLookup: renderCardLookup,
         renderRulings: renderRulings,
         renderTotalValue: renderTotalValue,
+        renderValueExtremes: renderValueExtremes,
         renderManaCurve: renderManaCurve,
         renderTypeBreakdown: renderTypeBreakdown,
         renderRarity: renderRarity,

--- a/web/src/main/resources/templates/cube.html
+++ b/web/src/main/resources/templates/cube.html
@@ -247,6 +247,7 @@
                             </select>
                         </label>
                     </div>
+                    <div class="cube-extremes" data-value-extremes="preview" hidden></div>
                 </div>
             </details>
         </section>

--- a/web/src/test/js/cube.test.js
+++ b/web/src/test/js/cube.test.js
@@ -537,6 +537,45 @@ describe('renderTotalValue', () => {
     });
 });
 
+describe('formatMoney (pure)', () => {
+    test('applies each currency symbol/suffix', () => {
+        expect(Cube.formatMoney(1.5, 'usd')).toBe('$1.50');
+        expect(Cube.formatMoney(1.5, 'eur')).toBe('€1.50');
+        expect(Cube.formatMoney(1.5, 'tix')).toBe('1.50 tix');
+    });
+});
+
+describe('renderValueExtremes', () => {
+    const extremes = [
+        { currency: 'usd', display: 'USD', mostName: 'Pricey', mostAmount: 60, leastName: 'Cheap', leastAmount: 0.25 },
+        { currency: 'eur', display: 'EUR', mostName: 'Pricey', mostAmount: 55, leastName: 'Cheap', leastAmount: 0.2 },
+    ];
+
+    test('renders most and least valuable rows for the chosen currency', () => {
+        const el = document.createElement('div');
+        el.hidden = true;
+        Cube.renderValueExtremes(el, extremes, 'usd');
+        expect(el.hidden).toBe(false);
+        const rows = el.querySelectorAll('.cube-extreme');
+        expect(rows).toHaveLength(2);
+        expect(rows[0].textContent).toContain('Pricey ($60.00)');
+        expect(rows[1].textContent).toContain('Cheap ($0.25)');
+
+        Cube.renderValueExtremes(el, extremes, 'eur');
+        expect(el.querySelector('.cube-extreme-card').textContent).toContain('Pricey (€55.00)');
+    });
+
+    test('hides when the chosen currency has no extremes', () => {
+        const el = document.createElement('div');
+        Cube.renderValueExtremes(el, extremes, 'tix');
+        expect(el.hidden).toBe(true);
+        expect(el.querySelectorAll('.cube-extreme')).toHaveLength(0);
+
+        Cube.renderValueExtremes(el, [], 'usd');
+        expect(el.hidden).toBe(true);
+    });
+});
+
 describe('renderDiff (compare two lists)', () => {
     test('renders Added / Removed / Count-changed sections with prefixes', () => {
         const container = document.createElement('div');
@@ -696,6 +735,8 @@ describe('cube report analytics renderers', () => {
         const pips = document.createElement('div');
         const value = document.createElement('p');
         value.hidden = true;
+        const extremes = document.createElement('div');
+        extremes.hidden = true;
         const valueCurrency = document.createElement('select');
         valueCurrency.innerHTML = '<option value="usd">USD</option><option value="eur">EUR</option>';
         valueCurrency.hidden = true;
@@ -710,8 +751,9 @@ describe('cube report analytics renderers', () => {
                 colorPairs: [{ pair: 'Azorius (WU)', count: 4 }],
                 colorPips: [{ color: 'White', count: 6 }],
                 totalValues: [{ currency: 'usd', display: 'USD', amount: 42.5 }, { currency: 'eur', display: 'EUR', amount: 38 }],
+                valueExtremes: [{ currency: 'usd', display: 'USD', mostName: 'Pricey', mostAmount: 40, leastName: 'Cheap', leastAmount: 0.5 }],
             },
-            { dupes: dupes, breakdown: breakdown, avgMv: avgMv, curve: curve, types: types, rarity: rarity, pairs: pairs, pips: pips, value: value, valueCurrency: valueCurrency },
+            { dupes: dupes, breakdown: breakdown, avgMv: avgMv, curve: curve, types: types, rarity: rarity, pairs: pairs, pips: pips, value: value, extremes: extremes, valueCurrency: valueCurrency },
         );
         expect(breakdown.hidden).toBe(false);
         expect(avgMv.textContent).toContain('Average mana value 2.50');
@@ -726,6 +768,10 @@ describe('cube report analytics renderers', () => {
         expect(value.hidden).toBe(false);
         expect(value.textContent).toContain('$42.50');
         expect(valueCurrency.hidden).toBe(false);
+        // Value extremes render in the same currency.
+        expect(extremes.hidden).toBe(false);
+        expect(extremes.textContent).toContain('Pricey ($40.00)');
+        expect(extremes.textContent).toContain('Cheap ($0.50)');
     });
 
     test('renderAnalytics hides the currency switch when nothing is priced', () => {

--- a/web/src/test/kotlin/web/service/CubeWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/CubeWebServiceTest.kt
@@ -71,6 +71,24 @@ class CubeWebServiceTest {
         assertTrue(service.analyticsView(unpriced, packSize = 1).totalValues.isEmpty())
     }
 
+    @Test
+    fun `analyticsView carries per-currency most and least valuable cards`() {
+        val pool = listOf(
+            CubeCard("Pricey", setOf(MtgColor.RED), typeLine = "Creature", manaValue = 4.0, priceUsd = "60.00", priceEur = "55.00"),
+            CubeCard("Cheap", setOf(MtgColor.BLUE), typeLine = "Instant", manaValue = 1.0, priceUsd = "0.25", priceEur = "0.20"),
+        )
+        val byCur = service.analyticsView(pool, packSize = 2).valueExtremes.associateBy { it.currency }
+        assertEquals("Pricey", byCur["usd"]!!.mostName)
+        assertEquals(60.0, byCur["usd"]!!.mostAmount, 1e-9)
+        assertEquals("Cheap", byCur["usd"]!!.leastName)
+        assertEquals("USD", byCur["usd"]!!.display)
+        assertEquals("Pricey", byCur["eur"]!!.mostName)
+        assertEquals(55.0, byCur["eur"]!!.mostAmount, 1e-9)
+
+        // Nothing priced → no extremes.
+        assertTrue(service.analyticsView(listOf(CubeCard("Token", typeLine = "Token")), packSize = 1).valueExtremes.isEmpty())
+    }
+
     // --- card lookup ---------------------------------------------------
 
     @Test


### PR DESCRIPTION
Three follow-ups that round out the cube-value tooling — the gaps noted after the prices/currency work landed.

## What's new

**1. Cube value on `/cube generate`**
The generate embed now shows a **Packs value** field — the total market value of the cards actually dealt into the packs, in the guild's configured currency. (Preview already had this; generate was the one place it was missing.)

**2. Per-card prices in the Discord pack-list file**
The attached `cube-packs.txt` now prints each card's price and a per-pack total, in the configured currency:
```
== Pack 1 (2 cards) — ≈ €1.58 ==
  Lightning Bolt (€1.50) — https://…
  Forest (€0.08)
```
Unpriced pools render exactly as before (no price suffix, no total).

**3. Most/least valuable cards in the preview (Discord + web)**
A shared `CubeAnalytics.valueExtremes(cards, currency)` powers a new **Top & bottom value** field on the Discord preview and a two-row block on the web preview. On the web, flipping the currency switch re-renders both the total *and* the extremes from the already-fetched payload — no refetch.

## Notes
- All currency-aware via the existing `MtgCurrency` + per-guild `CUBE_CURRENCY` config; falls back to USD.
- `valueExtremes` ignores unpriced/unparseable cards and is null/empty when nothing is priced.

## Testing
- `common`: `valueExtremes` (priciest/cheapest per currency, null when unpriced).
- Discord: preview extremes field, `generateEmbed` packs value, `packsFile` per-card prices + pack total (and the unpriced fallback), `valueExtremesBlock`; `/cube generate` + `/cube preview` command paths with a configured currency.
- Web: `analyticsView` per-currency extremes.
- jest: `formatMoney`, `renderValueExtremes` (per-currency + hide), and the `renderAnalytics` wiring.
- stylelint + `:common:` / `:web:` / `:discord-bot:` kover gates all green; full jest suite (724) passing.

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs

---
_Generated by [Claude Code](https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs)_