### PR TITLE
Add a deck legality checker (Discord + web)

### DIFF
--- a/common/src/main/kotlin/common/mtg/CubeCard.kt
+++ b/common/src/main/kotlin/common/mtg/CubeCard.kt
@@ -86,6 +86,14 @@ data class CubeCard(
      * Presentation-only.
      */
     val legalFormats: List<String> = emptyList(),
+    /**
+     * Raw Scryfall `legalities` status per format code we track (`"legal"`,
+     * `"not_legal"`, `"banned"`, `"restricted"`), for the formats in
+     * [CubeCard.FORMATS]. Drives the deck-legality checker, which needs to tell
+     * a banned card apart from one that's simply not in the format. Empty when
+     * unknown.
+     */
+    val legalities: Map<String, String> = emptyMap(),
 ) {
     /** Which as-fan bucket this card falls into. Lands first, then by colour count. */
     val category: CardCategory
@@ -122,6 +130,10 @@ data class CubeCard(
         /** The display-cased formats this card is legal in, from a Scryfall `legalities` map (key→status). */
         fun legalFormatsOf(statusByFormat: (String) -> String?): List<String> =
             FORMATS.filter { (key, _) -> statusByFormat(key) == "legal" }.map { it.second }
+
+        /** The raw status per tracked format from a Scryfall `legalities` lookup, present codes only. */
+        fun legalitiesOf(statusByFormat: (String) -> String?): Map<String, String> =
+            FORMATS.mapNotNull { (key, _) -> statusByFormat(key)?.let { key to it } }.toMap()
 
         /**
          * Whether a Scryfall `type_line` denotes a land, judged by the

--- a/common/src/main/kotlin/common/mtg/DeckLegality.kt
+++ b/common/src/main/kotlin/common/mtg/DeckLegality.kt
@@ -1,0 +1,75 @@
+package common.mtg
+
+/**
+ * Checks whether a resolved card pool is legal in a given format, using each
+ * card's Scryfall [CubeCard.legalities] status. Pure maths shared by the web
+ * deck checker and the Discord command so the two surfaces agree.
+ *
+ * A deck is **legal** when no card is banned or not-in-format. Restricted cards
+ * (Vintage) are legal but limited to one copy — flagged separately rather than
+ * failing the deck, since we check the card list, not per-copy counts.
+ */
+object DeckLegality {
+
+    /** How a single card sits in the chosen format. */
+    enum class Status { LEGAL, NOT_LEGAL, BANNED, RESTRICTED, UNKNOWN }
+
+    /** One card's name and its status in the format. */
+    data class CardStatus(val name: String, val status: Status)
+
+    /**
+     * The verdict for a format: [legal] is true only when nothing is banned or
+     * not-in-format. The buckets list the offending/flagged cards by name
+     * (deduped, input order preserved).
+     */
+    data class Report(
+        val format: String,
+        val legal: Boolean,
+        val banned: List<String>,
+        val notLegal: List<String>,
+        val restricted: List<String>,
+        val unknown: List<String>,
+        val total: Int,
+    )
+
+    /** Maps a raw Scryfall status string to a [Status]. */
+    fun statusOf(raw: String?): Status = when (raw) {
+        "legal" -> Status.LEGAL
+        "not_legal" -> Status.NOT_LEGAL
+        "banned" -> Status.BANNED
+        "restricted" -> Status.RESTRICTED
+        else -> Status.UNKNOWN
+    }
+
+    /**
+     * Checks [cards] against the format with Scryfall code [formatCode]
+     * (e.g. "modern"). Cards dedupe by name so a deck with four copies of a
+     * banned card reports it once. The deck is legal only when nothing is
+     * banned or not-in-format; restricted and unknown cards don't fail it but
+     * are surfaced.
+     */
+    fun check(cards: List<CubeCard>, formatCode: String): Report {
+        val banned = LinkedHashSet<String>()
+        val notLegal = LinkedHashSet<String>()
+        val restricted = LinkedHashSet<String>()
+        val unknown = LinkedHashSet<String>()
+        cards.forEach { card ->
+            when (statusOf(card.legalities[formatCode])) {
+                Status.BANNED -> banned += card.name
+                Status.NOT_LEGAL -> notLegal += card.name
+                Status.RESTRICTED -> restricted += card.name
+                Status.UNKNOWN -> unknown += card.name
+                Status.LEGAL -> {}
+            }
+        }
+        return Report(
+            format = formatCode,
+            legal = banned.isEmpty() && notLegal.isEmpty(),
+            banned = banned.toList(),
+            notLegal = notLegal.toList(),
+            restricted = restricted.toList(),
+            unknown = unknown.toList(),
+            total = cards.size,
+        )
+    }
+}

--- a/common/src/test/kotlin/common/mtg/CubeCardTest.kt
+++ b/common/src/test/kotlin/common/mtg/CubeCardTest.kt
@@ -115,6 +115,16 @@ class CubeCardTest {
     }
 
     @Test
+    fun `legalitiesOf keeps the raw status per present format code`() {
+        val status = mapOf("modern" to "legal", "legacy" to "banned", "vintage" to "restricted")
+        val map = CubeCard.legalitiesOf { status[it] }
+        assertEquals("legal", map["modern"])
+        assertEquals("banned", map["legacy"])
+        assertEquals("restricted", map["vintage"])
+        assertFalse(map.containsKey("standard")) // absent codes are dropped
+    }
+
+    @Test
     fun `mono-coloured card maps to its colour bucket`() {
         assertEquals(
             CardCategory.RED,

--- a/common/src/test/kotlin/common/mtg/DeckLegalityTest.kt
+++ b/common/src/test/kotlin/common/mtg/DeckLegalityTest.kt
@@ -1,0 +1,78 @@
+package common.mtg
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class DeckLegalityTest {
+
+    private fun card(name: String, vararg legalities: Pair<String, String>) =
+        CubeCard(name = name, legalities = legalities.toMap())
+
+    @Test
+    fun `statusOf maps the raw Scryfall strings`() {
+        assertEquals(DeckLegality.Status.LEGAL, DeckLegality.statusOf("legal"))
+        assertEquals(DeckLegality.Status.NOT_LEGAL, DeckLegality.statusOf("not_legal"))
+        assertEquals(DeckLegality.Status.BANNED, DeckLegality.statusOf("banned"))
+        assertEquals(DeckLegality.Status.RESTRICTED, DeckLegality.statusOf("restricted"))
+        assertEquals(DeckLegality.Status.UNKNOWN, DeckLegality.statusOf(null))
+        assertEquals(DeckLegality.Status.UNKNOWN, DeckLegality.statusOf("weird"))
+    }
+
+    @Test
+    fun `a deck with only legal cards is legal`() {
+        val deck = listOf(
+            card("Lightning Bolt", "modern" to "legal"),
+            card("Mountain", "modern" to "legal"),
+        )
+        val report = DeckLegality.check(deck, "modern")
+        assertTrue(report.legal)
+        assertEquals(2, report.total)
+        assertTrue(report.banned.isEmpty())
+        assertTrue(report.notLegal.isEmpty())
+    }
+
+    @Test
+    fun `banned and not-in-format cards make the deck illegal and are bucketed`() {
+        val deck = listOf(
+            card("Lightning Bolt", "modern" to "legal"),
+            card("Lurrus of the Dream-Den", "modern" to "banned"),
+            card("Black Lotus", "modern" to "not_legal"),
+        )
+        val report = DeckLegality.check(deck, "modern")
+        assertFalse(report.legal)
+        assertEquals(listOf("Lurrus of the Dream-Den"), report.banned)
+        assertEquals(listOf("Black Lotus"), report.notLegal)
+    }
+
+    @Test
+    fun `restricted cards are flagged but do not fail the deck`() {
+        val deck = listOf(
+            card("Sol Ring", "vintage" to "restricted"),
+            card("Island", "vintage" to "legal"),
+        )
+        val report = DeckLegality.check(deck, "vintage")
+        assertTrue(report.legal)
+        assertEquals(listOf("Sol Ring"), report.restricted)
+    }
+
+    @Test
+    fun `duplicate offenders are reported once, in first-seen order`() {
+        val deck = listOf(
+            card("Lurrus of the Dream-Den", "modern" to "banned"),
+            card("Lurrus of the Dream-Den", "modern" to "banned"),
+            card("Oko, Thief of Crowns", "modern" to "banned"),
+        )
+        val report = DeckLegality.check(deck, "modern")
+        assertEquals(listOf("Lurrus of the Dream-Den", "Oko, Thief of Crowns"), report.banned)
+    }
+
+    @Test
+    fun `a card missing the format's status counts as unknown, not legal-failing`() {
+        val deck = listOf(card("Mystery Card")) // no legalities at all
+        val report = DeckLegality.check(deck, "modern")
+        assertTrue(report.legal) // unknown doesn't fail the deck
+        assertEquals(listOf("Mystery Card"), report.unknown)
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeCommand.kt
@@ -7,6 +7,7 @@ import common.mtg.AsFan
 import common.mtg.CardListParser
 import common.mtg.CubeAnalytics
 import common.mtg.CubeCard
+import common.mtg.DeckLegality
 import common.mtg.MtgCurrency
 import common.mtg.MtgNames
 import common.mtg.PackGenerator
@@ -69,7 +70,8 @@ class CubeCommand @Autowired constructor(
             SUB_SAVED -> launchHandling(ctx) { handleSaved(ctx, requestingUserDto, deleteDelay) }
             SUB_CARD -> launchHandling(ctx) { handleCard(ctx, deleteDelay) }
             SUB_RULINGS -> launchHandling(ctx) { handleRulings(ctx, deleteDelay) }
-            else -> reply(ctx, CubeEmbeds.errorEmbed("Pick a subcommand: asfan, preview, generate, saved, card or rulings."), deleteDelay)
+            SUB_LEGALITY -> launchHandling(ctx) { handleLegality(ctx, requestingUserDto, deleteDelay) }
+            else -> reply(ctx, CubeEmbeds.errorEmbed("Pick a subcommand: asfan, preview, generate, saved, card, rulings or legality."), deleteDelay)
         }
     }
 
@@ -275,6 +277,23 @@ class CubeCommand @Autowired constructor(
         }
     }
 
+    /** Checks a saved cube / queried pool against a format's banned & legality list. */
+    private suspend fun handleLegality(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val formatKey = ctx.event.stringOption(OPT_FORMAT)?.trim()?.lowercase()
+        val format = CubeCard.FORMATS.firstOrNull { it.first == formatKey }
+        if (format == null) {
+            reply(ctx, CubeEmbeds.errorEmbed("Pick a `format` to check against (e.g. Modern, Commander)."), deleteDelay)
+            return
+        }
+        when (val resolved = resolvePool(ctx, requestingUserDto)) {
+            is PoolResult.Failed -> reply(ctx, CubeEmbeds.errorEmbed(resolved.message), deleteDelay)
+            is PoolResult.Ready -> {
+                val report = DeckLegality.check(resolved.pool, format.first)
+                reply(ctx, CubeEmbeds.legalityEmbed(report, format.second, resolved.label, resolved.notFound), deleteDelay)
+            }
+        }
+    }
+
     private fun reply(ctx: CommandContext, embed: MessageEmbed, deleteDelay: Int) {
         ctx.event.hook.sendMessageEmbeds(embed).queue(invokeDeleteOnMessageResponse(deleteDelay))
     }
@@ -313,6 +332,14 @@ class CubeCommand @Autowired constructor(
             .addOptions(OptionData(OptionType.STRING, OPT_NAME, "The card's name (e.g. Lightning Bolt).", true)),
         SubcommandData(SUB_RULINGS, "Look up a Magic card's official rulings by name.")
             .addOptions(OptionData(OptionType.STRING, OPT_NAME, "The card's name (e.g. Doubling Season).", true)),
+        SubcommandData(SUB_LEGALITY, "Check whether a saved cube/deck is legal in a format (banned & not-legal cards).")
+            .addOptions(
+                OptionData(OptionType.STRING, OPT_FORMAT, "Format to check against.", true)
+                    .addChoices(CubeCard.FORMATS.map { net.dv8tion.jda.api.interactions.commands.Command.Choice(it.second, it.first) }),
+                OptionData(OptionType.STRING, OPT_SAVED, "Name of a deck/cube you saved on the website.", false)
+                    .setAutoComplete(true),
+                OptionData(OptionType.STRING, OPT_QUERY, "Or a Scryfall search to check instead (e.g. set:mh3).", false),
+            ),
     )
 
     companion object {
@@ -322,9 +349,11 @@ class CubeCommand @Autowired constructor(
         const val SUB_SAVED = "saved"
         const val SUB_CARD = "card"
         const val SUB_RULINGS = "rulings"
+        const val SUB_LEGALITY = "legality"
 
         const val OPT_TOTAL = "total"
         const val OPT_NAME = "name"
+        const val OPT_FORMAT = "format"
         const val OPT_CUBE_SIZE = "cube-size"
         const val OPT_PACK_SIZE = "pack-size"
         const val OPT_QUERY = "query"

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
@@ -7,6 +7,7 @@ import common.mtg.CardCategory
 import common.mtg.CardListParser
 import common.mtg.CubeAnalytics
 import common.mtg.CubeCard
+import common.mtg.DeckLegality
 import common.mtg.MtgColor
 import common.mtg.MtgCurrency
 import common.mtg.Rarity
@@ -227,6 +228,29 @@ internal object CubeEmbeds {
             ?: return null
         val (cur, amount) = total
         return "≈ ${cur.symbol}${format(amount)}${cur.suffix} (priced cards, ${cur.display})"
+    }
+
+    /**
+     * The deck-legality verdict for a format: a clear legal/illegal headline,
+     * then the offending cards bucketed (banned / not in format / restricted),
+     * each within the 1024-char field cap.
+     */
+    fun legalityEmbed(
+        report: DeckLegality.Report,
+        formatName: String,
+        label: String,
+        notFound: List<String> = emptyList(),
+    ): MessageEmbed = embed(color = if (report.legal) OK_COLOR else ERROR_COLOR) {
+        setAuthor(AUTHOR)
+        setTitle(if (report.legal) "✅ Legal in $formatName" else "🚫 Not $formatName-legal")
+        setDescription("Checked **${report.total}** cards from `$label` against **$formatName**.")
+        if (report.banned.isNotEmpty()) field("⛔ Banned ${report.banned.size}", truncateField(report.banned.joinToString(", ")), inline = false)
+        if (report.notLegal.isNotEmpty()) field("🚫 Not in format ${report.notLegal.size}", truncateField(report.notLegal.joinToString(", ")), inline = false)
+        if (report.restricted.isNotEmpty()) field("⚠️ Restricted (max 1) ${report.restricted.size}", truncateField(report.restricted.joinToString(", ")), inline = false)
+        if (report.legal && report.restricted.isEmpty()) {
+            setFooter("Every card is legal in $formatName.")
+        }
+        addNotFoundField(notFound)
     }
 
     /** A two-line "most / least valuable card" block in the extremes' currency. */

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcher.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcher.kt
@@ -285,11 +285,14 @@ class ScryfallCubeFetcher @Autowired constructor(
             priceUsd = price(card, "usd"),
             priceEur = price(card, "eur"),
             priceTix = price(card, "tix"),
-            legalFormats = CubeCard.legalFormatsOf { fmt ->
-                card.getAsJsonObject("legalities")?.get(fmt)?.asString
-            },
+            legalFormats = CubeCard.legalFormatsOf { fmt -> legality(card, fmt) },
+            legalities = CubeCard.legalitiesOf { fmt -> legality(card, fmt) },
         )
     }
+
+    /** A Scryfall `legalities` status for a format code, or null when absent. */
+    fun legality(card: JsonObject, format: String): String? =
+        card.getAsJsonObject("legalities")?.get(format)?.takeIf { !it.isJsonNull }?.asString
 
     /** A Scryfall `prices` entry (e.g. "usd"), or null when absent/blank. */
     fun price(card: JsonObject, key: String): String? =

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeCommandTest.kt
@@ -557,13 +557,54 @@ class CubeCommandTest : CommandTest {
     }
 
     @Test
-    fun `exposes the six subcommands with their options`() {
+    fun `legality checks a saved deck against the chosen format and flags banned cards`() {
+        val slot = slot<MessageEmbed>()
+        every { event.hook.sendMessageEmbeds(capture(slot), *anyVararg()) } returns webhookMessageCreateAction
+        every { event.subcommandName } returns CubeCommand.SUB_LEGALITY
+        every { event.getOption(CubeCommand.OPT_FORMAT) } returns strOpt("modern")
+        every { event.getOption(CubeCommand.OPT_SAVED) } returns strOpt("My Deck")
+        every { event.getOption(CubeCommand.OPT_QUERY) } returns null
+        every { cubeListService.get(100L, "My Deck") } returns savedCube("My Deck", "Lightning Bolt\nLurrus")
+        coEvery { fetcher.fetchByNames(any()) } returns ScryfallCubeFetcher.Result.Success(
+            listOf(
+                CubeCard("Lightning Bolt", setOf(MtgColor.RED), legalities = mapOf("modern" to "legal")),
+                CubeCard("Lurrus", legalities = mapOf("modern" to "banned")),
+            ),
+        )
+
+        run()
+
+        assertTrue(slot.captured.title!!.contains("Not Modern-legal"))
+        assertTrue(slot.captured.fields.any { it.name!!.contains("Banned") && it.value!!.contains("Lurrus") })
+    }
+
+    @Test
+    fun `legality without a format returns an error`() {
+        val slot = slot<MessageEmbed>()
+        every { event.hook.sendMessageEmbeds(capture(slot), *anyVararg()) } returns webhookMessageCreateAction
+        every { event.subcommandName } returns CubeCommand.SUB_LEGALITY
+        every { event.getOption(CubeCommand.OPT_FORMAT) } returns null
+        every { event.getOption(CubeCommand.OPT_SAVED) } returns strOpt("My Deck")
+        every { event.getOption(CubeCommand.OPT_QUERY) } returns null
+
+        run()
+
+        assertEquals("Couldn't build that cube", slot.captured.title)
+        assertTrue(slot.captured.description!!.contains("format"))
+    }
+
+    @Test
+    fun `exposes the seven subcommands with their options`() {
         assertEquals("cube", command.name)
         val subs = command.subCommands.associateBy { it.name }
-        assertEquals(setOf("asfan", "preview", "generate", "saved", "card", "rulings"), subs.keys)
+        assertEquals(setOf("asfan", "preview", "generate", "saved", "card", "rulings", "legality"), subs.keys)
         assertEquals(OptionType.STRING, subs.getValue("card").options.first { it.name == "name" }.type)
         assertTrue(subs.getValue("card").options.first { it.name == "name" }.isRequired)
         assertTrue(subs.getValue("rulings").options.first { it.name == "name" }.isRequired)
+        // The legality format option is required and offers the tracked formats as choices.
+        val format = subs.getValue("legality").options.first { it.name == "format" }
+        assertTrue(format.isRequired)
+        assertEquals(common.mtg.CubeCard.FORMATS.size, format.choices.size)
 
         val asfan = subs.getValue("asfan").options
         assertEquals(OptionType.INTEGER, asfan.first { it.name == "total" }.type)

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeEmbedsTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeEmbedsTest.kt
@@ -326,6 +326,35 @@ class CubeEmbedsTest {
     }
 
     @Test
+    fun `legalityEmbed reports an illegal deck with banned and not-in-format buckets`() {
+        val report = common.mtg.DeckLegality.check(
+            listOf(
+                CubeCard("Lightning Bolt", legalities = mapOf("modern" to "legal")),
+                CubeCard("Lurrus", legalities = mapOf("modern" to "banned")),
+                CubeCard("Black Lotus", legalities = mapOf("modern" to "not_legal")),
+            ),
+            "modern",
+        )
+        val embed = CubeEmbeds.legalityEmbed(report, "Modern", "my deck")
+        assertTrue(embed.title!!.contains("Not Modern-legal"))
+        assertEquals(CubeEmbeds.ERROR_COLOR.rgb, embed.color!!.rgb)
+        assertTrue(field(embed, "⛔ Banned 1")!!.value!!.contains("Lurrus"))
+        assertTrue(field(embed, "🚫 Not in format 1")!!.value!!.contains("Black Lotus"))
+    }
+
+    @Test
+    fun `legalityEmbed reports a clean legal deck`() {
+        val report = common.mtg.DeckLegality.check(
+            listOf(CubeCard("Lightning Bolt", legalities = mapOf("modern" to "legal"))),
+            "modern",
+        )
+        val embed = CubeEmbeds.legalityEmbed(report, "Modern", "my deck")
+        assertTrue(embed.title!!.contains("Legal in Modern"))
+        assertEquals(CubeEmbeds.OK_COLOR.rgb, embed.color!!.rgb)
+        assertTrue(embed.footer!!.text!!.contains("Every card is legal"))
+    }
+
+    @Test
     fun `packsFile lists each card, appending its image link when present`() {
         val packs = listOf(
             listOf(

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcherTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcherTest.kt
@@ -168,9 +168,24 @@ class ScryfallCubeFetcherTest {
                  "vintage":"legal","pauper":"not_legal","commander":"legal"}}""")
         )!!
         assertEquals(listOf("Modern", "Legacy", "Vintage", "Commander"), card.legalFormats)
+        // The full raw status map drives the deck-legality checker.
+        assertEquals("not_legal", card.legalities["standard"])
+        assertEquals("legal", card.legalities["modern"])
 
         val noLegalities = fetcher.parseCard(obj("""{"name":"Token","color_identity":[],"type_line":"Token"}"""))!!
         assertTrue(noLegalities.legalFormats.isEmpty())
+        assertTrue(noLegalities.legalities.isEmpty())
+    }
+
+    @Test
+    fun `parseCard treats a banned status as kept in legalities but absent from legalFormats`() {
+        val card = fetcher.parseCard(
+            obj("""{"name":"Lurrus","color_identity":["W","B"],"type_line":"Creature",
+               "legalities":{"modern":"banned","legacy":"banned","vintage":"restricted"}}""")
+        )!!
+        assertTrue(card.legalFormats.isEmpty()) // banned/restricted aren't "legal"
+        assertEquals("banned", card.legalities["modern"])
+        assertEquals("restricted", card.legalities["vintage"])
     }
 
     @Test

--- a/web/src/main/kotlin/web/configuration/WebSecurityConfig.kt
+++ b/web/src/main/kotlin/web/configuration/WebSecurityConfig.kt
@@ -25,7 +25,7 @@ class WebSecurityConfig {
                     // shared cube (/cube/c/**) are public; the saved-lists and
                     // share-create APIs are deliberately NOT listed here so they
                     // fall through to anyRequest().authenticated().
-                    "/cube", "/cube/c/**", "/cube/api/asfan", "/cube/api/preview", "/cube/api/generate", "/cube/api/diff", "/cube/api/card", "/cube/api/rulings",
+                    "/cube", "/cube/c/**", "/cube/api/asfan", "/cube/api/preview", "/cube/api/generate", "/cube/api/diff", "/cube/api/card", "/cube/api/rulings", "/cube/api/legality",
                     "/sitemap.xml", "/robots.txt",
                     // Service worker for web push must be reachable
                     // unauthenticated — the browser registers it on

--- a/web/src/main/kotlin/web/controller/CubeController.kt
+++ b/web/src/main/kotlin/web/controller/CubeController.kt
@@ -144,6 +144,24 @@ class CubeController(
                 ResponseEntity.badRequest().body(CubeRulingsResponse(false, result.error, null, null, emptyList()))
         }
 
+    @PostMapping("/api/legality", consumes = ["application/json"], produces = ["application/json"])
+    @ResponseBody
+    fun legality(@RequestBody request: CubeLegalityRequest): ResponseEntity<CubeLegalityResponse> =
+        when (val result = cubeWebService.checkLegality(request.list, request.format)) {
+            is CubeResult.Success -> ResponseEntity.ok(
+                CubeLegalityResponse(
+                    ok = true, error = null,
+                    format = result.value.format, legal = result.value.legal, total = result.value.total,
+                    banned = result.value.banned, notLegal = result.value.notLegal,
+                    restricted = result.value.restricted, unknown = result.value.unknown,
+                    notFound = result.value.notFound, note = result.value.note,
+                )
+            )
+            is CubeResult.Failure -> ResponseEntity.badRequest().body(
+                CubeLegalityResponse(false, result.error, null, false, 0, emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), null)
+            )
+        }
+
     @PostMapping("/api/diff", consumes = ["application/json"], produces = ["application/json"])
     @ResponseBody
     fun diff(@RequestBody request: CubeDiffRequest): ResponseEntity<CubeDiffResponse> =
@@ -276,6 +294,22 @@ data class CubeRulingsResponse(
     val name: String?,
     val scryfallUri: String?,
     val rulings: List<RulingView>,
+)
+
+data class CubeLegalityRequest(val list: String = "", val format: String = "")
+
+data class CubeLegalityResponse(
+    val ok: Boolean,
+    val error: String?,
+    val format: String?,
+    val legal: Boolean,
+    val total: Int,
+    val banned: List<String>,
+    val notLegal: List<String>,
+    val restricted: List<String>,
+    val unknown: List<String>,
+    val notFound: List<String>,
+    val note: String?,
 )
 
 data class CubeDiffRequest(val listA: String = "", val listB: String = "")

--- a/web/src/main/kotlin/web/service/CubeWebService.kt
+++ b/web/src/main/kotlin/web/service/CubeWebService.kt
@@ -8,6 +8,7 @@ import common.mtg.CardListParser
 import common.mtg.CubeAnalytics
 import common.mtg.CubeCard
 import common.mtg.CubeDiff
+import common.mtg.DeckLegality
 import common.mtg.MtgCurrency
 import common.mtg.MtgNames
 import common.mtg.MtgColor
@@ -203,6 +204,37 @@ class CubeWebService {
         }
     }
 
+    /**
+     * Checks a pasted decklist against a format (the [DeckLegality] maths) —
+     * which cards are banned, not in the format, or restricted, and whether the
+     * deck is legal overall. Resolves the list against Scryfall for the per-card
+     * legality data.
+     */
+    fun checkLegality(list: String, format: String): CubeResult<LegalityData> {
+        val formatKey = format.trim().lowercase()
+        val display = CubeCard.FORMATS.firstOrNull { it.first == formatKey }
+            ?: return CubeResult.error("Unknown format. Pick one of: " + CubeCard.FORMATS.joinToString(", ") { it.second } + ".")
+        return when (val resolved = resolveList(list)) {
+            is CubeResult.Failure -> CubeResult.error(resolved.error)
+            is CubeResult.Success -> {
+                val report = DeckLegality.check(resolved.value.cards.map { it.card }, formatKey)
+                CubeResult.ok(
+                    LegalityData(
+                        format = display.second,
+                        legal = report.legal,
+                        total = report.total,
+                        banned = report.banned,
+                        notLegal = report.notLegal,
+                        restricted = report.restricted,
+                        unknown = report.unknown,
+                        notFound = resolved.value.notFound,
+                        note = resolved.value.note,
+                    )
+                )
+            }
+        }
+    }
+
     /** Draws a cube from a Scryfall query and deals balanced packs. */
     fun generate(query: String, packCount: Int, packSize: Int, balanced: Boolean): CubeResult<GenerateData> =
         when (val pool = fetchPool(query)) {
@@ -367,6 +399,7 @@ class CubeWebService {
                 priceEur = priceOf(node, "eur"),
                 priceTix = priceOf(node, "tix"),
                 legalFormats = CubeCard.legalFormatsOf { node.path("legalities").path(it).asText(null) },
+                legalities = CubeCard.legalitiesOf { node.path("legalities").path(it).asText(null) },
             ),
             imageUrl = imageOf(node, "small"),
             imageUrlLarge = imageOf(node, "normal"),
@@ -729,6 +762,19 @@ data class RulingsView(
 
 /** One published ruling: the ISO publish date and the note text. */
 data class RulingView(val publishedAt: String, val comment: String)
+
+/** The outcome of checking a pasted decklist against a format. */
+data class LegalityData(
+    val format: String,
+    val legal: Boolean,
+    val total: Int,
+    val banned: List<String>,
+    val notLegal: List<String>,
+    val restricted: List<String>,
+    val unknown: List<String>,
+    val notFound: List<String> = emptyList(),
+    val note: String? = null,
+)
 
 /** One card's change between two compared lists (copy counts from → to). */
 data class DiffLineView(val name: String, val from: Int, val to: Int)

--- a/web/src/main/resources/static/css/cube.css
+++ b/web/src/main/resources/static/css/cube.css
@@ -1279,6 +1279,58 @@ details[open] > .cube-section-summary .cube-collapse-chevron {
     }
 }
 
+/* Deck legality result. */
+.cube-legality {
+    display: grid;
+    gap: var(--space-3);
+    margin-top: var(--space-3);
+}
+
+.cube-legality[hidden] {
+    display: none;
+}
+
+.cube-legality-headline {
+    margin: 0;
+    font-weight: 600;
+}
+
+.cube-legality-headline.is-legal {
+    color: #22c55e;
+}
+
+.cube-legality-headline.is-illegal {
+    color: #ef4444;
+}
+
+.cube-legality-h {
+    margin: 0 0 var(--space-1);
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--heading);
+}
+
+.cube-legality-list {
+    margin: 0;
+    padding-left: 1.1rem;
+    display: grid;
+    gap: 2px;
+    font-size: 0.85rem;
+}
+
+.cube-legality-banned .cube-legality-h {
+    color: #ef4444;
+}
+
+.cube-legality-notlegal .cube-legality-h {
+    color: #f59e0b;
+}
+
+.cube-legality-empty {
+    color: var(--text-muted);
+}
+
 /* Single-card lookup: image beside its facts. */
 .cube-cardlookup-wrap[hidden] {
     display: none;

--- a/web/src/main/resources/static/js/cube.js
+++ b/web/src/main/resources/static/js/cube.js
@@ -7,10 +7,10 @@
 (function (root) {
     'use strict';
 
-    const TABS = ['generate', 'preview', 'asfan', 'compare', 'card'];
+    const TABS = ['generate', 'preview', 'asfan', 'compare', 'card', 'legality'];
 
     // Tools that work off their own inputs, not the shared "Your cube" source.
-    const NO_SHARED_SOURCE = ['asfan', 'compare', 'card'];
+    const NO_SHARED_SOURCE = ['asfan', 'compare', 'card', 'legality'];
 
     // Colour-pie palette for swatches/bars. Tuned to read on the dark
     // dashboard background while staying recognisably W/U/B/R/G + gold
@@ -614,6 +614,54 @@
             p.className = 'cube-diff-empty';
             p.textContent = 'No differences — the two lists match.';
             container.appendChild(p);
+        }
+        return container;
+    }
+
+    /** POST body builder isn't needed; the URL is constant. */
+    function legalityUrl() {
+        return '/cube/api/legality';
+    }
+
+    /**
+     * Renders a deck-legality verdict: a legal/illegal headline, then the
+     * offending cards bucketed (banned / not in format / restricted / unknown).
+     */
+    function renderLegality(container, data) {
+        container.replaceChildren();
+        const headline = document.createElement('p');
+        headline.className = 'cube-legality-headline ' + (data.legal ? 'is-legal' : 'is-illegal');
+        headline.textContent = (data.legal ? '✅ Legal in ' : '🚫 Not legal in ') + data.format +
+            ' — checked ' + data.total + ' card' + (data.total === 1 ? '' : 's');
+        container.appendChild(headline);
+
+        function bucket(title, names, kind) {
+            if (!names || !names.length) return;
+            const block = document.createElement('div');
+            block.className = 'cube-legality-group cube-legality-' + kind;
+            const h = document.createElement('h4');
+            h.className = 'cube-legality-h';
+            h.textContent = title + ' (' + names.length + ')';
+            block.appendChild(h);
+            const ul = document.createElement('ul');
+            ul.className = 'cube-legality-list';
+            names.forEach(function (name) {
+                const li = document.createElement('li');
+                li.textContent = name;
+                ul.appendChild(li);
+            });
+            block.appendChild(ul);
+            container.appendChild(block);
+        }
+        bucket('Banned', data.banned, 'banned');
+        bucket('Not in format', data.notLegal, 'notlegal');
+        bucket('Restricted (max 1)', data.restricted, 'restricted');
+        bucket('Unknown', data.unknown, 'unknown');
+        if (data.legal && (!data.restricted || !data.restricted.length)) {
+            const ok = document.createElement('p');
+            ok.className = 'cube-legality-empty';
+            ok.textContent = 'Every card is legal in ' + data.format + '.';
+            container.appendChild(ok);
         }
         return container;
     }
@@ -1299,6 +1347,33 @@
         });
     }
 
+    function wireLegality(doc) {
+        const form = q(doc, '[data-form="legality"]');
+        if (!form) return;
+        const status = statusFor(doc, 'legality');
+        const result = q(doc, '[data-result="legality"]');
+        form.addEventListener('submit', function (e) {
+            e.preventDefault();
+            const data = new FormData(form);
+            const list = (data.get('list') || '').trim();
+            const format = data.get('format') || 'modern';
+            if (!list) { setStatus(status, 'Paste a decklist to check.'); return; }
+            setStatus(status, 'Resolving your deck and checking legality…');
+            hide(result);
+            withBusy(form, true);
+            postJson(legalityUrl(), { list: list, format: format })
+                .then(function (json) {
+                    if (!json.ok) { setStatus(status, json.error || 'Could not check that deck.'); return; }
+                    setStatus(status, (json.note ? json.note : '') +
+                        (json.notFound && json.notFound.length ? ' Couldn’t find: ' + json.notFound.join(', ') : ''));
+                    renderLegality(result, json);
+                    show(result);
+                })
+                .catch(function () { setStatus(status, 'Something went wrong. Try again.'); })
+                .then(function () { withBusy(form, false); });
+        });
+    }
+
     function wireAsFan(doc) {
         const form = q(doc, '[data-form="asfan"]');
         if (!form) return;
@@ -1692,6 +1767,7 @@
         wireAsFan(doc);
         wireCompare(doc);
         wireCardLookup(doc);
+        wireLegality(doc);
         wirePreview(doc);
         wireGenerate(doc);
         wireCardFlip(doc);
@@ -1728,6 +1804,8 @@
         samplePackRequest: samplePackRequest,
         renderDistribution: renderDistribution,
         renderDiff: renderDiff,
+        legalityUrl: legalityUrl,
+        renderLegality: renderLegality,
         cardUrl: cardUrl,
         rulingsUrl: rulingsUrl,
         priceLine: priceLine,

--- a/web/src/main/resources/templates/cube.html
+++ b/web/src/main/resources/templates/cube.html
@@ -153,6 +153,12 @@
                 <span class="cube-tab-label">Card lookup</span>
                 <span class="cube-tab-sub">Find one card</span>
             </button>
+            <button type="button" id="tab-legality" class="cube-tab" role="tab"
+                    data-tab="legality" aria-controls="panel-legality" aria-selected="false" tabindex="-1">
+                <span class="cube-tab-icon" aria-hidden="true">⚖️</span>
+                <span class="cube-tab-label">Legality</span>
+                <span class="cube-tab-sub">Check a deck</span>
+            </button>
         </div>
 
         <!-- Generate -->
@@ -320,6 +326,35 @@
             </form>
             <p class="cube-status" data-status="card" aria-live="polite"></p>
             <div class="cube-cardlookup-wrap" data-result="card" hidden></div>
+        </section>
+
+        <!-- Legality -->
+        <section id="panel-legality" class="cube-panel" role="tabpanel" aria-labelledby="tab-legality"
+                 data-panel="legality" hidden>
+            <p class="cube-panel-intro">
+                Paste a decklist and pick a format to see whether it's legal — every banned or
+                not-in-format card is flagged. The website twin of <code>/cube legality</code>.
+            </p>
+            <form class="cube-form" data-form="legality" autocomplete="off">
+                <label>Decklist
+                    <textarea name="list" rows="10" spellcheck="false"
+                              placeholder="One card per line:&#10;4 Ragavan, Nimble Pilferer&#10;4 Lightning Bolt&#10;20 Mountain"></textarea>
+                </label>
+                <label>Format
+                    <select name="format">
+                        <option value="standard">Standard</option>
+                        <option value="pioneer">Pioneer</option>
+                        <option value="modern" selected>Modern</option>
+                        <option value="legacy">Legacy</option>
+                        <option value="vintage">Vintage</option>
+                        <option value="pauper">Pauper</option>
+                        <option value="commander">Commander</option>
+                    </select>
+                </label>
+                <button type="submit" class="btn cube-submit">Check legality</button>
+            </form>
+            <p class="cube-status" data-status="legality" aria-live="polite"></p>
+            <div class="cube-legality" data-result="legality" hidden></div>
         </section>
     </div>
 </main>

--- a/web/src/test/js/cube.test.js
+++ b/web/src/test/js/cube.test.js
@@ -67,6 +67,7 @@ describe('tabIdFromHash', () => {
         expect(Cube.tabIdFromHash('#asfan')).toBe('asfan');
         expect(Cube.tabIdFromHash('#compare')).toBe('compare');
         expect(Cube.tabIdFromHash('#card')).toBe('card');
+        expect(Cube.tabIdFromHash('#legality')).toBe('legality');
     });
 
     test('returns null for anything else', () => {
@@ -599,6 +600,41 @@ describe('renderDiff (compare two lists)', () => {
         const same = document.createElement('div');
         Cube.renderDiff(same, { added: [], removed: [], changed: [], sizeA: 1, sizeB: 1 });
         expect(same.querySelector('.cube-diff-empty').textContent).toContain('No differences');
+    });
+});
+
+describe('renderLegality (deck legality verdict)', () => {
+    test('illegal deck shows the headline and bucketed offenders', () => {
+        const el = document.createElement('div');
+        Cube.renderLegality(el, {
+            format: 'Modern', legal: false, total: 60,
+            banned: ['Lurrus of the Dream-Den'], notLegal: ['Black Lotus'], restricted: [], unknown: [],
+        });
+        expect(el.querySelector('.cube-legality-headline').classList.contains('is-illegal')).toBe(true);
+        expect(el.querySelector('.cube-legality-headline').textContent).toContain('Not legal in Modern');
+        expect(el.querySelector('.cube-legality-banned').textContent).toContain('Lurrus of the Dream-Den');
+        expect(el.querySelector('.cube-legality-notlegal').textContent).toContain('Black Lotus');
+        expect(el.querySelector('.cube-legality-empty')).toBeNull();
+    });
+
+    test('legal deck shows a positive headline and the all-clear note', () => {
+        const el = document.createElement('div');
+        Cube.renderLegality(el, {
+            format: 'Modern', legal: true, total: 60,
+            banned: [], notLegal: [], restricted: [], unknown: [],
+        });
+        expect(el.querySelector('.cube-legality-headline').classList.contains('is-legal')).toBe(true);
+        expect(el.querySelector('.cube-legality-empty').textContent).toContain('Every card is legal in Modern');
+    });
+
+    test('restricted cards are flagged without an all-clear note', () => {
+        const el = document.createElement('div');
+        Cube.renderLegality(el, {
+            format: 'Vintage', legal: true, total: 60,
+            banned: [], notLegal: [], restricted: ['Sol Ring'], unknown: [],
+        });
+        expect(el.querySelector('.cube-legality-restricted').textContent).toContain('Sol Ring');
+        expect(el.querySelector('.cube-legality-empty')).toBeNull();
     });
 });
 

--- a/web/src/test/kotlin/web/controller/CubeControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/CubeControllerTest.kt
@@ -185,6 +185,32 @@ class CubeControllerTest {
     }
 
     @Test
+    fun `legality returns 200 with the deck verdict`() {
+        every { service.checkLegality("4 Lurrus", "modern") } returns CubeResult.ok(
+            web.service.LegalityData(
+                format = "Modern", legal = false, total = 4,
+                banned = listOf("Lurrus of the Dream-Den"), notLegal = emptyList(),
+                restricted = emptyList(), unknown = emptyList(),
+            )
+        )
+        val response = controller.legality(CubeLegalityRequest("4 Lurrus", "modern"))
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertTrue(response.body!!.ok)
+        assertFalse(response.body!!.legal)
+        assertEquals("Modern", response.body!!.format)
+        assertEquals(listOf("Lurrus of the Dream-Den"), response.body!!.banned)
+    }
+
+    @Test
+    fun `legality returns 400 on an unknown format`() {
+        every { service.checkLegality(any(), any()) } returns CubeResult.error("Unknown format.")
+        val response = controller.legality(CubeLegalityRequest("Bolt", "yugioh"))
+        assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+        assertFalse(response.body!!.ok)
+        assertTrue(response.body!!.banned.isEmpty())
+    }
+
+    @Test
     fun `diff returns 200 with the comparison`() {
         every { service.diff("A list", "B list") } returns CubeResult.ok(
             DiffData(

--- a/web/src/test/kotlin/web/service/CubeWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/CubeWebServiceTest.kt
@@ -125,6 +125,31 @@ class CubeWebServiceTest {
         assertEquals(null, card.priceEur)
         assertEquals(null, card.priceTix)
         assertTrue(card.legalFormats.isEmpty())
+        assertTrue(card.legalities.isEmpty())
+    }
+
+    @Test
+    fun `cardOf keeps the raw per-format legality statuses`() {
+        val node = mapper.readTree(
+            """{"name":"Lurrus","color_identity":["W","B"],"type_line":"Creature",
+               "legalities":{"modern":"banned","legacy":"banned","vintage":"restricted","commander":"legal"}}"""
+        )
+        val card = service.cardOf(node)!!.card
+        assertEquals("banned", card.legalities["modern"])
+        assertEquals("restricted", card.legalities["vintage"])
+        assertEquals("legal", card.legalities["commander"])
+    }
+
+    @Test
+    fun `checkLegality rejects an unknown format without hitting the network`() {
+        val result = assertInstanceOf(CubeResult.Failure::class.java, service.checkLegality("Bolt", "yugioh"))
+        assertTrue(result.error.contains("Unknown format"))
+    }
+
+    @Test
+    fun `checkLegality rejects an empty list without hitting the network`() {
+        val result = assertInstanceOf(CubeResult.Failure::class.java, service.checkLegality("   ", "modern"))
+        assertTrue(result.error.contains("at least one card"))
     }
 
     @Test


### PR DESCRIPTION
First of the four features picked from the "what's next" list. Paste a decklist (or check a saved cube) against a format and find out whether it's legal — every **banned**, **not-in-format**, and **restricted** card is flagged.

## What's new

**Shared domain (`common`)**
- `CubeCard` now carries the full per-format `legalities` status map (`legal` / `not_legal` / `banned` / `restricted`), not just the "legal" list — needed to tell a *banned* card apart from one that's simply *not in the format*.
- New pure `DeckLegality.check(cards, format)` → a `Report` (legal overall? + banned / notLegal / restricted / unknown buckets, deduped, input order preserved). A deck is legal only when nothing is banned or not-in-format; restricted cards are flagged but don't fail it.

**Discord — `/cube legality format:<choice>`**
- Checks a `saved:` deck or a `query:` against the chosen format (format is a required choice option).
- `CubeEmbeds.legalityEmbed`: green ✅ "Legal in X" / red 🚫 "Not X-legal" headline, with bucketed offender fields (within the 1024-char field cap).

**Web — new "Legality" tab**
- Paste a decklist, pick a format → `POST /cube/api/legality` (anonymous, CSRF-exempt) → `CubeWebService.checkLegality`.
- Renders the verdict with banned / not-in-format / restricted buckets and an all-clear note when legal.

## Testing
- `common`: `DeckLegality` (legal/illegal, restricted-doesn't-fail, dedup, unknown), `CubeCard.legalitiesOf`.
- Discord: `legalityEmbed` (legal + illegal), `parseCard` populates `legalities` (incl. banned/restricted), `/cube legality` command (banned flagged + missing-format error), seven-subcommand registration.
- Web: `cardOf` keeps raw statuses, `checkLegality` validation branches, controller 200/400.
- jest: `renderLegality` (illegal/legal/restricted) + the `legality` tab hash.
- stylelint + `:common:` / `:web:` / `:discord-bot:` kover gates green; full jest suite (727) passing.

Next up from the list: combo finder, set/rules reference, price watch — as separate PRs.

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs

---
_Generated by [Claude Code](https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs)_