### PR TITLE
Add a combo finder via Commander Spellbook (Discord + web)

### DIFF
--- a/common/src/main/kotlin/common/mtg/CardCombos.kt
+++ b/common/src/main/kotlin/common/mtg/CardCombos.kt
@@ -1,0 +1,32 @@
+package common.mtg
+
+/**
+ * The combos a card takes part in, from the Commander Spellbook database — the
+ * pieces ("uses"), the payoff ("produces"), and a link to the full write-up.
+ * A pure value type shared by the bot's `/cube combos` command and the web
+ * card-lookup tool, both of which fetch from Commander Spellbook (over their
+ * own HTTP clients) and map the JSON into this. Presentation-only.
+ *
+ * [combos] is empty when the card exists but is in no known combos, which each
+ * surface presents as a friendly "no combos" state rather than an error.
+ */
+data class CardCombos(
+    val cardName: String,
+    val combos: List<Combo>,
+) {
+    /**
+     * One combo: the cards it [uses], the results it [produces], and the
+     * Commander Spellbook [url] for the full step-by-step.
+     */
+    data class Combo(
+        val id: String,
+        val uses: List<String>,
+        val produces: List<String>,
+        val url: String,
+    )
+
+    companion object {
+        /** The public Commander Spellbook page for a combo id. */
+        fun comboUrl(id: String): String = "https://commanderspellbook.com/combo/$id/"
+    }
+}

--- a/common/src/test/kotlin/common/mtg/CardCombosTest.kt
+++ b/common/src/test/kotlin/common/mtg/CardCombosTest.kt
@@ -1,0 +1,23 @@
+package common.mtg
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class CardCombosTest {
+
+    @Test
+    fun `comboUrl builds the public Commander Spellbook page`() {
+        assertEquals("https://commanderspellbook.com/combo/1234-5678/", CardCombos.comboUrl("1234-5678"))
+    }
+
+    @Test
+    fun `combos round-trips its fields`() {
+        val combos = CardCombos(
+            "Thassa's Oracle",
+            listOf(CardCombos.Combo("42", listOf("Thassa's Oracle", "Demonic Consultation"), listOf("Win the game"), "u")),
+        )
+        assertEquals("Thassa's Oracle", combos.cardName)
+        assertEquals(1, combos.combos.size)
+        assertEquals(listOf("Win the game"), combos.combos.first().produces)
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeCommand.kt
@@ -71,7 +71,8 @@ class CubeCommand @Autowired constructor(
             SUB_CARD -> launchHandling(ctx) { handleCard(ctx, deleteDelay) }
             SUB_RULINGS -> launchHandling(ctx) { handleRulings(ctx, deleteDelay) }
             SUB_LEGALITY -> launchHandling(ctx) { handleLegality(ctx, requestingUserDto, deleteDelay) }
-            else -> reply(ctx, CubeEmbeds.errorEmbed("Pick a subcommand: asfan, preview, generate, saved, card, rulings or legality."), deleteDelay)
+            SUB_COMBOS -> launchHandling(ctx) { handleCombos(ctx, deleteDelay) }
+            else -> reply(ctx, CubeEmbeds.errorEmbed("Pick a subcommand: asfan, preview, generate, saved, card, rulings, legality or combos."), deleteDelay)
         }
     }
 
@@ -277,6 +278,19 @@ class CubeCommand @Autowired constructor(
         }
     }
 
+    /** Looks up the combos a single card appears in, via Commander Spellbook. */
+    private suspend fun handleCombos(ctx: CommandContext, deleteDelay: Int) {
+        val name = ctx.event.stringOption(OPT_NAME)?.trim()
+        if (name.isNullOrEmpty()) {
+            reply(ctx, CubeEmbeds.errorEmbed("Give me a card `name` to find combos for."), deleteDelay)
+            return
+        }
+        when (val combos = fetcher.fetchCombos(name)) {
+            null -> reply(ctx, CubeEmbeds.errorEmbed("Couldn't reach Commander Spellbook. Try again later."), deleteDelay)
+            else -> reply(ctx, CubeEmbeds.combosEmbed(combos), deleteDelay)
+        }
+    }
+
     /** Checks a saved cube / queried pool against a format's banned & legality list. */
     private suspend fun handleLegality(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
         val formatKey = ctx.event.stringOption(OPT_FORMAT)?.trim()?.lowercase()
@@ -340,6 +354,8 @@ class CubeCommand @Autowired constructor(
                     .setAutoComplete(true),
                 OptionData(OptionType.STRING, OPT_QUERY, "Or a Scryfall search to check instead (e.g. set:mh3).", false),
             ),
+        SubcommandData(SUB_COMBOS, "Find the combos a Magic card is part of (Commander Spellbook).")
+            .addOptions(OptionData(OptionType.STRING, OPT_NAME, "The card's name (e.g. Thassa's Oracle).", true)),
     )
 
     companion object {
@@ -350,6 +366,7 @@ class CubeCommand @Autowired constructor(
         const val SUB_CARD = "card"
         const val SUB_RULINGS = "rulings"
         const val SUB_LEGALITY = "legality"
+        const val SUB_COMBOS = "combos"
 
         const val OPT_TOTAL = "total"
         const val OPT_NAME = "name"

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
@@ -2,6 +2,7 @@ package bot.toby.command.commands.mtg
 
 import common.discord.embed
 import common.discord.field
+import common.mtg.CardCombos
 import common.mtg.CardRulings
 import common.mtg.CardCategory
 import common.mtg.CardListParser
@@ -285,6 +286,32 @@ internal object CubeEmbeds {
         }
         setDescription(rulingsBlock(rulings.rulings))
         setFooter("${rulings.rulings.size} ruling${if (rulings.rulings.size == 1) "" else "s"} · source: Scryfall")
+    }
+
+    /**
+     * The combos panel for `/cube combos`: one field per combo listing the
+     * pieces it needs and what it produces, linked to Commander Spellbook.
+     * Shows a friendly empty state when the card is in no known combos.
+     */
+    fun combosEmbed(combos: CardCombos): MessageEmbed = embed(color = OK_COLOR) {
+        setAuthor(AUTHOR)
+        setTitle("${combos.cardName} — combos")
+        if (combos.combos.isEmpty()) {
+            setDescription("No combos found for this card on Commander Spellbook.")
+            return@embed
+        }
+        setDescription("Found **${combos.combos.size}** combo${if (combos.combos.size == 1) "" else "s"} using **${combos.cardName}**.")
+        combos.combos.forEachIndexed { i, combo ->
+            field("Combo ${i + 1}", comboField(combo), inline = false)
+        }
+        setFooter("Source: Commander Spellbook")
+    }
+
+    /** One combo as a `Cards: … → Produces: …` block with a Spellbook link, within the field cap. */
+    private fun comboField(combo: CardCombos.Combo): String {
+        val uses = combo.uses.joinToString(", ").ifEmpty { "—" }
+        val produces = combo.produces.joinToString(", ").ifEmpty { "—" }
+        return truncateField("**Cards:** $uses\n**Produces:** $produces\n[View combo](${combo.url})")
     }
 
     /**

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcher.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcher.kt
@@ -5,6 +5,7 @@ import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import common.logging.DiscordLogger
+import common.mtg.CardCombos
 import common.mtg.CardRulings
 import common.mtg.CubeCard
 import common.mtg.MtgColor
@@ -232,6 +233,49 @@ class ScryfallCubeFetcher @Autowired constructor(
             CardRulings.Ruling(obj.get("published_at")?.asString.orEmpty(), comment)
         } ?: emptyList()
 
+    /**
+     * Finds the combos a card appears in via the Commander Spellbook variants
+     * API, capped at [MAX_COMBOS]. Returns null when the lookup fails or the
+     * card name is blank; an empty [CardCombos.combos] list when the card is in
+     * no known combos. Suspends on [Dispatchers.IO].
+     */
+    suspend fun fetchCombos(name: String): CardCombos? = withContext(dispatcher) {
+        val trimmed = name.trim()
+        if (trimmed.isEmpty()) return@withContext null
+        // q=card:"Name" filters variants that use that exact card.
+        val query = URLEncoder.encode("card:\"$trimmed\"", StandardCharsets.UTF_8)
+        val url = "$SPELLBOOK_ENDPOINT?q=$query&limit=$MAX_COMBOS&ordering=-popularity"
+        try {
+            val response = client.get(url) {
+                header(HttpHeaders.Accept, "application/json")
+                timeout { requestTimeoutMillis = TIMEOUT_MS }
+            }
+            if (response.status.value != 200) return@withContext null
+            CardCombos(trimmed, parseCombos(JsonParser.parseString(response.bodyAsText()).asJsonObject))
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.error("Commander Spellbook lookup failed for '$trimmed': $e")
+            null
+        }
+    }
+
+    /** Maps a Commander Spellbook variants response into [CardCombos.Combo]s. */
+    fun parseCombos(root: JsonObject): List<CardCombos.Combo> =
+        root.getAsJsonArray("results")?.mapNotNull { element ->
+            val obj = element.asJsonObject
+            val id = obj.get("id")?.asString?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+            val uses = obj.getAsJsonArray("uses")?.mapNotNull { use ->
+                use.asJsonObject.getAsJsonObject("card")?.get("name")?.asString?.takeIf { it.isNotBlank() }
+            }.orEmpty()
+            val produces = obj.getAsJsonArray("produces")?.mapNotNull { prod ->
+                prod.asJsonObject.getAsJsonObject("feature")?.get("name")?.asString?.takeIf { it.isNotBlank() }
+            }.orEmpty()
+            // A combo with no listed pieces or payoff isn't worth showing.
+            if (uses.isEmpty() && produces.isEmpty()) return@mapNotNull null
+            CardCombos.Combo(id, uses, produces, CardCombos.comboUrl(id))
+        }.orEmpty()
+
     /** One `/cards/collection` POST for up to 75 names. */
     private suspend fun fetchCollectionBatch(chunk: List<String>): BatchResult {
         val response: HttpResponse = client.post(COLLECTION_ENDPOINT) {
@@ -356,6 +400,10 @@ class ScryfallCubeFetcher @Autowired constructor(
         private const val SEARCH_ENDPOINT = "https://api.scryfall.com/cards/search"
         private const val COLLECTION_ENDPOINT = "https://api.scryfall.com/cards/collection"
         private const val NAMED_ENDPOINT = "https://api.scryfall.com/cards/named"
+        private const val SPELLBOOK_ENDPOINT = "https://backend.commanderspellbook.com/variants/"
+
+        /** Cap on how many combos a single `/cube combos` lookup returns. */
+        const val MAX_COMBOS = 5
         const val DEFAULT_MAX_CARDS = 750
         private const val MAX_PAGES = 10
         private const val COLLECTION_BATCH = 75

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeCommandTest.kt
@@ -594,13 +594,45 @@ class CubeCommandTest : CommandTest {
     }
 
     @Test
-    fun `exposes the seven subcommands with their options`() {
+    fun `combos looks the card up and replies with a combos panel`() {
+        val slot = slot<MessageEmbed>()
+        every { event.hook.sendMessageEmbeds(capture(slot), *anyVararg()) } returns webhookMessageCreateAction
+        every { event.subcommandName } returns CubeCommand.SUB_COMBOS
+        every { event.getOption(CubeCommand.OPT_NAME) } returns strOpt("Kiki-Jiki")
+        coEvery { fetcher.fetchCombos("Kiki-Jiki") } returns common.mtg.CardCombos(
+            "Kiki-Jiki, Mirror Breaker",
+            listOf(common.mtg.CardCombos.Combo("7", listOf("Kiki-Jiki", "Zealous Conscripts"), listOf("Infinite haste"), "u")),
+        )
+
+        run()
+
+        assertEquals("Kiki-Jiki, Mirror Breaker — combos", slot.captured.title)
+        assertTrue(slot.captured.fields.any { it.value!!.contains("Infinite haste") })
+    }
+
+    @Test
+    fun `combos reports when Commander Spellbook is unreachable`() {
+        val slot = slot<MessageEmbed>()
+        every { event.hook.sendMessageEmbeds(capture(slot), *anyVararg()) } returns webhookMessageCreateAction
+        every { event.subcommandName } returns CubeCommand.SUB_COMBOS
+        every { event.getOption(CubeCommand.OPT_NAME) } returns strOpt("Kiki-Jiki")
+        coEvery { fetcher.fetchCombos(any()) } returns null
+
+        run()
+
+        assertEquals("Couldn't build that cube", slot.captured.title)
+        assertTrue(slot.captured.description!!.contains("Commander Spellbook"))
+    }
+
+    @Test
+    fun `exposes the eight subcommands with their options`() {
         assertEquals("cube", command.name)
         val subs = command.subCommands.associateBy { it.name }
-        assertEquals(setOf("asfan", "preview", "generate", "saved", "card", "rulings", "legality"), subs.keys)
+        assertEquals(setOf("asfan", "preview", "generate", "saved", "card", "rulings", "legality", "combos"), subs.keys)
         assertEquals(OptionType.STRING, subs.getValue("card").options.first { it.name == "name" }.type)
         assertTrue(subs.getValue("card").options.first { it.name == "name" }.isRequired)
         assertTrue(subs.getValue("rulings").options.first { it.name == "name" }.isRequired)
+        assertTrue(subs.getValue("combos").options.first { it.name == "name" }.isRequired)
         // The legality format option is required and offers the tracked formats as choices.
         val format = subs.getValue("legality").options.first { it.name == "format" }
         assertTrue(format.isRequired)

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeEmbedsTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeEmbedsTest.kt
@@ -316,6 +316,32 @@ class CubeEmbedsTest {
     }
 
     @Test
+    fun `combosEmbed lists each combo's pieces, payoff and link`() {
+        val combos = common.mtg.CardCombos(
+            "Kiki-Jiki, Mirror Breaker",
+            listOf(
+                common.mtg.CardCombos.Combo(
+                    "7", listOf("Kiki-Jiki, Mirror Breaker", "Zealous Conscripts"),
+                    listOf("Infinite haste creatures"), "https://commanderspellbook.com/combo/7/",
+                ),
+            ),
+        )
+        val embed = CubeEmbeds.combosEmbed(combos)
+        assertEquals("Kiki-Jiki, Mirror Breaker — combos", embed.title)
+        val field = embed.fields.first { it.name == "Combo 1" }.value!!
+        assertTrue(field.contains("Zealous Conscripts"))
+        assertTrue(field.contains("Infinite haste creatures"))
+        assertTrue(field.contains("commanderspellbook.com/combo/7"))
+    }
+
+    @Test
+    fun `combosEmbed shows an empty state when the card is in no combos`() {
+        val embed = CubeEmbeds.combosEmbed(common.mtg.CardCombos("Plains", emptyList()))
+        assertTrue(embed.description!!.contains("No combos found"))
+        assertTrue(embed.fields.isEmpty())
+    }
+
+    @Test
     fun `rulingsBlock drops overflow rulings and notes how many were hidden`() {
         // 60 long rulings can't all fit under the description cap — the block
         // must stop early and append an "…and N more" pointer.

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcherTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcherTest.kt
@@ -420,6 +420,61 @@ class ScryfallCubeFetcherTest {
         assertTrue(rulings!!.rulings.isEmpty())
     }
 
+    // --- combos (Commander Spellbook) ----------------------------------
+
+    @Test
+    fun `parseCombos maps uses, produces and the combo url`() {
+        val combos = fetcher.parseCombos(
+            obj("""{"results":[
+              {"id":"42-7","uses":[{"card":{"name":"Thassa's Oracle"}},{"card":{"name":"Demonic Consultation"}}],
+               "produces":[{"feature":{"name":"Win the game"}}]},
+              {"id":"","uses":[],"produces":[]},
+              {"id":"99","uses":[],"produces":[]}
+            ]}""")
+        )
+        assertEquals(1, combos.size) // blank id and empty uses+produces are dropped
+        assertEquals("42-7", combos[0].id)
+        assertEquals(listOf("Thassa's Oracle", "Demonic Consultation"), combos[0].uses)
+        assertEquals(listOf("Win the game"), combos[0].produces)
+        assertEquals("https://commanderspellbook.com/combo/42-7/", combos[0].url)
+    }
+
+    @Test
+    fun `parseCombos tolerates a missing results array`() {
+        assertTrue(fetcher.parseCombos(obj("""{"detail":"nope"}""")).isEmpty())
+    }
+
+    @Test
+    fun `fetchCombos resolves a card's combos from Commander Spellbook`() = runBlocking {
+        val engine = MockEngine { request ->
+            assertTrue(request.url.toString().contains("/variants/"))
+            respond(
+                """{"results":[{"id":"7","uses":[{"card":{"name":"Kiki-Jiki"}}],"produces":[{"feature":{"name":"Infinite haste creatures"}}]}]}""",
+                HttpStatusCode.OK, jsonHeaders,
+            )
+        }
+        val combos = fetcherWith(engine).fetchCombos("Kiki-Jiki, Mirror Breaker")
+        assertEquals("Kiki-Jiki, Mirror Breaker", combos?.cardName)
+        assertEquals(1, combos?.combos?.size)
+        assertEquals("Infinite haste creatures", combos?.combos?.first()?.produces?.first())
+    }
+
+    @Test
+    fun `fetchCombos returns an empty list when the card is in no combos`() = runBlocking {
+        val combos = fetcherWith(MockEngine { respond("""{"results":[]}""", HttpStatusCode.OK, jsonHeaders) })
+            .fetchCombos("Plains")
+        assertEquals("Plains", combos?.cardName)
+        assertTrue(combos!!.combos.isEmpty())
+    }
+
+    @Test
+    fun `fetchCombos returns null on a transport failure or blank name`() = runBlocking {
+        assertNull(fetcherWith(MockEngine { throw IOException("down") }).fetchCombos("Bolt"))
+        val engine = MockEngine { respond("{}", HttpStatusCode.OK, jsonHeaders) }
+        assertNull(fetcherWith(engine).fetchCombos("   "))
+        assertEquals(0, engine.requestHistory.size)
+    }
+
     // --- fetch ---------------------------------------------------------
 
     @Test

--- a/web/src/main/kotlin/web/configuration/WebSecurityConfig.kt
+++ b/web/src/main/kotlin/web/configuration/WebSecurityConfig.kt
@@ -25,7 +25,7 @@ class WebSecurityConfig {
                     // shared cube (/cube/c/**) are public; the saved-lists and
                     // share-create APIs are deliberately NOT listed here so they
                     // fall through to anyRequest().authenticated().
-                    "/cube", "/cube/c/**", "/cube/api/asfan", "/cube/api/preview", "/cube/api/generate", "/cube/api/diff", "/cube/api/card", "/cube/api/rulings", "/cube/api/legality",
+                    "/cube", "/cube/c/**", "/cube/api/asfan", "/cube/api/preview", "/cube/api/generate", "/cube/api/diff", "/cube/api/card", "/cube/api/rulings", "/cube/api/legality", "/cube/api/combos",
                     "/sitemap.xml", "/robots.txt",
                     // Service worker for web push must be reachable
                     // unauthenticated — the browser registers it on

--- a/web/src/main/kotlin/web/controller/CubeController.kt
+++ b/web/src/main/kotlin/web/controller/CubeController.kt
@@ -24,6 +24,7 @@ import web.service.CategoryGroup
 import web.service.CubeResult
 import web.service.DiffLineView
 import web.service.CubeWebService
+import web.service.ComboView
 import web.service.RulingView
 import web.service.GenerateData
 import web.service.PreviewData
@@ -142,6 +143,17 @@ class CubeController(
             )
             is CubeResult.Failure ->
                 ResponseEntity.badRequest().body(CubeRulingsResponse(false, result.error, null, null, emptyList()))
+        }
+
+    @GetMapping("/api/combos", produces = ["application/json"])
+    @ResponseBody
+    fun combos(@RequestParam("name") name: String): ResponseEntity<CubeCombosResponse> =
+        when (val result = cubeWebService.combos(name)) {
+            is CubeResult.Success -> ResponseEntity.ok(
+                CubeCombosResponse(true, null, result.value.name, result.value.combos)
+            )
+            is CubeResult.Failure ->
+                ResponseEntity.badRequest().body(CubeCombosResponse(false, result.error, null, emptyList()))
         }
 
     @PostMapping("/api/legality", consumes = ["application/json"], produces = ["application/json"])
@@ -294,6 +306,13 @@ data class CubeRulingsResponse(
     val name: String?,
     val scryfallUri: String?,
     val rulings: List<RulingView>,
+)
+
+data class CubeCombosResponse(
+    val ok: Boolean,
+    val error: String?,
+    val name: String?,
+    val combos: List<ComboView>,
 )
 
 data class CubeLegalityRequest(val list: String = "", val format: String = "")

--- a/web/src/main/kotlin/web/service/CubeWebService.kt
+++ b/web/src/main/kotlin/web/service/CubeWebService.kt
@@ -8,6 +8,7 @@ import common.mtg.CardListParser
 import common.mtg.CubeAnalytics
 import common.mtg.CubeCard
 import common.mtg.CubeDiff
+import common.mtg.CardCombos
 import common.mtg.DeckLegality
 import common.mtg.MtgCurrency
 import common.mtg.MtgNames
@@ -132,6 +133,43 @@ class CubeWebService {
         return data.mapNotNull { node ->
             val comment = node.path("comment").asText("").takeIf { it.isNotBlank() } ?: return@mapNotNull null
             RulingView(node.path("published_at").asText(""), comment)
+        }
+    }
+
+    /**
+     * Finds the combos a card appears in via the Commander Spellbook variants
+     * API — the website twin of `/cube combos`. A reachable card with no combos
+     * is a success with an empty list, not an error.
+     */
+    fun combos(name: String): CubeResult<CombosView> {
+        val trimmed = name.trim()
+        if (trimmed.isEmpty()) return CubeResult.error("Enter a card name to find combos.")
+        val query = URLEncoder.encode("card:\"$trimmed\"", StandardCharsets.UTF_8)
+        val url = "$SPELLBOOK_ENDPOINT?q=$query&limit=$MAX_COMBOS&ordering=-popularity"
+        return try {
+            val response = scryfallGet(url)
+            if (response.statusCode() != 200) {
+                return CubeResult.error("Couldn't reach Commander Spellbook (${response.statusCode()}).")
+            }
+            CubeResult.ok(CombosView(trimmed, combosOf(jackson.readTree(response.body()))))
+        } catch (e: IOException) {
+            CubeResult.error("Could not reach Commander Spellbook: ${e.message}")
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            CubeResult.error("Request interrupted.")
+        }
+    }
+
+    /** Maps a Commander Spellbook variants response into combo views. */
+    fun combosOf(root: JsonNode): List<ComboView> {
+        val results = root.path("results")
+        if (!results.isArray) return emptyList()
+        return results.mapNotNull { node ->
+            val id = node.path("id").asText("").takeIf { it.isNotBlank() } ?: return@mapNotNull null
+            val uses = node.path("uses").mapNotNull { it.path("card").path("name").asText("").takeIf { n -> n.isNotBlank() } }
+            val produces = node.path("produces").mapNotNull { it.path("feature").path("name").asText("").takeIf { n -> n.isNotBlank() } }
+            if (uses.isEmpty() && produces.isEmpty()) return@mapNotNull null
+            ComboView(id, uses, produces, CardCombos.comboUrl(id))
         }
     }
 
@@ -621,6 +659,8 @@ class CubeWebService {
         const val SEARCH_ENDPOINT = "https://api.scryfall.com/cards/search"
         const val COLLECTION_ENDPOINT = "https://api.scryfall.com/cards/collection"
         const val NAMED_ENDPOINT = "https://api.scryfall.com/cards/named"
+        const val SPELLBOOK_ENDPOINT = "https://backend.commanderspellbook.com/variants/"
+        const val MAX_COMBOS = 5
         const val MAX_CARDS = 750
         const val MAX_PAGES = 10
         const val COLLECTION_BATCH = 75
@@ -762,6 +802,12 @@ data class RulingsView(
 
 /** One published ruling: the ISO publish date and the note text. */
 data class RulingView(val publishedAt: String, val comment: String)
+
+/** The combos a card appears in, looked up by name. */
+data class CombosView(val name: String, val combos: List<ComboView>)
+
+/** One combo: its pieces, payoff, and Commander Spellbook link. */
+data class ComboView(val id: String, val uses: List<String>, val produces: List<String>, val url: String)
 
 /** The outcome of checking a pasted decklist against a format. */
 data class LegalityData(

--- a/web/src/main/resources/static/css/cube.css
+++ b/web/src/main/resources/static/css/cube.css
@@ -1152,6 +1152,52 @@ details[open] > .cube-section-summary .cube-collapse-chevron {
     font-size: 0.78rem;
 }
 
+/* Combos, loaded on demand under the card lookup (mirrors .cube-rulings). */
+.cube-combos {
+    margin-top: var(--space-3);
+}
+
+.cube-combos-h {
+    margin: 0 0 var(--space-2);
+    color: var(--heading);
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.cube-combos-empty {
+    margin: 0;
+    color: var(--text-muted);
+    font-size: 0.9rem;
+}
+
+.cube-combos-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+}
+
+.cube-combo {
+    padding: var(--space-2);
+    border-left: 3px solid var(--mtg-gold, #c7a14f);
+    background: var(--surface-2, rgba(255, 255, 255, 0.03));
+    font-size: 0.9rem;
+}
+
+.cube-combo-produces {
+    color: var(--text-muted);
+    margin-top: 2px;
+}
+
+.cube-combo-link {
+    display: inline-block;
+    margin-top: 4px;
+    font-size: 0.8rem;
+}
+
 /* Total cube value (sum of priced cards), shown under the analytics breakdown,
    with a currency switch sitting alongside it. */
 .cube-total-value-row {

--- a/web/src/main/resources/static/js/cube.js
+++ b/web/src/main/resources/static/js/cube.js
@@ -534,6 +534,15 @@
         rulingsBtn.textContent = 'Show rulings';
         facts.appendChild(rulingsBtn);
 
+        // On-demand combos: fetches /cube/api/combos for this card.
+        const combosBtn = document.createElement('button');
+        combosBtn.type = 'button';
+        combosBtn.className = 'btn btn-secondary cube-combos-btn';
+        combosBtn.setAttribute('data-load-combos', '');
+        combosBtn.setAttribute('data-card-name', card.name);
+        combosBtn.textContent = 'Show combos';
+        facts.appendChild(combosBtn);
+
         wrap.appendChild(facts);
         container.appendChild(wrap);
 
@@ -542,6 +551,60 @@
         rulingsBox.setAttribute('data-rulings-result', '');
         rulingsBox.hidden = true;
         container.appendChild(rulingsBox);
+
+        const combosBox = document.createElement('div');
+        combosBox.className = 'cube-combos';
+        combosBox.setAttribute('data-combos-result', '');
+        combosBox.hidden = true;
+        container.appendChild(combosBox);
+        return container;
+    }
+
+    /** GET URL for a card's combos. */
+    function combosUrl(name) {
+        return '/cube/api/combos?name=' + encodeURIComponent(name);
+    }
+
+    /** Renders a card's combos (pieces → produces, each linked), or a friendly empty state. */
+    function renderCombos(container, data) {
+        container.replaceChildren();
+        const h = document.createElement('h4');
+        h.className = 'cube-combos-h';
+        h.textContent = 'Combos';
+        container.appendChild(h);
+        const combos = (data && data.combos) || [];
+        if (!combos.length) {
+            const p = document.createElement('p');
+            p.className = 'cube-combos-empty';
+            p.textContent = 'No combos found for this card on Commander Spellbook.';
+            container.appendChild(p);
+            return container;
+        }
+        const ul = document.createElement('ul');
+        ul.className = 'cube-combos-list';
+        combos.forEach(function (combo) {
+            const li = document.createElement('li');
+            li.className = 'cube-combo';
+            const uses = document.createElement('div');
+            uses.className = 'cube-combo-uses';
+            uses.textContent = (combo.uses || []).join(', ');
+            const produces = document.createElement('div');
+            produces.className = 'cube-combo-produces';
+            produces.textContent = '→ ' + (combo.produces || []).join(', ');
+            li.appendChild(uses);
+            li.appendChild(produces);
+            if (combo.url) {
+                const a = document.createElement('a');
+                a.className = 'cube-combo-link';
+                a.href = combo.url;
+                a.target = '_blank';
+                a.rel = 'noopener';
+                a.textContent = 'View combo ↗';
+                li.appendChild(a);
+            }
+            ul.appendChild(li);
+        });
+        container.appendChild(ul);
         return container;
     }
 
@@ -1302,6 +1365,25 @@
                 .catch(function () { btn.disabled = false; btn.textContent = 'Show rulings'; });
         });
 
+        // Same pattern for the "Show combos" button.
+        result.addEventListener('click', function (e) {
+            const btn = e.target.closest && e.target.closest('[data-load-combos]');
+            if (!btn) return;
+            const name = btn.getAttribute('data-card-name');
+            const box = result.querySelector('[data-combos-result]');
+            if (!name || !box) return;
+            btn.disabled = true;
+            btn.textContent = 'Loading combos…';
+            getJson(combosUrl(name))
+                .then(function (json) {
+                    if (!json.ok) { btn.disabled = false; btn.textContent = json.error || 'No combos found.'; return; }
+                    renderCombos(box, json);
+                    box.hidden = false;
+                    btn.hidden = true;
+                })
+                .catch(function () { btn.disabled = false; btn.textContent = 'Show combos'; });
+        });
+
         form.addEventListener('submit', function (e) {
             e.preventDefault();
             const name = (new FormData(form).get('name') || '').trim();
@@ -1808,6 +1890,8 @@
         renderLegality: renderLegality,
         cardUrl: cardUrl,
         rulingsUrl: rulingsUrl,
+        combosUrl: combosUrl,
+        renderCombos: renderCombos,
         priceLine: priceLine,
         totalValueText: totalValueText,
         formatMoney: formatMoney,

--- a/web/src/test/js/cube.test.js
+++ b/web/src/test/js/cube.test.js
@@ -451,6 +451,46 @@ describe('card lookup (cardUrl / renderCardLookup)', () => {
         expect(box).not.toBeNull();
         expect(box.hidden).toBe(true);
     });
+
+    test('renderCardLookup includes a Show combos button and a hidden combos box', () => {
+        const container = document.createElement('div');
+        Cube.renderCardLookup(container, { name: 'Kiki-Jiki', imageUrlLarge: 'n.jpg', typeLine: 'Creature', manaValue: 5, rarity: 'Rare', colors: ['Red'] });
+        const btn = container.querySelector('[data-load-combos]');
+        expect(btn).not.toBeNull();
+        expect(btn.getAttribute('data-card-name')).toBe('Kiki-Jiki');
+        const box = container.querySelector('[data-combos-result]');
+        expect(box).not.toBeNull();
+        expect(box.hidden).toBe(true);
+    });
+});
+
+describe('combos (combosUrl / renderCombos)', () => {
+    test('combosUrl encodes the name', () => {
+        expect(Cube.combosUrl("Thassa's Oracle"))
+            .toBe('/cube/api/combos?name=' + encodeURIComponent("Thassa's Oracle"));
+    });
+
+    test('renderCombos lists each combo with pieces, payoff and a link', () => {
+        const container = document.createElement('div');
+        Cube.renderCombos(container, {
+            combos: [
+                { id: '7', uses: ['Kiki-Jiki', 'Zealous Conscripts'], produces: ['Infinite haste creatures'], url: 'https://commanderspellbook.com/combo/7/' },
+            ],
+        });
+        expect(container.querySelector('.cube-combos-h').textContent).toBe('Combos');
+        const items = container.querySelectorAll('.cube-combo');
+        expect(items).toHaveLength(1);
+        expect(items[0].querySelector('.cube-combo-uses').textContent).toContain('Zealous Conscripts');
+        expect(items[0].querySelector('.cube-combo-produces').textContent).toContain('Infinite haste creatures');
+        expect(items[0].querySelector('.cube-combo-link').getAttribute('href')).toBe('https://commanderspellbook.com/combo/7/');
+    });
+
+    test('renderCombos shows an empty state when there are none', () => {
+        const container = document.createElement('div');
+        Cube.renderCombos(container, { combos: [] });
+        expect(container.querySelector('.cube-combos-empty').textContent).toContain('No combos found');
+        expect(container.querySelectorAll('.cube-combo')).toHaveLength(0);
+    });
 });
 
 describe('rulings (rulingsUrl / renderRulings)', () => {

--- a/web/src/test/kotlin/web/controller/CubeControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/CubeControllerTest.kt
@@ -31,6 +31,8 @@ import web.service.DuplicateView
 import web.service.GenerateData
 import web.service.PreviewData
 import web.service.RarityCountView
+import web.service.ComboView
+import web.service.CombosView
 import web.service.RulingView
 import web.service.RulingsView
 import web.service.TypeCountView
@@ -182,6 +184,27 @@ class CubeControllerTest {
         assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
         assertFalse(response.body!!.ok)
         assertTrue(response.body!!.rulings.isEmpty())
+    }
+
+    @Test
+    fun `combos returns 200 with the card's combos`() {
+        every { service.combos("Kiki-Jiki") } returns CubeResult.ok(
+            CombosView("Kiki-Jiki", listOf(ComboView("7", listOf("Kiki-Jiki"), listOf("Infinite haste"), "u")))
+        )
+        val response = controller.combos("Kiki-Jiki")
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertTrue(response.body!!.ok)
+        assertEquals("Kiki-Jiki", response.body!!.name)
+        assertEquals(1, response.body!!.combos.size)
+    }
+
+    @Test
+    fun `combos returns 400 when the lookup fails`() {
+        every { service.combos(any()) } returns CubeResult.error("Could not reach Commander Spellbook: down")
+        val response = controller.combos("Kiki-Jiki")
+        assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+        assertFalse(response.body!!.ok)
+        assertTrue(response.body!!.combos.isEmpty())
     }
 
     @Test

--- a/web/src/test/kotlin/web/service/CubeWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/CubeWebServiceTest.kt
@@ -195,6 +195,35 @@ class CubeWebServiceTest {
         assertTrue(result.error.contains("card name"))
     }
 
+    // --- combos (Commander Spellbook) ----------------------------------
+
+    @Test
+    fun `combosOf maps uses, produces and the combo url, dropping empties`() {
+        val root = mapper.readTree(
+            """{"results":[
+              {"id":"42","uses":[{"card":{"name":"Thassa's Oracle"}}],"produces":[{"feature":{"name":"Win the game"}}]},
+              {"id":"","uses":[],"produces":[]},
+              {"id":"9","uses":[],"produces":[]}
+            ]}"""
+        )
+        val combos = service.combosOf(root)
+        assertEquals(1, combos.size)
+        assertEquals("42", combos.first().id)
+        assertEquals(listOf("Thassa's Oracle"), combos.first().uses)
+        assertEquals("https://commanderspellbook.com/combo/42/", combos.first().url)
+    }
+
+    @Test
+    fun `combosOf tolerates a missing results array`() {
+        assertTrue(service.combosOf(mapper.readTree("""{"detail":"nope"}""")).isEmpty())
+    }
+
+    @Test
+    fun `combos rejects a blank name without hitting the network`() {
+        val result = assertInstanceOf(CubeResult.Failure::class.java, service.combos("  "))
+        assertTrue(result.error.contains("card name"))
+    }
+
     // --- diff (compare two lists) --------------------------------------
 
     @Test


### PR DESCRIPTION
Look up the combos a Magic card is part of — the pieces it needs and the
payoff — from the Commander Spellbook database.

- common: CardCombos value type (card name + combos of uses/produces/url),
  shared by both surfaces.
- Discord: ScryfallCubeFetcher.fetchCombos queries the Spellbook variants
  API; /cube combos renders them via CubeEmbeds.combosEmbed (one field per
  combo, linked, empty-state when none).
- Web: CubeWebService.combos + GET /cube/api/combos (anonymous); the card-
  lookup tab gains an on-demand "Show combos" button rendering pieces →
  produces with links.
- Tests across common, web service/controller, jest and the Discord
  embeds/fetcher/command; stylelint + kover gates green.

Note: needs backend.commanderspellbook.com allow-listed in the
environment's network policy to work in production; degrades gracefully
(no combos / friendly error) when unreachable.

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs