### PR TITLE
Fix stale /cube command mentions + add a single source of truth for command names

### DIFF
--- a/common/src/main/kotlin/common/mtg/CardCombos.kt
+++ b/common/src/main/kotlin/common/mtg/CardCombos.kt
@@ -3,7 +3,7 @@ package common.mtg
 /**
  * The combos a card takes part in, from the Commander Spellbook database — the
  * pieces ("uses"), the payoff ("produces"), and a link to the full write-up.
- * A pure value type shared by the bot's `/cube combos` command and the web
+ * A pure value type shared by the bot's `/card combos` command and the web
  * card-lookup tool, both of which fetch from Commander Spellbook (over their
  * own HTTP clients) and map the JSON into this. Presentation-only.
  *

--- a/common/src/main/kotlin/common/mtg/CardRulings.kt
+++ b/common/src/main/kotlin/common/mtg/CardRulings.kt
@@ -3,7 +3,7 @@ package common.mtg
 /**
  * A card's official rulings (Scryfall `/cards/:id/rulings`) — the clarifying
  * notes the rules team publishes for tricky interactions. A pure value type
- * shared by the bot's `/cube rulings` command and the web card-lookup tool,
+ * shared by the bot's `/card rulings` command and the web card-lookup tool,
  * both of which fetch from Scryfall (over their own HTTP clients) and map the
  * JSON into this. Presentation-only — no maths depend on it.
  *

--- a/common/src/main/kotlin/common/mtg/MtgCommandRef.kt
+++ b/common/src/main/kotlin/common/mtg/MtgCommandRef.kt
@@ -1,0 +1,66 @@
+package common.mtg
+
+/**
+ * Single source of truth for the Magic command + subcommand names.
+ *
+ * Both the Discord command registration (`name` / `SubcommandData`) and every
+ * user-facing mention of a command — embeds, the card-price-watch notification
+ * preference, and the web Magic toolkit page — reference these constants, so a
+ * rename happens in exactly one place and the copy can never drift out of sync
+ * with the commands (the bug that motivated this: the #656 split renamed the
+ * subcommands but the prose still said `/cube card`, `/cube watch-add`, …).
+ *
+ * The bare tokens (e.g. [Card.LOOKUP] = `"lookup"`) drive registration; the
+ * pre-formatted [CARD_LOOKUP] = `"/card lookup"` strings are for copy. All are
+ * `const`, so they inline and can be referenced from enum constructors and
+ * other `const val`s.
+ */
+object MtgCommandRef {
+
+    // Top-level command names.
+    const val CUBE = "cube"
+    const val CARD = "card"
+    const val DECK = "deck"
+    const val MTG = "mtg"
+    const val PRICEWATCH = "pricewatch"
+
+    // Subcommand tokens, grouped by their parent command.
+    object Cube {
+        const val ASFAN = "asfan"
+        const val PREVIEW = "preview"
+        const val GENERATE = "generate"
+        const val SAVED = "saved"
+    }
+
+    object Card {
+        const val LOOKUP = "lookup"
+        const val RULINGS = "rulings"
+        const val COMBOS = "combos"
+    }
+
+    object Deck {
+        const val LEGALITY = "legality"
+    }
+
+    object Reference {
+        const val SET = "set"
+        const val RULE = "rule"
+    }
+
+    object PriceWatch {
+        const val ADD = "add"
+        const val LIST = "list"
+        const val REMOVE = "remove"
+    }
+
+    // Pre-formatted "/command subcommand" strings for user-facing copy.
+    const val CARD_LOOKUP = "/$CARD ${Card.LOOKUP}"
+    const val CARD_RULINGS = "/$CARD ${Card.RULINGS}"
+    const val CARD_COMBOS = "/$CARD ${Card.COMBOS}"
+    const val DECK_LEGALITY = "/$DECK ${Deck.LEGALITY}"
+    const val MTG_SET = "/$MTG ${Reference.SET}"
+    const val MTG_RULE = "/$MTG ${Reference.RULE}"
+    const val PRICEWATCH_ADD = "/$PRICEWATCH ${PriceWatch.ADD}"
+    const val PRICEWATCH_LIST = "/$PRICEWATCH ${PriceWatch.LIST}"
+    const val PRICEWATCH_REMOVE = "/$PRICEWATCH ${PriceWatch.REMOVE}"
+}

--- a/common/src/main/kotlin/common/mtg/MtgGlossary.kt
+++ b/common/src/main/kotlin/common/mtg/MtgGlossary.kt
@@ -2,13 +2,13 @@ package common.mtg
 
 /**
  * A small built-in glossary of Magic keywords and their reminder text — the
- * data behind `/cube rule` and its web twin. Curated (evergreen keywords plus
+ * data behind `/mtg rule` and its web twin. Curated (evergreen keywords plus
  * a handful of the most-asked-about non-evergreen ones) rather than fetched, so
  * it needs no external service and answers instantly. Beginner-friendly, which
  * broadens the bot's appeal beyond cube builders.
  *
  * Reminder text is paraphrased from the comprehensive rules / Oracle reminder
- * text; it's a quick refresher, not a rules ruling (use `/cube rulings` for
+ * text; it's a quick refresher, not a rules ruling (use `/card rulings` for
  * card-specific official rulings).
  */
 object MtgGlossary {

--- a/common/src/main/kotlin/common/mtg/MtgSet.kt
+++ b/common/src/main/kotlin/common/mtg/MtgSet.kt
@@ -1,7 +1,7 @@
 package common.mtg
 
 /**
- * A Magic set's headline facts (Scryfall `/sets/:code`) — for the `/cube set`
+ * A Magic set's headline facts (Scryfall `/sets/:code`) — for the `/mtg set`
  * quick-reference command and its web twin. A pure value type; both surfaces
  * fetch from Scryfall and map the JSON into this.
  */

--- a/common/src/main/kotlin/common/notification/NotificationChannelKind.kt
+++ b/common/src/main/kotlin/common/notification/NotificationChannelKind.kt
@@ -1,5 +1,7 @@
 package common.notification
 
+import common.mtg.MtgCommandRef
+
 /**
  * Catalogue of user-facing notification channels the bot routes through
  * [bot.toby.notify.NotificationRouter]. Each kind declares which
@@ -60,7 +62,7 @@ enum class NotificationChannelKind(
     ),
     CARD_PRICE_ALERT(
         displayName = "Card price watch",
-        description = "DM when a Magic card you're watching (/pricewatch add) crosses your target price.",
+        description = "DM when a Magic card you're watching (${MtgCommandRef.PRICEWATCH_ADD}) crosses your target price.",
         // DM-only and on by default — you opted in by creating the watch.
         perSurfaceDefaults = mapOf(Surface.DM to true),
     ),

--- a/common/src/main/kotlin/common/notification/NotificationChannelKind.kt
+++ b/common/src/main/kotlin/common/notification/NotificationChannelKind.kt
@@ -60,7 +60,7 @@ enum class NotificationChannelKind(
     ),
     CARD_PRICE_ALERT(
         displayName = "Card price watch",
-        description = "DM when a Magic card you're watching (/cube watch-add) crosses your target price.",
+        description = "DM when a Magic card you're watching (/pricewatch add) crosses your target price.",
         // DM-only and on by default — you opted in by creating the watch.
         perSurfaceDefaults = mapOf(Surface.DM to true),
     ),

--- a/common/src/test/kotlin/common/mtg/MtgCommandRefTest.kt
+++ b/common/src/test/kotlin/common/mtg/MtgCommandRefTest.kt
@@ -1,0 +1,34 @@
+package common.mtg
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Locks the single source of truth for Magic command names: the pre-formatted
+ * "/command subcommand" copy strings must compose from the bare tokens, so the
+ * Discord registration and the user-facing copy stay in lockstep.
+ */
+class MtgCommandRefTest {
+
+    @Test
+    fun `formatted strings compose from the command and subcommand tokens`() {
+        assertEquals("/${MtgCommandRef.CARD} ${MtgCommandRef.Card.LOOKUP}", MtgCommandRef.CARD_LOOKUP)
+        assertEquals("/${MtgCommandRef.CARD} ${MtgCommandRef.Card.RULINGS}", MtgCommandRef.CARD_RULINGS)
+        assertEquals("/${MtgCommandRef.CARD} ${MtgCommandRef.Card.COMBOS}", MtgCommandRef.CARD_COMBOS)
+        assertEquals("/${MtgCommandRef.DECK} ${MtgCommandRef.Deck.LEGALITY}", MtgCommandRef.DECK_LEGALITY)
+        assertEquals("/${MtgCommandRef.MTG} ${MtgCommandRef.Reference.SET}", MtgCommandRef.MTG_SET)
+        assertEquals("/${MtgCommandRef.MTG} ${MtgCommandRef.Reference.RULE}", MtgCommandRef.MTG_RULE)
+        assertEquals("/${MtgCommandRef.PRICEWATCH} ${MtgCommandRef.PriceWatch.ADD}", MtgCommandRef.PRICEWATCH_ADD)
+        assertEquals("/${MtgCommandRef.PRICEWATCH} ${MtgCommandRef.PriceWatch.LIST}", MtgCommandRef.PRICEWATCH_LIST)
+        assertEquals("/${MtgCommandRef.PRICEWATCH} ${MtgCommandRef.PriceWatch.REMOVE}", MtgCommandRef.PRICEWATCH_REMOVE)
+    }
+
+    @Test
+    fun `the expected current command and subcommand names`() {
+        assertEquals("/card lookup", MtgCommandRef.CARD_LOOKUP)
+        assertEquals("/deck legality", MtgCommandRef.DECK_LEGALITY)
+        assertEquals("/mtg set", MtgCommandRef.MTG_SET)
+        assertEquals("/pricewatch add", MtgCommandRef.PRICEWATCH_ADD)
+        assertEquals("pricewatch", MtgCommandRef.PRICEWATCH)
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CardCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CardCommand.kt
@@ -1,6 +1,7 @@
 package bot.toby.command.commands.mtg
 
 import bot.toby.helpers.stringOption
+import common.mtg.MtgCommandRef
 import common.mtg.MtgNames
 import core.command.CommandContext
 import database.dto.user.UserDto
@@ -23,7 +24,7 @@ class CardCommand @Autowired constructor(
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : AbstractMtgCommand(dispatcher) {
 
-    override val name: String = "card"
+    override val name: String = MtgCommandRef.CARD
     override val description: String = "Look up a Magic card — its details, official rulings, or combos."
 
     override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
@@ -92,9 +93,9 @@ class CardCommand @Autowired constructor(
     )
 
     companion object {
-        const val SUB_LOOKUP = "lookup"
-        const val SUB_RULINGS = "rulings"
-        const val SUB_COMBOS = "combos"
+        const val SUB_LOOKUP = MtgCommandRef.Card.LOOKUP
+        const val SUB_RULINGS = MtgCommandRef.Card.RULINGS
+        const val SUB_COMBOS = MtgCommandRef.Card.COMBOS
 
         const val OPT_NAME = "name"
     }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeCommand.kt
@@ -5,6 +5,7 @@ import bot.toby.helpers.intOption
 import bot.toby.helpers.stringOption
 import common.mtg.AsFan
 import common.mtg.CubeAnalytics
+import common.mtg.MtgCommandRef
 import common.mtg.MtgCurrency
 import common.mtg.PackGenerator
 import core.command.CommandContext
@@ -40,7 +41,7 @@ class CubeCommand @Autowired constructor(
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : AbstractMtgCommand(dispatcher) {
 
-    override val name: String = "cube"
+    override val name: String = MtgCommandRef.CUBE
     override val description: String = "Magic: The Gathering cube tools — as-fan maths and randomised draft packs."
 
     override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
@@ -178,10 +179,10 @@ class CubeCommand @Autowired constructor(
     )
 
     companion object {
-        const val SUB_ASFAN = "asfan"
-        const val SUB_PREVIEW = "preview"
-        const val SUB_GENERATE = "generate"
-        const val SUB_SAVED = "saved"
+        const val SUB_ASFAN = MtgCommandRef.Cube.ASFAN
+        const val SUB_PREVIEW = MtgCommandRef.Cube.PREVIEW
+        const val SUB_GENERATE = MtgCommandRef.Cube.GENERATE
+        const val SUB_SAVED = MtgCommandRef.Cube.SAVED
 
         const val OPT_TOTAL = "total"
         const val OPT_CUBE_SIZE = "cube-size"

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
@@ -4,6 +4,7 @@ import common.discord.embed
 import common.discord.field
 import common.mtg.CardCombos
 import common.mtg.CardRulings
+import common.mtg.MtgCommandRef
 import common.mtg.MtgGlossary
 import common.mtg.MtgSet
 import database.dto.user.CardPriceWatchDto
@@ -340,7 +341,7 @@ internal object CubeEmbeds {
         val now = currentPrice?.let { " (now ${money(it, currency)})" }.orEmpty()
         setDescription(
             "I'll DM you when **${card.name}** is **$dir ${money(watch.threshold, currency)}**$now.\n" +
-                "Watch **#${watch.id}** · one-shot · remove with `/pricewatch remove id:${watch.id}`."
+                "Watch **#${watch.id}** · one-shot · remove with `${MtgCommandRef.PRICEWATCH_REMOVE} id:${watch.id}`."
         )
         setFooter("Manage card-price-watch DMs in /preferences notifications.")
     }
@@ -350,7 +351,7 @@ internal object CubeEmbeds {
         setAuthor(AUTHOR)
         setTitle("Your card price watches")
         if (watches.isEmpty()) {
-            setDescription("You're not watching any cards. Add one with `/pricewatch add`.")
+            setDescription("You're not watching any cards. Add one with `${MtgCommandRef.PRICEWATCH_ADD}`.")
             return@embed
         }
         setDescription(
@@ -359,7 +360,7 @@ internal object CubeEmbeds {
                 "• **#${w.id}** ${w.cardName} — ${w.directionEnum.name.lowercase()} ${money(w.threshold, cur)}"
             }
         )
-        setFooter("Remove one with /pricewatch remove id:<id>")
+        setFooter("Remove one with ${MtgCommandRef.PRICEWATCH_REMOVE} id:<id>")
     }
 
     /** Confirmation that a watch was removed. */
@@ -378,7 +379,7 @@ internal object CubeEmbeds {
         setAuthor(AUTHOR)
         setTitle(term.keyword)
         setDescription(term.text)
-        setFooter("Reminder text · use /card rulings for card-specific official rulings")
+        setFooter("Reminder text · use ${MtgCommandRef.CARD_RULINGS} for card-specific official rulings")
     }
 
     /** One combo as a `Cards: … → Produces: …` block with a Spellbook link, within the field cap. */

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
@@ -193,7 +193,7 @@ internal object CubeEmbeds {
         setDescription(message)
     }
 
-    /** A single-card panel for `/cube card`: image plus its key facts. */
+    /** A single-card panel for `/card lookup`: image plus its key facts. */
     fun cardEmbed(card: CubeCard): MessageEmbed = embed(color = OK_COLOR) {
         setAuthor(AUTHOR)
         setTitle(card.name)
@@ -275,7 +275,7 @@ internal object CubeEmbeds {
     }.takeIf { it.isNotEmpty() }?.joinToString(" · ")
 
     /**
-     * The official rulings panel for `/cube rulings`: each ruling as a
+     * The official rulings panel for `/card rulings`: each ruling as a
      * `> date — comment` block, oldest first, trimmed to stay within an embed
      * description. Shows a friendly empty state when the card has no rulings.
      */
@@ -292,7 +292,7 @@ internal object CubeEmbeds {
     }
 
     /**
-     * The combos panel for `/cube combos`: one field per combo listing the
+     * The combos panel for `/card combos`: one field per combo listing the
      * pieces it needs and what it produces, linked to Commander Spellbook.
      * Shows a friendly empty state when the card is in no known combos.
      */
@@ -310,7 +310,7 @@ internal object CubeEmbeds {
         setFooter("Source: Commander Spellbook")
     }
 
-    /** A set's headline facts for `/cube set`: type, release date, card count, with the set icon. */
+    /** A set's headline facts for `/mtg set`: type, release date, card count, with the set icon. */
     fun setEmbed(set: MtgSet): MessageEmbed = embed(color = OK_COLOR) {
         setAuthor(AUTHOR)
         setTitle("${set.name} (${set.code})")
@@ -340,7 +340,7 @@ internal object CubeEmbeds {
         val now = currentPrice?.let { " (now ${money(it, currency)})" }.orEmpty()
         setDescription(
             "I'll DM you when **${card.name}** is **$dir ${money(watch.threshold, currency)}**$now.\n" +
-                "Watch **#${watch.id}** · one-shot · remove with `/cube watch-remove id:${watch.id}`."
+                "Watch **#${watch.id}** · one-shot · remove with `/pricewatch remove id:${watch.id}`."
         )
         setFooter("Manage card-price-watch DMs in /preferences notifications.")
     }
@@ -350,7 +350,7 @@ internal object CubeEmbeds {
         setAuthor(AUTHOR)
         setTitle("Your card price watches")
         if (watches.isEmpty()) {
-            setDescription("You're not watching any cards. Add one with `/cube watch-add`.")
+            setDescription("You're not watching any cards. Add one with `/pricewatch add`.")
             return@embed
         }
         setDescription(
@@ -359,7 +359,7 @@ internal object CubeEmbeds {
                 "• **#${w.id}** ${w.cardName} — ${w.directionEnum.name.lowercase()} ${money(w.threshold, cur)}"
             }
         )
-        setFooter("Remove one with /cube watch-remove id:<id>")
+        setFooter("Remove one with /pricewatch remove id:<id>")
     }
 
     /** Confirmation that a watch was removed. */
@@ -373,12 +373,12 @@ internal object CubeEmbeds {
     private fun money(amount: Double, currency: MtgCurrency): String =
         "${currency.symbol}${format(amount)}${currency.suffix}"
 
-    /** A keyword's reminder text for `/cube rule`. */
+    /** A keyword's reminder text for `/mtg rule`. */
     fun ruleEmbed(term: MtgGlossary.Term): MessageEmbed = embed(color = OK_COLOR) {
         setAuthor(AUTHOR)
         setTitle(term.keyword)
         setDescription(term.text)
-        setFooter("Reminder text · use /cube rulings for card-specific official rulings")
+        setFooter("Reminder text · use /card rulings for card-specific official rulings")
     }
 
     /** One combo as a `Cards: … → Produces: …` block with a Spellbook link, within the field cap. */

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/DeckCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/DeckCommand.kt
@@ -2,6 +2,7 @@ package bot.toby.command.commands.mtg
 
 import bot.toby.helpers.stringOption
 import common.mtg.CubeCard
+import common.mtg.MtgCommandRef
 import common.mtg.DeckLegality
 import core.command.CommandContext
 import database.dto.user.UserDto
@@ -24,7 +25,7 @@ class DeckCommand @Autowired constructor(
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : AbstractMtgCommand(dispatcher) {
 
-    override val name: String = "deck"
+    override val name: String = MtgCommandRef.DECK
     override val description: String = "Analyse a Magic deck — check its legality in a format."
 
     override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
@@ -65,7 +66,7 @@ class DeckCommand @Autowired constructor(
     )
 
     companion object {
-        const val SUB_LEGALITY = "legality"
+        const val SUB_LEGALITY = MtgCommandRef.Deck.LEGALITY
 
         const val OPT_FORMAT = "format"
         const val OPT_SAVED = "saved"

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/MtgReferenceCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/MtgReferenceCommand.kt
@@ -1,6 +1,7 @@
 package bot.toby.command.commands.mtg
 
 import bot.toby.helpers.stringOption
+import common.mtg.MtgCommandRef
 import common.mtg.MtgGlossary
 import core.command.CommandContext
 import database.dto.user.UserDto
@@ -22,7 +23,7 @@ class MtgReferenceCommand @Autowired constructor(
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : AbstractMtgCommand(dispatcher) {
 
-    override val name: String = "mtg"
+    override val name: String = MtgCommandRef.MTG
     override val description: String = "Magic quick reference — set info and keyword reminder text."
 
     override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
@@ -68,8 +69,8 @@ class MtgReferenceCommand @Autowired constructor(
     )
 
     companion object {
-        const val SUB_SET = "set"
-        const val SUB_RULE = "rule"
+        const val SUB_SET = MtgCommandRef.Reference.SET
+        const val SUB_RULE = MtgCommandRef.Reference.RULE
 
         const val OPT_CODE = "code"
         const val OPT_TERM = "term"

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/PriceWatchCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/PriceWatchCommand.kt
@@ -1,6 +1,7 @@
 package bot.toby.command.commands.mtg
 
 import bot.toby.helpers.stringOption
+import common.mtg.MtgCommandRef
 import common.mtg.MtgCurrency
 import core.command.CommandContext
 import database.dto.user.CardPriceWatchDto
@@ -27,7 +28,7 @@ class PriceWatchCommand @Autowired constructor(
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : AbstractMtgCommand(dispatcher) {
 
-    override val name: String = "pricewatch"
+    override val name: String = MtgCommandRef.PRICEWATCH
     override val description: String = "Get DM'd when a Magic card's price crosses your target."
 
     override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
@@ -71,7 +72,7 @@ class PriceWatchCommand @Autowired constructor(
             priceAtCreation = currentPrice,
         )
         if (created == null) {
-            reply(ctx, CubeEmbeds.errorEmbed("You've hit the watch limit (${priceWatchService.maxPerUser}). Remove one with `/pricewatch remove` first."), deleteDelay)
+            reply(ctx, CubeEmbeds.errorEmbed("You've hit the watch limit (${priceWatchService.maxPerUser}). Remove one with `${MtgCommandRef.PRICEWATCH_REMOVE}` first."), deleteDelay)
         } else {
             reply(ctx, CubeEmbeds.watchAddedEmbed(created, card, currency, currentPrice), deleteDelay)
         }
@@ -87,7 +88,7 @@ class PriceWatchCommand @Autowired constructor(
     private fun handleRemove(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
         val id = ctx.event.getOption(OPT_WATCH_ID)?.asLong
         if (id == null) {
-            reply(ctx, CubeEmbeds.errorEmbed("Give me the watch `id` to remove (see `/pricewatch list`)."), deleteDelay); return
+            reply(ctx, CubeEmbeds.errorEmbed("Give me the watch `id` to remove (see `${MtgCommandRef.PRICEWATCH_LIST}`)."), deleteDelay); return
         }
         val removed = priceWatchService.remove(id, requestingUserDto.discordId)
         reply(
@@ -115,9 +116,9 @@ class PriceWatchCommand @Autowired constructor(
     )
 
     companion object {
-        const val SUB_ADD = "add"
-        const val SUB_LIST = "list"
-        const val SUB_REMOVE = "remove"
+        const val SUB_ADD = MtgCommandRef.PriceWatch.ADD
+        const val SUB_LIST = MtgCommandRef.PriceWatch.LIST
+        const val SUB_REMOVE = MtgCommandRef.PriceWatch.REMOVE
 
         const val OPT_NAME = "name"
         const val OPT_DIRECTION = "direction"

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcher.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcher.kt
@@ -442,7 +442,7 @@ class ScryfallCubeFetcher @Autowired constructor(
         private const val SETS_ENDPOINT = "https://api.scryfall.com/sets"
         private const val SPELLBOOK_ENDPOINT = "https://backend.commanderspellbook.com/variants/"
 
-        /** Cap on how many combos a single `/cube combos` lookup returns. */
+        /** Cap on how many combos a single `/card combos` lookup returns. */
         const val MAX_COMBOS = 5
         const val DEFAULT_MAX_CARDS = 750
         private const val MAX_PAGES = 10

--- a/discord-bot/src/main/kotlin/bot/toby/notify/CardPriceAlertBuilder.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/notify/CardPriceAlertBuilder.kt
@@ -11,7 +11,7 @@ import java.awt.Color
 /**
  * Renders the DM sent when a [CardPriceWatchDto] fires — a card-price-watch
  * alert. The watch is one-shot, so this is a "your target was hit" notice;
- * the footer nudges the user to re-arm with `/cube watch-add`.
+ * the footer nudges the user to re-arm with `/pricewatch add`.
  */
 object CardPriceAlertBuilder {
 
@@ -40,7 +40,7 @@ object CardPriceAlertBuilder {
             embed.addField("When you set this", money(it, currency), true)
         }
         embed.addField("Now", money(currentPrice, currency), true)
-        embed.setFooter("One-shot alert — use /cube watch-add to set another.")
+        embed.setFooter("One-shot alert — use /pricewatch add to set another.")
         return MessageCreateBuilder().setEmbeds(embed.build()).build()
     }
 

--- a/discord-bot/src/main/kotlin/bot/toby/notify/CardPriceAlertBuilder.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/notify/CardPriceAlertBuilder.kt
@@ -1,6 +1,7 @@
 package bot.toby.notify
 
 import common.mtg.CubeCard
+import common.mtg.MtgCommandRef
 import common.mtg.MtgCurrency
 import database.dto.user.CardPriceWatchDto
 import net.dv8tion.jda.api.EmbedBuilder
@@ -40,7 +41,7 @@ object CardPriceAlertBuilder {
             embed.addField("When you set this", money(it, currency), true)
         }
         embed.addField("Now", money(currentPrice, currency), true)
-        embed.setFooter("One-shot alert — use /pricewatch add to set another.")
+        embed.setFooter("One-shot alert — use ${MtgCommandRef.PRICEWATCH_ADD} to set another.")
         return MessageCreateBuilder().setEmbeds(embed.build()).build()
     }
 

--- a/web/src/main/kotlin/web/controller/CubeController.kt
+++ b/web/src/main/kotlin/web/controller/CubeController.kt
@@ -1,5 +1,6 @@
 package web.controller
 
+import common.mtg.MtgCommandRef
 import common.mtg.MtgCurrency
 import database.dto.user.CardPriceWatchDto
 import database.service.user.CardPriceWatchService
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
@@ -59,6 +61,21 @@ class CubeController(
     private val sharedCubes: SharedCubeService,
     private val priceWatches: CardPriceWatchService,
 ) {
+
+    /**
+     * The Magic command names for the page copy, sourced from [MtgCommandRef]
+     * so the prose (e.g. "the website twin of `/card lookup`") can never drift
+     * from the actual Discord commands. Available to this controller's views as
+     * `${mtgCmd.cardLookup}` etc.
+     */
+    @ModelAttribute("mtgCmd")
+    fun mtgCommands(): Map<String, String> = mapOf(
+        "cardLookup" to MtgCommandRef.CARD_LOOKUP,
+        "deckLegality" to MtgCommandRef.DECK_LEGALITY,
+        "mtgSet" to MtgCommandRef.MTG_SET,
+        "mtgRule" to MtgCommandRef.MTG_RULE,
+        "pricewatchAdd" to MtgCommandRef.PRICEWATCH_ADD,
+    )
 
     @GetMapping
     fun page(

--- a/web/src/main/kotlin/web/service/CubeWebService.kt
+++ b/web/src/main/kotlin/web/service/CubeWebService.kt
@@ -51,7 +51,7 @@ class CubeWebService {
 
     /**
      * Looks a single card up by (fuzzy) name via Scryfall's `/cards/named`,
-     * for the web card-lookup tool — the website twin of `/cube card`.
+     * for the web card-lookup tool — the website twin of `/card lookup`.
      */
     fun card(name: String): CubeResult<CardLookupView> {
         val trimmed = name.trim()
@@ -84,7 +84,7 @@ class CubeWebService {
 
     /**
      * Looks a card up by (fuzzy) name and fetches its official rulings — the
-     * website twin of `/cube rulings`. Two calls: `/cards/named` to resolve the
+     * website twin of `/card rulings`. Two calls: `/cards/named` to resolve the
      * card (and its `rulings_uri`), then a GET of that uri. A resolved card
      * with no rulings is a success with an empty list, not an error.
      */
@@ -139,7 +139,7 @@ class CubeWebService {
 
     /**
      * Finds the combos a card appears in via the Commander Spellbook variants
-     * API — the website twin of `/cube combos`. A reachable card with no combos
+     * API — the website twin of `/card combos`. A reachable card with no combos
      * is a success with an empty list, not an error.
      */
     fun combos(name: String): CubeResult<CombosView> {
@@ -161,7 +161,7 @@ class CubeWebService {
         }
     }
 
-    /** Looks up a Magic set by code via Scryfall's `/sets/:code` — the web twin of `/cube set`. */
+    /** Looks up a Magic set by code via Scryfall's `/sets/:code` — the web twin of `/mtg set`. */
     fun set(code: String): CubeResult<SetView> {
         val trimmed = code.trim().lowercase()
         if (trimmed.isEmpty()) return CubeResult.error("Enter a set code (e.g. vow).")
@@ -196,7 +196,7 @@ class CubeWebService {
         }
     }
 
-    /** Looks a keyword up in the built-in glossary (pure, no network) — the web twin of `/cube rule`. */
+    /** Looks a keyword up in the built-in glossary (pure, no network) — the web twin of `/mtg rule`. */
     fun rule(term: String): CubeResult<RuleView> {
         if (term.trim().isEmpty()) return CubeResult.error("Enter a keyword (e.g. trample).")
         return MtgGlossary.lookup(term)

--- a/web/src/main/resources/templates/magic.html
+++ b/web/src/main/resources/templates/magic.html
@@ -342,7 +342,7 @@
                  data-panel="card" hidden>
             <p class="cube-panel-intro">
                 Look up any Magic card by name and see its image and details — the website twin of
-                the <code>/cube card</code> Discord command.
+                the <code>/card lookup</code> Discord command.
             </p>
             <form class="cube-form" data-form="card" autocomplete="off">
                 <label>Card name
@@ -359,7 +359,7 @@
                  data-panel="legality" hidden>
             <p class="cube-panel-intro">
                 Paste a decklist and pick a format to see whether it's legal — every banned or
-                not-in-format card is flagged. The website twin of <code>/cube legality</code>.
+                not-in-format card is flagged. The website twin of <code>/deck legality</code>.
             </p>
             <form class="cube-form" data-form="legality" autocomplete="off">
                 <label>Decklist
@@ -388,7 +388,7 @@
                  data-panel="reference" hidden>
             <p class="cube-panel-intro">
                 Quick reference — look up a Magic set by its code, or a keyword's reminder text.
-                The website twin of <code>/cube set</code> and <code>/cube rule</code>.
+                The website twin of <code>/mtg set</code> and <code>/mtg rule</code>.
             </p>
             <form class="cube-form" data-form="set" autocomplete="off">
                 <label>Set code
@@ -414,7 +414,7 @@
                  data-panel="watch" hidden>
             <p class="cube-panel-intro">
                 Get DM'd on Discord when a card's market price crosses your target — the website twin
-                of <code>/cube watch-add</code>. Prices are checked periodically; alerts are one-shot.
+                of <code>/pricewatch add</code>. Prices are checked periodically; alerts are one-shot.
             </p>
             <div th:if="${loggedIn}" data-watch-block>
                 <form class="cube-form cube-watch-form" data-form="watch" autocomplete="off">

--- a/web/src/main/resources/templates/magic.html
+++ b/web/src/main/resources/templates/magic.html
@@ -342,7 +342,7 @@
                  data-panel="card" hidden>
             <p class="cube-panel-intro">
                 Look up any Magic card by name and see its image and details — the website twin of
-                the <code>/card lookup</code> Discord command.
+                the <code th:text="${mtgCmd.cardLookup}">/card lookup</code> Discord command.
             </p>
             <form class="cube-form" data-form="card" autocomplete="off">
                 <label>Card name
@@ -359,7 +359,7 @@
                  data-panel="legality" hidden>
             <p class="cube-panel-intro">
                 Paste a decklist and pick a format to see whether it's legal — every banned or
-                not-in-format card is flagged. The website twin of <code>/deck legality</code>.
+                not-in-format card is flagged. The website twin of <code th:text="${mtgCmd.deckLegality}">/deck legality</code>.
             </p>
             <form class="cube-form" data-form="legality" autocomplete="off">
                 <label>Decklist
@@ -388,7 +388,7 @@
                  data-panel="reference" hidden>
             <p class="cube-panel-intro">
                 Quick reference — look up a Magic set by its code, or a keyword's reminder text.
-                The website twin of <code>/mtg set</code> and <code>/mtg rule</code>.
+                The website twin of <code th:text="${mtgCmd.mtgSet}">/mtg set</code> and <code th:text="${mtgCmd.mtgRule}">/mtg rule</code>.
             </p>
             <form class="cube-form" data-form="set" autocomplete="off">
                 <label>Set code
@@ -414,7 +414,7 @@
                  data-panel="watch" hidden>
             <p class="cube-panel-intro">
                 Get DM'd on Discord when a card's market price crosses your target — the website twin
-                of <code>/pricewatch add</code>. Prices are checked periodically; alerts are one-shot.
+                of <code th:text="${mtgCmd.pricewatchAdd}">/pricewatch add</code>. Prices are checked periodically; alerts are one-shot.
             </p>
             <div th:if="${loggedIn}" data-watch-block>
                 <form class="cube-form cube-watch-form" data-form="watch" autocomplete="off">

--- a/web/src/test/kotlin/web/template/MagicTemplateRenderTest.kt
+++ b/web/src/test/kotlin/web/template/MagicTemplateRenderTest.kt
@@ -1,5 +1,6 @@
 package web.template
 
+import common.mtg.MtgCommandRef
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.springframework.context.support.GenericApplicationContext
@@ -42,11 +43,24 @@ class MagicTemplateRenderTest {
         setTemplateResolver(resolver)
     }
 
+    // Mirrors CubeController.mtgCommands() — the page reads command names from
+    // this model attribute (sourced from MtgCommandRef) rather than hardcoding.
+    private val mtgCmd = mapOf(
+        "cardLookup" to MtgCommandRef.CARD_LOOKUP,
+        "deckLegality" to MtgCommandRef.DECK_LEGALITY,
+        "mtgSet" to MtgCommandRef.MTG_SET,
+        "mtgRule" to MtgCommandRef.MTG_RULE,
+        "pricewatchAdd" to MtgCommandRef.PRICEWATCH_ADD,
+    )
+
     private fun render(vars: Map<String, Any?>): String {
         val request = MockHttpServletRequest(servletContext)
         val response = MockHttpServletResponse()
         val exchange = webApp.buildExchange(request, response)
-        val ctx = WebContext(exchange).apply { vars.forEach { (k, v) -> setVariable(k, v) } }
+        val ctx = WebContext(exchange).apply {
+            setVariable("mtgCmd", mtgCmd)
+            vars.forEach { (k, v) -> setVariable(k, v) }
+        }
         return engine.process("magic", ctx)
     }
 
@@ -72,6 +86,19 @@ class MagicTemplateRenderTest {
         }
         // The logged-in price-watch form is present.
         assertTrue(html.contains("data-form=\"watch\"")) { "expected the price-watch form for a logged-in user" }
+    }
+
+    @Test
+    fun `command names render from the MtgCommandRef model attribute`() {
+        val html = render(mapOf("loggedIn" to true, "username" to "tester"))
+
+        // The page copy pulls the command names from the model (single source of
+        // truth), so a command rename can't leave the prose stale.
+        assertTrue(html.contains(MtgCommandRef.CARD_LOOKUP)) { "expected '${MtgCommandRef.CARD_LOOKUP}' in the card tab copy" }
+        assertTrue(html.contains(MtgCommandRef.DECK_LEGALITY)) { "expected '${MtgCommandRef.DECK_LEGALITY}' in the legality tab copy" }
+        assertTrue(html.contains(MtgCommandRef.MTG_SET)) { "expected '${MtgCommandRef.MTG_SET}' in the reference tab copy" }
+        assertTrue(html.contains(MtgCommandRef.MTG_RULE)) { "expected '${MtgCommandRef.MTG_RULE}' in the reference tab copy" }
+        assertTrue(html.contains(MtgCommandRef.PRICEWATCH_ADD)) { "expected '${MtgCommandRef.PRICEWATCH_ADD}' in the price-watch tab copy" }
     }
 
     @Test


### PR DESCRIPTION
## What

After #656 split the `/cube` super-command into focused top-level commands (`/card`, `/deck`, `/mtg`, `/pricewatch`), several places still named the **old** subcommands. This PR (1) corrects every stale mention and (2) adds a single source of truth so the copy can't drift from the commands again.

## 1. Fix the stale references

**User-facing copy (the bug you'd actually hit):**
- **Web — `magic.html`** tab intros: `/cube card` → `/card lookup`, `/cube legality` → `/deck legality`, `/cube set`/`/cube rule` → `/mtg set`/`/mtg rule`, `/cube watch-add` → `/pricewatch add`.
- **Discord embeds:** price-watch confirm/list embeds + `CardPriceAlertBuilder` DM footer (`/cube watch-add`/`-remove` → `/pricewatch add`/`remove`), `ruleEmbed` footer (`/cube rulings` → `/card rulings`), and the `CARD_PRICE_ALERT` notification-pref description.

**Docs/KDoc:** `CubeEmbeds`, `CubeWebService`, `ScryfallCubeFetcher`, and the `common` value types now name the right commands.

| Old | New |
|---|---|
| `/cube card` | `/card lookup` |
| `/cube rulings` | `/card rulings` |
| `/cube combos` | `/card combos` |
| `/cube legality` | `/deck legality` |
| `/cube set` | `/mtg set` |
| `/cube rule` | `/mtg rule` |
| `/cube watch-add\|list\|remove` | `/pricewatch add\|list\|remove` |

## 2. Single source of truth — `common/mtg/MtgCommandRef`

New object holding the command/subcommand names once:
- **Bare tokens** (`CARD = "card"`, `Card.LOOKUP = "lookup"`, …) drive Discord registration. Each command's `name`/`SUB_*` constants now alias `MtgCommandRef` (kept as aliases so existing tests compile unchanged, but the literal lives in one place).
- **Pre-formatted display strings** (`CARD_LOOKUP = "/card lookup"`, …) drive all user-facing copy: the embeds, the `PriceWatch` error messages, the notification-pref description, and the web page.
- **Web:** `CubeController` exposes the names as an `mtgCmd` model attribute (`@ModelAttribute`), and `magic.html`'s `<code>` mentions render from it via `th:text` (literal kept as fallback text).

A rename now happens in exactly one file.

## Testing
- `MtgCommandRefTest` (new) pins the composed strings.
- `MagicTemplateRenderTest` feeds the `mtgCmd` attribute and asserts the command names render from it — so a future rename provably flows to the page.
- Pure copy/wiring change, no behaviour change. jest (738) + `:common:test` + `:discord-bot:test` + `:web:test` + `koverVerify` green.

> Note: KDoc prose can't reference constants, so those mentions stay manually maintained (covered by review, not the SSOT).

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs