### PR TITLE
Add operator-only /admin/installs page showing who installed the bot

### DIFF
--- a/application/src/main/resources/application.properties
+++ b/application/src/main/resources/application.properties
@@ -40,6 +40,12 @@ server.tomcat.threads.min-spare=2
 
 app.base-url=${APP_BASE_URL:}
 
+# Bot operator(s) — comma-separated Discord user ids allowed to see the
+# operator-only /admin surface (e.g. /admin/installs). Absent/blank means
+# the page is denied to everyone and its navbar link stays hidden
+# (fail-closed). Parsed by web.service.BotOwnerAuthorizer.
+bot.owner-ids=${BOT_OWNER_IDS:}
+
 # Multipart limits for intro uploads
 spring.servlet.multipart.max-file-size=600KB
 spring.servlet.multipart.max-request-size=600KB

--- a/web/src/main/kotlin/web/configuration/WebSecurityConfig.kt
+++ b/web/src/main/kotlin/web/configuration/WebSecurityConfig.kt
@@ -38,6 +38,10 @@ class WebSecurityConfig {
                 ).permitAll()
                 auth.requestMatchers("/intro/**").authenticated()
                 auth.requestMatchers("/moderation/**").authenticated()
+                // Operator-only surface. Authentication is enforced here;
+                // the bot-operator check (BOT_OWNER_IDS) happens in
+                // AdminController, which redirects non-operators home.
+                auth.requestMatchers("/admin/**").authenticated()
                 auth.requestMatchers("/economy/**").authenticated()
                 auth.requestMatchers("/tip/**").authenticated()
                 auth.requestMatchers("/duel/**").authenticated()

--- a/web/src/main/kotlin/web/controller/admin/AdminController.kt
+++ b/web/src/main/kotlin/web/controller/admin/AdminController.kt
@@ -1,0 +1,47 @@
+package web.controller.admin
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.service.AdminInstallsService
+import web.service.BotOwnerAuthorizer
+import web.util.discordIdOrNull
+import web.util.displayName
+
+/**
+ * Bot-operator-only surface. Gated by [BotOwnerAuthorizer.isBotOwner]
+ * (the `BOT_OWNER_IDS` env var) rather than the per-guild moderation
+ * gate — these pages are for whoever runs the bot, not per-server admins.
+ *
+ * Spring Security already bounces anonymous callers to OAuth login
+ * (the `/admin` paths require authentication), so the
+ * controller only has to enforce the operator check. Non-operators are
+ * redirected home with a flash error, matching the moderation pages'
+ * redirect-on-deny house style.
+ */
+@Controller
+@RequestMapping("/admin")
+class AdminController(
+    private val adminInstallsService: AdminInstallsService,
+    private val botOwnerAuthorizer: BotOwnerAuthorizer,
+) {
+
+    @GetMapping("/installs")
+    fun installs(
+        @AuthenticationPrincipal user: OAuth2User?,
+        model: Model,
+        ra: RedirectAttributes,
+    ): String {
+        if (!botOwnerAuthorizer.isBotOwner(user?.discordIdOrNull())) {
+            ra.addFlashAttribute("error", "Not authorized.")
+            return "redirect:/"
+        }
+        model.addAttribute("installs", adminInstallsService.listInstalls())
+        model.addAttribute("username", user.displayName())
+        return "admin-installs"
+    }
+}

--- a/web/src/main/kotlin/web/service/AdminInstallsService.kt
+++ b/web/src/main/kotlin/web/service/AdminInstallsService.kt
@@ -1,0 +1,95 @@
+package web.service
+
+import database.dto.guild.ConfigDto
+import database.service.guild.ConfigService
+import net.dv8tion.jda.api.JDA
+import org.springframework.stereotype.Service
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+
+/**
+ * Assembles the bot-operator "who installed me" list for `/admin/installs`.
+ *
+ * Every guild JDA is currently in counts as an install; the install
+ * *wizard* sentinel ([ConfigDto.Configurations.INSTALL_MODE] /
+ * `INSTALLED_AT`, written by `InstallSentinel`) tells us how/when the
+ * owner completed setup. Guilds the bot joined before the wizard existed
+ * (or whose owner skipped it) have no sentinel and surface as
+ * "legacy/unknown" with no date — they're still installs, just unmeasured.
+ *
+ * Kept separate from the 1750-line [ModerationWebService] (parallels the
+ * [CasinoAuditService] extraction) and deliberately does NOT route through
+ * [ModerationWebService.getGuildOverview], which iterates every member of
+ * every guild — far too heavy for a flat list across the whole install base.
+ */
+@Service
+class AdminInstallsService(
+    private val jda: JDA,
+    private val configService: ConfigService,
+) {
+
+    data class InstallRow(
+        val guildId: String,
+        val guildName: String,
+        val iconUrl: String?,
+        val ownerId: String,
+        /** Owner display name when the member is cached; null → template shows the id. */
+        val ownerName: String?,
+        val memberCount: Int,
+        /** "express" | "custom" | [LEGACY]. */
+        val installMode: String,
+        val installedAtMillis: Long?,
+    ) {
+        /** Human date for the template; blank when the wizard was never completed. */
+        val installedAtDisplay: String
+            get() = installedAtMillis?.let {
+                DATE_FORMAT.format(Instant.ofEpochMilli(it).atZone(ZoneOffset.UTC))
+            } ?: ""
+    }
+
+    fun listInstalls(): List<InstallRow> {
+        // One bulk read of every config row (cached, @Cacheable["configs"]),
+        // not N per-guild getConfigByName calls. Index by guild → key → value,
+        // skipping the global "all" pseudo-guild.
+        val configByGuild: Map<String, Map<String, String>> =
+            configService.listAllConfig().orEmpty()
+                .filterNotNull()
+                .filter { it.guildId != null && it.guildId != GLOBAL_GUILD && it.name != null }
+                .groupBy { it.guildId!! }
+                .mapValues { (_, rows) -> rows.associate { it.name!! to (it.value ?: "") } }
+
+        return jda.guildCache.mapNotNull { guild ->
+            val cfg = configByGuild[guild.id].orEmpty()
+            val mode = cfg[ConfigDto.Configurations.INSTALL_MODE.configValue]
+                ?.takeIf { it.isNotBlank() } ?: LEGACY
+            val installedAt = cfg[ConfigDto.Configurations.INSTALLED_AT.configValue]?.toLongOrNull()
+            // Cache-only owner lookup. retrieveOwner() would be a network
+            // round-trip per guild — unacceptable across the whole list, so
+            // an uncached owner just shows as its id.
+            val ownerName = guild.getMemberById(guild.ownerIdLong)?.effectiveName
+
+            InstallRow(
+                guildId = guild.id,
+                guildName = guild.name,
+                iconUrl = guild.iconUrl,
+                ownerId = guild.ownerId,
+                ownerName = ownerName,
+                memberCount = guild.memberCount,
+                installMode = mode,
+                installedAtMillis = installedAt,
+            )
+        }.sortedWith(
+            // Newest installs first; legacy/unknown (null date) sink to the bottom.
+            compareByDescending<InstallRow> { it.installedAtMillis ?: Long.MIN_VALUE }
+                .thenBy { it.guildName.lowercase() }
+        )
+    }
+
+    companion object {
+        const val LEGACY = "legacy/unknown"
+        private const val GLOBAL_GUILD = "all"
+        private val DATE_FORMAT: DateTimeFormatter =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm 'UTC'")
+    }
+}

--- a/web/src/main/kotlin/web/service/BotOwnerAuthorizer.kt
+++ b/web/src/main/kotlin/web/service/BotOwnerAuthorizer.kt
@@ -1,0 +1,35 @@
+package web.service
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+/**
+ * Single source of truth for "is this Discord user a bot operator" — the
+ * person(s) who run TobyBot, as opposed to a per-guild owner/super-user.
+ *
+ * The operator list is a global gate (not per-guild), sourced from the
+ * `BOT_OWNER_IDS` env var: a comma-separated list of Discord user ids.
+ * Parsed once at construction since the raw value is final.
+ *
+ * Fail-closed by design: an unset/blank env var yields an empty owner set,
+ * so [isBotOwner] denies everyone and any operator-only surface (the
+ * `/admin/installs` page, its navbar link) stays hidden. A fresh deploy
+ * that forgets the env var exposes nothing rather than everything.
+ *
+ * Mirrors [ModerationAuthorizer]'s role (one place that owns an access
+ * predicate) but for the bot-operator gate rather than the per-guild one.
+ */
+@Component
+class BotOwnerAuthorizer(
+    @param:Value($$"${bot.owner-ids:}") botOwnerIdsRaw: String,
+) {
+    private val ownerIds: Set<Long> =
+        botOwnerIdsRaw.split(",")
+            .mapNotNull { it.trim().toLongOrNull() }
+            .toSet()
+
+    fun isBotOwner(discordId: Long?): Boolean = discordId != null && discordId in ownerIds
+
+    /** True when at least one valid operator id is configured. */
+    val hasAnyOwner: Boolean get() = ownerIds.isNotEmpty()
+}

--- a/web/src/main/kotlin/web/util/DefaultGuildModelAdvice.kt
+++ b/web/src/main/kotlin/web/util/DefaultGuildModelAdvice.kt
@@ -2,8 +2,11 @@ package web.util
 
 import jakarta.servlet.http.HttpServletRequest
 import net.dv8tion.jda.api.JDA
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ModelAttribute
+import web.service.BotOwnerAuthorizer
 
 /**
  * Exposes the current anchored guild id + name to every page model so
@@ -19,11 +22,23 @@ import org.springframework.web.bind.annotation.ModelAttribute
  * showing a phantom server name.
  */
 @ControllerAdvice
-class DefaultGuildModelAdvice(private val jda: JDA) {
+class DefaultGuildModelAdvice(
+    private val jda: JDA,
+    private val botOwnerAuthorizer: BotOwnerAuthorizer,
+) {
 
     @ModelAttribute("currentDefaultGuildId")
     fun currentDefaultGuildId(request: HttpServletRequest): Long? =
         DefaultGuildCookie.read(request)
+
+    /**
+     * Exposes the bot-operator flag to every page so the shared navbar
+     * can conditionally render the operator-only "Installs" link. Hidden
+     * (false) for anonymous users and anyone not in `BOT_OWNER_IDS`.
+     */
+    @ModelAttribute("isBotOwner")
+    fun isBotOwner(@AuthenticationPrincipal user: OAuth2User?): Boolean =
+        botOwnerAuthorizer.isBotOwner(user?.discordIdOrNull())
 
     @ModelAttribute("currentDefaultGuildName")
     fun currentDefaultGuildName(request: HttpServletRequest): String? {

--- a/web/src/main/resources/templates/admin-installs.html
+++ b/web/src/main/resources/templates/admin-installs.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: head('TobyBot - Installs', null)}"></head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<style>
+    .installs-table {
+        width: 100%;
+        border-collapse: collapse;
+        background: var(--bg-elevated);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        overflow: hidden;
+    }
+    .installs-table th, .installs-table td {
+        padding: var(--space-3) var(--space-4);
+        text-align: left;
+        border-bottom: 1px solid var(--border);
+        vertical-align: middle;
+        white-space: nowrap;
+    }
+    .installs-table th {
+        font-size: 0.8rem;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: var(--text-muted);
+    }
+    .installs-table tr:last-child td { border-bottom: none; }
+    .installs-guild { display: flex; align-items: center; gap: var(--space-3); }
+    .installs-icon, .installs-icon-placeholder {
+        width: 32px; height: 32px; border-radius: 50%; flex: 0 0 auto;
+    }
+    .installs-icon-placeholder {
+        background: var(--accent); color: #fff;
+        font-weight: 700; font-size: 0.9rem;
+        display: flex; align-items: center; justify-content: center;
+    }
+    .installs-owner-id { color: var(--text-muted); font-size: 0.85rem; }
+    .installs-num { text-align: right; font-variant-numeric: tabular-nums; }
+    .mode-badge {
+        display: inline-block;
+        padding: 2px 10px;
+        border-radius: var(--radius-pill, 999px);
+        font-size: 0.78rem; font-weight: 600;
+        text-transform: capitalize;
+    }
+    .mode-express { background: rgba(46, 160, 67, 0.18); color: #3fb950; }
+    .mode-custom  { background: rgba(88, 166, 255, 0.18); color: #58a6ff; }
+    .mode-legacy  { background: var(--bg); color: var(--text-muted); border: 1px dashed var(--border-strong); }
+    .installs-scroll { overflow-x: auto; }
+    .empty-hero {
+        background: var(--bg-elevated);
+        border: 1px dashed var(--border-strong);
+        border-radius: var(--radius-lg);
+        padding: 48px 24px; text-align: center; color: var(--text-muted);
+    }
+    .empty-hero h2 { color: var(--text); margin-bottom: 10px; }
+    .empty-hero .emoji { font-size: 2.4rem; display: block; margin-bottom: 12px; }
+</style>
+
+<main id="main" class="container">
+    <h1 class="mb-3">Installs</h1>
+    <p class="muted mb-5">
+        Every server TobyBot is currently in
+        (<span th:text="${#lists.size(installs)}">0</span> total). Install mode and
+        date come from the setup wizard; servers that joined before the wizard or
+        skipped it show as <em>legacy/unknown</em>.
+    </p>
+
+    <div th:replace="~{fragments/alerts :: error}"></div>
+
+    <div class="installs-scroll" th:if="${not #lists.isEmpty(installs)}">
+        <table class="installs-table">
+            <thead>
+            <tr>
+                <th scope="col">Server</th>
+                <th scope="col">Owner</th>
+                <th scope="col" class="installs-num">Members</th>
+                <th scope="col">Mode</th>
+                <th scope="col">Installed</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="row : ${installs}">
+                <td>
+                    <div class="installs-guild">
+                        <img th:if="${row.iconUrl != null}"
+                             th:src="${row.iconUrl}"
+                             th:alt="${row.guildName} + ' icon'"
+                             class="installs-icon"
+                             onerror="this.style.display='none'">
+                        <div th:unless="${row.iconUrl != null}"
+                             class="installs-icon-placeholder"
+                             aria-hidden="true"
+                             th:text="${#strings.substring(row.guildName, 0, 1).toUpperCase()}">G</div>
+                        <span th:text="${row.guildName}" th:title="${row.guildId}">Server</span>
+                    </div>
+                </td>
+                <td>
+                    <span th:if="${row.ownerName != null}" th:text="${row.ownerName}">Owner</span>
+                    <span th:unless="${row.ownerName != null}" class="installs-owner-id"
+                          th:text="${row.ownerId}">000</span>
+                </td>
+                <td class="installs-num" th:text="${row.memberCount}">0</td>
+                <td>
+                    <span class="mode-badge"
+                          th:classappend="${row.installMode == 'express' ? 'mode-express' : (row.installMode == 'custom' ? 'mode-custom' : 'mode-legacy')}"
+                          th:text="${row.installMode}">mode</span>
+                </td>
+                <td>
+                    <span th:if="${row.installedAtMillis != null}" th:text="${row.installedAtDisplay}">date</span>
+                    <span th:unless="${row.installedAtMillis != null}" class="muted">—</span>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+
+    <div class="empty-hero" th:if="${#lists.isEmpty(installs)}">
+        <span class="emoji" aria-hidden="true">&#128229;</span>
+        <h2>No installs yet</h2>
+        <p>TobyBot isn't in any servers right now.</p>
+    </div>
+</main>
+
+<footer th:replace="~{fragments/footer :: footer}"></footer>
+</body>
+</html>

--- a/web/src/main/resources/templates/fragments/navbar.html
+++ b/web/src/main/resources/templates/fragments/navbar.html
@@ -201,6 +201,7 @@
         <div class="nav-section">
             <div class="nav-section-eyebrow">Moderation</div>
             <a class="nav-item" href="/moderation/guilds"><span class="nav-item-icon" aria-hidden="true">&#128737;&#65039;</span><span>Admin</span></a>
+            <a th:if="${isBotOwner}" class="nav-item" href="/admin/installs"><span class="nav-item-icon" aria-hidden="true">&#128229;</span><span>Installs</span></a>
         </div>
 
         <div class="nav-auth">

--- a/web/src/test/kotlin/web/controller/admin/AdminControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/admin/AdminControllerTest.kt
@@ -1,0 +1,71 @@
+package web.controller.admin
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.ui.Model
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.service.AdminInstallsService
+import web.service.BotOwnerAuthorizer
+
+class AdminControllerTest {
+
+    private val ownerId = 777L
+    private val strangerId = 123L
+
+    private lateinit var adminInstallsService: AdminInstallsService
+    private lateinit var controller: AdminController
+    private val botOwnerAuthorizer = BotOwnerAuthorizer(ownerId.toString())
+
+    @BeforeEach
+    fun setup() {
+        adminInstallsService = mockk(relaxed = true)
+        controller = AdminController(adminInstallsService, botOwnerAuthorizer)
+    }
+
+    private fun userWithId(id: Long): OAuth2User = mockk {
+        every { getAttribute<String>("id") } returns id.toString()
+        every { getAttribute<String>("username") } returns "tester"
+    }
+
+    @Test
+    fun `operator sees the installs page with the install list in the model`() {
+        val rows = listOf(
+            AdminInstallsService.InstallRow(
+                guildId = "10", guildName = "Alpha", iconUrl = null,
+                ownerId = "1", ownerName = "Alice", memberCount = 5,
+                installMode = "express", installedAtMillis = 1700000000000L,
+            )
+        )
+        every { adminInstallsService.listInstalls() } returns rows
+        val model = mockk<Model>(relaxed = true)
+
+        val view = controller.installs(userWithId(ownerId), model, mockk(relaxed = true))
+
+        assertEquals("admin-installs", view)
+        verify { model.addAttribute("installs", rows) }
+    }
+
+    @Test
+    fun `non-operator is redirected home and never queries the service`() {
+        val ra = mockk<RedirectAttributes>(relaxed = true)
+
+        val view = controller.installs(userWithId(strangerId), mockk(relaxed = true), ra)
+
+        assertEquals("redirect:/", view)
+        verify(exactly = 0) { adminInstallsService.listInstalls() }
+        verify { ra.addFlashAttribute("error", "Not authorized.") }
+    }
+
+    @Test
+    fun `anonymous user is redirected home`() {
+        val view = controller.installs(null, mockk(relaxed = true), mockk(relaxed = true))
+
+        assertEquals("redirect:/", view)
+        verify(exactly = 0) { adminInstallsService.listInstalls() }
+    }
+}

--- a/web/src/test/kotlin/web/service/AdminInstallsServiceTest.kt
+++ b/web/src/test/kotlin/web/service/AdminInstallsServiceTest.kt
@@ -1,0 +1,142 @@
+package web.service
+
+import database.dto.guild.ConfigDto
+import database.service.guild.ConfigService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.utils.cache.SnowflakeCacheView
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class AdminInstallsServiceTest {
+
+    private lateinit var jda: JDA
+    private lateinit var configService: ConfigService
+    private lateinit var service: AdminInstallsService
+
+    @BeforeEach
+    fun setup() {
+        jda = mockk(relaxed = true)
+        configService = mockk(relaxed = true)
+        service = AdminInstallsService(jda, configService)
+    }
+
+    private fun guild(
+        id: String,
+        name: String,
+        ownerId: Long,
+        ownerName: String?,
+        members: Int = 5,
+        icon: String? = null,
+    ): Guild = mockk {
+        every { this@mockk.id } returns id
+        every { this@mockk.name } returns name
+        every { iconUrl } returns icon
+        every { memberCount } returns members
+        every { ownerIdLong } returns ownerId
+        every { this@mockk.ownerId } returns ownerId.toString()
+        every { getMemberById(ownerId) } returns
+            ownerName?.let { n -> mockk<Member> { every { effectiveName } returns n } }
+    }
+
+    private fun stubGuilds(vararg guilds: Guild) {
+        val cache = mockk<SnowflakeCacheView<Guild>>(relaxed = true)
+        every { jda.guildCache } returns cache
+        every { cache.iterator() } returns guilds.toMutableList().iterator()
+    }
+
+    @Test
+    fun `express install surfaces mode and timestamp with resolved owner name`() {
+        stubGuilds(guild("10", "Alpha", ownerId = 1L, ownerName = "Alice"))
+        every { configService.listAllConfig() } returns listOf(
+            ConfigDto(ConfigDto.Configurations.INSTALL_MODE.configValue, "express", "10"),
+            ConfigDto(ConfigDto.Configurations.INSTALLED_AT.configValue, "1700000000000", "10"),
+        )
+
+        val rows = service.listInstalls()
+
+        assertEquals(1, rows.size)
+        val row = rows.first()
+        assertEquals("express", row.installMode)
+        assertEquals(1700000000000L, row.installedAtMillis)
+        assertEquals("Alice", row.ownerName)
+        assertEquals("1", row.ownerId)
+        assertEquals(5, row.memberCount)
+    }
+
+    @Test
+    fun `guild without install sentinel is reported as legacy with no date`() {
+        stubGuilds(guild("20", "Beta", ownerId = 2L, ownerName = "Bob"))
+        every { configService.listAllConfig() } returns emptyList()
+
+        val row = service.listInstalls().single()
+
+        assertEquals(AdminInstallsService.LEGACY, row.installMode)
+        assertNull(row.installedAtMillis)
+        assertEquals("", row.installedAtDisplay)
+    }
+
+    @Test
+    fun `uncached owner falls back to id-only with null name`() {
+        stubGuilds(guild("30", "Gamma", ownerId = 3L, ownerName = null))
+        every { configService.listAllConfig() } returns emptyList()
+
+        val row = service.listInstalls().single()
+
+        assertNull(row.ownerName)
+        assertEquals("3", row.ownerId)
+    }
+
+    @Test
+    fun `installed rows sort newest first and legacy sinks to the bottom`() {
+        stubGuilds(
+            guild("10", "Older", ownerId = 1L, ownerName = "A"),
+            guild("20", "Newer", ownerId = 2L, ownerName = "B"),
+            guild("30", "Legacy", ownerId = 3L, ownerName = "C"),
+        )
+        every { configService.listAllConfig() } returns listOf(
+            ConfigDto(ConfigDto.Configurations.INSTALL_MODE.configValue, "custom", "10"),
+            ConfigDto(ConfigDto.Configurations.INSTALLED_AT.configValue, "1000", "10"),
+            ConfigDto(ConfigDto.Configurations.INSTALL_MODE.configValue, "express", "20"),
+            ConfigDto(ConfigDto.Configurations.INSTALLED_AT.configValue, "2000", "20"),
+        )
+
+        val names = service.listInstalls().map { it.guildName }
+
+        assertEquals(listOf("Newer", "Older", "Legacy"), names)
+    }
+
+    @Test
+    fun `the global all-guild config row is ignored when indexing installs`() {
+        stubGuilds(guild("10", "Alpha", ownerId = 1L, ownerName = "Alice"))
+        every { configService.listAllConfig() } returns listOf(
+            // A global default sharing the INSTALL_MODE key name must not
+            // leak onto a real guild that never ran the wizard.
+            ConfigDto(ConfigDto.Configurations.INSTALL_MODE.configValue, "express", "all"),
+        )
+
+        val row = service.listInstalls().single()
+
+        assertEquals(AdminInstallsService.LEGACY, row.installMode)
+    }
+
+    @Test
+    fun `config is read exactly once in bulk - never per guild`() {
+        stubGuilds(
+            guild("10", "Alpha", ownerId = 1L, ownerName = "A"),
+            guild("20", "Beta", ownerId = 2L, ownerName = "B"),
+        )
+        every { configService.listAllConfig() } returns emptyList()
+
+        service.listInstalls()
+
+        verify(exactly = 1) { configService.listAllConfig() }
+        verify(exactly = 0) { configService.getConfigByName(any(), any()) }
+    }
+}

--- a/web/src/test/kotlin/web/service/BotOwnerAuthorizerTest.kt
+++ b/web/src/test/kotlin/web/service/BotOwnerAuthorizerTest.kt
@@ -1,0 +1,43 @@
+package web.service
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class BotOwnerAuthorizerTest {
+
+    @Test
+    fun `parses comma-separated ids tolerating surrounding whitespace`() {
+        val authorizer = BotOwnerAuthorizer("123, 456 ,789")
+        assertTrue(authorizer.isBotOwner(123L))
+        assertTrue(authorizer.isBotOwner(456L))
+        assertTrue(authorizer.isBotOwner(789L))
+    }
+
+    @Test
+    fun `blank env denies everyone and reports no owners`() {
+        val authorizer = BotOwnerAuthorizer("")
+        assertFalse(authorizer.hasAnyOwner)
+        assertFalse(authorizer.isBotOwner(123L))
+    }
+
+    @Test
+    fun `non-numeric tokens are skipped but valid ones still parse`() {
+        val authorizer = BotOwnerAuthorizer("abc,123,")
+        assertTrue(authorizer.hasAnyOwner)
+        assertTrue(authorizer.isBotOwner(123L))
+        assertFalse(authorizer.isBotOwner(0L))
+    }
+
+    @Test
+    fun `null discord id is denied`() {
+        val authorizer = BotOwnerAuthorizer("123")
+        assertFalse(authorizer.isBotOwner(null))
+    }
+
+    @Test
+    fun `id outside the configured set is denied`() {
+        val authorizer = BotOwnerAuthorizer("123")
+        assertFalse(authorizer.isBotOwner(999L))
+    }
+}

--- a/web/src/test/kotlin/web/template/AdminInstallsTemplateRenderTest.kt
+++ b/web/src/test/kotlin/web/template/AdminInstallsTemplateRenderTest.kt
@@ -1,0 +1,111 @@
+package web.template
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.context.support.GenericApplicationContext
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.mock.web.MockServletContext
+import org.thymeleaf.context.WebContext
+import org.thymeleaf.spring6.SpringTemplateEngine
+import org.thymeleaf.spring6.templateresolver.SpringResourceTemplateResolver
+import org.thymeleaf.templatemode.TemplateMode
+import org.thymeleaf.web.servlet.JakartaServletWebApplication
+import web.service.AdminInstallsService
+
+/**
+ * Renders the real `templates/admin-installs.html` against a Spring-backed
+ * Thymeleaf engine (same SpringEL dialect prod uses) so the per-row
+ * expressions — the mode-badge `th:classappend` ternary, the
+ * icon/placeholder branch, the owner-name fallback, and the installed-at
+ * date column — are exercised, not just the controller wiring.
+ */
+class AdminInstallsTemplateRenderTest {
+
+    private val servletContext = MockServletContext()
+    private val webApp = JakartaServletWebApplication.buildApplication(servletContext)
+
+    private val engine: SpringTemplateEngine = SpringTemplateEngine().apply {
+        val appCtx = GenericApplicationContext().also { it.refresh() }
+        val resolver = SpringResourceTemplateResolver().apply {
+            setApplicationContext(appCtx)
+            prefix = "classpath:/templates/"
+            suffix = ".html"
+            templateMode = TemplateMode.HTML
+            characterEncoding = "UTF-8"
+            isCacheable = false
+        }
+        setTemplateResolver(resolver)
+    }
+
+    private fun render(installs: List<AdminInstallsService.InstallRow>): String {
+        val request = MockHttpServletRequest(servletContext)
+        val response = MockHttpServletResponse()
+        val exchange = webApp.buildExchange(request, response)
+        val ctx = WebContext(exchange).apply {
+            setVariable("installs", installs)
+            setVariable("username", "operator")
+            setVariable("isBotOwner", true)
+        }
+        return engine.process("admin-installs", ctx)
+    }
+
+    private fun row(
+        guildId: String,
+        name: String,
+        ownerId: String = "1",
+        ownerName: String? = "Owner",
+        icon: String? = null,
+        mode: String = "express",
+        installedAt: Long? = 1_700_000_000_000L,
+    ) = AdminInstallsService.InstallRow(
+        guildId = guildId, guildName = name, iconUrl = icon,
+        ownerId = ownerId, ownerName = ownerName, memberCount = 7,
+        installMode = mode, installedAtMillis = installedAt,
+    )
+
+    @Test
+    fun `express and custom installs render their mode badges with the right modifier class`() {
+        val html = render(
+            listOf(
+                row("10", "Alpha", mode = "express"),
+                row("20", "Beta", mode = "custom"),
+            )
+        )
+        assertTrue(html.contains("mode-express")) { "express badge class missing:\n$html" }
+        assertTrue(html.contains("mode-custom")) { "custom badge class missing:\n$html" }
+        assertTrue(html.contains("Alpha") && html.contains("Beta"))
+        // 2 installs counted in the header.
+        assertTrue(html.contains(">2<") || html.contains("2 total"))
+    }
+
+    @Test
+    fun `legacy install renders the legacy badge and an em-dash for the missing date`() {
+        val html = render(listOf(row("30", "Gamma", mode = AdminInstallsService.LEGACY, installedAt = null)))
+        assertTrue(html.contains("mode-legacy")) { "legacy badge class missing:\n$html" }
+        assertTrue(html.contains("legacy/unknown"))
+        assertTrue(html.contains("&mdash;") || html.contains("—")) { "missing-date dash not rendered:\n$html" }
+    }
+
+    @Test
+    fun `uncached owner falls back to showing the owner id`() {
+        val html = render(listOf(row("40", "Delta", ownerId = "9988", ownerName = null)))
+        assertTrue(html.contains("9988")) { "owner id fallback missing:\n$html" }
+    }
+
+    @Test
+    fun `guild without an icon renders the initial placeholder instead of an img`() {
+        val html = render(listOf(row("50", "Echo", icon = null)))
+        assertTrue(html.contains("installs-icon-placeholder")) { "icon placeholder missing:\n$html" }
+    }
+
+    @Test
+    fun `empty install list renders the empty-state hero`() {
+        val html = render(emptyList())
+        assertTrue(html.contains("No installs yet")) { "empty hero missing:\n$html" }
+        // The CSS class name lives in the <style> block regardless; assert on the
+        // actual table element instead.
+        assertFalse(html.contains("<table")) { "table should not render when there are no installs:\n$html" }
+    }
+}

--- a/web/src/test/kotlin/web/util/DefaultGuildModelAdviceTest.kt
+++ b/web/src/test/kotlin/web/util/DefaultGuildModelAdviceTest.kt
@@ -7,8 +7,12 @@ import jakarta.servlet.http.HttpServletRequest
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.Guild
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.springframework.security.oauth2.core.user.OAuth2User
+import web.service.BotOwnerAuthorizer
 
 /**
  * The controller advice exposes the anchored guild id + name to every
@@ -23,7 +27,8 @@ import org.junit.jupiter.api.Test
 internal class DefaultGuildModelAdviceTest {
 
     private val jda: JDA = mockk()
-    private val advice = DefaultGuildModelAdvice(jda)
+    private val botOwnerAuthorizer = BotOwnerAuthorizer("777")
+    private val advice = DefaultGuildModelAdvice(jda, botOwnerAuthorizer)
 
     private fun requestWith(vararg cookies: Cookie): HttpServletRequest = mockk {
         every { this@mockk.cookies } returns if (cookies.isEmpty()) null else cookies
@@ -67,5 +72,22 @@ internal class DefaultGuildModelAdviceTest {
     fun `currentDefaultGuildName returns null when cookie malformed`() {
         val req = requestWith(Cookie(DefaultGuildCookie.COOKIE_NAME, "garbage"))
         assertNull(advice.currentDefaultGuildName(req))
+    }
+
+    @Test
+    fun `isBotOwner is true for a configured operator id`() {
+        val user = mockk<OAuth2User> { every { getAttribute<String>("id") } returns "777" }
+        assertTrue(advice.isBotOwner(user))
+    }
+
+    @Test
+    fun `isBotOwner is false for a non-operator id`() {
+        val user = mockk<OAuth2User> { every { getAttribute<String>("id") } returns "123" }
+        assertFalse(advice.isBotOwner(user))
+    }
+
+    @Test
+    fun `isBotOwner is false for an anonymous (null) user`() {
+        assertFalse(advice.isBotOwner(null))
     }
 }


### PR DESCRIPTION
## Why

Answering "is there a way for me to tell who has installed my bot?"

Today: **only partially.** The bot already records install events (`INSTALL_MODE` + `INSTALLED_AT` per guild via `InstallSentinel`) and inherently knows every guild it's in (the homepage even shows a server *count*). But there was **no operator-facing place** to see *which* servers installed it, who owns them, and when. The existing `/moderation/guilds` page only lists servers the *signed-in user* can moderate, and `super_user` is a per-guild flag — not a global "bot operator" concept.

## What

A bot-operator-only web page at **`/admin/installs`** listing every server the bot is in: name, icon, owner, member count, install mode (`express`/`custom`, or `legacy/unknown` for servers that joined before the wizard or skipped it), and installed-at date.

- **`BotOwnerAuthorizer`** — global gate parsing the new `BOT_OWNER_IDS` env var (comma-separated Discord user ids). **Fail-closed**: an unset/blank value denies everyone and hides the navbar link.
- **`AdminInstallsService.listInstalls()`** — one bulk `listAllConfig()` read (not N per-guild lookups) joined to a `jda.guildCache` walk. Owner name is resolved cache-only with an id fallback to avoid a per-guild network round-trip; guilds without the wizard sentinel surface as `legacy/unknown`. Sorted newest-first, legacy last.
- **`AdminController`** `GET /admin/installs` — operator check; non-operators are redirected home with a flash error (matching the moderation pages' house style).
- **`admin-installs.html`** table + a conditional **"Installs"** navbar link, exposed via a new `isBotOwner` model attribute on `DefaultGuildModelAdvice`.
- Wiring: `bot.owner-ids=${BOT_OWNER_IDS:}` in `application.properties` and an explicit `/admin/**` `authenticated()` matcher.

## Notes
- **No cache staleness**: config writes evict the whole `configs` cache (`allEntries = true`), so a brand-new install appears immediately.
- **Fail-closed by default**: if `BOT_OWNER_IDS` is unset the page is hidden and denied to everyone.

## Setup
Set `BOT_OWNER_IDS` to your Discord user id (comma-separated for multiple operators), then the "Installs" link appears in the nav for those users.

## Testing
- New unit tests: `BotOwnerAuthorizerTest` (parsing, allow/deny, fail-closed), `AdminInstallsServiceTest` (row assembly, legacy fallback, owner id-fallback, ordering, single bulk read), `AdminControllerTest` (operator/non-operator/anonymous gating), `AdminInstallsTemplateRenderTest` (Thymeleaf render of badges, placeholder, owner fallback, empty state), plus added cases to `DefaultGuildModelAdviceTest`.
- **`:web:test` — all 1502 tests pass.** The `:application` `@SpringBootTest` context tests require Docker/Testcontainers (Postgres) and can't run in this sandbox; the run confirmed the new beans scan and wire correctly before failing at the Docker step.

https://claude.ai/code/session_01KZNzPZmpXZrhcqPHTF6K9t

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZNzPZmpXZrhcqPHTF6K9t)_