### PR TITLE
Reframe the Magic tools as a "Magic toolkit" at /magic (+ SEO)

### DIFF
--- a/web/src/main/kotlin/web/configuration/WebSecurityConfig.kt
+++ b/web/src/main/kotlin/web/configuration/WebSecurityConfig.kt
@@ -21,11 +21,11 @@ class WebSecurityConfig {
                     "/v3/api-docs/**", "/swagger-ui/**", "/login", "/error",
                     "/images/**", "/js/**", "/css/**",
                     "/dnd", "/dnd/**",
-                    // The cube tool's page, its anonymous lookups, and opening a
-                    // shared cube (/cube/c/**) are public; the saved-lists and
+                    // The Magic toolkit page, its anonymous lookups, and opening a
+                    // shared cube (/magic/c/**) are public; the saved-lists and
                     // share-create APIs are deliberately NOT listed here so they
                     // fall through to anyRequest().authenticated().
-                    "/cube", "/cube/c/**", "/cube/api/asfan", "/cube/api/preview", "/cube/api/generate", "/cube/api/diff", "/cube/api/card", "/cube/api/rulings", "/cube/api/legality", "/cube/api/combos", "/cube/api/set", "/cube/api/rule",
+                    "/magic", "/magic/c/**", "/magic/api/asfan", "/magic/api/preview", "/magic/api/generate", "/magic/api/diff", "/magic/api/card", "/magic/api/rulings", "/magic/api/legality", "/magic/api/combos", "/magic/api/set", "/magic/api/rule",
                     "/sitemap.xml", "/robots.txt",
                     // Service worker for web push must be reachable
                     // unauthenticated — the browser registers it on
@@ -76,7 +76,7 @@ class WebSecurityConfig {
                     // the saved-lists PUT/DELETE operate only on the authenticated
                     // user's own rows (discord id from the session) — same per-user
                     // ownership rationale as the engagement API below.
-                    "/cube/api/**",
+                    "/magic/api/**",
                     // Push subscription lifecycle (subscribe / unsubscribe)
                     // is called from the same authenticated dashboard JS
                     // and protected by the same OAuth2 session + per-user

--- a/web/src/main/kotlin/web/controller/CubeController.kt
+++ b/web/src/main/kotlin/web/controller/CubeController.kt
@@ -37,21 +37,22 @@ import web.util.discordIdOrNull
 import web.util.displayName
 
 /**
- * Public web surface for the MTG cube tool — the same as-fan maths and
- * pack generation as the `/cube` Discord command, no login required (like
- * `/dnd` and `/utils`). GET renders the page. The `/api/...` GET endpoints
- * take a Scryfall query; the POST variants take the user's own pasted card
- * list (too large for a query string) — both return the same JSON.
+ * Public web surface for the Magic toolkit — the same as-fan maths, pack
+ * generation, card lookups, legality, reference and price watches as the
+ * Discord commands, no login required (like `/dnd` and `/utils`). The page
+ * itself is served at `/magic` by [MagicPageController]; this controller
+ * carries the shared-cube deep links and the `/magic/api/...` JSON endpoints.
+ * The `/api/...` GET endpoints take a Scryfall query; the POST variants take
+ * the user's own pasted card list (too large for a query string).
  *
  * Saving a list is account-bound: the `/api/lists` endpoints require a
  * logged-in Discord user and persist per-user via [CubeListService], so a
- * saved cube follows the user across devices (unlike the rest of the page,
- * which is anonymous). A logged-in user can also publish an immutable
- * shareable snapshot via [SharedCubeService]; anyone can open it at
- * `/cube/c/{token}` (no login).
+ * saved cube follows the user across devices. A logged-in user can also
+ * publish an immutable shareable snapshot via [SharedCubeService]; anyone can
+ * open it at `/magic/c/{token}` (no login).
  */
 @Controller
-@RequestMapping("/cube")
+@RequestMapping("/magic")
 class CubeController(
     private val cubeWebService: CubeWebService,
     private val cubeLists: CubeListService,
@@ -350,7 +351,7 @@ class CubeController(
         }
         val name = request.name.trim().ifEmpty { "Shared cube" }.take(MAX_NAME_LENGTH)
         val row = sharedCubes.create(discordId, name, request.cards)
-        return ResponseEntity.ok(ShareCubeResponse(token = row.token, url = "/cube/c/${row.token}", name = row.name))
+        return ResponseEntity.ok(ShareCubeResponse(token = row.token, url = "/magic/c/${row.token}", name = row.name))
     }
 
     private companion object {

--- a/web/src/main/resources/static/css/cube.css
+++ b/web/src/main/resources/static/css/cube.css
@@ -142,7 +142,8 @@
 
 .cube-tabs {
     display: flex;
-    gap: 6px;
+    flex-direction: column;
+    gap: 12px;
     padding: 6px;
     margin-bottom: var(--space-5);
     background: var(--bg);
@@ -150,8 +151,28 @@
     border-radius: var(--radius-md);
 }
 
+/* Each tab group ("Build a cube" / "Card & deck tools" / "Reference") is a
+   labelled row of tabs. role="presentation" keeps the tablist→tab semantics. */
+.cube-tab-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.cube-tab-group-label {
+    flex-basis: 100%;
+    margin: 0;
+    padding: 0 4px;
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+}
+
 .cube-tab {
-    flex: 1;
+    flex: 1 1 9rem;
+    max-width: 18rem;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -1492,11 +1513,9 @@ details[open] > .cube-section-summary .cube-collapse-chevron {
         font-size: 1.7rem;
     }
 
-    .cube-tabs {
-        flex-direction: column;
-    }
-
     .cube-tab {
+        flex: 1 1 100%;
+        max-width: none;
         flex-direction: row;
         gap: 8px;
     }

--- a/web/src/main/resources/static/js/cube.js
+++ b/web/src/main/resources/static/js/cube.js
@@ -1,5 +1,6 @@
-// MTG cube workshop page. A guided, tabbed tool (generate packs / preview
-// a cube / as-fan calculator) over the /cube/api/* JSON endpoints. The
+// Magic toolkit page (/cube). A tabbed hub — cube building (generate / preview
+// / as-fan / compare), card tools (lookup / legality / price watch) and
+// reference (sets / keywords) — over the /cube/api/* JSON endpoints. The
 // emphasis is on showing the actual CARDS: generated packs and the preview
 // both list real card names linked to Scryfall. Pure helpers (URL builders,
 // formatting, colours, card links, hash↔tab mapping, DOM renderers) are

--- a/web/src/main/resources/static/js/cube.js
+++ b/web/src/main/resources/static/js/cube.js
@@ -1,6 +1,6 @@
-// Magic toolkit page (/cube). A tabbed hub — cube building (generate / preview
+// Magic toolkit page (/magic). A tabbed hub — cube building (generate / preview
 // / as-fan / compare), card tools (lookup / legality / price watch) and
-// reference (sets / keywords) — over the /cube/api/* JSON endpoints. The
+// reference (sets / keywords) — over the /magic/api/* JSON endpoints. The
 // emphasis is on showing the actual CARDS: generated packs and the preview
 // both list real card names linked to Scryfall. Pure helpers (URL builders,
 // formatting, colours, card links, hash↔tab mapping, DOM renderers) are
@@ -114,12 +114,12 @@
 
     function asfanUrl(p) {
         const q = new URLSearchParams({ total: p.total, cubeSize: p.cubeSize, packSize: p.packSize });
-        return '/cube/api/asfan?' + q.toString();
+        return '/magic/api/asfan?' + q.toString();
     }
 
     function previewUrl(p) {
         const q = new URLSearchParams({ query: p.query, packSize: p.packSize });
-        return '/cube/api/preview?' + q.toString();
+        return '/magic/api/preview?' + q.toString();
     }
 
     function generateUrl(p) {
@@ -129,7 +129,7 @@
             packSize: p.packSize,
             balanced: p.balanced ? 'true' : 'false',
         });
-        return '/cube/api/generate?' + q.toString();
+        return '/magic/api/generate?' + q.toString();
     }
 
     /**
@@ -140,7 +140,7 @@
     function samplePackRequest(src, packSize) {
         const ps = Number(packSize) || 15;
         if (src.mode === 'list') {
-            return { method: 'POST', url: '/cube/api/generate', body: { list: src.list, packs: 1, packSize: ps, balanced: true } };
+            return { method: 'POST', url: '/magic/api/generate', body: { list: src.list, packs: 1, packSize: ps, balanced: true } };
         }
         return { method: 'GET', url: generateUrl({ query: src.query, packs: 1, packSize: ps, balanced: true }) };
     }
@@ -434,12 +434,12 @@
 
     /** GET URL for the single-card lookup. */
     function cardUrl(name) {
-        return '/cube/api/card?name=' + encodeURIComponent(name);
+        return '/magic/api/card?name=' + encodeURIComponent(name);
     }
 
     /** GET URL for a card's official rulings. */
     function rulingsUrl(name) {
-        return '/cube/api/rulings?name=' + encodeURIComponent(name);
+        return '/magic/api/rulings?name=' + encodeURIComponent(name);
     }
 
     /**
@@ -525,7 +525,7 @@
         link.textContent = 'View on Scryfall ↗';
         facts.appendChild(link);
 
-        // On-demand rulings: a button that fetches /cube/api/rulings for this
+        // On-demand rulings: a button that fetches /magic/api/rulings for this
         // card and renders them into the box below (wired in wireCardLookup).
         const rulingsBtn = document.createElement('button');
         rulingsBtn.type = 'button';
@@ -535,7 +535,7 @@
         rulingsBtn.textContent = 'Show rulings';
         facts.appendChild(rulingsBtn);
 
-        // On-demand combos: fetches /cube/api/combos for this card.
+        // On-demand combos: fetches /magic/api/combos for this card.
         const combosBtn = document.createElement('button');
         combosBtn.type = 'button';
         combosBtn.className = 'btn btn-secondary cube-combos-btn';
@@ -563,7 +563,7 @@
 
     /** GET URL for a card's combos. */
     function combosUrl(name) {
-        return '/cube/api/combos?name=' + encodeURIComponent(name);
+        return '/magic/api/combos?name=' + encodeURIComponent(name);
     }
 
     /** Renders a card's combos (pieces → produces, each linked), or a friendly empty state. */
@@ -684,7 +684,7 @@
 
     /** POST body builder isn't needed; the URL is constant. */
     function legalityUrl() {
-        return '/cube/api/legality';
+        return '/magic/api/legality';
     }
 
     /**
@@ -913,7 +913,7 @@
 
     /**
      * Re-activate the matching tab when only the URL hash changes — i.e. a
-     * deep-link like /cube#preview clicked while already on /cube (e.g. from
+     * deep-link like /magic#preview clicked while already on /magic (e.g. from
      * the navbar dropdown), where no reload fires wireTabs again. Registered
      * unconditionally so it's live even if wireTabs bailed for lack of tabs.
      */
@@ -952,7 +952,7 @@
 
     /** A shareable URL that pre-loads a Scryfall query (no login needed). */
     function queryShareUrl(origin, query) {
-        return (origin || '') + '/cube?q=' + encodeURIComponent(query);
+        return (origin || '') + '/magic?q=' + encodeURIComponent(query);
     }
 
     /** Reads ?q= / ?list= prefill params from a URL search string. */
@@ -1000,7 +1000,7 @@
         });
     }
 
-    /** "Copy link" for the current Scryfall search → /cube?q=... */
+    /** "Copy link" for the current Scryfall search → /magic?q=... */
     function wireCopyQuery(doc) {
         const btn = doc.querySelector('[data-copy-query]');
         const input = doc.querySelector('[data-source-panel="search"] input[name="query"]');
@@ -1043,7 +1043,7 @@
 
     // --- Saved lists (account-bound; persisted server-side) ------------
 
-    const LISTS_API = '/cube/api/lists';
+    const LISTS_API = '/magic/api/lists';
 
     /** DELETE URL for a saved list, with the name safely encoded. */
     function deleteListUrl(name) {
@@ -1111,7 +1111,7 @@
 
     /**
      * Account-bound saved lists: persisted server-side against the logged-in
-     * Discord user via `/cube/api/lists`, so they follow the user across
+     * Discord user via `/magic/api/lists`, so they follow the user across
      * devices. The saved-cube picker is a datalist-backed typeahead — type to
      * filter your cube names, pick one to load it. The controls only exist in
      * the DOM for a logged-in user (see cube.html), so this no-ops otherwise.
@@ -1182,7 +1182,7 @@
 
     /**
      * Publishes the current list as a public, immutable snapshot (logged-in
-     * only) and shows the resulting `/cube/c/<token>` link, copying it to the
+     * only) and shows the resulting `/magic/c/<token>` link, copying it to the
      * clipboard. The Share controls only exist in the DOM for a logged-in user.
      */
     function wireShare(doc) {
@@ -1209,7 +1209,7 @@
             if (!text) { setStatus(status, 'Nothing to share — paste a list first.'); return; }
             const name = ((nameInput && nameInput.value) || '').trim();
             setStatus(status, 'Creating link…');
-            fetch('/cube/api/share', {
+            fetch('/magic/api/share', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ name: name, cards: text }),
@@ -1418,7 +1418,7 @@
             setStatus(status, 'Comparing…');
             hide(result);
             withBusy(form, true);
-            postJson('/cube/api/diff', { listA: listA, listB: listB })
+            postJson('/magic/api/diff', { listA: listA, listB: listB })
                 .then(function (json) {
                     if (!json.ok) { setStatus(status, json.error || 'Could not compare.'); return; }
                     setStatus(status, 'List A: ' + json.sizeA + ' cards · List B: ' + json.sizeB + ' cards');
@@ -1459,12 +1459,12 @@
 
     /** GET URL for a set lookup by code. */
     function setUrl(code) {
-        return '/cube/api/set?code=' + encodeURIComponent(code);
+        return '/magic/api/set?code=' + encodeURIComponent(code);
     }
 
     /** GET URL for a glossary keyword lookup. */
     function ruleUrl(term) {
-        return '/cube/api/rule?term=' + encodeURIComponent(term);
+        return '/magic/api/rule?term=' + encodeURIComponent(term);
     }
 
     /** Renders a set's headline facts (type, release date, card count) with a Scryfall link. */
@@ -1518,7 +1518,7 @@
         wireLookupForm(doc, 'rule', 'term', ruleUrl, function (json) { return json.rule; }, renderRule, 'Enter a keyword.');
     }
 
-    const WATCHES_API = '/cube/api/watches';
+    const WATCHES_API = '/magic/api/watches';
 
     /** Formats a watch as "Card — below $30 (USD)". Pure. */
     function watchLine(watch) {
@@ -1758,7 +1758,7 @@
             withBusy(form, true);
             setSpinner(doc, 'preview', true);
             const request = src.mode === 'list'
-                ? postJson('/cube/api/preview', { list: src.list, packSize: Number(packSize) })
+                ? postJson('/magic/api/preview', { list: src.list, packSize: Number(packSize) })
                 : getJson(previewUrl({ query: src.query, packSize: packSize }));
             request
                 .then(function (json) {
@@ -1820,7 +1820,7 @@
             withBusy(form, true);
             setSpinner(doc, 'generate', true);
             const request = src.mode === 'list'
-                ? postJson('/cube/api/generate', { list: src.list, packs: Number(packs), packSize: Number(packSize), balanced: balanced })
+                ? postJson('/magic/api/generate', { list: src.list, packs: Number(packs), packSize: Number(packSize), balanced: balanced })
                 : getJson(generateUrl({ query: src.query, packs: packs, packSize: packSize, balanced: balanced }));
             request
                 .then(function (json) {

--- a/web/src/main/resources/static/sitemap.xml
+++ b/web/src/main/resources/static/sitemap.xml
@@ -11,6 +11,11 @@
         <priority>0.8</priority>
     </url>
     <url>
+        <loc>https://www.toby-bot.co.uk/magic</loc>
+        <changefreq>weekly</changefreq>
+        <priority>0.8</priority>
+    </url>
+    <url>
         <loc>https://www.toby-bot.co.uk/changelog</loc>
         <changefreq>weekly</changefreq>
         <priority>0.7</priority>

--- a/web/src/main/resources/templates/cube.html
+++ b/web/src/main/resources/templates/cube.html
@@ -1,6 +1,10 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="en">
-<head th:replace="~{fragments/head :: head('TobyBot - Magic toolkit', '/css/cube.css')}"></head>
+<head th:replace="~{fragments/headSeo :: headSeo(
+        'TobyBot — Magic toolkit',
+        'Build and balance Magic: The Gathering draft cubes, look up any card''s details, rulings and combos, check deck legality, browse set &amp; keyword reference, and set card price alerts.',
+        null,
+        '/css/cube.css')}"></head>
 <body>
 <a href="#main" class="skip-link">Skip to content</a>
 <div th:replace="~{fragments/navbar :: navbar}"></div>

--- a/web/src/main/resources/templates/cube.html
+++ b/web/src/main/resources/templates/cube.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="en">
-<head th:replace="~{fragments/head :: head('TobyBot - MTG Cube workshop', '/css/cube.css')}"></head>
+<head th:replace="~{fragments/head :: head('TobyBot - Magic toolkit', '/css/cube.css')}"></head>
 <body>
 <a href="#main" class="skip-link">Skip to content</a>
 <div th:replace="~{fragments/navbar :: navbar}"></div>
@@ -9,10 +9,11 @@
     <header class="cube-hero">
         <div class="cube-hero-inner">
             <p class="cube-eyebrow">Magic: The Gathering</p>
-            <h1>Cube workshop</h1>
+            <h1>Magic toolkit</h1>
             <p class="cube-lede">
-                Turn any pile of cards into a balanced draft. Tell it which cards you're using —
-                a Scryfall search or your own list — then preview the balance or deal the packs.
+                A grab-bag of Magic: The Gathering tools — build and balance a draft cube, look up any
+                card's details, rulings and combos, check a deck's format legality, browse set and
+                keyword reference, and set price-watch alerts. Pick a tool below.
             </p>
 
             <ol class="cube-steps" aria-label="How it works">
@@ -122,7 +123,9 @@
         </section>
 
         <p class="cube-tabs-hint" id="cube-tabs-hint" data-needs-cube>Then pick a tool:</p>
-        <div class="cube-tabs segmented" role="tablist" aria-label="Cube tools" aria-describedby="cube-tabs-hint">
+        <div class="cube-tabs" role="tablist" aria-label="Magic tools" aria-describedby="cube-tabs-hint">
+            <div class="cube-tab-group" role="presentation">
+                <span class="cube-tab-group-label" aria-hidden="true">Build a cube</span>
             <button type="button" id="tab-generate" class="cube-tab" role="tab"
                     data-tab="generate" aria-controls="panel-generate" aria-selected="true">
                 <span class="cube-tab-icon" aria-hidden="true">🃏</span>
@@ -147,6 +150,9 @@
                 <span class="cube-tab-label">Compare</span>
                 <span class="cube-tab-sub">Diff two lists</span>
             </button>
+            </div>
+            <div class="cube-tab-group" role="presentation">
+                <span class="cube-tab-group-label" aria-hidden="true">Card &amp; deck tools</span>
             <button type="button" id="tab-card" class="cube-tab" role="tab"
                     data-tab="card" aria-controls="panel-card" aria-selected="false" tabindex="-1">
                 <span class="cube-tab-icon" aria-hidden="true">🔍</span>
@@ -159,18 +165,22 @@
                 <span class="cube-tab-label">Legality</span>
                 <span class="cube-tab-sub">Check a deck</span>
             </button>
-            <button type="button" id="tab-reference" class="cube-tab" role="tab"
-                    data-tab="reference" aria-controls="panel-reference" aria-selected="false" tabindex="-1">
-                <span class="cube-tab-icon" aria-hidden="true">📖</span>
-                <span class="cube-tab-label">Reference</span>
-                <span class="cube-tab-sub">Sets &amp; keywords</span>
-            </button>
             <button type="button" id="tab-watch" class="cube-tab" role="tab"
                     data-tab="watch" aria-controls="panel-watch" aria-selected="false" tabindex="-1">
                 <span class="cube-tab-icon" aria-hidden="true">🔔</span>
                 <span class="cube-tab-label">Price watch</span>
                 <span class="cube-tab-sub">Alert on price</span>
             </button>
+            </div>
+            <div class="cube-tab-group" role="presentation">
+                <span class="cube-tab-group-label" aria-hidden="true">Reference</span>
+            <button type="button" id="tab-reference" class="cube-tab" role="tab"
+                    data-tab="reference" aria-controls="panel-reference" aria-selected="false" tabindex="-1">
+                <span class="cube-tab-icon" aria-hidden="true">📖</span>
+                <span class="cube-tab-label">Reference</span>
+                <span class="cube-tab-sub">Sets &amp; keywords</span>
+            </button>
+            </div>
         </div>
 
         <!-- Generate -->

--- a/web/src/main/resources/templates/fragments/navbar.html
+++ b/web/src/main/resources/templates/fragments/navbar.html
@@ -172,13 +172,13 @@
                         aria-expanded="false"
                         onclick="toggleDropdown(this)"><span class="nav-item-icon" aria-hidden="true">&#127183;</span><span class="nav-dropdown-label">Magic</span><span class="nav-dropdown-caret" aria-hidden="true">&#9662;</span></button>
                 <div class="nav-dropdown-menu" role="menu">
-                    <a href="/cube" role="menuitem">&#129443; Magic toolkit</a>
-                    <a href="/cube#card" role="menuitem">&#128269; Card lookup</a>
-                    <a href="/cube#legality" role="menuitem">&#9878; Deck legality</a>
-                    <a href="/cube#reference" role="menuitem">&#128214; Sets &amp; keywords</a>
-                    <a href="/cube#asfan" role="menuitem">&#128290; As-fan calculator</a>
-                    <a href="/cube#preview" role="menuitem">&#128202; Cube preview</a>
-                    <a href="/cube#generate" role="menuitem">&#127183; Pack generator</a>
+                    <a href="/magic" role="menuitem">&#129443; Magic toolkit</a>
+                    <a href="/magic#card" role="menuitem">&#128269; Card lookup</a>
+                    <a href="/magic#legality" role="menuitem">&#9878; Deck legality</a>
+                    <a href="/magic#reference" role="menuitem">&#128214; Sets &amp; keywords</a>
+                    <a href="/magic#asfan" role="menuitem">&#128290; As-fan calculator</a>
+                    <a href="/magic#preview" role="menuitem">&#128202; Cube preview</a>
+                    <a href="/magic#generate" role="menuitem">&#127183; Pack generator</a>
                 </div>
             </div>
         </div>

--- a/web/src/main/resources/templates/fragments/navbar.html
+++ b/web/src/main/resources/templates/fragments/navbar.html
@@ -172,7 +172,7 @@
                         aria-expanded="false"
                         onclick="toggleDropdown(this)"><span class="nav-item-icon" aria-hidden="true">&#127183;</span><span class="nav-dropdown-label">Magic</span><span class="nav-dropdown-caret" aria-hidden="true">&#9662;</span></button>
                 <div class="nav-dropdown-menu" role="menu">
-                    <a href="/cube" role="menuitem">&#129443; Cube workshop</a>
+                    <a href="/cube" role="menuitem">&#129443; Magic toolkit</a>
                     <a href="/cube#card" role="menuitem">&#128269; Card lookup</a>
                     <a href="/cube#legality" role="menuitem">&#9878; Deck legality</a>
                     <a href="/cube#reference" role="menuitem">&#128214; Sets &amp; keywords</a>

--- a/web/src/main/resources/templates/home.html
+++ b/web/src/main/resources/templates/home.html
@@ -251,7 +251,7 @@
         <h2 id="tabletop-title">Sundries that earn their keep</h2>
     </header>
     <div class="feature-grid">
-        <a class="feature-card" href="/cube" data-reveal>
+        <a class="feature-card" href="/magic" data-reveal>
             <div class="feature-icon">&#127183;</div>
             <h3>Magic toolkit</h3>
             <p>A grab-bag of Magic: The Gathering tools &mdash; build and balance a draft cube, look up any

--- a/web/src/main/resources/templates/home.html
+++ b/web/src/main/resources/templates/home.html
@@ -253,10 +253,10 @@
     <div class="feature-grid">
         <a class="feature-card" href="/cube" data-reveal>
             <div class="feature-icon">&#127183;</div>
-            <h3>MTG cube workshop</h3>
-            <p>Build a balanced Magic: The Gathering draft from a Scryfall search or your own list &mdash;
-                preview its colour, curve, type &amp; rarity balance, deal randomised packs, compare two
-                lists, or look up any card. Save &amp; share cubes when signed in.</p>
+            <h3>Magic toolkit</h3>
+            <p>A grab-bag of Magic: The Gathering tools &mdash; build and balance a draft cube, look up any
+                card's details, rulings &amp; combos, check deck legality, browse set &amp; keyword reference,
+                and set price-watch alerts. Save &amp; share cubes when signed in.</p>
             <span class="feature-card-tag">New</span>
         </a>
         <a class="feature-card" href="/dnd" data-reveal>

--- a/web/src/test/js/cube.test.js
+++ b/web/src/test/js/cube.test.js
@@ -94,19 +94,19 @@ describe('packsToText', () => {
 describe('URL builders', () => {
     test('asfanUrl carries the three calculator params', () => {
         expect(Cube.asfanUrl({ total: 60, cubeSize: 540, packSize: 15 }))
-            .toBe('/cube/api/asfan?total=60&cubeSize=540&packSize=15');
+            .toBe('/magic/api/asfan?total=60&cubeSize=540&packSize=15');
     });
 
     test('previewUrl url-encodes the query', () => {
         expect(Cube.previewUrl({ query: 't:dragon c:r', packSize: 15 }))
-            .toBe('/cube/api/preview?query=t%3Adragon+c%3Ar&packSize=15');
+            .toBe('/magic/api/preview?query=t%3Adragon+c%3Ar&packSize=15');
     });
 
     test('generateUrl encodes the boolean balanced flag', () => {
         expect(Cube.generateUrl({ query: 'set:vow', packs: 24, packSize: 15, balanced: true }))
-            .toBe('/cube/api/generate?query=set%3Avow&packs=24&packSize=15&balanced=true');
+            .toBe('/magic/api/generate?query=set%3Avow&packs=24&packSize=15&balanced=true');
         expect(Cube.generateUrl({ query: 'set:vow', packs: 8, packSize: 15, balanced: false }))
-            .toBe('/cube/api/generate?query=set%3Avow&packs=8&packSize=15&balanced=false');
+            .toBe('/magic/api/generate?query=set%3Avow&packs=8&packSize=15&balanced=false');
     });
 });
 
@@ -324,7 +324,7 @@ describe('collapsible result sections', () => {
 describe('deep-link hash activates the matching tab on in-page navigation', () => {
     // wire() ran at require time and registered a hashchange listener on the
     // window; here we stand up the tab markup and fire a hashchange to prove a
-    // /cube#preview deep-link (clicked while already on /cube) switches tabs.
+    // /magic#preview deep-link (clicked while already on /magic) switches tabs.
     // Append to a throwaway container (not innerHTML on body) so the shared
     // zoom/lightbox overlays wire() created at require time survive.
     let host;
@@ -391,7 +391,7 @@ describe('deep-link hash activates the matching tab on in-page navigation', () =
 
 describe('card lookup (cardUrl / renderCardLookup)', () => {
     test('cardUrl encodes the name', () => {
-        expect(Cube.cardUrl('Urza, Lord High Artificer')).toBe('/cube/api/card?name=' + encodeURIComponent('Urza, Lord High Artificer'));
+        expect(Cube.cardUrl('Urza, Lord High Artificer')).toBe('/magic/api/card?name=' + encodeURIComponent('Urza, Lord High Artificer'));
     });
 
     test('renderCardLookup shows the large image, facts, mana symbols and a Scryfall link', () => {
@@ -468,7 +468,7 @@ describe('card lookup (cardUrl / renderCardLookup)', () => {
 describe('combos (combosUrl / renderCombos)', () => {
     test('combosUrl encodes the name', () => {
         expect(Cube.combosUrl("Thassa's Oracle"))
-            .toBe('/cube/api/combos?name=' + encodeURIComponent("Thassa's Oracle"));
+            .toBe('/magic/api/combos?name=' + encodeURIComponent("Thassa's Oracle"));
     });
 
     test('renderCombos lists each combo with pieces, payoff and a link', () => {
@@ -497,7 +497,7 @@ describe('combos (combosUrl / renderCombos)', () => {
 describe('rulings (rulingsUrl / renderRulings)', () => {
     test('rulingsUrl encodes the name', () => {
         expect(Cube.rulingsUrl('Urza, Lord High Artificer'))
-            .toBe('/cube/api/rulings?name=' + encodeURIComponent('Urza, Lord High Artificer'));
+            .toBe('/magic/api/rulings?name=' + encodeURIComponent('Urza, Lord High Artificer'));
     });
 
     test('renderRulings lists each ruling with its date', () => {
@@ -525,8 +525,8 @@ describe('rulings (rulingsUrl / renderRulings)', () => {
 
 describe('reference (set + rule lookup)', () => {
     test('setUrl and ruleUrl encode their query', () => {
-        expect(Cube.setUrl('vow')).toBe('/cube/api/set?code=vow');
-        expect(Cube.ruleUrl('double strike')).toBe('/cube/api/rule?term=' + encodeURIComponent('double strike'));
+        expect(Cube.setUrl('vow')).toBe('/magic/api/set?code=vow');
+        expect(Cube.ruleUrl('double strike')).toBe('/magic/api/rule?term=' + encodeURIComponent('double strike'));
     });
 
     test('renderSet shows the headline facts and a Scryfall link', () => {
@@ -747,7 +747,7 @@ describe('samplePackRequest (open a sample pack from the preview source)', () =>
     test('a pasted list becomes a POST body with packs=1', () => {
         const req = Cube.samplePackRequest({ mode: 'list', list: '40 Bolt' }, '20');
         expect(req.method).toBe('POST');
-        expect(req.url).toBe('/cube/api/generate');
+        expect(req.url).toBe('/magic/api/generate');
         expect(req.body).toEqual({ list: '40 Bolt', packs: 1, packSize: 20, balanced: true });
     });
 
@@ -1070,26 +1070,26 @@ describe('hover-to-enlarge', () => {
 
 describe('deleteListUrl', () => {
     test('encodes the saved-list name into the delete query', () => {
-        expect(Cube.deleteListUrl('My Cube')).toBe('/cube/api/lists?name=My%20Cube');
-        expect(Cube.deleteListUrl('Pauper / Peasant')).toBe('/cube/api/lists?name=Pauper%20%2F%20Peasant');
+        expect(Cube.deleteListUrl('My Cube')).toBe('/magic/api/lists?name=My%20Cube');
+        expect(Cube.deleteListUrl('Pauper / Peasant')).toBe('/magic/api/lists?name=Pauper%20%2F%20Peasant');
     });
 });
 
 describe('absoluteUrl', () => {
     test('joins the page origin with the relative share path', () => {
-        expect(Cube.absoluteUrl('https://toby-bot.co.uk', '/cube/c/abc123'))
-            .toBe('https://toby-bot.co.uk/cube/c/abc123');
+        expect(Cube.absoluteUrl('https://toby-bot.co.uk', '/magic/c/abc123'))
+            .toBe('https://toby-bot.co.uk/magic/c/abc123');
     });
 
     test('tolerates a missing origin', () => {
-        expect(Cube.absoluteUrl(null, '/cube/c/abc123')).toBe('/cube/c/abc123');
+        expect(Cube.absoluteUrl(null, '/magic/c/abc123')).toBe('/magic/c/abc123');
     });
 });
 
 describe('queryShareUrl', () => {
     test('builds a ?q= deep link, encoding the query', () => {
         expect(Cube.queryShareUrl('https://toby-bot.co.uk', 't:dragon c:r'))
-            .toBe('https://toby-bot.co.uk/cube?q=t%3Adragon%20c%3Ar');
+            .toBe('https://toby-bot.co.uk/magic?q=t%3Adragon%20c%3Ar');
     });
 });
 

--- a/web/src/test/js/navbar.test.js
+++ b/web/src/test/js/navbar.test.js
@@ -198,11 +198,11 @@ describe('navbar fragment', () => {
             /<div class="nav-dropdown">[\s\S]*?Magic[\s\S]*?<\/div>\s*<\/div>/
         );
         expect(magic).not.toBeNull();
-        expect(magic[0]).toMatch(/href="\/cube#card"[^>]*>[^<]*Card lookup/);
-        expect(magic[0]).toMatch(/href="\/cube#legality"[^>]*>[^<]*Deck legality/);
-        expect(magic[0]).toMatch(/href="\/cube#reference"[^>]*>[^<]*Sets/);
+        expect(magic[0]).toMatch(/href="\/magic#card"[^>]*>[^<]*Card lookup/);
+        expect(magic[0]).toMatch(/href="\/magic#legality"[^>]*>[^<]*Deck legality/);
+        expect(magic[0]).toMatch(/href="\/magic#reference"[^>]*>[^<]*Sets/);
         // The cube-builder entries are still there.
-        expect(magic[0]).toMatch(/href="\/cube#generate"[^>]*>[^<]*Pack generator/);
+        expect(magic[0]).toMatch(/href="\/magic#generate"[^>]*>[^<]*Pack generator/);
     });
 
     test('Market and Titles are no longer top-level nav-links siblings', () => {

--- a/web/src/test/kotlin/web/controller/CubeControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/CubeControllerTest.kt
@@ -510,7 +510,7 @@ class CubeControllerTest {
 
         assertEquals(HttpStatus.OK, response.statusCode)
         assertEquals("tok123", response.body!!.token)
-        assertEquals("/cube/c/tok123", response.body!!.url)
+        assertEquals("/magic/c/tok123", response.body!!.url)
     }
 
     @Test

--- a/web/src/test/kotlin/web/static/HomeFeatureCardsTemplateTest.kt
+++ b/web/src/test/kotlin/web/static/HomeFeatureCardsTemplateTest.kt
@@ -139,8 +139,8 @@ class HomeFeatureCardsTemplateTest {
                 "so the Magic tooling is discoverable from the landing page."
         )
         assertTrue(
-            html.contains("href=\"/cube\""),
-            "the Magic toolkit feature-card must link to `/cube`."
+            html.contains("href=\"/magic\""),
+            "the Magic toolkit feature-card must link to `/magic`."
         )
         val tabletopMarker = html.indexOf(">Tabletop &amp; Tools<")
         val ctaMarker = html.indexOf("Ready to add")

--- a/web/src/test/kotlin/web/static/HomeFeatureCardsTemplateTest.kt
+++ b/web/src/test/kotlin/web/static/HomeFeatureCardsTemplateTest.kt
@@ -128,28 +128,28 @@ class HomeFeatureCardsTemplateTest {
     }
 
     @Test
-    fun `magic cube card is present in the tabletop and tools section`() {
-        // The MTG cube workshop (/cube) is a substantial tool — workshop,
-        // the cube report, compare, card lookup — but was only reachable
-        // from the navbar. Pin a discoverable feature card next to the
-        // D&D / Utilities cluster it belongs with.
+    fun `magic toolkit card is present in the tabletop and tools section`() {
+        // The Magic toolkit (/cube) is a substantial tool — cube building,
+        // the cube report, compare, card lookup, legality, reference, price
+        // watches — but is otherwise only reachable from the navbar. Pin a
+        // discoverable feature card next to the D&D / Utilities cluster.
         assertTrue(
-            html.contains("<h3>MTG cube workshop</h3>"),
-            "home.html must include an `<h3>MTG cube workshop</h3>` feature-card heading " +
-                "so the Magic cube tooling is discoverable from the landing page."
+            html.contains("<h3>Magic toolkit</h3>"),
+            "home.html must include an `<h3>Magic toolkit</h3>` feature-card heading " +
+                "so the Magic tooling is discoverable from the landing page."
         )
         assertTrue(
             html.contains("href=\"/cube\""),
-            "the MTG cube feature-card must link to `/cube` — the cube workshop page."
+            "the Magic toolkit feature-card must link to `/cube`."
         )
         val tabletopMarker = html.indexOf(">Tabletop &amp; Tools<")
         val ctaMarker = html.indexOf("Ready to add")
-        val cubeMarker = html.indexOf("<h3>MTG cube workshop</h3>")
+        val cubeMarker = html.indexOf("<h3>Magic toolkit</h3>")
         check(tabletopMarker >= 0) { "expected a `>Tabletop &amp; Tools<` section eyebrow on home.html" }
         check(ctaMarker >= 0) { "expected the final CTA on home.html" }
         assertTrue(
             cubeMarker in (tabletopMarker + 1) until ctaMarker,
-            "the MTG cube card must sit inside the Tabletop & Tools section, " +
+            "the Magic toolkit card must sit inside the Tabletop & Tools section, " +
                 "grouped with D&D lookups and Utilities."
         )
     }


### PR DESCRIPTION
The Magic web surface was a single tabbed page at `/cube` titled "Cube workshop" — a good hub pattern, but the title mislabelled the card/legality/reference/price-watch tabs as cube-only, and the `/cube` slug carries no "magic"/"mtg" keyword.

This keeps the single tabbed hub but reframes and relocates it. **Nothing is live yet, so it's a clean rename with no back-compat redirects.**

### Reframe
- Retitled **"Magic toolkit"** (page `<title>`, hero heading, broadened lede) and the home feature card + navbar label.
- Tabs grouped into three labelled sections: **Build a cube** (generate, preview, as-fan, compare) · **Card & deck tools** (card, legality, price watch) · **Reference** (sets & keywords). Group wrappers use `role="presentation"`, so the `tablist → tab` semantics and the JS are unchanged.

### Move to `/magic` + SEO
- The page and its whole web surface move to `/magic`: page at `/magic`, shared cubes at `/magic/c/{token}`, all JSON at `/magic/api/*` (`CubeController` is now `@RequestMapping("/magic")`). Old `/cube` routes are removed.
- The page now uses the **`headSeo`** fragment — `<meta name="description">` + Open Graph/Twitter cards (proper search snippet + rich social preview) — instead of the bare `head` fragment.
- **`/magic` added to `sitemap.xml`** so crawlers are pointed at it.
- `cube.js` calls `/magic/api/*` and mints `/magic` share links; navbar deep-links and the home card point at `/magic`.

No behaviour change beyond the URL — tabs, hash deep-links (`/magic#card`, `#legality`, `#reference`), and endpoints all work as before.

Tests updated (controller share URL, home feature-card href, navbar deep-links, jest API/share URLs). Full web suite + kover + jest (738) + stylelint green.

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs