### PR TITLE
Reprioritise the Magic toolkit page as a multi-tool hub (not cube-first)

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
@@ -32,7 +32,7 @@ internal object CubeEmbeds {
     val OK_COLOR: Color = Color(199, 161, 79)
     val ERROR_COLOR: Color = Color(237, 66, 69)
 
-    private const val AUTHOR = "🃏  Cube workshop" // 🃏
+    private const val AUTHOR = "🃏  Magic toolkit" // 🃏
 
     /** Keep the "couldn't find" field under Discord's 1024-char field cap. */
     private const val NOT_FOUND_LIMIT = 1000

--- a/web/src/main/resources/static/css/magic.css
+++ b/web/src/main/resources/static/css/magic.css
@@ -1,4 +1,4 @@
-/* MTG Cube workshop. Gold "five-colour" accent over the dashboard's dark
+/* MTG Magic toolkit. Gold "five-colour" accent over the dashboard's dark
    theme, a guided hero, a tabbed tool shell, and card-first results: the
    generated packs and the preview both list real cards linked to Scryfall.
    Tokens come from base.css :root. */

--- a/web/src/main/resources/static/css/magic.css
+++ b/web/src/main/resources/static/css/magic.css
@@ -130,6 +130,11 @@
     padding-left: var(--space-5);
 }
 
+/* Cube-building onboarding (steps + explainer), shown only on the cube tools. */
+.cube-onboarding {
+    margin-bottom: var(--space-5);
+}
+
 /* --- Tabs ------------------------------------------------------------ */
 
 .cube-tabs-hint {

--- a/web/src/main/resources/static/js/magic.js
+++ b/web/src/main/resources/static/js/magic.js
@@ -8,7 +8,11 @@
 (function (root) {
     'use strict';
 
-    const TABS = ['generate', 'preview', 'asfan', 'compare', 'card', 'legality', 'reference', 'watch'];
+    const TABS = ['card', 'legality', 'watch', 'reference', 'generate', 'preview', 'asfan', 'compare'];
+
+    // The tab shown on load when there's no #hash deep-link. The toolkit leads
+    // with the broadly-useful card lookup rather than the niche cube builder.
+    const DEFAULT_TAB = 'card';
 
     // Tools that work off their own inputs, not the shared "Your cube" source.
     const NO_SHARED_SOURCE = ['asfan', 'compare', 'card', 'legality', 'reference', 'watch'];
@@ -907,8 +911,10 @@
                 }
             });
         });
+        // Normalise the initial state: a #hash deep-link wins, else the default
+        // tab — this also hides the cube-only scaffolding when defaulting to card.
         const fromHash = tabIdFromHash(root.location && root.location.hash);
-        if (fromHash) activateTab(doc, fromHash);
+        activateTab(doc, fromHash || DEFAULT_TAB);
     }
 
     /**

--- a/web/src/main/resources/templates/magic.html
+++ b/web/src/main/resources/templates/magic.html
@@ -15,11 +15,18 @@
             <p class="cube-eyebrow">Magic: The Gathering</p>
             <h1>Magic toolkit</h1>
             <p class="cube-lede">
-                A grab-bag of Magic: The Gathering tools — build and balance a draft cube, look up any
-                card's details, rulings and combos, check a deck's format legality, browse set and
-                keyword reference, and set price-watch alerts. Pick a tool below.
+                A grab-bag of Magic: The Gathering tools — look up any card's details, rulings and
+                combos, check a deck's format legality, browse set and keyword reference, build and
+                balance a draft cube, and set price-watch alerts. Pick a tool below.
             </p>
+        </div>
+    </header>
 
+    <div class="cube-shell">
+        <!-- Cube-building onboarding — only shown when a cube tool (Preview /
+             Generate) is active, via data-needs-cube; hidden on the default
+             (Card lookup) tab and the other standalone tools. -->
+        <div class="cube-onboarding" data-needs-cube hidden>
             <ol class="cube-steps" aria-label="How it works">
                 <li class="cube-step"><span class="cube-step-num">1</span>
                     <span class="cube-step-text"><strong>Choose your cards</strong> (search or paste a list).</span></li>
@@ -47,12 +54,10 @@
                 </div>
             </details>
         </div>
-    </header>
 
-    <div class="cube-shell">
         <!-- Shared card source, used by Preview and Generate (hidden on the
              standalone As-fan calculator via data-needs-cube). -->
-        <section class="cube-source-card" data-needs-cube>
+        <section class="cube-source-card" data-needs-cube hidden>
             <div class="cube-source-head">
                 <h2>Your cube</h2>
                 <span class="cube-source-note">Used by Preview &amp; Generate</span>
@@ -126,39 +131,12 @@
             </div>
         </section>
 
-        <p class="cube-tabs-hint" id="cube-tabs-hint" data-needs-cube>Then pick a tool:</p>
-        <div class="cube-tabs" role="tablist" aria-label="Magic tools" aria-describedby="cube-tabs-hint">
-            <div class="cube-tab-group" role="presentation">
-                <span class="cube-tab-group-label" aria-hidden="true">Build a cube</span>
-            <button type="button" id="tab-generate" class="cube-tab" role="tab"
-                    data-tab="generate" aria-controls="panel-generate" aria-selected="true">
-                <span class="cube-tab-icon" aria-hidden="true">🃏</span>
-                <span class="cube-tab-label">Generate packs</span>
-                <span class="cube-tab-sub">Deal a draft</span>
-            </button>
-            <button type="button" id="tab-preview" class="cube-tab" role="tab"
-                    data-tab="preview" aria-controls="panel-preview" aria-selected="false" tabindex="-1">
-                <span class="cube-tab-icon" aria-hidden="true">📊</span>
-                <span class="cube-tab-label">Preview a cube</span>
-                <span class="cube-tab-sub">Check the balance</span>
-            </button>
-            <button type="button" id="tab-asfan" class="cube-tab" role="tab"
-                    data-tab="asfan" aria-controls="panel-asfan" aria-selected="false" tabindex="-1">
-                <span class="cube-tab-icon" aria-hidden="true">🔢</span>
-                <span class="cube-tab-label">As-fan calculator</span>
-                <span class="cube-tab-sub">Quick maths</span>
-            </button>
-            <button type="button" id="tab-compare" class="cube-tab" role="tab"
-                    data-tab="compare" aria-controls="panel-compare" aria-selected="false" tabindex="-1">
-                <span class="cube-tab-icon" aria-hidden="true">🔀</span>
-                <span class="cube-tab-label">Compare</span>
-                <span class="cube-tab-sub">Diff two lists</span>
-            </button>
-            </div>
+        <p class="cube-tabs-hint" id="cube-tabs-hint" data-needs-cube hidden>Then pick a tool:</p>
+        <div class="cube-tabs" role="tablist" aria-label="Magic tools">
             <div class="cube-tab-group" role="presentation">
                 <span class="cube-tab-group-label" aria-hidden="true">Card &amp; deck tools</span>
             <button type="button" id="tab-card" class="cube-tab" role="tab"
-                    data-tab="card" aria-controls="panel-card" aria-selected="false" tabindex="-1">
+                    data-tab="card" aria-controls="panel-card" aria-selected="true">
                 <span class="cube-tab-icon" aria-hidden="true">🔍</span>
                 <span class="cube-tab-label">Card lookup</span>
                 <span class="cube-tab-sub">Find one card</span>
@@ -185,11 +163,38 @@
                 <span class="cube-tab-sub">Sets &amp; keywords</span>
             </button>
             </div>
+            <div class="cube-tab-group" role="presentation">
+                <span class="cube-tab-group-label" aria-hidden="true">Build a cube</span>
+            <button type="button" id="tab-generate" class="cube-tab" role="tab"
+                    data-tab="generate" aria-controls="panel-generate" aria-selected="false" tabindex="-1">
+                <span class="cube-tab-icon" aria-hidden="true">🃏</span>
+                <span class="cube-tab-label">Generate packs</span>
+                <span class="cube-tab-sub">Deal a draft</span>
+            </button>
+            <button type="button" id="tab-preview" class="cube-tab" role="tab"
+                    data-tab="preview" aria-controls="panel-preview" aria-selected="false" tabindex="-1">
+                <span class="cube-tab-icon" aria-hidden="true">📊</span>
+                <span class="cube-tab-label">Preview a cube</span>
+                <span class="cube-tab-sub">Check the balance</span>
+            </button>
+            <button type="button" id="tab-asfan" class="cube-tab" role="tab"
+                    data-tab="asfan" aria-controls="panel-asfan" aria-selected="false" tabindex="-1">
+                <span class="cube-tab-icon" aria-hidden="true">🔢</span>
+                <span class="cube-tab-label">As-fan calculator</span>
+                <span class="cube-tab-sub">Quick maths</span>
+            </button>
+            <button type="button" id="tab-compare" class="cube-tab" role="tab"
+                    data-tab="compare" aria-controls="panel-compare" aria-selected="false" tabindex="-1">
+                <span class="cube-tab-icon" aria-hidden="true">🔀</span>
+                <span class="cube-tab-label">Compare</span>
+                <span class="cube-tab-sub">Diff two lists</span>
+            </button>
+            </div>
         </div>
 
         <!-- Generate -->
         <section id="panel-generate" class="cube-panel" role="tabpanel" aria-labelledby="tab-generate"
-                 data-panel="generate">
+                 data-panel="generate" hidden>
             <p class="cube-panel-intro">
                 Draws cards at random from <strong>your cube</strong> above and deals them into
                 evenly-sized, balanced booster packs.
@@ -339,7 +344,7 @@
 
         <!-- Card lookup -->
         <section id="panel-card" class="cube-panel" role="tabpanel" aria-labelledby="tab-card"
-                 data-panel="card" hidden>
+                 data-panel="card">
             <p class="cube-panel-intro">
                 Look up any Magic card by name and see its image and details — the website twin of
                 the <code th:text="${mtgCmd.cardLookup}">/mtgcard lookup</code> Discord command.

--- a/web/src/test/kotlin/web/template/MagicTemplateRenderTest.kt
+++ b/web/src/test/kotlin/web/template/MagicTemplateRenderTest.kt
@@ -89,6 +89,29 @@ class MagicTemplateRenderTest {
     }
 
     @Test
+    fun `the toolkit leads with card lookup, not the cube builder`() {
+        val html = render(mapOf("loggedIn" to false))
+
+        // Card lookup is the default tab; the cube builder is no longer the
+        // landing tool now the page is a multi-tool hub.
+        assertTrue(
+            html.contains(Regex("""data-tab="card"[^>]*aria-selected="true"""")),
+        ) { "expected the Card lookup tab to be selected by default" }
+        assertTrue(
+            html.contains(Regex("""data-tab="generate"[^>]*aria-selected="false"""")),
+        ) { "expected the Generate tab to NOT be selected by default" }
+        // The card panel is the visible one; generate is hidden initially.
+        assertTrue(html.contains(Regex("""id="panel-card"[^>]*data-panel="card">"""))) {
+            "expected the card panel to be visible (no hidden attribute) by default"
+        }
+        // The cube-only onboarding (steps + explainer) is gated behind data-needs-cube
+        // and hidden by default, rather than greeting every visitor in the hero.
+        assertTrue(html.contains(Regex("""class="cube-onboarding" data-needs-cube hidden"""))) {
+            "expected the cube onboarding to be hidden behind data-needs-cube by default"
+        }
+    }
+
+    @Test
     fun `command names render from the MtgCommandRef model attribute`() {
         val html = render(mapOf("loggedIn" to true, "username" to "tester"))
 


### PR DESCRIPTION
## Why

The page was retitled **"Magic toolkit"** and the tabs grouped in #657, but it still **opened and read as a cube builder**:
- the hero was cube onboarding (the 1‑2‑3 `Choose cards → Preview → Generate` steps + a "what's a cube / as‑fan" explainer),
- the default tab was the niche **Generate packs**, and
- a big **"Your cube"** input sat at the very top.

Meanwhile the broadly-useful, zero-friction tools (card lookup, reference, legality) were tucked into the 2nd/3rd tab groups — inverting the appeal funnel the broadening was meant to fix.

## What (chosen approach: "reprioritise the hub")

Flip the priority while keeping the tabbed layout and **every tool/endpoint**:

- **Neutral hero** — eyebrow + title + lede only; the lede now leads with card lookup / rulings / legality / reference before cube building.
- **Cube onboarding relocated** — the steps + explainer move out of the hero into a `data-needs-cube` block in the shell, so they only appear on the cube tools (Preview / Generate) instead of greeting every visitor.
- **Default tab is now Card lookup**, and the tab groups are reordered **Card & deck tools · Reference · Build a cube**. The "Your cube" source card and "then pick a tool" hint are hidden by default (already `data-needs-cube`) and surface on the cube tools.
- **JS** — `TABS` reordered, new `DEFAULT_TAB = 'card'`, and `wireTabs` now activates the hash tab *or* the default on load (so the cube-only scaffolding is hidden via the same code path). Hash deep-links (`/magic#preview`, navbar dropdown, etc.) are unchanged.

## Also folded in: Discord embed byline

Every MTG embed (card lookup, rulings, legality, set, reference, price-watch, plus the cube ones) carried a **`🃏 Cube workshop`** author byline — the same cube-first labelling on the Discord side. Renamed the shared `CubeEmbeds.AUTHOR` to **`🃏 Magic toolkit`** to match the toolkit framing (+ fixed the stale `magic.css` header comment).

## Testing
- `MagicTemplateRenderTest` gains a guard: the page leads with Card lookup (selected tab + visible panel) and the cube onboarding is hidden by default.
- jest (738) + stylelint + `:web:test` + `:web:koverVerify` + `:discord-bot:test` green. No test asserts the embed byline.

https://claude.ai/code/session_01BB5Q4S4kpD1YgfqmNKhQFs