### PR TITLE
Add card price watch alerts (Discord + web)

### DIFF
--- a/common/src/main/kotlin/common/notification/NotificationChannelKind.kt
+++ b/common/src/main/kotlin/common/notification/NotificationChannelKind.kt
@@ -58,6 +58,12 @@ enum class NotificationChannelKind(
         description = "Off by default — DM receipts when a /pricealert trigger auto-executes a buy or sell on your behalf.",
         perSurfaceDefaults = mapOf(Surface.DM to false, Surface.PUSH to false),
     ),
+    CARD_PRICE_ALERT(
+        displayName = "Card price watch",
+        description = "DM when a Magic card you're watching (/cube watch-add) crosses your target price.",
+        // DM-only and on by default — you opted in by creating the watch.
+        perSurfaceDefaults = mapOf(Surface.DM to true),
+    ),
     INTRO_PROMPT(
         displayName = "Intro setup prompt",
         description = "First-time prompt to set your voice-channel intro song.",

--- a/database/src/main/kotlin/database/dto/user/CardPriceWatchDto.kt
+++ b/database/src/main/kotlin/database/dto/user/CardPriceWatchDto.kt
@@ -1,0 +1,90 @@
+package database.dto.user
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.NamedQueries
+import jakarta.persistence.NamedQuery
+import jakarta.persistence.Table
+import org.hibernate.annotations.DynamicUpdate
+import org.springframework.transaction.annotation.Transactional
+import java.io.Serializable
+import java.time.Instant
+
+/**
+ * A user-defined Magic card price watch. The scheduler DMs [discordId] when
+ * the card [cardName]'s market price (in [currency]) crosses [threshold] in
+ * [direction]. One-shot: on fire the scheduler stamps [firedAt] and flips
+ * [enabled] false, so an oscillating price can't re-alert; the user re-arms by
+ * adding the watch again.
+ *
+ * [guildId] is the guild the watch was created in (0 for web-created watches),
+ * used only to resolve the user's per-guild notification opt-in.
+ */
+@NamedQueries(
+    NamedQuery(
+        name = "CardPriceWatchDto.listEnabled",
+        query = "select w from CardPriceWatchDto w where w.enabled = true"
+    ),
+    NamedQuery(
+        name = "CardPriceWatchDto.listByUser",
+        query = "select w from CardPriceWatchDto w where w.discordId = :discordId order by w.id"
+    )
+)
+@Entity
+@DynamicUpdate
+@Table(name = "card_price_watch", schema = "public")
+@Transactional
+class CardPriceWatchDto(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    var id: Long? = null,
+
+    @Column(name = "discord_id", nullable = false)
+    var discordId: Long = 0,
+
+    @Column(name = "guild_id", nullable = false)
+    var guildId: Long = 0,
+
+    @Column(name = "card_name", nullable = false)
+    var cardName: String = "",
+
+    @Column(name = "currency", nullable = false, length = 8)
+    var currency: String = "usd",
+
+    @Column(name = "direction", nullable = false, length = 8)
+    var direction: String = Direction.BELOW.name,
+
+    @Column(name = "threshold", nullable = false)
+    var threshold: Double = 0.0,
+
+    @Column(name = "price_at_creation")
+    var priceAtCreation: Double? = null,
+
+    @Column(name = "enabled", nullable = false)
+    var enabled: Boolean = true,
+
+    @Column(name = "fired_at")
+    var firedAt: Instant? = null,
+
+    @Column(name = "created_at", nullable = false)
+    var createdAt: Instant = Instant.now(),
+) : Serializable {
+
+    /** Which way the price must move to fire the alert. */
+    enum class Direction { BELOW, ABOVE }
+
+    /** Typed accessor over the stringly-typed [direction] column. */
+    var directionEnum: Direction
+        get() = Direction.valueOf(direction)
+        set(value) { direction = value.name }
+
+    /** True when [price] satisfies this watch's [direction] vs [threshold]. */
+    fun isTriggeredBy(price: Double): Boolean = when (directionEnum) {
+        Direction.BELOW -> price <= threshold
+        Direction.ABOVE -> price >= threshold
+    }
+}

--- a/database/src/main/kotlin/database/persistence/user/CardPriceWatchPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/user/CardPriceWatchPersistence.kt
@@ -1,0 +1,15 @@
+package database.persistence.user
+
+import database.dto.user.CardPriceWatchDto
+
+interface CardPriceWatchPersistence {
+    fun save(watch: CardPriceWatchDto): CardPriceWatchDto
+
+    fun findById(id: Long): CardPriceWatchDto?
+
+    fun listEnabled(): List<CardPriceWatchDto>
+
+    fun listByUser(discordId: Long): List<CardPriceWatchDto>
+
+    fun deleteById(id: Long): Boolean
+}

--- a/database/src/main/kotlin/database/persistence/user/impl/DefaultCardPriceWatchPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/user/impl/DefaultCardPriceWatchPersistence.kt
@@ -1,0 +1,46 @@
+package database.persistence.user.impl
+
+import database.dto.user.CardPriceWatchDto
+import database.persistence.saveOrMerge
+import database.persistence.user.CardPriceWatchPersistence
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import jakarta.persistence.TypedQuery
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+
+@Repository
+@Transactional
+class DefaultCardPriceWatchPersistence : CardPriceWatchPersistence {
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    override fun save(watch: CardPriceWatchDto): CardPriceWatchDto =
+        entityManager.saveOrMerge(watch, isNew = { it.id == null })
+
+    override fun findById(id: Long): CardPriceWatchDto? =
+        entityManager.find(CardPriceWatchDto::class.java, id)
+
+    override fun listEnabled(): List<CardPriceWatchDto> {
+        val q: TypedQuery<CardPriceWatchDto> = entityManager.createNamedQuery(
+            "CardPriceWatchDto.listEnabled", CardPriceWatchDto::class.java
+        )
+        return q.resultList
+    }
+
+    override fun listByUser(discordId: Long): List<CardPriceWatchDto> {
+        val q: TypedQuery<CardPriceWatchDto> = entityManager.createNamedQuery(
+            "CardPriceWatchDto.listByUser", CardPriceWatchDto::class.java
+        )
+        q.setParameter("discordId", discordId)
+        return q.resultList
+    }
+
+    override fun deleteById(id: Long): Boolean {
+        val existing = entityManager.find(CardPriceWatchDto::class.java, id) ?: return false
+        entityManager.remove(existing)
+        entityManager.flush()
+        return true
+    }
+}

--- a/database/src/main/kotlin/database/service/user/CardPriceWatchService.kt
+++ b/database/src/main/kotlin/database/service/user/CardPriceWatchService.kt
@@ -1,0 +1,35 @@
+package database.service.user
+
+import database.dto.user.CardPriceWatchDto
+import java.time.Instant
+
+interface CardPriceWatchService {
+    /** Max watches one account may hold, to bound the job's fetch fan-out. */
+    val maxPerUser: Int
+
+    /**
+     * Create a watch. Returns null when the user is already at [maxPerUser].
+     * [priceAtCreation] is the card's price when the watch was set (context
+     * for the alert), or null when unknown.
+     */
+    fun create(
+        discordId: Long,
+        guildId: Long,
+        cardName: String,
+        currency: String,
+        direction: CardPriceWatchDto.Direction,
+        threshold: Double,
+        priceAtCreation: Double? = null,
+    ): CardPriceWatchDto?
+
+    fun listForUser(discordId: Long): List<CardPriceWatchDto>
+
+    /** Every enabled watch across all users (the scheduler's scan). */
+    fun listEnabled(): List<CardPriceWatchDto>
+
+    /** Delete watch [id] only if it belongs to [requestingDiscordId]. */
+    fun remove(id: Long, requestingDiscordId: Long): Boolean
+
+    /** Mark [id] fired at [firedAt] and disable it (one-shot). */
+    fun markFired(id: Long, firedAt: Instant)
+}

--- a/database/src/main/kotlin/database/service/user/impl/DefaultCardPriceWatchService.kt
+++ b/database/src/main/kotlin/database/service/user/impl/DefaultCardPriceWatchService.kt
@@ -1,0 +1,64 @@
+package database.service.user.impl
+
+import database.dto.user.CardPriceWatchDto
+import database.persistence.user.CardPriceWatchPersistence
+import database.service.user.CardPriceWatchService
+import org.springframework.stereotype.Service
+import java.time.Instant
+
+@Service
+class DefaultCardPriceWatchService(
+    private val persistence: CardPriceWatchPersistence,
+) : CardPriceWatchService {
+
+    override val maxPerUser: Int = MAX_PER_USER
+
+    override fun create(
+        discordId: Long,
+        guildId: Long,
+        cardName: String,
+        currency: String,
+        direction: CardPriceWatchDto.Direction,
+        threshold: Double,
+        priceAtCreation: Double?,
+    ): CardPriceWatchDto? {
+        require(cardName.isNotBlank()) { "cardName must not be blank" }
+        require(threshold > 0.0) { "threshold must be positive (was $threshold)" }
+        if (persistence.listByUser(discordId).size >= MAX_PER_USER) return null
+        return persistence.save(
+            CardPriceWatchDto(
+                discordId = discordId,
+                guildId = guildId,
+                cardName = cardName,
+                currency = currency,
+                direction = direction.name,
+                threshold = threshold,
+                priceAtCreation = priceAtCreation,
+                enabled = true,
+                createdAt = Instant.now(),
+            )
+        )
+    }
+
+    override fun listForUser(discordId: Long): List<CardPriceWatchDto> =
+        persistence.listByUser(discordId)
+
+    override fun listEnabled(): List<CardPriceWatchDto> = persistence.listEnabled()
+
+    override fun remove(id: Long, requestingDiscordId: Long): Boolean {
+        val row = persistence.findById(id) ?: return false
+        if (row.discordId != requestingDiscordId) return false
+        return persistence.deleteById(id)
+    }
+
+    override fun markFired(id: Long, firedAt: Instant) {
+        val row = persistence.findById(id) ?: return
+        row.firedAt = firedAt
+        row.enabled = false
+        persistence.save(row)
+    }
+
+    private companion object {
+        const val MAX_PER_USER = 25
+    }
+}

--- a/database/src/main/resources/db/migration/V47__card_price_watch.sql
+++ b/database/src/main/resources/db/migration/V47__card_price_watch.sql
@@ -1,0 +1,34 @@
+-- Per-user Magic card price watches. A user asks to be alerted when a
+-- card's market price (Scryfall, in their chosen currency) crosses a
+-- threshold in a direction (BELOW / ABOVE). A scheduled job batch-fetches
+-- prices for every watched card and DMs the user via the CARD_PRICE_ALERT
+-- notification kind when a watch's condition is met.
+--
+-- One-shot: on fire, `fired_at` is stamped and `enabled` flipped false so a
+-- price oscillating around the threshold can't re-alert. The user re-arms by
+-- adding the watch again. `guild_id` records where the watch was created so
+-- the notification router can resolve the user's per-guild DM opt-in (0 for
+-- watches created on the web, which has no guild context — those route via
+-- the CARD_PRICE_ALERT default opt-in).
+CREATE TABLE card_price_watch (
+    id              BIGSERIAL     PRIMARY KEY,
+    discord_id      BIGINT        NOT NULL,
+    guild_id        BIGINT        NOT NULL DEFAULT 0,
+    card_name       VARCHAR(255)  NOT NULL,
+    currency        VARCHAR(8)    NOT NULL,
+    direction       VARCHAR(8)    NOT NULL,
+    threshold       NUMERIC(20,6) NOT NULL,
+    price_at_creation NUMERIC(20,6),
+    enabled         BOOLEAN       NOT NULL DEFAULT TRUE,
+    fired_at        TIMESTAMPTZ,
+    created_at      TIMESTAMPTZ   NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Job hot path: scan every enabled watch (prices are global, one fetch
+-- pass covers all guilds/users).
+CREATE INDEX idx_card_price_watch_enabled
+    ON card_price_watch (enabled) WHERE enabled;
+
+-- "list my watches" lookup.
+CREATE INDEX idx_card_price_watch_user
+    ON card_price_watch (discord_id);

--- a/database/src/test/kotlin/database/service/CardPriceWatchServiceTest.kt
+++ b/database/src/test/kotlin/database/service/CardPriceWatchServiceTest.kt
@@ -1,0 +1,129 @@
+package database.service
+
+import database.dto.user.CardPriceWatchDto
+import database.dto.user.CardPriceWatchDto.Direction
+import database.persistence.user.CardPriceWatchPersistence
+import database.service.user.impl.DefaultCardPriceWatchService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class CardPriceWatchServiceTest {
+
+    private val discordId = 42L
+    private val guildId = 100L
+    private lateinit var persistence: CardPriceWatchPersistence
+    private lateinit var service: DefaultCardPriceWatchService
+
+    @BeforeEach
+    fun setUp() {
+        persistence = mockk(relaxed = true)
+        service = DefaultCardPriceWatchService(persistence)
+    }
+
+    @Test
+    fun `create persists an enabled watch with the direction stored as its name`() {
+        every { persistence.listByUser(discordId) } returns emptyList()
+        val saved = slot<CardPriceWatchDto>()
+        every { persistence.save(capture(saved)) } answers { firstArg() }
+
+        val result = service.create(discordId, guildId, "Ragavan", "usd", Direction.BELOW, 30.0, 45.0)
+
+        assertNotNull(result)
+        assertEquals("Ragavan", saved.captured.cardName)
+        assertEquals("usd", saved.captured.currency)
+        assertEquals("BELOW", saved.captured.direction)
+        assertEquals(30.0, saved.captured.threshold)
+        assertEquals(45.0, saved.captured.priceAtCreation)
+        assertTrue(saved.captured.enabled)
+    }
+
+    @Test
+    fun `create returns null when the user is at the watch cap`() {
+        every { persistence.listByUser(discordId) } returns
+            (1..service.maxPerUser).map { CardPriceWatchDto(id = it.toLong(), discordId = discordId) }
+
+        assertNull(service.create(discordId, guildId, "Ragavan", "usd", Direction.BELOW, 30.0, null))
+        verify(exactly = 0) { persistence.save(any()) }
+    }
+
+    @Test
+    fun `create rejects a blank name or non-positive threshold`() {
+        every { persistence.listByUser(discordId) } returns emptyList()
+        assertTrue(runCatching { service.create(discordId, guildId, "  ", "usd", Direction.BELOW, 30.0, null) }
+            .exceptionOrNull() is IllegalArgumentException)
+        assertTrue(runCatching { service.create(discordId, guildId, "Bolt", "usd", Direction.BELOW, 0.0, null) }
+            .exceptionOrNull() is IllegalArgumentException)
+    }
+
+    @Test
+    fun `remove enforces ownership`() {
+        val row = CardPriceWatchDto(id = 7, discordId = discordId)
+        every { persistence.findById(7L) } returns row
+        every { persistence.deleteById(7L) } returns true
+
+        assertFalse(service.remove(7L, requestingDiscordId = 9999L))
+        assertTrue(service.remove(7L, requestingDiscordId = discordId))
+    }
+
+    @Test
+    fun `remove returns false when the row is missing`() {
+        every { persistence.findById(404L) } returns null
+        assertFalse(service.remove(404L, discordId))
+        verify(exactly = 0) { persistence.deleteById(any()) }
+    }
+
+    @Test
+    fun `markFired stamps firedAt and disables`() {
+        val row = CardPriceWatchDto(id = 5, discordId = discordId, enabled = true)
+        every { persistence.findById(5L) } returns row
+        val saved = slot<CardPriceWatchDto>()
+        every { persistence.save(capture(saved)) } answers { firstArg() }
+
+        val now = Instant.parse("2026-06-06T12:00:00Z")
+        service.markFired(5L, now)
+
+        assertEquals(now, saved.captured.firedAt)
+        assertFalse(saved.captured.enabled)
+    }
+
+    @Test
+    fun `listForUser and listEnabled delegate to persistence`() {
+        every { persistence.listByUser(discordId) } returns listOf(CardPriceWatchDto(id = 1, discordId = discordId))
+        every { persistence.listEnabled() } returns listOf(CardPriceWatchDto(id = 2))
+        assertEquals(1, service.listForUser(discordId).size)
+        assertEquals(1, service.listEnabled().size)
+    }
+
+    // --- DTO logic ----------------------------------------------------
+
+    @Test
+    fun `isTriggeredBy fires below or above the threshold per direction`() {
+        val below = CardPriceWatchDto(direction = Direction.BELOW.name, threshold = 30.0)
+        assertTrue(below.isTriggeredBy(30.0))
+        assertTrue(below.isTriggeredBy(29.0))
+        assertFalse(below.isTriggeredBy(31.0))
+
+        val above = CardPriceWatchDto(direction = Direction.ABOVE.name, threshold = 30.0)
+        assertTrue(above.isTriggeredBy(30.0))
+        assertTrue(above.isTriggeredBy(31.0))
+        assertFalse(above.isTriggeredBy(29.0))
+    }
+
+    @Test
+    fun `directionEnum round-trips through the string column`() {
+        val dto = CardPriceWatchDto(direction = Direction.BELOW.name)
+        assertEquals(Direction.BELOW, dto.directionEnum)
+        dto.directionEnum = Direction.ABOVE
+        assertEquals("ABOVE", dto.direction)
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeCommand.kt
@@ -14,8 +14,10 @@ import common.mtg.PackGenerator
 import core.command.Command.Companion.invokeDeleteOnMessageResponse
 import core.command.CommandContext
 import database.dto.guild.ConfigDto
+import database.dto.user.CardPriceWatchDto
 import database.dto.user.UserDto
 import database.service.guild.ConfigService
+import database.service.user.CardPriceWatchService
 import database.service.user.CubeListService
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -52,6 +54,7 @@ class CubeCommand @Autowired constructor(
     private val fetcher: ScryfallCubeFetcher,
     private val cubeListService: CubeListService,
     private val configService: ConfigService,
+    private val priceWatchService: CardPriceWatchService,
     // Mirrors the /dnd command: IO-bound subcommands run on this dispatcher
     // (tests pass Dispatchers.Unconfined so the launched work resolves
     // synchronously).
@@ -74,7 +77,10 @@ class CubeCommand @Autowired constructor(
             SUB_COMBOS -> launchHandling(ctx) { handleCombos(ctx, deleteDelay) }
             SUB_SET -> launchHandling(ctx) { handleSet(ctx, deleteDelay) }
             SUB_RULE -> handleRule(ctx, deleteDelay) // static glossary, no IO
-            else -> reply(ctx, CubeEmbeds.errorEmbed("Pick a subcommand: asfan, preview, generate, saved, card, rulings, legality, combos, set or rule."), deleteDelay)
+            SUB_WATCH_ADD -> launchHandling(ctx) { handleWatchAdd(ctx, requestingUserDto, deleteDelay) }
+            SUB_WATCH_LIST -> handleWatchList(ctx, requestingUserDto, deleteDelay) // DB read, no network
+            SUB_WATCH_REMOVE -> handleWatchRemove(ctx, requestingUserDto, deleteDelay)
+            else -> reply(ctx, CubeEmbeds.errorEmbed("Pick a subcommand: asfan, preview, generate, saved, card, rulings, legality, combos, set, rule, watch-add, watch-list or watch-remove."), deleteDelay)
         }
     }
 
@@ -319,6 +325,64 @@ class CubeCommand @Autowired constructor(
         }
     }
 
+    /** Adds a card price watch: resolves the card, captures its current price, persists. */
+    private suspend fun handleWatchAdd(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val name = ctx.event.stringOption(OPT_NAME)?.trim()
+        val directionKey = ctx.event.stringOption(OPT_DIRECTION)?.trim()?.uppercase()
+        val price = ctx.event.getOption(OPT_PRICE)?.asDouble
+        val currency = MtgCurrency.fromCode(ctx.event.stringOption(OPT_CURRENCY)) ?: MtgCurrency.DEFAULT
+        if (name.isNullOrEmpty()) {
+            reply(ctx, CubeEmbeds.errorEmbed("Give me a card `name` to watch."), deleteDelay); return
+        }
+        val direction = directionKey?.let { runCatching { CardPriceWatchDto.Direction.valueOf(it) }.getOrNull() }
+        if (direction == null) {
+            reply(ctx, CubeEmbeds.errorEmbed("Pick a `direction`: below or above."), deleteDelay); return
+        }
+        if (price == null || price <= 0.0) {
+            reply(ctx, CubeEmbeds.errorEmbed("Give me a positive target `price`."), deleteDelay); return
+        }
+        val card = fetcher.fetchNamed(name)
+        if (card == null) {
+            reply(ctx, CubeEmbeds.errorEmbed("Couldn't find a card named `$name`."), deleteDelay); return
+        }
+        val currentPrice = card.price(currency)?.toDoubleOrNull()
+        val created = priceWatchService.create(
+            discordId = requestingUserDto.discordId,
+            guildId = ctx.guild.idLong,
+            cardName = card.name,
+            currency = currency.code,
+            direction = direction,
+            threshold = price,
+            priceAtCreation = currentPrice,
+        )
+        if (created == null) {
+            reply(ctx, CubeEmbeds.errorEmbed("You've hit the watch limit (${priceWatchService.maxPerUser}). Remove one with `/cube watch-remove` first."), deleteDelay)
+        } else {
+            reply(ctx, CubeEmbeds.watchAddedEmbed(created, card, currency, currentPrice), deleteDelay)
+        }
+    }
+
+    /** Lists the caller's card price watches. */
+    private fun handleWatchList(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val watches = priceWatchService.listForUser(requestingUserDto.discordId)
+        reply(ctx, CubeEmbeds.watchListEmbed(watches), deleteDelay)
+    }
+
+    /** Removes one of the caller's watches by id (ownership-checked). */
+    private fun handleWatchRemove(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val id = ctx.event.getOption(OPT_WATCH_ID)?.asLong
+        if (id == null) {
+            reply(ctx, CubeEmbeds.errorEmbed("Give me the watch `id` to remove (see `/cube watch-list`)."), deleteDelay); return
+        }
+        val removed = priceWatchService.remove(id, requestingUserDto.discordId)
+        reply(
+            ctx,
+            if (removed) CubeEmbeds.watchRemovedEmbed(id)
+            else CubeEmbeds.errorEmbed("No watch #$id of yours to remove."),
+            deleteDelay,
+        )
+    }
+
     /** Checks a saved cube / queried pool against a format's banned & legality list. */
     private suspend fun handleLegality(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
         val formatKey = ctx.event.stringOption(OPT_FORMAT)?.trim()?.lowercase()
@@ -388,6 +452,19 @@ class CubeCommand @Autowired constructor(
             .addOptions(OptionData(OptionType.STRING, OPT_CODE, "The set code (e.g. vow, mh3).", true)),
         SubcommandData(SUB_RULE, "Look up a Magic keyword's reminder text (e.g. trample, flying).")
             .addOptions(OptionData(OptionType.STRING, OPT_TERM, "The keyword to explain.", true)),
+        SubcommandData(SUB_WATCH_ADD, "Get DM'd when a card's price crosses your target.")
+            .addOptions(
+                OptionData(OptionType.STRING, OPT_NAME, "The card to watch (e.g. Ragavan).", true),
+                OptionData(OptionType.STRING, OPT_DIRECTION, "Alert when the price goes…", true)
+                    .addChoice("below", CardPriceWatchDto.Direction.BELOW.name)
+                    .addChoice("above", CardPriceWatchDto.Direction.ABOVE.name),
+                OptionData(OptionType.NUMBER, OPT_PRICE, "Target price.", true).setMinValue(0.0),
+                OptionData(OptionType.STRING, OPT_CURRENCY, "Currency (default USD).", false)
+                    .addChoices(MtgCurrency.entries.map { net.dv8tion.jda.api.interactions.commands.Command.Choice(it.display, it.code) }),
+            ),
+        SubcommandData(SUB_WATCH_LIST, "List your card price watches."),
+        SubcommandData(SUB_WATCH_REMOVE, "Remove one of your card price watches.")
+            .addOptions(OptionData(OptionType.INTEGER, OPT_WATCH_ID, "The watch id (from /cube watch-list).", true).setMinValue(1)),
     )
 
     companion object {
@@ -401,12 +478,19 @@ class CubeCommand @Autowired constructor(
         const val SUB_COMBOS = "combos"
         const val SUB_SET = "set"
         const val SUB_RULE = "rule"
+        const val SUB_WATCH_ADD = "watch-add"
+        const val SUB_WATCH_LIST = "watch-list"
+        const val SUB_WATCH_REMOVE = "watch-remove"
 
         const val OPT_TOTAL = "total"
         const val OPT_NAME = "name"
         const val OPT_FORMAT = "format"
         const val OPT_CODE = "code"
         const val OPT_TERM = "term"
+        const val OPT_DIRECTION = "direction"
+        const val OPT_PRICE = "price"
+        const val OPT_CURRENCY = "currency"
+        const val OPT_WATCH_ID = "id"
         const val OPT_CUBE_SIZE = "cube-size"
         const val OPT_PACK_SIZE = "pack-size"
         const val OPT_QUERY = "query"

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
@@ -6,6 +6,7 @@ import common.mtg.CardCombos
 import common.mtg.CardRulings
 import common.mtg.MtgGlossary
 import common.mtg.MtgSet
+import database.dto.user.CardPriceWatchDto
 import common.mtg.CardCategory
 import common.mtg.CardListParser
 import common.mtg.CubeAnalytics
@@ -324,6 +325,53 @@ internal object CubeEmbeds {
         setDescription(facts)
         setFooter("Source: Scryfall")
     }
+
+    /** Confirmation that a card price watch was created. */
+    fun watchAddedEmbed(
+        watch: CardPriceWatchDto,
+        card: CubeCard,
+        currency: MtgCurrency,
+        currentPrice: Double?,
+    ): MessageEmbed = embed(color = OK_COLOR) {
+        setAuthor(AUTHOR)
+        setTitle("🔔 Watching ${card.name}")
+        card.imageUrl?.let { setThumbnail(it) }
+        val dir = watch.directionEnum.name.lowercase()
+        val now = currentPrice?.let { " (now ${money(it, currency)})" }.orEmpty()
+        setDescription(
+            "I'll DM you when **${card.name}** is **$dir ${money(watch.threshold, currency)}**$now.\n" +
+                "Watch **#${watch.id}** · one-shot · remove with `/cube watch-remove id:${watch.id}`."
+        )
+        setFooter("Manage card-price-watch DMs in /preferences notifications.")
+    }
+
+    /** Lists the user's card price watches, or an empty-state nudge. */
+    fun watchListEmbed(watches: List<CardPriceWatchDto>): MessageEmbed = embed(color = OK_COLOR) {
+        setAuthor(AUTHOR)
+        setTitle("Your card price watches")
+        if (watches.isEmpty()) {
+            setDescription("You're not watching any cards. Add one with `/cube watch-add`.")
+            return@embed
+        }
+        setDescription(
+            watches.joinToString("\n") { w ->
+                val cur = MtgCurrency.fromCode(w.currency) ?: MtgCurrency.DEFAULT
+                "• **#${w.id}** ${w.cardName} — ${w.directionEnum.name.lowercase()} ${money(w.threshold, cur)}"
+            }
+        )
+        setFooter("Remove one with /cube watch-remove id:<id>")
+    }
+
+    /** Confirmation that a watch was removed. */
+    fun watchRemovedEmbed(id: Long): MessageEmbed = embed(color = OK_COLOR) {
+        setAuthor(AUTHOR)
+        setTitle("Watch removed")
+        setDescription("Stopped watching **#$id**.")
+    }
+
+    /** A money amount in a currency: `$1.50` / `€1.50` / `1.50 tix`. */
+    private fun money(amount: Double, currency: MtgCurrency): String =
+        "${currency.symbol}${format(amount)}${currency.suffix}"
 
     /** A keyword's reminder text for `/cube rule`. */
     fun ruleEmbed(term: MtgGlossary.Term): MessageEmbed = embed(color = OK_COLOR) {

--- a/discord-bot/src/main/kotlin/bot/toby/notify/CardPriceAlertBuilder.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/notify/CardPriceAlertBuilder.kt
@@ -1,0 +1,49 @@
+package bot.toby.notify
+
+import common.mtg.CubeCard
+import common.mtg.MtgCurrency
+import database.dto.user.CardPriceWatchDto
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder
+import net.dv8tion.jda.api.utils.messages.MessageCreateData
+import java.awt.Color
+
+/**
+ * Renders the DM sent when a [CardPriceWatchDto] fires — a card-price-watch
+ * alert. The watch is one-shot, so this is a "your target was hit" notice;
+ * the footer nudges the user to re-arm with `/cube watch-add`.
+ */
+object CardPriceAlertBuilder {
+
+    private val GOLD = Color(199, 161, 79)
+
+    fun buildDm(
+        watch: CardPriceWatchDto,
+        card: CubeCard,
+        currency: MtgCurrency,
+        currentPrice: Double,
+    ): MessageCreateData {
+        val arrow = when (watch.directionEnum) {
+            CardPriceWatchDto.Direction.BELOW -> "dropped to"
+            CardPriceWatchDto.Direction.ABOVE -> "risen to"
+        }
+        val embed = EmbedBuilder()
+            .setColor(GOLD)
+            .setTitle("📉 Price alert — ${card.name}")
+            .setDescription(
+                "**${card.name}** has $arrow **${money(currentPrice, currency)}**, " +
+                    "crossing your ${watch.directionEnum.name.lowercase()} target of " +
+                    "**${money(watch.threshold, currency)}**."
+            )
+        card.imageUrl?.let { embed.setThumbnail(it) }
+        watch.priceAtCreation?.let {
+            embed.addField("When you set this", money(it, currency), true)
+        }
+        embed.addField("Now", money(currentPrice, currency), true)
+        embed.setFooter("One-shot alert — use /cube watch-add to set another.")
+        return MessageCreateBuilder().setEmbeds(embed.build()).build()
+    }
+
+    private fun money(amount: Double, currency: MtgCurrency): String =
+        "${currency.symbol}${"%.2f".format(amount)}${currency.suffix}"
+}

--- a/discord-bot/src/main/kotlin/bot/toby/scheduling/CardPriceWatchJob.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/scheduling/CardPriceWatchJob.kt
@@ -1,0 +1,81 @@
+package bot.toby.scheduling
+
+import bot.toby.command.commands.mtg.ScryfallCubeFetcher
+import bot.toby.notify.CardPriceAlertBuilder
+import common.logging.DiscordLogger
+import common.mtg.CubeCard
+import common.mtg.MtgCurrency
+import common.notification.NotificationChannelKind
+import bot.toby.notify.NotificationRouter
+import database.dto.user.CardPriceWatchDto
+import database.service.user.CardPriceWatchService
+import kotlinx.coroutines.runBlocking
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Profile
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import java.time.Instant
+
+/**
+ * Periodically checks every enabled [CardPriceWatchDto] against current
+ * Scryfall prices and DMs the owner when a watch's threshold is crossed.
+ *
+ * Card prices are global, so one batched fetch (deduped by name) covers
+ * every user's watches. Each fired watch is one-shot: after the DM it's
+ * stamped and disabled so an oscillating price can't re-alert. A watch whose
+ * card can't be priced (unknown name, or no price in that currency) is left
+ * enabled and simply skipped this pass.
+ */
+@Component
+@Profile("prod")
+class CardPriceWatchJob @Autowired constructor(
+    private val watchService: CardPriceWatchService,
+    private val fetcher: ScryfallCubeFetcher,
+    private val notificationRouter: NotificationRouter,
+) {
+    private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
+
+    @Scheduled(fixedDelayString = "PT6H", initialDelayString = "PT2M")
+    fun checkAll() {
+        val watches = watchService.listEnabled()
+        if (watches.isEmpty()) return
+
+        val byName = fetchPrices(watches.map { it.cardName }.distinct())
+        if (byName.isEmpty()) return
+
+        val now = Instant.now()
+        watches.forEach { watch ->
+            runCatching { evaluate(watch, byName, now) }
+                .onFailure { logger.warn("Card price watch ${watch.id} eval failed: ${it.message}") }
+        }
+    }
+
+    /** Batched, deduped price fetch keyed by lower-cased card name. */
+    private fun fetchPrices(names: List<String>): Map<String, CubeCard> =
+        runBlocking {
+            when (val res = fetcher.fetchByNames(names)) {
+                is ScryfallCubeFetcher.Result.Success -> res.cards.associateBy { it.name.lowercase() }
+                is ScryfallCubeFetcher.Result.Failure -> {
+                    logger.warn("Card price watch price fetch failed: ${res.message}")
+                    emptyMap()
+                }
+            }
+        }
+
+    private fun evaluate(watch: CardPriceWatchDto, byName: Map<String, CubeCard>, now: Instant) {
+        val card = byName[watch.cardName.lowercase()] ?: return // unknown card — skip, stay armed
+        val currency = MtgCurrency.fromCode(watch.currency) ?: run {
+            // Corrupt currency on the row — disable so it doesn't churn forever.
+            logger.warn("Card price watch ${watch.id} has unknown currency '${watch.currency}'; disabling.")
+            watch.id?.let { watchService.markFired(it, now) }
+            return
+        }
+        val price = card.price(currency)?.toDoubleOrNull() ?: return // not priced in this currency — skip
+        if (!watch.isTriggeredBy(price)) return
+
+        notificationRouter.dispatch(NotificationChannelKind.CARD_PRICE_ALERT, watch.discordId, watch.guildId) {
+            dm { CardPriceAlertBuilder.buildDm(watch, card, currency, price) }
+        }
+        watch.id?.let { watchService.markFired(it, now) }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeCommandTest.kt
@@ -7,6 +7,7 @@ import bot.toby.command.CommandTest.Companion.webhookMessageCreateAction
 import bot.toby.command.DefaultCommandContext
 import common.mtg.CubeCard
 import common.mtg.MtgColor
+import database.dto.user.CardPriceWatchDto
 import database.dto.user.CubeListDto
 import database.service.user.CubeListService
 import io.mockk.coEvery
@@ -33,6 +34,7 @@ class CubeCommandTest : CommandTest {
     private lateinit var fetcher: ScryfallCubeFetcher
     private lateinit var cubeListService: CubeListService
     private lateinit var configService: database.service.guild.ConfigService
+    private lateinit var priceWatchService: database.service.user.CardPriceWatchService
     private lateinit var command: CubeCommand
 
     @BeforeEach
@@ -41,8 +43,9 @@ class CubeCommandTest : CommandTest {
         fetcher = mockk()
         cubeListService = mockk(relaxed = true)
         configService = mockk(relaxed = true) // null config → USD default
+        priceWatchService = mockk(relaxed = true)
         // Unconfined so the launched IO coroutine resolves synchronously in tests.
-        command = CubeCommand(fetcher, cubeListService, configService, Dispatchers.Unconfined)
+        command = CubeCommand(fetcher, cubeListService, configService, priceWatchService, Dispatchers.Unconfined)
         every { requestingUserDto.discordId } returns 100L
         every { webhookMessageCreateAction.addFiles(any<FileUpload>()) } returns webhookMessageCreateAction
         every { webhookMessageCreateAction.queue() } just runs
@@ -51,6 +54,8 @@ class CubeCommandTest : CommandTest {
     private fun intOpt(value: Int): OptionMapping = mockk { every { asInt } returns value }
     private fun strOpt(value: String): OptionMapping = mockk { every { asString } returns value }
     private fun boolOpt(value: Boolean): OptionMapping = mockk { every { asBoolean } returns value }
+    private fun numOpt(value: Double): OptionMapping = mockk { every { asDouble } returns value }
+    private fun longOpt(value: Long): OptionMapping = mockk { every { asLong } returns value }
 
     private fun run() = command.handle(DefaultCommandContext(event), requestingUserDto, deleteDelay = 0)
 
@@ -678,13 +683,84 @@ class CubeCommandTest : CommandTest {
     }
 
     @Test
-    fun `exposes the ten subcommands with their options`() {
+    fun `watch-add resolves the card, captures the price and confirms`() {
+        val slot = slot<MessageEmbed>()
+        every { event.hook.sendMessageEmbeds(capture(slot), *anyVararg()) } returns webhookMessageCreateAction
+        every { event.subcommandName } returns CubeCommand.SUB_WATCH_ADD
+        every { event.getOption(CubeCommand.OPT_NAME) } returns strOpt("Ragavan")
+        every { event.getOption(CubeCommand.OPT_DIRECTION) } returns strOpt("BELOW")
+        every { event.getOption(CubeCommand.OPT_PRICE) } returns numOpt(30.0)
+        every { event.getOption(CubeCommand.OPT_CURRENCY) } returns strOpt("usd")
+        coEvery { fetcher.fetchNamed("Ragavan") } returns CubeCard("Ragavan, Nimble Pilferer", priceUsd = "45.00")
+        every {
+            priceWatchService.create(100L, any(), "Ragavan, Nimble Pilferer", "usd", CardPriceWatchDto.Direction.BELOW, 30.0, 45.0)
+        } returns CardPriceWatchDto(id = 5, cardName = "Ragavan, Nimble Pilferer", currency = "usd", direction = "BELOW", threshold = 30.0)
+
+        run()
+
+        assertTrue(slot.captured.title!!.contains("Watching"))
+        verify(exactly = 1) { priceWatchService.create(100L, any(), "Ragavan, Nimble Pilferer", "usd", CardPriceWatchDto.Direction.BELOW, 30.0, 45.0) }
+    }
+
+    @Test
+    fun `watch-add reports when the card can't be found`() {
+        val slot = slot<MessageEmbed>()
+        every { event.hook.sendMessageEmbeds(capture(slot), *anyVararg()) } returns webhookMessageCreateAction
+        every { event.subcommandName } returns CubeCommand.SUB_WATCH_ADD
+        every { event.getOption(CubeCommand.OPT_NAME) } returns strOpt("Notacard")
+        every { event.getOption(CubeCommand.OPT_DIRECTION) } returns strOpt("BELOW")
+        every { event.getOption(CubeCommand.OPT_PRICE) } returns numOpt(30.0)
+        every { event.getOption(CubeCommand.OPT_CURRENCY) } returns null
+        coEvery { fetcher.fetchNamed(any()) } returns null
+
+        run()
+
+        assertEquals("Couldn't build that cube", slot.captured.title)
+        verify(exactly = 0) { priceWatchService.create(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `watch-list shows the user's watches`() {
+        val slot = slot<MessageEmbed>()
+        every { event.hook.sendMessageEmbeds(capture(slot), *anyVararg()) } returns webhookMessageCreateAction
+        every { event.subcommandName } returns CubeCommand.SUB_WATCH_LIST
+        every { priceWatchService.listForUser(100L) } returns listOf(
+            CardPriceWatchDto(id = 1, cardName = "Ragavan", currency = "usd", direction = "BELOW", threshold = 30.0)
+        )
+
+        run()
+
+        assertEquals("Your card price watches", slot.captured.title)
+        assertTrue(slot.captured.description!!.contains("Ragavan"))
+    }
+
+    @Test
+    fun `watch-remove deletes by id`() {
+        val slot = slot<MessageEmbed>()
+        every { event.hook.sendMessageEmbeds(capture(slot), *anyVararg()) } returns webhookMessageCreateAction
+        every { event.subcommandName } returns CubeCommand.SUB_WATCH_REMOVE
+        every { event.getOption(CubeCommand.OPT_WATCH_ID) } returns longOpt(5L)
+        every { priceWatchService.remove(5L, 100L) } returns true
+
+        run()
+
+        assertTrue(slot.captured.title!!.contains("Watch removed"))
+        verify(exactly = 1) { priceWatchService.remove(5L, 100L) }
+    }
+
+    @Test
+    fun `exposes the thirteen subcommands with their options`() {
         assertEquals("cube", command.name)
         val subs = command.subCommands.associateBy { it.name }
         assertEquals(
-            setOf("asfan", "preview", "generate", "saved", "card", "rulings", "legality", "combos", "set", "rule"),
+            setOf(
+                "asfan", "preview", "generate", "saved", "card", "rulings", "legality", "combos",
+                "set", "rule", "watch-add", "watch-list", "watch-remove",
+            ),
             subs.keys,
         )
+        assertTrue(subs.getValue("watch-add").options.first { it.name == "name" }.isRequired)
+        assertTrue(subs.getValue("watch-remove").options.first { it.name == "id" }.isRequired)
         assertEquals(OptionType.STRING, subs.getValue("card").options.first { it.name == "name" }.type)
         assertTrue(subs.getValue("card").options.first { it.name == "name" }.isRequired)
         assertTrue(subs.getValue("rulings").options.first { it.name == "name" }.isRequired)

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeEmbedsTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeEmbedsTest.kt
@@ -358,6 +358,34 @@ class CubeEmbedsTest {
     }
 
     @Test
+    fun `watchAddedEmbed describes the watch and its target`() {
+        val watch = database.dto.user.CardPriceWatchDto(
+            id = 9, discordId = 7, cardName = "Ragavan", currency = "usd",
+            direction = database.dto.user.CardPriceWatchDto.Direction.BELOW.name, threshold = 30.0,
+        )
+        val card = CubeCard("Ragavan, Nimble Pilferer", imageUrl = "https://img/r.jpg")
+        val embed = CubeEmbeds.watchAddedEmbed(watch, card, common.mtg.MtgCurrency.USD, 45.0)
+        val desc = embed.description!!
+        assertTrue(desc.contains("below \$30.00"), desc)
+        assertTrue(desc.contains("#9"))
+        assertTrue(desc.contains("now \$45.00"), desc)
+    }
+
+    @Test
+    fun `watchListEmbed lists watches or shows an empty state`() {
+        val empty = CubeEmbeds.watchListEmbed(emptyList())
+        assertTrue(empty.description!!.contains("not watching any"))
+
+        val watches = listOf(
+            database.dto.user.CardPriceWatchDto(id = 1, cardName = "Ragavan", currency = "usd", direction = "BELOW", threshold = 30.0),
+            database.dto.user.CardPriceWatchDto(id = 2, cardName = "Mox", currency = "eur", direction = "ABOVE", threshold = 100.0),
+        )
+        val desc = CubeEmbeds.watchListEmbed(watches).description!!
+        assertTrue(desc.contains("#1") && desc.contains("Ragavan") && desc.contains("below \$30.00"), desc)
+        assertTrue(desc.contains("#2") && desc.contains("€100.00"), desc)
+    }
+
+    @Test
     fun `ruleEmbed shows the keyword and its reminder text`() {
         val embed = CubeEmbeds.ruleEmbed(common.mtg.MtgGlossary.Term("Trample", "This creature can deal excess combat damage…"))
         assertEquals("Trample", embed.title)

--- a/discord-bot/src/test/kotlin/bot/toby/notify/CardPriceAlertBuilderTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/notify/CardPriceAlertBuilderTest.kt
@@ -1,0 +1,41 @@
+package bot.toby.notify
+
+import common.mtg.CubeCard
+import common.mtg.MtgCurrency
+import database.dto.user.CardPriceWatchDto
+import database.dto.user.CardPriceWatchDto.Direction
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class CardPriceAlertBuilderTest {
+
+    @Test
+    fun `below alert names the card, the crossing and the target in the right currency`() {
+        val watch = CardPriceWatchDto(
+            id = 3, discordId = 7, cardName = "Ragavan", currency = "usd",
+            direction = Direction.BELOW.name, threshold = 30.0, priceAtCreation = 45.0,
+        )
+        val card = CubeCard("Ragavan, Nimble Pilferer", priceUsd = "20.00", imageUrl = "https://img/r.jpg")
+        val dm = CardPriceAlertBuilder.buildDm(watch, card, MtgCurrency.USD, 20.0)
+        val embed = dm.embeds.first()
+        assertTrue(embed.title!!.contains("Ragavan, Nimble Pilferer"))
+        val desc = embed.description!!
+        assertTrue(desc.contains("dropped to"), desc)
+        assertTrue(desc.contains("$20.00"), desc)
+        assertTrue(desc.contains("$30.00"), desc)
+    }
+
+    @Test
+    fun `above alert uses the risen wording and the chosen currency symbol`() {
+        val watch = CardPriceWatchDto(
+            id = 4, discordId = 7, cardName = "Mox", currency = "eur",
+            direction = Direction.ABOVE.name, threshold = 100.0,
+        )
+        val card = CubeCard("Mox Diamond", priceEur = "120.00")
+        val dm = CardPriceAlertBuilder.buildDm(watch, card, MtgCurrency.EUR, 120.0)
+        val desc = dm.embeds.first().description!!
+        assertTrue(desc.contains("risen to"), desc)
+        assertTrue(desc.contains("€120.00"), desc)
+        assertTrue(desc.contains("€100.00"), desc)
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/scheduling/CardPriceWatchJobTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/scheduling/CardPriceWatchJobTest.kt
@@ -1,0 +1,95 @@
+package bot.toby.scheduling
+
+import bot.toby.command.commands.mtg.ScryfallCubeFetcher
+import bot.toby.notify.NotificationDispatch
+import bot.toby.notify.NotificationRouter
+import common.mtg.CubeCard
+import common.notification.NotificationChannelKind
+import database.dto.user.CardPriceWatchDto
+import database.dto.user.CardPriceWatchDto.Direction
+import database.service.user.CardPriceWatchService
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class CardPriceWatchJobTest {
+
+    private lateinit var watchService: CardPriceWatchService
+    private lateinit var fetcher: ScryfallCubeFetcher
+    private lateinit var router: NotificationRouter
+    private lateinit var job: CardPriceWatchJob
+
+    @BeforeEach
+    fun setUp() {
+        watchService = mockk(relaxed = true)
+        fetcher = mockk()
+        router = mockk(relaxed = true)
+        job = CardPriceWatchJob(watchService, fetcher, router)
+    }
+
+    private fun watch(id: Long, name: String, dir: Direction, threshold: Double, currency: String = "usd") =
+        CardPriceWatchDto(
+            id = id, discordId = 7L, guildId = 1L, cardName = name,
+            currency = currency, direction = dir.name, threshold = threshold, enabled = true,
+        )
+
+    @Test
+    fun `fires, DMs and disables a watch whose target is crossed`() {
+        every { watchService.listEnabled() } returns listOf(watch(1, "Ragavan", Direction.BELOW, 30.0))
+        coEvery { fetcher.fetchByNames(listOf("Ragavan")) } returns
+            ScryfallCubeFetcher.Result.Success(listOf(CubeCard("Ragavan", priceUsd = "20.00")))
+        every { router.dispatch(any(), any<Long>(), any<Long>(), any<NotificationDispatch.() -> Unit>()) } just runs
+
+        job.checkAll()
+
+        verify(exactly = 1) { router.dispatch(NotificationChannelKind.CARD_PRICE_ALERT, 7L, 1L, any<NotificationDispatch.() -> Unit>()) }
+        verify(exactly = 1) { watchService.markFired(1L, any()) }
+    }
+
+    @Test
+    fun `does not fire while the price stays the wrong side of the threshold`() {
+        every { watchService.listEnabled() } returns listOf(watch(1, "Ragavan", Direction.BELOW, 30.0))
+        coEvery { fetcher.fetchByNames(any()) } returns
+            ScryfallCubeFetcher.Result.Success(listOf(CubeCard("Ragavan", priceUsd = "45.00")))
+
+        job.checkAll()
+
+        verify(exactly = 0) { router.dispatch(any(), any<Long>(), any<Long>(), any<NotificationDispatch.() -> Unit>()) }
+        verify(exactly = 0) { watchService.markFired(any(), any()) }
+    }
+
+    @Test
+    fun `a card with no price in the chosen currency is skipped and left armed`() {
+        every { watchService.listEnabled() } returns listOf(watch(1, "Ragavan", Direction.BELOW, 30.0, currency = "eur"))
+        coEvery { fetcher.fetchByNames(any()) } returns
+            ScryfallCubeFetcher.Result.Success(listOf(CubeCard("Ragavan", priceUsd = "20.00"))) // no EUR price
+
+        job.checkAll()
+
+        verify(exactly = 0) { router.dispatch(any(), any<Long>(), any<Long>(), any<NotificationDispatch.() -> Unit>()) }
+        verify(exactly = 0) { watchService.markFired(any(), any()) }
+    }
+
+    @Test
+    fun `no enabled watches short-circuits without fetching`() {
+        every { watchService.listEnabled() } returns emptyList()
+        job.checkAll()
+        verify(exactly = 0) { router.dispatch(any(), any<Long>(), any<Long>(), any<NotificationDispatch.() -> Unit>()) }
+    }
+
+    @Test
+    fun `a fetch failure notifies nobody`() {
+        every { watchService.listEnabled() } returns listOf(watch(1, "Ragavan", Direction.BELOW, 30.0))
+        coEvery { fetcher.fetchByNames(any()) } returns ScryfallCubeFetcher.Result.Failure("Scryfall down")
+
+        job.checkAll()
+
+        verify(exactly = 0) { router.dispatch(any(), any<Long>(), any<Long>(), any<NotificationDispatch.() -> Unit>()) }
+    }
+}

--- a/web/src/main/kotlin/web/controller/CubeController.kt
+++ b/web/src/main/kotlin/web/controller/CubeController.kt
@@ -1,5 +1,8 @@
 package web.controller
 
+import common.mtg.MtgCurrency
+import database.dto.user.CardPriceWatchDto
+import database.service.user.CardPriceWatchService
 import database.service.user.CubeListService
 import database.service.user.SharedCubeService
 import org.springframework.http.ResponseEntity
@@ -53,6 +56,7 @@ class CubeController(
     private val cubeWebService: CubeWebService,
     private val cubeLists: CubeListService,
     private val sharedCubes: SharedCubeService,
+    private val priceWatches: CardPriceWatchService,
 ) {
 
     @GetMapping
@@ -283,6 +287,55 @@ class CubeController(
         return ResponseEntity.noContent().build()
     }
 
+    // --- Card price watches (account-bound; require a logged-in Discord user) ---
+
+    @GetMapping("/api/watches", produces = ["application/json"])
+    @ResponseBody
+    fun watches(@AuthenticationPrincipal user: OAuth2User?): ResponseEntity<List<CardWatchView>> {
+        val discordId = user?.discordIdOrNull() ?: return ResponseEntity.status(401).build()
+        return ResponseEntity.ok(priceWatches.listForUser(discordId).map { it.toView() })
+    }
+
+    @PostMapping("/api/watches", consumes = ["application/json"], produces = ["application/json"])
+    @ResponseBody
+    fun addWatch(
+        @RequestBody request: AddWatchRequest,
+        @AuthenticationPrincipal user: OAuth2User?,
+    ): ResponseEntity<AddWatchResponse> {
+        val discordId = user?.discordIdOrNull() ?: return ResponseEntity.status(401).build()
+        val currency = MtgCurrency.fromCode(request.currency) ?: MtgCurrency.DEFAULT
+        val direction = runCatching { CardPriceWatchDto.Direction.valueOf(request.direction.trim().uppercase()) }
+            .getOrNull() ?: return ResponseEntity.badRequest().body(AddWatchResponse(false, "Direction must be below or above.", null))
+        if (request.threshold <= 0.0) {
+            return ResponseEntity.badRequest().body(AddWatchResponse(false, "Target price must be positive.", null))
+        }
+        // Resolve the card (canonical name + current price) via Scryfall.
+        val resolved = when (val r = cubeWebService.card(request.name)) {
+            is CubeResult.Success -> r.value
+            is CubeResult.Failure -> return ResponseEntity.badRequest().body(AddWatchResponse(false, r.error, null))
+        }
+        val current = when (currency) {
+            MtgCurrency.USD -> resolved.priceUsd
+            MtgCurrency.EUR -> resolved.priceEur
+            MtgCurrency.TIX -> resolved.priceTix
+        }?.toDoubleOrNull()
+        // Web has no guild context — guild 0 routes the DM via the default opt-in.
+        val created = priceWatches.create(discordId, 0L, resolved.name, currency.code, direction, request.threshold, current)
+            ?: return ResponseEntity.status(409).body(AddWatchResponse(false, "You've hit the watch limit (${priceWatches.maxPerUser}).", null))
+        return ResponseEntity.ok(AddWatchResponse(true, null, created.toView()))
+    }
+
+    @DeleteMapping("/api/watches")
+    @ResponseBody
+    fun deleteWatch(
+        @RequestParam("id") id: Long,
+        @AuthenticationPrincipal user: OAuth2User?,
+    ): ResponseEntity<Void> {
+        val discordId = user?.discordIdOrNull() ?: return ResponseEntity.status(401).build()
+        return if (priceWatches.remove(id, discordId)) ResponseEntity.noContent().build()
+        else ResponseEntity.notFound().build()
+    }
+
     // --- Share links (logged-in user mints a public, immutable snapshot) ---
 
     @PostMapping("/api/share", consumes = ["application/json"], produces = ["application/json"])
@@ -309,6 +362,32 @@ class CubeController(
         const val MAX_CARDS_LENGTH = 100_000
     }
 }
+
+data class AddWatchRequest(
+    val name: String = "",
+    val currency: String = "usd",
+    val direction: String = "below",
+    val threshold: Double = 0.0,
+)
+
+data class AddWatchResponse(val ok: Boolean, val error: String?, val watch: CardWatchView?)
+
+/** A card price watch as JSON for the web. */
+data class CardWatchView(
+    val id: Long,
+    val cardName: String,
+    val currency: String,
+    val direction: String,
+    val threshold: Double,
+)
+
+private fun CardPriceWatchDto.toView() = CardWatchView(
+    id = id ?: 0,
+    cardName = cardName,
+    currency = currency,
+    direction = direction.lowercase(),
+    threshold = threshold,
+)
 
 data class ShareCubeRequest(val name: String = "", val cards: String = "")
 

--- a/web/src/main/resources/static/css/cube.css
+++ b/web/src/main/resources/static/css/cube.css
@@ -1224,6 +1224,32 @@ details[open] > .cube-section-summary .cube-collapse-chevron {
     font-size: 0.95rem;
 }
 
+/* Price-watch list. */
+.cube-watches {
+    margin-top: var(--space-3);
+}
+
+.cube-watches-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+}
+
+.cube-watch {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-2);
+    padding: var(--space-2);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--surface-2, rgba(255, 255, 255, 0.03));
+    font-size: 0.9rem;
+}
+
 /* Total cube value (sum of priced cards), shown under the analytics breakdown,
    with a currency switch sitting alongside it. */
 .cube-total-value-row {

--- a/web/src/main/resources/static/js/cube.js
+++ b/web/src/main/resources/static/js/cube.js
@@ -7,10 +7,10 @@
 (function (root) {
     'use strict';
 
-    const TABS = ['generate', 'preview', 'asfan', 'compare', 'card', 'legality', 'reference'];
+    const TABS = ['generate', 'preview', 'asfan', 'compare', 'card', 'legality', 'reference', 'watch'];
 
     // Tools that work off their own inputs, not the shared "Your cube" source.
-    const NO_SHARED_SOURCE = ['asfan', 'compare', 'card', 'legality', 'reference'];
+    const NO_SHARED_SOURCE = ['asfan', 'compare', 'card', 'legality', 'reference', 'watch'];
 
     // Colour-pie palette for swatches/bars. Tuned to read on the dark
     // dashboard background while staying recognisably W/U/B/R/G + gold
@@ -1517,6 +1517,91 @@
         wireLookupForm(doc, 'rule', 'term', ruleUrl, function (json) { return json.rule; }, renderRule, 'Enter a keyword.');
     }
 
+    const WATCHES_API = '/cube/api/watches';
+
+    /** Formats a watch as "Card — below $30 (USD)". Pure. */
+    function watchLine(watch) {
+        const m = currencyMeta(watch.currency);
+        return watch.cardName + ' — ' + watch.direction + ' ' + m.symbol +
+            Number(watch.threshold).toFixed(2) + m.suffix + ' (' + m.display + ')';
+    }
+
+    /** Renders the user's price watches with a Remove button each; [onRemove] gets the id. */
+    function renderWatches(container, watches, onRemove) {
+        container.replaceChildren();
+        if (!watches || !watches.length) {
+            const p = document.createElement('p');
+            p.className = 'cube-watches-empty muted';
+            p.textContent = 'No price watches yet. Add one above.';
+            container.appendChild(p);
+            return container;
+        }
+        const ul = document.createElement('ul');
+        ul.className = 'cube-watches-list';
+        watches.forEach(function (w) {
+            const li = document.createElement('li');
+            li.className = 'cube-watch';
+            const span = document.createElement('span');
+            span.className = 'cube-watch-text';
+            span.textContent = watchLine(w);
+            li.appendChild(span);
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'btn btn-secondary cube-watch-remove';
+            btn.textContent = 'Remove';
+            btn.addEventListener('click', function () { onRemove(w.id); });
+            li.appendChild(btn);
+            ul.appendChild(li);
+        });
+        container.appendChild(ul);
+        return container;
+    }
+
+    function wireWatch(doc) {
+        const block = doc.querySelector('[data-watch-block]');
+        if (!block) return; // logged out — nothing to wire
+        const form = q(doc, '[data-form="watch"]');
+        const status = statusFor(doc, 'watch');
+        const result = q(doc, '[data-result="watch"]');
+
+        function remove(id) {
+            fetch(WATCHES_API + '?id=' + encodeURIComponent(id), { method: 'DELETE' })
+                .then(function () { reload(); })
+                .catch(function () { setStatus(status, 'Couldn’t remove that watch. Try again.'); });
+        }
+        function reload() {
+            return getJson(WATCHES_API)
+                .then(function (rows) { renderWatches(result, rows || [], remove); })
+                .catch(function () { /* leave as-is on a transient error */ });
+        }
+        reload();
+
+        if (form) form.addEventListener('submit', function (e) {
+            e.preventDefault();
+            const data = new FormData(form);
+            const name = (data.get('name') || '').trim();
+            const threshold = Number(data.get('threshold'));
+            if (!name) { setStatus(status, 'Enter a card name.'); return; }
+            if (!(threshold > 0)) { setStatus(status, 'Enter a positive target price.'); return; }
+            setStatus(status, 'Adding…');
+            withBusy(form, true);
+            postJson(WATCHES_API, {
+                name: name,
+                direction: data.get('direction') || 'below',
+                currency: data.get('currency') || 'usd',
+                threshold: threshold,
+            })
+                .then(function (json) {
+                    if (!json.ok) { setStatus(status, json.error || 'Couldn’t add that watch.'); return; }
+                    setStatus(status, 'Watching ' + json.watch.cardName + '. You\'ll be DM\'d when it crosses your target.');
+                    form.reset();
+                    reload();
+                })
+                .catch(function () { setStatus(status, 'Something went wrong. Try again.'); })
+                .then(function () { withBusy(form, false); });
+        });
+    }
+
     /** Shared wiring for a single-field GET lookup form (set / rule). */
     function wireLookupForm(doc, name, field, urlFn, pick, render, emptyMsg) {
         const form = q(doc, '[data-form="' + name + '"]');
@@ -1937,6 +2022,7 @@
         wireCardLookup(doc);
         wireLegality(doc);
         wireReference(doc);
+        wireWatch(doc);
         wirePreview(doc);
         wireGenerate(doc);
         wireCardFlip(doc);
@@ -1979,6 +2065,8 @@
         ruleUrl: ruleUrl,
         renderSet: renderSet,
         renderRule: renderRule,
+        watchLine: watchLine,
+        renderWatches: renderWatches,
         cardUrl: cardUrl,
         rulingsUrl: rulingsUrl,
         combosUrl: combosUrl,

--- a/web/src/main/resources/templates/cube.html
+++ b/web/src/main/resources/templates/cube.html
@@ -165,6 +165,12 @@
                 <span class="cube-tab-label">Reference</span>
                 <span class="cube-tab-sub">Sets &amp; keywords</span>
             </button>
+            <button type="button" id="tab-watch" class="cube-tab" role="tab"
+                    data-tab="watch" aria-controls="panel-watch" aria-selected="false" tabindex="-1">
+                <span class="cube-tab-icon" aria-hidden="true">🔔</span>
+                <span class="cube-tab-label">Price watch</span>
+                <span class="cube-tab-sub">Alert on price</span>
+            </button>
         </div>
 
         <!-- Generate -->
@@ -387,6 +393,44 @@
             </form>
             <p class="cube-status" data-status="rule" aria-live="polite"></p>
             <div class="cube-rule" data-result="rule" hidden></div>
+        </section>
+
+        <!-- Price watch (account-bound; logged-in only) -->
+        <section id="panel-watch" class="cube-panel" role="tabpanel" aria-labelledby="tab-watch"
+                 data-panel="watch" hidden>
+            <p class="cube-panel-intro">
+                Get DM'd on Discord when a card's market price crosses your target — the website twin
+                of <code>/cube watch-add</code>. Prices are checked periodically; alerts are one-shot.
+            </p>
+            <div th:if="${loggedIn}" data-watch-block>
+                <form class="cube-form cube-watch-form" data-form="watch" autocomplete="off">
+                    <label>Card
+                        <input type="text" name="name" placeholder="e.g. Ragavan, Nimble Pilferer" autocomplete="off" required>
+                    </label>
+                    <label>Alert when price is
+                        <select name="direction">
+                            <option value="below" selected>below</option>
+                            <option value="above">above</option>
+                        </select>
+                    </label>
+                    <label>Target
+                        <input type="number" name="threshold" min="0" step="0.01" placeholder="30.00" required>
+                    </label>
+                    <label>Currency
+                        <select name="currency">
+                            <option value="usd" selected>USD ($)</option>
+                            <option value="eur">EUR (€)</option>
+                            <option value="tix">MTGO Tix</option>
+                        </select>
+                    </label>
+                    <button type="submit" class="btn cube-submit">Add watch</button>
+                </form>
+                <p class="cube-status" data-status="watch" aria-live="polite"></p>
+                <div class="cube-watches" data-result="watch"></div>
+            </div>
+            <p class="cube-saved-login muted" th:unless="${loggedIn}">
+                <a href="/oauth2/authorization/discord">Log in with Discord</a> to set price-watch alerts.
+            </p>
         </section>
     </div>
 </main>

--- a/web/src/test/js/cube.test.js
+++ b/web/src/test/js/cube.test.js
@@ -551,6 +551,35 @@ describe('reference (set + rule lookup)', () => {
     });
 });
 
+describe('price watches (watchLine / renderWatches)', () => {
+    test('watchLine formats a watch with its currency', () => {
+        expect(Cube.watchLine({ cardName: 'Ragavan', currency: 'usd', direction: 'below', threshold: 30 }))
+            .toBe('Ragavan — below $30.00 (USD)');
+        expect(Cube.watchLine({ cardName: 'Mox', currency: 'eur', direction: 'above', threshold: 100 }))
+            .toBe('Mox — above €100.00 (EUR)');
+    });
+
+    test('renderWatches lists watches with a wired Remove button', () => {
+        const el = document.createElement('div');
+        const removed = [];
+        Cube.renderWatches(el, [
+            { id: 1, cardName: 'Ragavan', currency: 'usd', direction: 'below', threshold: 30 },
+            { id: 2, cardName: 'Mox', currency: 'usd', direction: 'above', threshold: 100 },
+        ], function (id) { removed.push(id); });
+        const items = el.querySelectorAll('.cube-watch');
+        expect(items).toHaveLength(2);
+        expect(items[0].querySelector('.cube-watch-text').textContent).toContain('Ragavan — below $30.00');
+        items[0].querySelector('.cube-watch-remove').click();
+        expect(removed).toEqual([1]);
+    });
+
+    test('renderWatches shows an empty state', () => {
+        const el = document.createElement('div');
+        Cube.renderWatches(el, [], function () {});
+        expect(el.querySelector('.cube-watches-empty').textContent).toContain('No price watches');
+    });
+});
+
 describe('priceLine (pure)', () => {
     test('joins present currencies only', () => {
         expect(Cube.priceLine({ priceUsd: '1.50' })).toBe('$1.50');

--- a/web/src/test/kotlin/web/controller/CubeControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/CubeControllerTest.kt
@@ -47,6 +47,7 @@ class CubeControllerTest {
     private lateinit var service: CubeWebService
     private lateinit var cubeLists: CubeListService
     private lateinit var sharedCubes: SharedCubeService
+    private lateinit var priceWatches: database.service.user.CardPriceWatchService
     private lateinit var controller: CubeController
 
     private fun loggedIn() = mockk<OAuth2User> {
@@ -75,7 +76,8 @@ class CubeControllerTest {
         service = mockk()
         cubeLists = mockk(relaxed = true)
         sharedCubes = mockk(relaxed = true)
-        controller = CubeController(service, cubeLists, sharedCubes)
+        priceWatches = mockk(relaxed = true)
+        controller = CubeController(service, cubeLists, sharedCubes, priceWatches)
     }
 
     @Test
@@ -547,5 +549,63 @@ class CubeControllerTest {
         assertEquals("cube", controller.sharedPage("nope", null, model))
 
         verify { model.addAttribute("sharedMissing", true) }
+    }
+
+    // --- price watches -------------------------------------------------
+
+    @Test
+    fun `watches requires login`() {
+        assertEquals(401, controller.watches(anon()).statusCode.value())
+        assertEquals(401, controller.watches(null).statusCode.value())
+    }
+
+    @Test
+    fun `addWatch resolves the card, captures its price and creates the watch`() {
+        every { service.card("Ragavan") } returns CubeResult.ok(
+            CardLookupView(
+                name = "Ragavan, Nimble Pilferer", imageUrl = null, imageUrlLarge = null, imageUrlBack = null,
+                typeLine = "Legendary Creature", manaValue = 1.0, manaCost = "{R}", rarity = "Mythic",
+                colors = listOf("Red"), priceUsd = "45.00",
+            )
+        )
+        every {
+            priceWatches.create(discordId, 0L, "Ragavan, Nimble Pilferer", "usd", database.dto.user.CardPriceWatchDto.Direction.BELOW, 30.0, 45.0)
+        } returns database.dto.user.CardPriceWatchDto(id = 9, cardName = "Ragavan, Nimble Pilferer", currency = "usd", direction = "BELOW", threshold = 30.0)
+
+        val response = controller.addWatch(AddWatchRequest("Ragavan", "usd", "below", 30.0), loggedIn())
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertTrue(response.body!!.ok)
+        assertEquals(9, response.body!!.watch!!.id)
+    }
+
+    @Test
+    fun `addWatch 400s on an unknown card and 409s at the watch cap`() {
+        every { service.card(any()) } returns CubeResult.error("No card found matching “zzz”.")
+        val notFound = controller.addWatch(AddWatchRequest("zzz", "usd", "below", 30.0), loggedIn())
+        assertEquals(HttpStatus.BAD_REQUEST, notFound.statusCode)
+        assertFalse(notFound.body!!.ok)
+
+        every { service.card("Ragavan") } returns CubeResult.ok(
+            CardLookupView(
+                name = "Ragavan", imageUrl = null, imageUrlLarge = null, imageUrlBack = null,
+                typeLine = "", manaValue = 0.0, manaCost = null, rarity = null, colors = emptyList(), priceUsd = "45.00",
+            )
+        )
+        every { priceWatches.create(any(), any(), any(), any(), any(), any(), any()) } returns null
+        every { priceWatches.maxPerUser } returns 25
+        val capped = controller.addWatch(AddWatchRequest("Ragavan", "usd", "below", 30.0), loggedIn())
+        assertEquals(409, capped.statusCode.value())
+    }
+
+    @Test
+    fun `deleteWatch requires login and reports removal`() {
+        assertEquals(401, controller.deleteWatch(5L, anon()).statusCode.value())
+
+        every { priceWatches.remove(5L, discordId) } returns true
+        assertEquals(HttpStatus.NO_CONTENT, controller.deleteWatch(5L, loggedIn()).statusCode)
+
+        every { priceWatches.remove(6L, discordId) } returns false
+        assertEquals(HttpStatus.NOT_FOUND, controller.deleteWatch(6L, loggedIn()).statusCode)
     }
 }


### PR DESCRIPTION
Add card price watch alerts (Discord + web)

Get DM'd on Discord when a Magic card's market price crosses a target —
the fourth of the four card-bot features.

- DB: V47 card_price_watch table; CardPriceWatchDto (BELOW/ABOVE direction,
  one-shot fire) + persistence + service (max 25/user), mirroring the
  economy price-trigger pattern.
- New CARD_PRICE_ALERT notification kind (DM-only, on by default — you opted
  in by creating the watch); auto-surfaces in the notification prefs UI.
- Scheduled CardPriceWatchJob: batch-fetches Scryfall prices for every
  enabled watch (deduped), DMs via NotificationRouter on a crossing, and
  disables the fired watch. Skips unpriced/unknown cards, stays armed.
- Discord: /cube watch-add (name/direction/price/currency), watch-list,
  watch-remove; confirmation/list embeds + CardPriceAlertBuilder DM.
- Web: account-bound Price-watch tab (login-gated) + GET/POST/DELETE
  /cube/api/watches.
- Tests across DB service+DTO, the job, the DM builder, Discord
  command+embeds, web controller, and jest; stylelint + kover gates green.

Stacked on the reference/navbar branches; retarget to main as they merge.

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs