### PR TITLE
Prefix the Magic commands with "mtg" so they're obviously MTG in Discord

### DIFF
--- a/common/src/main/kotlin/common/mtg/CardCombos.kt
+++ b/common/src/main/kotlin/common/mtg/CardCombos.kt
@@ -3,7 +3,7 @@ package common.mtg
 /**
  * The combos a card takes part in, from the Commander Spellbook database — the
  * pieces ("uses"), the payoff ("produces"), and a link to the full write-up.
- * A pure value type shared by the bot's `/card combos` command and the web
+ * A pure value type shared by the bot's `/mtgcard combos` command and the web
  * card-lookup tool, both of which fetch from Commander Spellbook (over their
  * own HTTP clients) and map the JSON into this. Presentation-only.
  *

--- a/common/src/main/kotlin/common/mtg/CardRulings.kt
+++ b/common/src/main/kotlin/common/mtg/CardRulings.kt
@@ -3,7 +3,7 @@ package common.mtg
 /**
  * A card's official rulings (Scryfall `/cards/:id/rulings`) — the clarifying
  * notes the rules team publishes for tricky interactions. A pure value type
- * shared by the bot's `/card rulings` command and the web card-lookup tool,
+ * shared by the bot's `/mtgcard rulings` command and the web card-lookup tool,
  * both of which fetch from Scryfall (over their own HTTP clients) and map the
  * JSON into this. Presentation-only — no maths depend on it.
  *

--- a/common/src/main/kotlin/common/mtg/MtgCommandRef.kt
+++ b/common/src/main/kotlin/common/mtg/MtgCommandRef.kt
@@ -11,18 +11,21 @@ package common.mtg
  * subcommands but the prose still said `/cube card`, `/cube watch-add`, …).
  *
  * The bare tokens (e.g. [Card.LOOKUP] = `"lookup"`) drive registration; the
- * pre-formatted [CARD_LOOKUP] = `"/card lookup"` strings are for copy. All are
+ * pre-formatted [CARD_LOOKUP] = `"/mtgcard lookup"` strings are for copy. All are
  * `const`, so they inline and can be referenced from enum constructors and
  * other `const val`s.
  */
 object MtgCommandRef {
 
-    // Top-level command names.
-    const val CUBE = "cube"
-    const val CARD = "card"
-    const val DECK = "deck"
+    // Top-level command names. All carry the `mtg` prefix so the Magic suite is
+    // obviously Magic in Discord's (alphabetical) command picker, groups under
+    // typing "/mtg", and doesn't clash with generically-named commands (e.g. the
+    // economy `/pricealert`). `/mtg` itself is the quick-reference command.
+    const val CUBE = "mtgcube"
+    const val CARD = "mtgcard"
+    const val DECK = "mtgdeck"
     const val MTG = "mtg"
-    const val PRICEWATCH = "pricewatch"
+    const val PRICEWATCH = "mtgprice"
 
     // Subcommand tokens, grouped by their parent command.
     object Cube {
@@ -54,6 +57,8 @@ object MtgCommandRef {
     }
 
     // Pre-formatted "/command subcommand" strings for user-facing copy.
+    const val CUBE_PREVIEW = "/$CUBE ${Cube.PREVIEW}"
+    const val CUBE_GENERATE = "/$CUBE ${Cube.GENERATE}"
     const val CARD_LOOKUP = "/$CARD ${Card.LOOKUP}"
     const val CARD_RULINGS = "/$CARD ${Card.RULINGS}"
     const val CARD_COMBOS = "/$CARD ${Card.COMBOS}"

--- a/common/src/main/kotlin/common/mtg/MtgGlossary.kt
+++ b/common/src/main/kotlin/common/mtg/MtgGlossary.kt
@@ -8,7 +8,7 @@ package common.mtg
  * broadens the bot's appeal beyond cube builders.
  *
  * Reminder text is paraphrased from the comprehensive rules / Oracle reminder
- * text; it's a quick refresher, not a rules ruling (use `/card rulings` for
+ * text; it's a quick refresher, not a rules ruling (use `/mtgcard rulings` for
  * card-specific official rulings).
  */
 object MtgGlossary {

--- a/common/src/test/kotlin/common/mtg/MtgCommandRefTest.kt
+++ b/common/src/test/kotlin/common/mtg/MtgCommandRefTest.kt
@@ -25,10 +25,10 @@ class MtgCommandRefTest {
 
     @Test
     fun `the expected current command and subcommand names`() {
-        assertEquals("/card lookup", MtgCommandRef.CARD_LOOKUP)
-        assertEquals("/deck legality", MtgCommandRef.DECK_LEGALITY)
+        assertEquals("/mtgcard lookup", MtgCommandRef.CARD_LOOKUP)
+        assertEquals("/mtgdeck legality", MtgCommandRef.DECK_LEGALITY)
         assertEquals("/mtg set", MtgCommandRef.MTG_SET)
-        assertEquals("/pricewatch add", MtgCommandRef.PRICEWATCH_ADD)
-        assertEquals("pricewatch", MtgCommandRef.PRICEWATCH)
+        assertEquals("/mtgprice add", MtgCommandRef.PRICEWATCH_ADD)
+        assertEquals("mtgprice", MtgCommandRef.PRICEWATCH)
     }
 }

--- a/database/src/main/kotlin/database/dto/guild/ConfigDto.kt
+++ b/database/src/main/kotlin/database/dto/guild/ConfigDto.kt
@@ -36,7 +36,7 @@ class ConfigDto(
         // Inline [[card]] Magic lookups. Opt-out: enabled unless explicitly
         // set to "false" for the guild.
         CARD_MENTIONS("CARD_MENTIONS"),
-        // Currency the /cube preview's "cube value" total is reported in.
+        // Currency the /mtgcube preview's "cube value" total is reported in.
         // One of "usd", "eur" or "tix" (see common.mtg.MtgCurrency). Defaults
         // to USD when unset or unrecognised.
         CUBE_CURRENCY("CUBE_CURRENCY"),

--- a/database/src/main/kotlin/database/dto/user/CubeListDto.kt
+++ b/database/src/main/kotlin/database/dto/user/CubeListDto.kt
@@ -11,7 +11,7 @@ import java.io.Serializable
 import java.time.Instant
 
 /**
- * A cube card list a user saved on the `/cube` web tool, keyed by
+ * A cube card list a user saved on the Magic toolkit web tool (`/magic`), keyed by
  * (discord_id, name) so a name is unique per account and re-saving the same
  * name upserts. `cards` is the raw pasted text (one card per line); the web
  * layer re-parses it on load so the format can evolve without a migration.

--- a/database/src/main/kotlin/database/dto/user/SharedCubeDto.kt
+++ b/database/src/main/kotlin/database/dto/user/SharedCubeDto.kt
@@ -12,7 +12,7 @@ import java.time.Instant
 
 /**
  * An immutable, publicly-shareable snapshot of a cube card list, addressed
- * by a short random [token] (`/cube/c/<token>`). Created by a logged-in
+ * by a short random [token] (`/magic/c/<token>`). Created by a logged-in
  * user; readable by anyone with the link. `cards` is the raw list text so
  * the web layer re-parses it on open (same format as [CubeListDto]).
  */

--- a/discord-bot/src/main/kotlin/bot/toby/autocomplete/autocompletes/CubeAutoComplete.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/autocomplete/autocompletes/CubeAutoComplete.kt
@@ -1,6 +1,7 @@
 package bot.toby.autocomplete.autocompletes
 
 import bot.toby.command.commands.mtg.CubeCommand
+import common.mtg.MtgCommandRef
 import core.autocomplete.AutocompleteHandler
 import database.service.user.CubeListService
 import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent
@@ -10,7 +11,7 @@ import org.springframework.stereotype.Component
 
 /**
  * Suggests the requesting user's own saved cube names as they type the
- * `saved` option of `/cube preview` / `/cube generate`. Saved cubes are
+ * `saved` option of `/mtgcube preview` / `/mtgcube generate`. Saved cubes are
  * keyed per Discord account, so the lookup uses the autocomplete event's
  * own user id — a user only ever sees their own cubes.
  */
@@ -19,7 +20,7 @@ class CubeAutoComplete @Autowired constructor(
     private val cubeListService: CubeListService,
 ) : AutocompleteHandler {
 
-    override val name = "cube"
+    override val name = MtgCommandRef.CUBE
 
     override fun handle(event: CommandAutoCompleteInteractionEvent) {
         if (event.focusedOption.name != CubeCommand.OPT_SAVED) return

--- a/discord-bot/src/main/kotlin/bot/toby/autocomplete/autocompletes/DeckAutoComplete.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/autocomplete/autocompletes/DeckAutoComplete.kt
@@ -1,6 +1,7 @@
 package bot.toby.autocomplete.autocompletes
 
 import bot.toby.command.commands.mtg.DeckCommand
+import common.mtg.MtgCommandRef
 import core.autocomplete.AutocompleteHandler
 import database.service.user.CubeListService
 import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent
@@ -10,8 +11,8 @@ import org.springframework.stereotype.Component
 
 /**
  * Suggests the requesting user's own saved cube/deck names as they type the
- * `saved` option of `/deck legality` — the counterpart to [CubeAutoComplete],
- * keyed to the `deck` command. Saved cubes are per Discord account, so a user
+ * `saved` option of `/mtgdeck legality` — the counterpart to [CubeAutoComplete],
+ * keyed to the `mtgdeck` command. Saved cubes are per Discord account, so a user
  * only ever sees their own.
  */
 @Component
@@ -19,7 +20,7 @@ class DeckAutoComplete @Autowired constructor(
     private val cubeListService: CubeListService,
 ) : AutocompleteHandler {
 
-    override val name = "deck"
+    override val name = MtgCommandRef.DECK
 
     override fun handle(event: CommandAutoCompleteInteractionEvent) {
         if (event.focusedOption.name != DeckCommand.OPT_SAVED) return

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/fetch/MemeCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/fetch/MemeCommand.kt
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component
 @Component
 class MemeCommand @Autowired constructor(
     private val fetcher: RedditMemeFetcher,
-    // Mirrors /dnd and /cube: the Reddit fetch runs on this dispatcher
+    // Mirrors /dnd and /mtgcube: the Reddit fetch runs on this dispatcher
     // (tests pass Dispatchers.Unconfined so the launched work resolves
     // synchronously).
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/fetch/RedditMemeFetcher.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/fetch/RedditMemeFetcher.kt
@@ -21,7 +21,7 @@ import kotlin.random.Random
 /**
  * Pulls a random SFW post off a subreddit's top listing for `/meme`.
  *
- * Uses the same coroutine + ktor stack as the `/dnd` and `/cube` lookups:
+ * Uses the same coroutine + ktor stack as the `/dnd` and `/mtgcube` lookups:
  * a `suspend` function that hops onto [Dispatchers.IO] via [withContext],
  * fed by the shared injectable ktor [HttpClient] with a per-request
  * timeout, so the blocking network work never ties up the CPU-bound

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CardCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CardCommand.kt
@@ -14,7 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 /**
- * `/card` — single-card lookups: image + facts (`lookup`), official rulings
+ * `/mtgcard` — single-card lookups: image + facts (`lookup`), official rulings
  * (`rulings`), and the combos a card appears in (`combos`, via Commander
  * Spellbook). Card-centric, not cube-specific.
  */

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeCommand.kt
@@ -24,7 +24,7 @@ import org.springframework.stereotype.Component
 import kotlin.random.Random
 
 /**
- * `/cube` — the cube-design tools: as-fan maths, pack preview/generation, and
+ * `/mtgcube` — the cube-design tools: as-fan maths, pack preview/generation, and
  * listing your saved cubes. Card lookups, deck legality, set/keyword reference
  * and price watches each live in their own command ([CardCommand],
  * [DeckCommand], [MtgReferenceCommand], [PriceWatchCommand]).

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
@@ -22,7 +22,7 @@ import java.awt.Color
 import java.nio.charset.StandardCharsets
 
 /**
- * Embed + attachment factories for `/cube`. Keeps the visual grammar of
+ * Embed + attachment factories for the Magic commands. Keeps the visual grammar of
  * the other polished utility commands (`MemeEmbeds`, `RollEmbeds`) so the
  * MTG tool feels like part of the set.
  */
@@ -163,8 +163,8 @@ internal object CubeEmbeds {
 
     /**
      * Lists the cubes a user has saved on the website, each with its card
-     * count, so they can see what's available to `/cube preview` or
-     * `/cube generate` without leaving Discord. Shows an empty-state nudge
+     * count, so they can see what's available to `/mtgcube preview` or
+     * `/mtgcube generate` without leaving Discord. Shows an empty-state nudge
      * when they have none saved yet.
      */
     fun savedCubesEmbed(saved: List<CubeListDto>): MessageEmbed = embed(color = OK_COLOR) {
@@ -173,8 +173,8 @@ internal object CubeEmbeds {
         if (saved.isEmpty()) {
             setDescription(
                 "You haven't saved any cubes yet. Build one on the website's " +
-                    "Cube workshop, hit **Save**, then use it here with " +
-                    "`/cube preview saved:` or `/cube generate saved:`."
+                    "Magic toolkit, hit **Save**, then use it here with " +
+                    "`${MtgCommandRef.CUBE_PREVIEW} saved:` or `${MtgCommandRef.CUBE_GENERATE} saved:`."
             )
             return@embed
         }
@@ -185,7 +185,7 @@ internal object CubeEmbeds {
         }
         val more = if (saved.size > shown.size) "\n…and ${saved.size - shown.size} more." else ""
         setDescription(lines + more)
-        setFooter("Use one with /cube preview saved: or /cube generate saved:")
+        setFooter("Use one with ${MtgCommandRef.CUBE_PREVIEW} saved: or ${MtgCommandRef.CUBE_GENERATE} saved:")
     }
 
     fun errorEmbed(message: String): MessageEmbed = embed(color = ERROR_COLOR) {
@@ -194,7 +194,7 @@ internal object CubeEmbeds {
         setDescription(message)
     }
 
-    /** A single-card panel for `/card lookup`: image plus its key facts. */
+    /** A single-card panel for `/mtgcard lookup`: image plus its key facts. */
     fun cardEmbed(card: CubeCard): MessageEmbed = embed(color = OK_COLOR) {
         setAuthor(AUTHOR)
         setTitle(card.name)
@@ -276,7 +276,7 @@ internal object CubeEmbeds {
     }.takeIf { it.isNotEmpty() }?.joinToString(" · ")
 
     /**
-     * The official rulings panel for `/card rulings`: each ruling as a
+     * The official rulings panel for `/mtgcard rulings`: each ruling as a
      * `> date — comment` block, oldest first, trimmed to stay within an embed
      * description. Shows a friendly empty state when the card has no rulings.
      */
@@ -293,7 +293,7 @@ internal object CubeEmbeds {
     }
 
     /**
-     * The combos panel for `/card combos`: one field per combo listing the
+     * The combos panel for `/mtgcard combos`: one field per combo listing the
      * pieces it needs and what it produces, linked to Commander Spellbook.
      * Shows a friendly empty state when the card is in no known combos.
      */

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/DeckCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/DeckCommand.kt
@@ -15,7 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 /**
- * `/deck` — deck-level analysis. Today: `legality`, which checks a saved cube
+ * `/mtgdeck` — deck-level analysis. Today: `legality`, which checks a saved cube
  * (or a Scryfall query) against a format and flags banned / not-in-format /
  * restricted cards.
  */

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/MtgPoolResolver.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/MtgPoolResolver.kt
@@ -11,8 +11,8 @@ import org.springframework.stereotype.Component
  * Resolves a draftable card pool from whichever source a user gave — a saved
  * cube (looked up for their Discord account, then resolved name-by-name via
  * Scryfall) which takes precedence over a Scryfall `query`. Shared by the
- * cube tools (`/cube preview` / `/cube generate`) and the deck checker
- * (`/deck legality`) so they resolve pools identically.
+ * cube tools (`/mtgcube preview` / `/mtgcube generate`) and the deck checker
+ * (`/mtgdeck legality`) so they resolve pools identically.
  */
 @Component
 class MtgPoolResolver @Autowired constructor(

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/PriceWatchCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/PriceWatchCommand.kt
@@ -16,7 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 /**
- * `/pricewatch` — get DM'd when a Magic card's market price crosses a target.
+ * `/mtgprice` — get DM'd when a Magic card's market price crosses a target.
  * `add` resolves the card and captures its current price; `list` and `remove`
  * manage your watches. The scheduled [bot.toby.scheduling.CardPriceWatchJob]
  * does the periodic checking and DMing.
@@ -112,7 +112,7 @@ class PriceWatchCommand @Autowired constructor(
             ),
         SubcommandData(SUB_LIST, "List your card price watches."),
         SubcommandData(SUB_REMOVE, "Remove one of your card price watches.")
-            .addOptions(OptionData(OptionType.INTEGER, OPT_WATCH_ID, "The watch id (from /pricewatch list).", true).setMinValue(1)),
+            .addOptions(OptionData(OptionType.INTEGER, OPT_WATCH_ID, "The watch id (from ${MtgCommandRef.PRICEWATCH_LIST}).", true).setMinValue(1)),
     )
 
     companion object {

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcher.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcher.kt
@@ -442,7 +442,7 @@ class ScryfallCubeFetcher @Autowired constructor(
         private const val SETS_ENDPOINT = "https://api.scryfall.com/sets"
         private const val SPELLBOOK_ENDPOINT = "https://backend.commanderspellbook.com/variants/"
 
-        /** Cap on how many combos a single `/card combos` lookup returns. */
+        /** Cap on how many combos a single `/mtgcard combos` lookup returns. */
         const val MAX_COMBOS = 5
         const val DEFAULT_MAX_CARDS = 750
         private const val MAX_PAGES = 10

--- a/discord-bot/src/main/kotlin/bot/toby/notify/CardPriceAlertBuilder.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/notify/CardPriceAlertBuilder.kt
@@ -12,7 +12,7 @@ import java.awt.Color
 /**
  * Renders the DM sent when a [CardPriceWatchDto] fires — a card-price-watch
  * alert. The watch is one-shot, so this is a "your target was hit" notice;
- * the footer nudges the user to re-arm with `/pricewatch add`.
+ * the footer nudges the user to re-arm with `/mtgprice add`.
  */
 object CardPriceAlertBuilder {
 

--- a/discord-bot/src/test/kotlin/bot/toby/autocomplete/autocompletes/CubeAutoCompleteTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/autocomplete/autocompletes/CubeAutoCompleteTest.kt
@@ -100,6 +100,6 @@ class CubeAutoCompleteTest {
 
     @Test
     fun `is registered against the cube command`() {
-        assertEquals("cube", autoComplete.name)
+        assertEquals("mtgcube", autoComplete.name)
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CardCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CardCommandTest.kt
@@ -114,7 +114,7 @@ class CardCommandTest : CommandTest {
 
     @Test
     fun `exposes lookup, rulings and combos subcommands`() {
-        assertEquals("card", command.name)
+        assertEquals("mtgcard", command.name)
         assertEquals(setOf("lookup", "rulings", "combos"), command.subCommands.map { it.name }.toSet())
         command.subCommands.forEach { sub ->
             assertTrue(sub.options.first { it.name == "name" }.isRequired)

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeCommandTest.kt
@@ -429,7 +429,7 @@ class CubeCommandTest : CommandTest {
 
     @Test
     fun `exposes the four cube subcommands with their options`() {
-        assertEquals("cube", command.name)
+        assertEquals("mtgcube", command.name)
         val subs = command.subCommands.associateBy { it.name }
         assertEquals(setOf("asfan", "preview", "generate", "saved"), subs.keys)
 

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/DeckCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/DeckCommandTest.kt
@@ -80,7 +80,7 @@ class DeckCommandTest : CommandTest {
 
     @Test
     fun `exposes the legality subcommand with format choices`() {
-        assertEquals("deck", command.name)
+        assertEquals("mtgdeck", command.name)
         assertEquals(setOf("legality"), command.subCommands.map { it.name }.toSet())
         val format = command.subCommands.first().options.first { it.name == "format" }
         assertTrue(format.isRequired)

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/PriceWatchCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/PriceWatchCommandTest.kt
@@ -109,7 +109,7 @@ class PriceWatchCommandTest : CommandTest {
 
     @Test
     fun `exposes add, list and remove subcommands`() {
-        assertEquals("pricewatch", command.name)
+        assertEquals("mtgprice", command.name)
         val subs = command.subCommands.associateBy { it.name }
         assertEquals(setOf("add", "list", "remove"), subs.keys)
         assertTrue(subs.getValue("add").options.first { it.name == "name" }.isRequired)

--- a/web/src/main/kotlin/web/controller/CubeController.kt
+++ b/web/src/main/kotlin/web/controller/CubeController.kt
@@ -64,7 +64,7 @@ class CubeController(
 
     /**
      * The Magic command names for the page copy, sourced from [MtgCommandRef]
-     * so the prose (e.g. "the website twin of `/card lookup`") can never drift
+     * so the prose (e.g. "the website twin of `/mtgcard lookup`") can never drift
      * from the actual Discord commands. Available to this controller's views as
      * `${mtgCmd.cardLookup}` etc.
      */

--- a/web/src/main/kotlin/web/service/CubeWebService.kt
+++ b/web/src/main/kotlin/web/service/CubeWebService.kt
@@ -51,7 +51,7 @@ class CubeWebService {
 
     /**
      * Looks a single card up by (fuzzy) name via Scryfall's `/cards/named`,
-     * for the web card-lookup tool — the website twin of `/card lookup`.
+     * for the web card-lookup tool — the website twin of `/mtgcard lookup`.
      */
     fun card(name: String): CubeResult<CardLookupView> {
         val trimmed = name.trim()
@@ -84,7 +84,7 @@ class CubeWebService {
 
     /**
      * Looks a card up by (fuzzy) name and fetches its official rulings — the
-     * website twin of `/card rulings`. Two calls: `/cards/named` to resolve the
+     * website twin of `/mtgcard rulings`. Two calls: `/cards/named` to resolve the
      * card (and its `rulings_uri`), then a GET of that uri. A resolved card
      * with no rulings is a success with an empty list, not an error.
      */
@@ -139,7 +139,7 @@ class CubeWebService {
 
     /**
      * Finds the combos a card appears in via the Commander Spellbook variants
-     * API — the website twin of `/card combos`. A reachable card with no combos
+     * API — the website twin of `/mtgcard combos`. A reachable card with no combos
      * is a success with an empty list, not an error.
      */
     fun combos(name: String): CubeResult<CombosView> {

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -824,7 +824,7 @@ class ModerationWebService(
                 v
             }
             ConfigDto.Configurations.CUBE_CURRENCY -> {
-                // The /cube preview's "cube value" currency. Normalise to the
+                // The /mtgcube preview's "cube value" currency. Normalise to the
                 // MtgCurrency code so the bot reads it back cleanly.
                 common.mtg.MtgCurrency.fromCode(rawValue)?.code
                     ?: return "Value must be one of usd, eur or tix."

--- a/web/src/main/resources/templates/magic.html
+++ b/web/src/main/resources/templates/magic.html
@@ -342,7 +342,7 @@
                  data-panel="card" hidden>
             <p class="cube-panel-intro">
                 Look up any Magic card by name and see its image and details — the website twin of
-                the <code th:text="${mtgCmd.cardLookup}">/card lookup</code> Discord command.
+                the <code th:text="${mtgCmd.cardLookup}">/mtgcard lookup</code> Discord command.
             </p>
             <form class="cube-form" data-form="card" autocomplete="off">
                 <label>Card name
@@ -359,7 +359,7 @@
                  data-panel="legality" hidden>
             <p class="cube-panel-intro">
                 Paste a decklist and pick a format to see whether it's legal — every banned or
-                not-in-format card is flagged. The website twin of <code th:text="${mtgCmd.deckLegality}">/deck legality</code>.
+                not-in-format card is flagged. The website twin of <code th:text="${mtgCmd.deckLegality}">/mtgdeck legality</code>.
             </p>
             <form class="cube-form" data-form="legality" autocomplete="off">
                 <label>Decklist
@@ -414,7 +414,7 @@
                  data-panel="watch" hidden>
             <p class="cube-panel-intro">
                 Get DM'd on Discord when a card's market price crosses your target — the website twin
-                of <code th:text="${mtgCmd.pricewatchAdd}">/pricewatch add</code>. Prices are checked periodically; alerts are one-shot.
+                of <code th:text="${mtgCmd.pricewatchAdd}">/mtgprice add</code>. Prices are checked periodically; alerts are one-shot.
             </p>
             <div th:if="${loggedIn}" data-watch-block>
                 <form class="cube-form cube-watch-form" data-form="watch" autocomplete="off">

--- a/web/src/main/resources/templates/moderation/settings.html
+++ b/web/src/main/resources/templates/moderation/settings.html
@@ -217,7 +217,7 @@
                             </select>
                             <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                         </div>
-                        <!-- Currency the /cube preview's "cube value" total is shown in.
+                        <!-- Currency the /mtgcube preview's "cube value" total is shown in.
                              Null/absent reads as USD. -->
                         <div class="config-row" data-key="CUBE_CURRENCY">
                             <label>Cube value currency</label>


### PR DESCRIPTION
## Why

After #656 split the Magic suite into granular top-level commands, only `/mtg` was self-evidently Magic. The others (`/cube`, `/card`, `/deck`, `/pricewatch`) are generic, so in Discord's **alphabetical** command picker they scatter among the bot's ~40 commands (interleaved with casino/economy), don't read as a Magic suite, and `/pricewatch` sits right next to the unrelated economy `/pricealert`.

## What

Rename the four generic commands to carry an `mtg` prefix (the reference command stays `/mtg`):

| Before | After |
|---|---|
| `/cube` | `/mtgcube` |
| `/card` | `/mtgcard` |
| `/deck` | `/mtgdeck` |
| `/pricewatch` | `/mtgprice` |
| `/mtg` | `/mtg` (unchanged) |

Now the whole suite groups under typing **`/mtg`**, reads as Magic at a glance, and the `/pricewatch`↔`/pricealert` clash is gone. **Subcommands are unchanged** — `/mtgcard lookup`, `/mtgcube generate`, `/mtgprice add`, etc.

## How (one-place change, thanks to #659's SSOT)

Flipping the five name constants in `MtgCommandRef` flows through:
- Discord command registration (`name`)
- the autocomplete handlers (keyed by command name)
- every embed, the price-watch error strings, the notification-pref description
- the web page copy (via the `mtgCmd` model attribute)

The remaining edits are the matching **KDoc/comment prose** (can't reference constants) and the **tests** that assert literal names. Also corrected a few stale `/cube` web-tool/URL comments left over from the `/cube`→`/magic` page rename (#657).

## Testing
- Updated: command-name assertions (`CardCommandTest`, `DeckCommandTest`, `PriceWatchCommandTest`, `CubeCommandTest`), `CubeAutoCompleteTest`, and `MtgCommandRefTest`.
- The application-module enumeration tests are class/count-based, so they're unaffected.
- `:common` + `:discord-bot` + `:web` suites + `koverVerify` green.

## Heads-up
Renaming slash commands means Discord drops the old `/cube`, `/card`, `/deck`, `/pricewatch` and registers the new names on the next command sync at startup. (You'd noted earlier nothing's relying on the old names yet.)

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs

---
_Generated by [Claude Code](https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs)_