### PR TITLE
Add install metrics, churn tracking and UI polish to /admin/installs

### DIFF
--- a/database/src/main/kotlin/database/dto/activity/InstallEventDto.kt
+++ b/database/src/main/kotlin/database/dto/activity/InstallEventDto.kt
@@ -1,0 +1,60 @@
+package database.dto.activity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.NamedQueries
+import jakarta.persistence.NamedQuery
+import jakarta.persistence.Table
+import org.springframework.transaction.annotation.Transactional
+import java.io.Serializable
+import java.time.Instant
+
+/** The two install lifecycle events the operator dashboard tracks. */
+enum class InstallEventType { JOIN, LEAVE }
+
+/**
+ * Append-only row in the install lifecycle ledger (one per bot
+ * join/leave). Backed by `install_event` (V48). The surrogate
+ * `BIGSERIAL` id keeps the log append-only — a guild can legitimately
+ * join, leave, and re-join, so there's no natural composite key to
+ * dedupe on (and we don't want to: each transition is a distinct event).
+ *
+ * Read paths aggregate by [eventType] and [occurredAt]; see
+ * [database.persistence.activity.InstallEventPersistence].
+ */
+@NamedQueries(
+    NamedQuery(
+        name = "InstallEventDto.countByType",
+        query = "select count(e) from InstallEventDto e where e.eventType = :eventType"
+    ),
+    NamedQuery(
+        name = "InstallEventDto.countByTypeSince",
+        query = "select count(e) from InstallEventDto e " +
+                "where e.eventType = :eventType and e.occurredAt >= :since"
+    ),
+    NamedQuery(
+        name = "InstallEventDto.findSince",
+        query = "select e from InstallEventDto e where e.occurredAt >= :since order by e.occurredAt asc"
+    ),
+)
+@Entity
+@Table(name = "install_event", schema = "public")
+@Transactional
+class InstallEventDto(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    var id: Long = 0,
+
+    @Column(name = "guild_id", nullable = false)
+    var guildId: Long = 0,
+
+    @Column(name = "event_type", nullable = false, length = 8)
+    var eventType: String = InstallEventType.JOIN.name,
+
+    @Column(name = "occurred_at", nullable = false)
+    var occurredAt: Instant = Instant.now(),
+) : Serializable

--- a/database/src/main/kotlin/database/persistence/activity/InstallEventPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/activity/InstallEventPersistence.kt
@@ -1,0 +1,24 @@
+package database.persistence.activity
+
+import database.dto.activity.InstallEventDto
+import database.dto.activity.InstallEventType
+import java.time.Instant
+
+/**
+ * Append + aggregate plumbing for the install lifecycle ledger. Writes
+ * are pure inserts (the log is append-only); reads are coarse aggregates
+ * for the operator dashboard — never per-guild hot-path lookups.
+ */
+interface InstallEventPersistence {
+    /** Append a single [type] event for [guildId] at [occurredAt]. */
+    fun record(guildId: Long, type: InstallEventType, occurredAt: Instant)
+
+    /** Lifetime count of events of [type]. */
+    fun countByType(type: InstallEventType): Long
+
+    /** Count of [type] events at or after [since]. */
+    fun countByTypeSince(type: InstallEventType, since: Instant): Long
+
+    /** Every event at or after [since], ascending — for time-bucketed charts. */
+    fun findSince(since: Instant): List<InstallEventDto>
+}

--- a/database/src/main/kotlin/database/persistence/activity/impl/DefaultInstallEventPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/activity/impl/DefaultInstallEventPersistence.kt
@@ -1,0 +1,48 @@
+package database.persistence.activity.impl
+
+import database.dto.activity.InstallEventDto
+import database.dto.activity.InstallEventType
+import database.persistence.activity.InstallEventPersistence
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import jakarta.persistence.TypedQuery
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+@Repository
+@Transactional
+class DefaultInstallEventPersistence : InstallEventPersistence {
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    override fun record(guildId: Long, type: InstallEventType, occurredAt: Instant) {
+        entityManager.persist(
+            InstallEventDto(guildId = guildId, eventType = type.name, occurredAt = occurredAt)
+        )
+        entityManager.flush()
+    }
+
+    override fun countByType(type: InstallEventType): Long {
+        val q: TypedQuery<Long> =
+            entityManager.createNamedQuery("InstallEventDto.countByType", Long::class.javaObjectType)
+        q.setParameter("eventType", type.name)
+        return q.singleResult ?: 0L
+    }
+
+    override fun countByTypeSince(type: InstallEventType, since: Instant): Long {
+        val q: TypedQuery<Long> =
+            entityManager.createNamedQuery("InstallEventDto.countByTypeSince", Long::class.javaObjectType)
+        q.setParameter("eventType", type.name)
+        q.setParameter("since", since)
+        return q.singleResult ?: 0L
+    }
+
+    override fun findSince(since: Instant): List<InstallEventDto> {
+        val q: TypedQuery<InstallEventDto> =
+            entityManager.createNamedQuery("InstallEventDto.findSince", InstallEventDto::class.java)
+        q.setParameter("since", since)
+        return q.resultList
+    }
+}

--- a/database/src/main/kotlin/database/service/activity/InstallEventService.kt
+++ b/database/src/main/kotlin/database/service/activity/InstallEventService.kt
@@ -1,0 +1,22 @@
+package database.service.activity
+
+import database.dto.activity.InstallEventDto
+import database.dto.activity.InstallEventType
+import java.time.Instant
+
+/**
+ * Records and aggregates bot install lifecycle events (JOIN / LEAVE).
+ * Recorded from the JDA event handlers; aggregated by the operator
+ * `/admin/installs` dashboard for churn + growth metrics.
+ */
+interface InstallEventService {
+    /** Append a JOIN for [guildId] (defaults to now). */
+    fun recordJoin(guildId: Long, occurredAt: Instant = Instant.now())
+
+    /** Append a LEAVE for [guildId] (defaults to now). */
+    fun recordLeave(guildId: Long, occurredAt: Instant = Instant.now())
+
+    fun countByType(type: InstallEventType): Long
+    fun countByTypeSince(type: InstallEventType, since: Instant): Long
+    fun findSince(since: Instant): List<InstallEventDto>
+}

--- a/database/src/main/kotlin/database/service/activity/impl/DefaultInstallEventService.kt
+++ b/database/src/main/kotlin/database/service/activity/impl/DefaultInstallEventService.kt
@@ -1,0 +1,28 @@
+package database.service.activity.impl
+
+import database.dto.activity.InstallEventDto
+import database.dto.activity.InstallEventType
+import database.persistence.activity.InstallEventPersistence
+import database.service.activity.InstallEventService
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import java.time.Instant
+
+@Service
+class DefaultInstallEventService @Autowired constructor(
+    private val persistence: InstallEventPersistence,
+) : InstallEventService {
+
+    override fun recordJoin(guildId: Long, occurredAt: Instant) =
+        persistence.record(guildId, InstallEventType.JOIN, occurredAt)
+
+    override fun recordLeave(guildId: Long, occurredAt: Instant) =
+        persistence.record(guildId, InstallEventType.LEAVE, occurredAt)
+
+    override fun countByType(type: InstallEventType): Long = persistence.countByType(type)
+
+    override fun countByTypeSince(type: InstallEventType, since: Instant): Long =
+        persistence.countByTypeSince(type, since)
+
+    override fun findSince(since: Instant): List<InstallEventDto> = persistence.findSince(since)
+}

--- a/database/src/main/resources/db/migration/V48__install_event_ledger.sql
+++ b/database/src/main/resources/db/migration/V48__install_event_ledger.sql
@@ -1,0 +1,18 @@
+-- Append-only ledger of bot install lifecycle events: one row per
+-- GuildJoinEvent (JOIN) and GuildLeaveEvent (LEAVE). Unlike the config
+-- sentinel (INSTALL_MODE / INSTALLED_AT), which is a current-state
+-- snapshot keyed by guild, this is an event log so the operator dashboard
+-- can show churn (joins vs. leaves) and growth over time. Only captures
+-- events from this migration's deploy onward — there is no retroactive
+-- history for guilds that joined before the ledger existed.
+CREATE TABLE IF NOT EXISTS install_event (
+    id          BIGSERIAL PRIMARY KEY,
+    guild_id    BIGINT      NOT NULL,
+    event_type  VARCHAR(8)  NOT NULL,
+    occurred_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+-- The dashboard's time-bucketed queries (events per month, counts since a
+-- cutoff) all filter/scan on occurred_at.
+CREATE INDEX IF NOT EXISTS idx_install_event_occurred_at
+    ON install_event (occurred_at);

--- a/database/src/test/kotlin/database/service/activity/InstallEventServiceTest.kt
+++ b/database/src/test/kotlin/database/service/activity/InstallEventServiceTest.kt
@@ -1,0 +1,44 @@
+package database.service.activity
+
+import database.dto.activity.InstallEventType
+import database.persistence.activity.InstallEventPersistence
+import database.service.activity.impl.DefaultInstallEventService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class InstallEventServiceTest {
+
+    private val persistence: InstallEventPersistence = mockk(relaxed = true)
+    private val service = DefaultInstallEventService(persistence)
+
+    @Test
+    fun `recordJoin appends a JOIN at the supplied instant`() {
+        val at = Instant.parse("2026-01-02T03:04:05Z")
+        service.recordJoin(42L, at)
+        verify(exactly = 1) { persistence.record(42L, InstallEventType.JOIN, at) }
+    }
+
+    @Test
+    fun `recordLeave appends a LEAVE at the supplied instant`() {
+        val at = Instant.parse("2026-02-03T04:05:06Z")
+        service.recordLeave(99L, at)
+        verify(exactly = 1) { persistence.record(99L, InstallEventType.LEAVE, at) }
+    }
+
+    @Test
+    fun `count delegates to persistence by type`() {
+        every { persistence.countByType(InstallEventType.JOIN) } returns 7L
+        assertEquals(7L, service.countByType(InstallEventType.JOIN))
+    }
+
+    @Test
+    fun `countSince delegates to persistence by type and cutoff`() {
+        val since = Instant.parse("2026-01-01T00:00:00Z")
+        every { persistence.countByTypeSince(InstallEventType.LEAVE, since) } returns 3L
+        assertEquals(3L, service.countByTypeSince(InstallEventType.LEAVE, since))
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/handler/GuildLeaveCleanupHandler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/handler/GuildLeaveCleanupHandler.kt
@@ -6,6 +6,7 @@ import common.logging.DiscordLogger
 import database.blackjack.BlackjackTableRegistry
 import database.poker.CasinoHoldemTableRegistry
 import database.poker.PokerTableRegistry
+import database.service.activity.InstallEventService
 import database.service.casino.CasinoBotSuspicionService
 import net.dv8tion.jda.api.events.guild.GuildLeaveEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
@@ -31,6 +32,7 @@ class GuildLeaveCleanupHandler(
     private val antiAutoclickNotifier: AntiAutoclickNotifier,
     private val casinoBotSuspicionService: CasinoBotSuspicionService,
     private val voiceCompanyTracker: VoiceCompanyTracker,
+    private val installEventService: InstallEventService,
 ) : ListenerAdapter() {
 
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
@@ -38,6 +40,11 @@ class GuildLeaveCleanupHandler(
     override fun onGuildLeave(event: GuildLeaveEvent) {
         val guildId = event.guild.idLong
         logger.info { "Guild $guildId left — evicting per-guild caches" }
+        // Record the LEAVE for the operator churn dashboard before the
+        // cache eviction fan-out (order is irrelevant, but keeping it first
+        // means the metric is captured even if an evict call later throws).
+        runCatching { installEventService.recordLeave(guildId) }
+            .onFailure { logger.error { "Failed to record LEAVE for guild $guildId: ${it.message}" } }
         runCatching { pokerTableRegistry.evictGuild(guildId) }
         runCatching { blackjackTableRegistry.evictGuild(guildId) }
         runCatching { casinoHoldemTableRegistry.evictGuild(guildId) }

--- a/discord-bot/src/main/kotlin/bot/toby/install/InstallWelcomeHandler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/InstallWelcomeHandler.kt
@@ -2,6 +2,7 @@ package bot.toby.install
 
 import common.logging.DiscordLogger
 import database.dto.guild.ConfigDto.Configurations
+import database.service.activity.InstallEventService
 import database.service.guild.ConfigService
 import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.entities.Guild
@@ -23,12 +24,19 @@ import org.springframework.stereotype.Service
 @Service
 class InstallWelcomeHandler(
     private val configService: ConfigService,
+    private val installEventService: InstallEventService,
 ) : ListenerAdapter() {
 
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
 
     override fun onGuildJoin(event: GuildJoinEvent) {
         val guild = event.guild
+        // Record the JOIN unconditionally (even on re-invite) so the
+        // operator churn dashboard sees every lifecycle transition. Kept
+        // separate from the welcome try/catch so a ledger write failure
+        // never suppresses the welcome, and vice-versa.
+        runCatching { installEventService.recordJoin(guild.idLong) }
+            .onFailure { logger.error { "Failed to record JOIN for guild ${guild.id}: ${it.message}" } }
         try {
             postWelcomeOrDmOwner(guild)
         } catch (e: Exception) {

--- a/discord-bot/src/test/kotlin/bot/toby/handler/GuildLeaveCleanupHandlerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/handler/GuildLeaveCleanupHandlerTest.kt
@@ -5,6 +5,7 @@ import bot.toby.voice.VoiceCompanyTracker
 import database.blackjack.BlackjackTableRegistry
 import database.poker.CasinoHoldemTableRegistry
 import database.poker.PokerTableRegistry
+import database.service.activity.InstallEventService
 import database.service.casino.CasinoBotSuspicionService
 import io.mockk.every
 import io.mockk.mockk
@@ -26,6 +27,7 @@ class GuildLeaveCleanupHandlerTest {
     private val antiAutoclickNotifier: AntiAutoclickNotifier = mockk(relaxed = true)
     private val casinoBotSuspicionService: CasinoBotSuspicionService = mockk(relaxed = true)
     private val voiceCompanyTracker: VoiceCompanyTracker = mockk(relaxed = true)
+    private val installEventService: InstallEventService = mockk(relaxed = true)
 
     private val handler = GuildLeaveCleanupHandler(
         pokerTableRegistry,
@@ -35,6 +37,7 @@ class GuildLeaveCleanupHandlerTest {
         antiAutoclickNotifier,
         casinoBotSuspicionService,
         voiceCompanyTracker,
+        installEventService,
     )
 
     private fun leaveEvent(guildId: Long): GuildLeaveEvent {
@@ -46,6 +49,7 @@ class GuildLeaveCleanupHandlerTest {
     fun `guild leave evicts the leaving guild from every per-guild cache`() {
         handler.onGuildLeave(leaveEvent(42L))
 
+        verify(exactly = 1) { installEventService.recordLeave(42L, any()) }
         verify(exactly = 1) { pokerTableRegistry.evictGuild(42L) }
         verify(exactly = 1) { blackjackTableRegistry.evictGuild(42L) }
         verify(exactly = 1) { casinoHoldemTableRegistry.evictGuild(42L) }

--- a/discord-bot/src/test/kotlin/bot/toby/install/InstallWelcomeHandlerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/InstallWelcomeHandlerTest.kt
@@ -2,6 +2,7 @@ package bot.toby.install
 
 import database.dto.guild.ConfigDto
 import database.dto.guild.ConfigDto.Configurations
+import database.service.activity.InstallEventService
 import database.service.guild.ConfigService
 import io.mockk.every
 import io.mockk.just
@@ -28,6 +29,7 @@ import org.junit.jupiter.api.Test
 internal class InstallWelcomeHandlerTest {
 
     private lateinit var configService: ConfigService
+    private lateinit var installEventService: InstallEventService
     private lateinit var handler: InstallWelcomeHandler
     private lateinit var event: GuildJoinEvent
     private lateinit var guild: Guild
@@ -39,7 +41,8 @@ internal class InstallWelcomeHandlerTest {
     @BeforeEach
     fun setUp() {
         configService = mockk(relaxed = true)
-        handler = InstallWelcomeHandler(configService)
+        installEventService = mockk(relaxed = true)
+        handler = InstallWelcomeHandler(configService, installEventService)
 
         event = mockk(relaxed = true)
         guild = mockk(relaxed = true)
@@ -50,6 +53,7 @@ internal class InstallWelcomeHandlerTest {
 
         every { event.guild } returns guild
         every { guild.id } returns "100"
+        every { guild.idLong } returns 100L
         every { guild.name } returns "Test Guild"
         every { guild.selfMember } returns selfMember
         every { systemChannel.name } returns "general"
@@ -59,6 +63,32 @@ internal class InstallWelcomeHandlerTest {
         every { fallbackChannel.sendMessageEmbeds(any<MessageEmbed>()) } returns messageAction
         every { messageAction.addComponents(any<ActionRow>()) } returns messageAction
         every { messageAction.queue() } just runs
+    }
+
+    @Test
+    fun `records the JOIN event even when the welcome is skipped (already installed)`() {
+        // The ledger captures every lifecycle transition independently of
+        // the welcome message — re-invites still count as a JOIN.
+        every { configService.getConfigByName(Configurations.INSTALL_MODE.configValue, "100") } returns
+            ConfigDto(Configurations.INSTALL_MODE.configValue, "express", "100")
+
+        handler.onGuildJoin(event)
+
+        verify(exactly = 1) { installEventService.recordJoin(100L, any()) }
+    }
+
+    @Test
+    fun `records the JOIN event when posting a fresh welcome`() {
+        every { configService.getConfigByName(any(), any()) } returns null
+        every { guild.systemChannel } returns systemChannel
+        every {
+            selfMember.hasPermission(systemChannel, Permission.VIEW_CHANNEL, Permission.MESSAGE_SEND)
+        } returns true
+
+        handler.onGuildJoin(event)
+
+        verify(exactly = 1) { installEventService.recordJoin(100L, any()) }
+        verify(exactly = 1) { systemChannel.sendMessageEmbeds(any<MessageEmbed>()) }
     }
 
     @Test

--- a/web/src/main/kotlin/web/controller/admin/AdminController.kt
+++ b/web/src/main/kotlin/web/controller/admin/AdminController.kt
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.service.AdminInstallsService
 import web.service.BotOwnerAuthorizer
+import web.service.InstallChartsService
 import web.util.discordIdOrNull
 import web.util.displayName
 
@@ -27,6 +28,7 @@ import web.util.displayName
 @RequestMapping("/admin")
 class AdminController(
     private val adminInstallsService: AdminInstallsService,
+    private val installChartsService: InstallChartsService,
     private val botOwnerAuthorizer: BotOwnerAuthorizer,
 ) {
 
@@ -40,7 +42,10 @@ class AdminController(
             ra.addFlashAttribute("error", "Not authorized.")
             return "redirect:/"
         }
-        model.addAttribute("installs", adminInstallsService.listInstalls())
+        val rows = adminInstallsService.listInstalls()
+        model.addAttribute("installs", rows)
+        model.addAttribute("stats", adminInstallsService.buildStats(rows))
+        model.addAttribute("chart", installChartsService.build(rows))
         model.addAttribute("username", user.displayName())
         return "admin-installs"
     }

--- a/web/src/main/kotlin/web/service/AdminInstallsService.kt
+++ b/web/src/main/kotlin/web/service/AdminInstallsService.kt
@@ -1,32 +1,42 @@
 package web.service
 
+import database.dto.activity.InstallEventType
 import database.dto.guild.ConfigDto
+import database.service.activity.InstallEventService
 import database.service.guild.ConfigService
 import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.entities.Guild
 import org.springframework.stereotype.Service
+import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
 
 /**
- * Assembles the bot-operator "who installed me" list for `/admin/installs`.
+ * Assembles the bot-operator "who installed me" view for `/admin/installs`:
+ * the per-guild rows, the headline summary stats, and the churn numbers.
  *
- * Every guild JDA is currently in counts as an install; the install
- * *wizard* sentinel ([ConfigDto.Configurations.INSTALL_MODE] /
- * `INSTALLED_AT`, written by `InstallSentinel`) tells us how/when the
- * owner completed setup. Guilds the bot joined before the wizard existed
- * (or whose owner skipped it) have no sentinel and surface as
- * "legacy/unknown" with no date — they're still installs, just unmeasured.
+ * Two data sources, deliberately kept distinct:
+ *  - **Current state** — JDA's guild cache (every guild the bot is in right
+ *    now) joined to the install *wizard* sentinel
+ *    ([ConfigDto.Configurations.INSTALL_MODE] / `INSTALLED_AT`). This is a
+ *    snapshot; it has no notion of guilds that have since left.
+ *  - **Lifecycle ledger** — [InstallEventService] records every JOIN/LEAVE
+ *    from deploy onward, so churn (removals, net growth) can be reported
+ *    even though the config snapshot can't see departed guilds.
  *
- * Kept separate from the 1750-line [ModerationWebService] (parallels the
- * [CasinoAuditService] extraction) and deliberately does NOT route through
- * [ModerationWebService.getGuildOverview], which iterates every member of
- * every guild — far too heavy for a flat list across the whole install base.
+ * Per-guild detail (boost tier, locale, channel/role counts, age, feature
+ * flags) is read straight off the cached [Guild] — all in-memory, no
+ * Discord API round-trips — and wrapped defensively so one guild with an
+ * odd cache state can't blank the whole page.
  */
 @Service
 class AdminInstallsService(
     private val jda: JDA,
     private val configService: ConfigService,
+    private val installEventService: InstallEventService,
+    private val clock: Clock = Clock.systemUTC(),
 ) {
 
     data class InstallRow(
@@ -40,15 +50,47 @@ class AdminInstallsService(
         /** "express" | "custom" | [LEGACY]. */
         val installMode: String,
         val installedAtMillis: Long?,
+        // --- deducible server info (all best-effort, off the cached Guild) ---
+        val botJoinedAtMillis: Long?,
+        val serverCreatedMillis: Long?,
+        val boostTier: Int,
+        val boostCount: Int,
+        val locale: String?,
+        val channelCount: Int,
+        val roleCount: Int,
+        val features: List<String>,
+        val daysSinceInstall: Long?,
+        val serverAgeDays: Long?,
     ) {
-        /** Human date for the template; blank when the wizard was never completed. */
-        val installedAtDisplay: String
-            get() = installedAtMillis?.let {
-                DATE_FORMAT.format(Instant.ofEpochMilli(it).atZone(ZoneOffset.UTC))
-            } ?: ""
+        /** True when the owner completed the wizard (vs. legacy/skipped). */
+        val wizardCompleted: Boolean get() = installMode != LEGACY
+        val installedAtDisplay: String get() = formatMillis(installedAtMillis)
+        val botJoinedAtDisplay: String get() = formatMillis(botJoinedAtMillis)
+        val serverCreatedDisplay: String get() = formatMillis(serverCreatedMillis)
     }
 
+    /** Headline numbers for the stats strip. */
+    data class InstallStats(
+        val totalInstalls: Int,
+        val expressCount: Int,
+        val customCount: Int,
+        val legacyCount: Int,
+        val totalMembers: Long,
+        val avgMembers: Long,
+        val installsLast7Days: Int,
+        val installsLast30Days: Int,
+        // churn — from the lifecycle ledger (post-deploy only)
+        val lifetimeJoins: Long,
+        val lifetimeLeaves: Long,
+        val netGrowth: Long,
+        val joinsLast30Days: Long,
+        val leavesLast30Days: Long,
+        /** False until the ledger has accrued at least one event. */
+        val hasLedgerData: Boolean,
+    )
+
     fun listInstalls(): List<InstallRow> {
+        val nowMillis = clock.millis()
         // One bulk read of every config row (cached, @Cacheable["configs"]),
         // not N per-guild getConfigByName calls. Index by guild → key → value,
         // skipping the global "all" pseudo-guild.
@@ -68,6 +110,7 @@ class AdminInstallsService(
             // round-trip per guild — unacceptable across the whole list, so
             // an uncached owner just shows as its id.
             val ownerName = guild.getMemberById(guild.ownerIdLong)?.effectiveName
+            val detail = guildDetail(guild)
 
             InstallRow(
                 guildId = guild.id,
@@ -78,6 +121,16 @@ class AdminInstallsService(
                 memberCount = guild.memberCount,
                 installMode = mode,
                 installedAtMillis = installedAt,
+                botJoinedAtMillis = detail.botJoinedAtMillis,
+                serverCreatedMillis = detail.serverCreatedMillis,
+                boostTier = detail.boostTier,
+                boostCount = detail.boostCount,
+                locale = detail.locale,
+                channelCount = detail.channelCount,
+                roleCount = detail.roleCount,
+                features = detail.features,
+                daysSinceInstall = installedAt?.let { daysBetween(it, nowMillis) },
+                serverAgeDays = detail.serverCreatedMillis?.let { daysBetween(it, nowMillis) },
             )
         }.sortedWith(
             // Newest installs first; legacy/unknown (null date) sink to the bottom.
@@ -86,10 +139,81 @@ class AdminInstallsService(
         )
     }
 
+    fun buildStats(rows: List<InstallRow>): InstallStats {
+        val now = clock.instant()
+        val totalMembers = rows.sumOf { it.memberCount.toLong() }
+        val last7 = now.minus(7, ChronoUnit.DAYS).toEpochMilli()
+        val last30 = now.minus(30, ChronoUnit.DAYS).toEpochMilli()
+
+        val lifetimeJoins = installEventService.countByType(InstallEventType.JOIN)
+        val lifetimeLeaves = installEventService.countByType(InstallEventType.LEAVE)
+        val joins30 = installEventService.countByTypeSince(InstallEventType.JOIN, now.minus(30, ChronoUnit.DAYS))
+        val leaves30 = installEventService.countByTypeSince(InstallEventType.LEAVE, now.minus(30, ChronoUnit.DAYS))
+
+        return InstallStats(
+            totalInstalls = rows.size,
+            expressCount = rows.count { it.installMode == "express" },
+            customCount = rows.count { it.installMode == "custom" },
+            legacyCount = rows.count { it.installMode == LEGACY },
+            totalMembers = totalMembers,
+            avgMembers = if (rows.isEmpty()) 0L else totalMembers / rows.size,
+            installsLast7Days = rows.count { (it.installedAtMillis ?: 0L) >= last7 },
+            installsLast30Days = rows.count { (it.installedAtMillis ?: 0L) >= last30 },
+            lifetimeJoins = lifetimeJoins,
+            lifetimeLeaves = lifetimeLeaves,
+            netGrowth = lifetimeJoins - lifetimeLeaves,
+            joinsLast30Days = joins30,
+            leavesLast30Days = leaves30,
+            hasLedgerData = (lifetimeJoins + lifetimeLeaves) > 0L,
+        )
+    }
+
+    private data class GuildDetail(
+        val botJoinedAtMillis: Long? = null,
+        val serverCreatedMillis: Long? = null,
+        val boostTier: Int = 0,
+        val boostCount: Int = 0,
+        val locale: String? = null,
+        val channelCount: Int = 0,
+        val roleCount: Int = 0,
+        val features: List<String> = emptyList(),
+    )
+
+    /** Best-effort detail straight off the cached guild; never throws. */
+    private fun guildDetail(guild: Guild): GuildDetail = runCatching {
+        GuildDetail(
+            botJoinedAtMillis = guild.selfMember.timeJoined.toInstant().toEpochMilli(),
+            serverCreatedMillis = guild.timeCreated.toInstant().toEpochMilli(),
+            boostTier = guild.boostTier.key,
+            boostCount = guild.boostCount,
+            locale = guild.locale.languageName,
+            channelCount = guild.textChannels.size + guild.voiceChannels.size,
+            roleCount = guild.roles.size,
+            features = NOTABLE_FEATURES
+                .filter { it in guild.features }
+                .map { prettyFeature(it) },
+        )
+    }.getOrDefault(GuildDetail())
+
     companion object {
         const val LEGACY = "legacy/unknown"
         private const val GLOBAL_GUILD = "all"
         private val DATE_FORMAT: DateTimeFormatter =
             DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm 'UTC'")
+
+        /** Discord guild feature flags worth surfacing as badges (ignore the noisy rest). */
+        private val NOTABLE_FEATURES: List<String> = listOf(
+            "COMMUNITY", "PARTNERED", "VERIFIED", "DISCOVERABLE", "BANNER", "VANITY_URL",
+        )
+
+        private fun prettyFeature(raw: String): String =
+            raw.split('_').joinToString(" ") { it.lowercase().replaceFirstChar(Char::titlecase) }
+
+        private fun formatMillis(millis: Long?): String = millis?.let {
+            DATE_FORMAT.format(Instant.ofEpochMilli(it).atZone(ZoneOffset.UTC))
+        } ?: ""
+
+        private fun daysBetween(fromMillis: Long, toMillis: Long): Long =
+            ChronoUnit.DAYS.between(Instant.ofEpochMilli(fromMillis), Instant.ofEpochMilli(toMillis))
     }
 }

--- a/web/src/main/kotlin/web/service/InstallChartsService.kt
+++ b/web/src/main/kotlin/web/service/InstallChartsService.kt
@@ -1,0 +1,111 @@
+package web.service
+
+import database.dto.activity.InstallEventType
+import database.service.activity.InstallEventService
+import org.springframework.stereotype.Service
+import java.time.Clock
+import java.time.YearMonth
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+
+/**
+ * Builds the monthly install-growth + churn bar chart for the operator
+ * `/admin/installs` page. One bar group per calendar month over a trailing
+ * window, each with an "installs" bar and a "removals" bar:
+ *
+ *  - **Installs** come from the wizard `INSTALLED_AT` timestamps carried on
+ *    the [AdminInstallsService.InstallRow]s — historical and available
+ *    retroactively, but only counts guilds that completed the wizard.
+ *  - **Removals** come from the [InstallEventService] LEAVE ledger — exact,
+ *    but only from the ledger's deploy onward (zero for earlier months).
+ *
+ * The two sources differ deliberately: install dates exist in config
+ * history, but a departed guild leaves no config trace, so its removal can
+ * only come from the event ledger. The page caption notes this.
+ *
+ * Rendered as CSS bars (heights are pre-computed percentages) rather than
+ * the SVG line used by the Activity tab — grouped monthly counts read more
+ * clearly as bars, and it keeps this service free of SVG geometry.
+ */
+@Service
+class InstallChartsService(
+    private val installEventService: InstallEventService,
+    private val clock: Clock = Clock.systemUTC(),
+) {
+
+    data class MonthBucket(
+        val label: String,
+        val installs: Int,
+        val removals: Int,
+        val net: Int,
+        /** 0..100 — bar height as a percentage of the busiest month. */
+        val installsHeightPct: Int,
+        val removalsHeightPct: Int,
+    )
+
+    data class InstallChartView(
+        val buckets: List<MonthBucket>,
+        val maxValue: Int,
+        val totalInstalls: Int,
+        val totalRemovals: Int,
+    ) {
+        val isEmpty: Boolean get() = maxValue == 0
+        val netTotal: Int get() = totalInstalls - totalRemovals
+    }
+
+    fun build(rows: List<AdminInstallsService.InstallRow>, months: Int = DEFAULT_MONTHS): InstallChartView {
+        val thisMonth = YearMonth.now(clock.withZone(ZoneOffset.UTC))
+        val window = (months - 1 downTo 0).map { thisMonth.minusMonths(it.toLong()) }
+        val windowSet = window.toSet()
+
+        val installsByMonth: Map<YearMonth, Int> = rows
+            .mapNotNull { it.installedAtMillis?.let(::toYearMonth) }
+            .filter { it in windowSet }
+            .groupingBy { it }
+            .eachCount()
+
+        val since = window.first().atDay(1).atStartOfDay(ZoneOffset.UTC).toInstant()
+        val removalsByMonth: Map<YearMonth, Int> = installEventService.findSince(since)
+            .asSequence()
+            .filter { it.eventType == InstallEventType.LEAVE.name }
+            .map { toYearMonth(it.occurredAt.toEpochMilli()) }
+            .filter { it in windowSet }
+            .groupingBy { it }
+            .eachCount()
+
+        val maxValue = window.maxOfOrNull { ym ->
+            maxOf(installsByMonth[ym] ?: 0, removalsByMonth[ym] ?: 0)
+        } ?: 0
+
+        val buckets = window.map { ym ->
+            val installs = installsByMonth[ym] ?: 0
+            val removals = removalsByMonth[ym] ?: 0
+            MonthBucket(
+                label = LABEL_FORMAT.format(ym),
+                installs = installs,
+                removals = removals,
+                net = installs - removals,
+                installsHeightPct = pct(installs, maxValue),
+                removalsHeightPct = pct(removals, maxValue),
+            )
+        }
+
+        return InstallChartView(
+            buckets = buckets,
+            maxValue = maxValue,
+            totalInstalls = buckets.sumOf { it.installs },
+            totalRemovals = buckets.sumOf { it.removals },
+        )
+    }
+
+    companion object {
+        const val DEFAULT_MONTHS: Int = 12
+        private val LABEL_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("MMM yyyy")
+
+        private fun toYearMonth(epochMillis: Long): YearMonth =
+            YearMonth.from(java.time.Instant.ofEpochMilli(epochMillis).atZone(ZoneOffset.UTC))
+
+        private fun pct(value: Int, max: Int): Int =
+            if (max <= 0) 0 else ((value.toDouble() / max) * 100).toInt()
+    }
+}

--- a/web/src/main/resources/templates/admin-installs.html
+++ b/web/src/main/resources/templates/admin-installs.html
@@ -6,71 +6,199 @@
 <div th:replace="~{fragments/navbar :: navbar}"></div>
 
 <style>
-    .installs-table {
-        width: 100%;
-        border-collapse: collapse;
+    /* ---- stats strip ---- */
+    .installs-stats {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: var(--space-4);
+        margin-bottom: var(--space-6);
+    }
+    .stat-card {
         background: var(--bg-elevated);
         border: 1px solid var(--border);
         border-radius: var(--radius-lg);
-        overflow: hidden;
+        padding: var(--space-4) var(--space-5);
+    }
+    .stat-eyebrow {
+        font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.06em;
+        color: var(--text-muted); margin-bottom: 6px;
+    }
+    .stat-value { font-size: 1.9rem; font-weight: 700; line-height: 1.1; }
+    .stat-sub { font-size: 0.82rem; color: var(--text-muted); margin-top: 4px; }
+    .stat-pos { color: #3fb950; }
+    .stat-neg { color: #f85149; }
+
+    /* ---- chart ---- */
+    .chart-card {
+        background: var(--bg-elevated);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        padding: var(--space-5);
+        margin-bottom: var(--space-6);
+    }
+    .chart-head { display: flex; justify-content: space-between; align-items: baseline; flex-wrap: wrap; gap: var(--space-3); margin-bottom: var(--space-4); }
+    .chart-legend { display: flex; gap: var(--space-4); font-size: 0.82rem; color: var(--text-muted); }
+    .legend-dot { display: inline-block; width: 10px; height: 10px; border-radius: 2px; margin-right: 6px; vertical-align: middle; }
+    .legend-installs { background: #3fb950; }
+    .legend-removals { background: #f85149; }
+    .chart-bars { display: flex; align-items: flex-end; gap: var(--space-2); }
+    .chart-col { flex: 1 1 0; display: flex; flex-direction: column; align-items: center; min-width: 0; }
+    .chart-col-bars { display: flex; align-items: flex-end; gap: 3px; height: 130px; width: 100%; justify-content: center; }
+    .chart-bar { width: 14px; max-width: 45%; border-radius: 3px 3px 0 0; transition: opacity .15s; min-height: 2px; }
+    .chart-bar:hover { opacity: 0.75; }
+    .chart-bar-installs { background: #3fb950; }
+    .chart-bar-removals { background: #f85149; }
+    .chart-bar-empty { background: var(--border); min-height: 0; }
+    .chart-col-label {
+        font-size: 0.68rem; color: var(--text-muted); margin-top: 14px;
+        white-space: nowrap; transform: rotate(-35deg); transform-origin: top center; height: 20px;
+    }
+    .chart-caption { font-size: 0.78rem; color: var(--text-muted); margin-top: var(--space-5); }
+
+    /* ---- table ---- */
+    .installs-scroll { overflow-x: auto; }
+    .installs-table {
+        width: 100%; border-collapse: collapse;
+        background: var(--bg-elevated); border: 1px solid var(--border);
+        border-radius: var(--radius-lg); overflow: hidden;
     }
     .installs-table th, .installs-table td {
-        padding: var(--space-3) var(--space-4);
-        text-align: left;
-        border-bottom: 1px solid var(--border);
-        vertical-align: middle;
-        white-space: nowrap;
+        padding: var(--space-3) var(--space-4); text-align: left;
+        border-bottom: 1px solid var(--border); vertical-align: top;
     }
     .installs-table th {
-        font-size: 0.8rem;
-        text-transform: uppercase;
-        letter-spacing: 0.04em;
-        color: var(--text-muted);
+        font-size: 0.74rem; text-transform: uppercase; letter-spacing: 0.04em;
+        color: var(--text-muted); white-space: nowrap;
     }
     .installs-table tr:last-child td { border-bottom: none; }
+    .installs-table tbody tr:hover { background: rgba(255,255,255,0.02); }
     .installs-guild { display: flex; align-items: center; gap: var(--space-3); }
-    .installs-icon, .installs-icon-placeholder {
-        width: 32px; height: 32px; border-radius: 50%; flex: 0 0 auto;
-    }
+    .installs-icon, .installs-icon-placeholder { width: 36px; height: 36px; border-radius: 50%; flex: 0 0 auto; }
     .installs-icon-placeholder {
-        background: var(--accent); color: #fff;
-        font-weight: 700; font-size: 0.9rem;
+        background: var(--accent); color: #fff; font-weight: 700; font-size: 0.95rem;
         display: flex; align-items: center; justify-content: center;
     }
+    .installs-name { font-weight: 600; }
+    .installs-sub { font-size: 0.75rem; color: var(--text-muted); }
     .installs-owner-id { color: var(--text-muted); font-size: 0.85rem; }
-    .installs-num { text-align: right; font-variant-numeric: tabular-nums; }
+    .installs-num { text-align: right; font-variant-numeric: tabular-nums; white-space: nowrap; }
+    .meta-chips { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 6px; }
+    .chip {
+        display: inline-block; padding: 1px 8px; border-radius: 999px;
+        font-size: 0.7rem; background: var(--bg); border: 1px solid var(--border);
+        color: var(--text-muted); white-space: nowrap;
+    }
+    .chip-boost { color: #ff73fa; border-color: rgba(255,115,250,0.4); }
+    .chip-feature { color: var(--accent); border-color: rgba(88,166,255,0.4); }
     .mode-badge {
-        display: inline-block;
-        padding: 2px 10px;
-        border-radius: var(--radius-pill, 999px);
-        font-size: 0.78rem; font-weight: 600;
-        text-transform: capitalize;
+        display: inline-block; padding: 2px 10px; border-radius: 999px;
+        font-size: 0.76rem; font-weight: 600; text-transform: capitalize; white-space: nowrap;
     }
     .mode-express { background: rgba(46, 160, 67, 0.18); color: #3fb950; }
     .mode-custom  { background: rgba(88, 166, 255, 0.18); color: #58a6ff; }
     .mode-legacy  { background: var(--bg); color: var(--text-muted); border: 1px dashed var(--border-strong); }
-    .installs-scroll { overflow-x: auto; }
+
     .empty-hero {
-        background: var(--bg-elevated);
-        border: 1px dashed var(--border-strong);
-        border-radius: var(--radius-lg);
-        padding: 48px 24px; text-align: center; color: var(--text-muted);
+        background: var(--bg-elevated); border: 1px dashed var(--border-strong);
+        border-radius: var(--radius-lg); padding: 48px 24px; text-align: center; color: var(--text-muted);
     }
     .empty-hero h2 { color: var(--text); margin-bottom: 10px; }
     .empty-hero .emoji { font-size: 2.4rem; display: block; margin-bottom: 12px; }
+    .chart-empty { text-align: center; color: var(--text-muted); padding: 32px 16px; font-size: 0.9rem; }
 </style>
 
 <main id="main" class="container">
     <h1 class="mb-3">Installs</h1>
     <p class="muted mb-5">
-        Every server TobyBot is currently in
-        (<span th:text="${#lists.size(installs)}">0</span> total). Install mode and
-        date come from the setup wizard; servers that joined before the wizard or
-        skipped it show as <em>legacy/unknown</em>.
+        Every server TobyBot is currently in, with adoption and churn metrics.
     </p>
 
     <div th:replace="~{fragments/alerts :: error}"></div>
 
+    <!-- ===================== summary stats strip ===================== -->
+    <div class="installs-stats">
+        <div class="stat-card">
+            <div class="stat-eyebrow">Total installs</div>
+            <div class="stat-value" th:text="${stats.totalInstalls}">0</div>
+            <div class="stat-sub">servers right now</div>
+        </div>
+        <div class="stat-card">
+            <div class="stat-eyebrow">Members reached</div>
+            <div class="stat-value" th:text="${#numbers.formatInteger(stats.totalMembers, 1, 'COMMA')}">0</div>
+            <div class="stat-sub"><span th:text="${#numbers.formatInteger(stats.avgMembers, 1, 'COMMA')}">0</span> avg / server</div>
+        </div>
+        <div class="stat-card">
+            <div class="stat-eyebrow">Setup mode</div>
+            <div class="stat-value" th:text="${stats.expressCount + stats.customCount}">0</div>
+            <div class="stat-sub">
+                <span th:text="${stats.expressCount}">0</span> express ·
+                <span th:text="${stats.customCount}">0</span> custom ·
+                <span th:text="${stats.legacyCount}">0</span> legacy
+            </div>
+        </div>
+        <div class="stat-card">
+            <div class="stat-eyebrow">New installs</div>
+            <div class="stat-value" th:text="${stats.installsLast30Days}">0</div>
+            <div class="stat-sub"><span th:text="${stats.installsLast7Days}">0</span> in last 7 days · 30-day total</div>
+        </div>
+        <div class="stat-card">
+            <div class="stat-eyebrow">Net growth</div>
+            <div class="stat-value"
+                 th:classappend="${stats.netGrowth >= 0 ? 'stat-pos' : 'stat-neg'}"
+                 th:text="${(stats.netGrowth >= 0 ? '+' : '') + stats.netGrowth}">0</div>
+            <div class="stat-sub" th:if="${stats.hasLedgerData}">
+                <span th:text="${stats.lifetimeJoins}">0</span> joined ·
+                <span th:text="${stats.lifetimeLeaves}">0</span> left (lifetime)
+            </div>
+            <div class="stat-sub" th:unless="${stats.hasLedgerData}">no event history yet</div>
+        </div>
+        <div class="stat-card">
+            <div class="stat-eyebrow">Churn (30 days)</div>
+            <div class="stat-value">
+                <span class="stat-pos" th:text="'+' + ${stats.joinsLast30Days}">+0</span>
+                <span class="stat-neg" th:text="'&minus;' + ${stats.leavesLast30Days}">&minus;0</span>
+            </div>
+            <div class="stat-sub">joined · left in last 30 days</div>
+        </div>
+    </div>
+
+    <!-- ===================== growth + churn chart ===================== -->
+    <div class="chart-card">
+        <div class="chart-head">
+            <strong>Installs &amp; removals per month</strong>
+            <div class="chart-legend">
+                <span><span class="legend-dot legend-installs"></span>Installs</span>
+                <span><span class="legend-dot legend-removals"></span>Removals</span>
+            </div>
+        </div>
+
+        <div th:if="${chart.isEmpty}" class="chart-empty">
+            Not enough history yet — install dates and removal events will populate this chart over time.
+        </div>
+
+        <div th:unless="${chart.isEmpty}">
+            <div class="chart-bars">
+                <div class="chart-col" th:each="b : ${chart.buckets}">
+                    <div class="chart-col-bars"
+                         th:title="${b.label + ': ' + b.installs + ' installed, ' + b.removals + ' left (net ' + (b.net >= 0 ? '+' : '') + b.net + ')'}">
+                        <div th:class="${b.installs > 0 ? 'chart-bar chart-bar-installs' : 'chart-bar chart-bar-empty'}"
+                             th:style="'height:' + ${b.installsHeightPct} + '%'"></div>
+                        <div th:class="${b.removals > 0 ? 'chart-bar chart-bar-removals' : 'chart-bar chart-bar-empty'}"
+                             th:style="'height:' + ${b.removalsHeightPct} + '%'"></div>
+                    </div>
+                    <div class="chart-col-label" th:text="${b.label}">Jan 2026</div>
+                </div>
+            </div>
+        </div>
+
+        <p class="chart-caption">
+            Installs are counted from each server's setup-wizard completion date (historical);
+            removals come from the live JOIN/LEAVE event ledger, which only records events from
+            its deploy onward — so removals for older months read as zero.
+        </p>
+    </div>
+
+    <!-- ===================== per-install table ===================== -->
     <div class="installs-scroll" th:if="${not #lists.isEmpty(installs)}">
         <table class="installs-table">
             <thead>
@@ -80,6 +208,7 @@
                 <th scope="col" class="installs-num">Members</th>
                 <th scope="col">Mode</th>
                 <th scope="col">Installed</th>
+                <th scope="col">Details</th>
             </tr>
             </thead>
             <tbody>
@@ -95,15 +224,17 @@
                              class="installs-icon-placeholder"
                              aria-hidden="true"
                              th:text="${#strings.substring(row.guildName, 0, 1).toUpperCase()}">G</div>
-                        <span th:text="${row.guildName}" th:title="${row.guildId}">Server</span>
+                        <div>
+                            <div class="installs-name" th:text="${row.guildName}">Server</div>
+                            <div class="installs-sub" th:text="${row.guildId}">000</div>
+                        </div>
                     </div>
                 </td>
                 <td>
                     <span th:if="${row.ownerName != null}" th:text="${row.ownerName}">Owner</span>
-                    <span th:unless="${row.ownerName != null}" class="installs-owner-id"
-                          th:text="${row.ownerId}">000</span>
+                    <span th:unless="${row.ownerName != null}" class="installs-owner-id" th:text="${row.ownerId}">000</span>
                 </td>
-                <td class="installs-num" th:text="${row.memberCount}">0</td>
+                <td class="installs-num" th:text="${#numbers.formatInteger(row.memberCount, 1, 'COMMA')}">0</td>
                 <td>
                     <span class="mode-badge"
                           th:classappend="${row.installMode == 'express' ? 'mode-express' : (row.installMode == 'custom' ? 'mode-custom' : 'mode-legacy')}"
@@ -111,7 +242,22 @@
                 </td>
                 <td>
                     <span th:if="${row.installedAtMillis != null}" th:text="${row.installedAtDisplay}">date</span>
-                    <span th:unless="${row.installedAtMillis != null}" class="muted">—</span>
+                    <span th:unless="${row.installedAtMillis != null}" class="muted">&mdash;</span>
+                    <div class="installs-sub" th:if="${row.daysSinceInstall != null}"
+                         th:text="${row.daysSinceInstall + ' days ago'}">x days ago</div>
+                </td>
+                <td>
+                    <div class="meta-chips">
+                        <span class="chip" th:if="${row.serverAgeDays != null}"
+                              th:title="'Server created ' + ${row.serverCreatedDisplay}"
+                              th:text="'age ' + ${#numbers.formatInteger(row.serverAgeDays, 1, 'COMMA')} + 'd'">age</span>
+                        <span class="chip" th:if="${row.channelCount > 0}" th:text="${row.channelCount} + ' ch'">ch</span>
+                        <span class="chip" th:if="${row.roleCount > 0}" th:text="${row.roleCount} + ' roles'">roles</span>
+                        <span class="chip" th:if="${row.locale != null}" th:text="${row.locale}">locale</span>
+                        <span class="chip chip-boost" th:if="${row.boostTier > 0}"
+                              th:text="'Tier ' + ${row.boostTier} + ' (' + ${row.boostCount} + ')'">boost</span>
+                        <span class="chip chip-feature" th:each="f : ${row.features}" th:text="${f}">feature</span>
+                    </div>
                 </td>
             </tr>
             </tbody>

--- a/web/src/test/kotlin/web/controller/admin/AdminControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/admin/AdminControllerTest.kt
@@ -11,6 +11,7 @@ import org.springframework.ui.Model
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.service.AdminInstallsService
 import web.service.BotOwnerAuthorizer
+import web.service.InstallChartsService
 
 class AdminControllerTest {
 
@@ -18,13 +19,15 @@ class AdminControllerTest {
     private val strangerId = 123L
 
     private lateinit var adminInstallsService: AdminInstallsService
+    private lateinit var installChartsService: InstallChartsService
     private lateinit var controller: AdminController
     private val botOwnerAuthorizer = BotOwnerAuthorizer(ownerId.toString())
 
     @BeforeEach
     fun setup() {
         adminInstallsService = mockk(relaxed = true)
-        controller = AdminController(adminInstallsService, botOwnerAuthorizer)
+        installChartsService = mockk(relaxed = true)
+        controller = AdminController(adminInstallsService, installChartsService, botOwnerAuthorizer)
     }
 
     private fun userWithId(id: Long): OAuth2User = mockk {
@@ -39,6 +42,9 @@ class AdminControllerTest {
                 guildId = "10", guildName = "Alpha", iconUrl = null,
                 ownerId = "1", ownerName = "Alice", memberCount = 5,
                 installMode = "express", installedAtMillis = 1700000000000L,
+                botJoinedAtMillis = null, serverCreatedMillis = null, boostTier = 0, boostCount = 0,
+                locale = null, channelCount = 0, roleCount = 0, features = emptyList(),
+                daysSinceInstall = null, serverAgeDays = null,
             )
         )
         every { adminInstallsService.listInstalls() } returns rows
@@ -48,6 +54,8 @@ class AdminControllerTest {
 
         assertEquals("admin-installs", view)
         verify { model.addAttribute("installs", rows) }
+        verify { adminInstallsService.buildStats(rows) }
+        verify { installChartsService.build(rows) }
     }
 
     @Test

--- a/web/src/test/kotlin/web/service/AdminInstallsServiceTest.kt
+++ b/web/src/test/kotlin/web/service/AdminInstallsServiceTest.kt
@@ -1,6 +1,8 @@
 package web.service
 
+import database.dto.activity.InstallEventType
 import database.dto.guild.ConfigDto
+import database.service.activity.InstallEventService
 import database.service.guild.ConfigService
 import io.mockk.every
 import io.mockk.mockk
@@ -8,25 +10,39 @@ import io.mockk.verify
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.SelfMember
 import net.dv8tion.jda.api.utils.cache.SnowflakeCacheView
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 
 class AdminInstallsServiceTest {
 
+    private val now = Instant.parse("2026-06-06T00:00:00Z")
+    private val clock = Clock.fixed(now, ZoneOffset.UTC)
+
     private lateinit var jda: JDA
     private lateinit var configService: ConfigService
+    private lateinit var installEventService: InstallEventService
     private lateinit var service: AdminInstallsService
 
     @BeforeEach
     fun setup() {
         jda = mockk(relaxed = true)
         configService = mockk(relaxed = true)
-        service = AdminInstallsService(jda, configService)
+        installEventService = mockk(relaxed = true)
+        service = AdminInstallsService(jda, configService, installEventService, clock)
     }
 
+    /** Strict guild mock — detail accessors are intentionally left unstubbed
+     *  (they throw and the service's runCatching falls back to defaults),
+     *  so these tests exercise the core install fields only. */
     private fun guild(
         id: String,
         name: String,
@@ -51,19 +67,21 @@ class AdminInstallsServiceTest {
         every { cache.iterator() } returns guilds.toMutableList().iterator()
     }
 
+    private fun cfg(name: String, value: String, guildId: String) =
+        ConfigDto(name, value, guildId)
+
     @Test
     fun `express install surfaces mode and timestamp with resolved owner name`() {
         stubGuilds(guild("10", "Alpha", ownerId = 1L, ownerName = "Alice"))
         every { configService.listAllConfig() } returns listOf(
-            ConfigDto(ConfigDto.Configurations.INSTALL_MODE.configValue, "express", "10"),
-            ConfigDto(ConfigDto.Configurations.INSTALLED_AT.configValue, "1700000000000", "10"),
+            cfg(ConfigDto.Configurations.INSTALL_MODE.configValue, "express", "10"),
+            cfg(ConfigDto.Configurations.INSTALLED_AT.configValue, "1700000000000", "10"),
         )
 
-        val rows = service.listInstalls()
+        val row = service.listInstalls().single()
 
-        assertEquals(1, rows.size)
-        val row = rows.first()
         assertEquals("express", row.installMode)
+        assertTrue(row.wizardCompleted)
         assertEquals(1700000000000L, row.installedAtMillis)
         assertEquals("Alice", row.ownerName)
         assertEquals("1", row.ownerId)
@@ -79,6 +97,7 @@ class AdminInstallsServiceTest {
 
         assertEquals(AdminInstallsService.LEGACY, row.installMode)
         assertNull(row.installedAtMillis)
+        assertNull(row.daysSinceInstall)
         assertEquals("", row.installedAtDisplay)
     }
 
@@ -101,29 +120,23 @@ class AdminInstallsServiceTest {
             guild("30", "Legacy", ownerId = 3L, ownerName = "C"),
         )
         every { configService.listAllConfig() } returns listOf(
-            ConfigDto(ConfigDto.Configurations.INSTALL_MODE.configValue, "custom", "10"),
-            ConfigDto(ConfigDto.Configurations.INSTALLED_AT.configValue, "1000", "10"),
-            ConfigDto(ConfigDto.Configurations.INSTALL_MODE.configValue, "express", "20"),
-            ConfigDto(ConfigDto.Configurations.INSTALLED_AT.configValue, "2000", "20"),
+            cfg(ConfigDto.Configurations.INSTALL_MODE.configValue, "custom", "10"),
+            cfg(ConfigDto.Configurations.INSTALLED_AT.configValue, "1000", "10"),
+            cfg(ConfigDto.Configurations.INSTALL_MODE.configValue, "express", "20"),
+            cfg(ConfigDto.Configurations.INSTALLED_AT.configValue, "2000", "20"),
         )
 
-        val names = service.listInstalls().map { it.guildName }
-
-        assertEquals(listOf("Newer", "Older", "Legacy"), names)
+        assertEquals(listOf("Newer", "Older", "Legacy"), service.listInstalls().map { it.guildName })
     }
 
     @Test
     fun `the global all-guild config row is ignored when indexing installs`() {
         stubGuilds(guild("10", "Alpha", ownerId = 1L, ownerName = "Alice"))
         every { configService.listAllConfig() } returns listOf(
-            // A global default sharing the INSTALL_MODE key name must not
-            // leak onto a real guild that never ran the wizard.
-            ConfigDto(ConfigDto.Configurations.INSTALL_MODE.configValue, "express", "all"),
+            cfg(ConfigDto.Configurations.INSTALL_MODE.configValue, "express", "all"),
         )
 
-        val row = service.listInstalls().single()
-
-        assertEquals(AdminInstallsService.LEGACY, row.installMode)
+        assertEquals(AdminInstallsService.LEGACY, service.listInstalls().single().installMode)
     }
 
     @Test
@@ -139,4 +152,99 @@ class AdminInstallsServiceTest {
         verify(exactly = 1) { configService.listAllConfig() }
         verify(exactly = 0) { configService.getConfigByName(any(), any()) }
     }
+
+    @Test
+    fun `deducible server detail is read off the cached guild`() {
+        val self = mockk<SelfMember> {
+            every { timeJoined } returns OffsetDateTime.parse("2026-05-07T00:00:00Z") // 30 days before clock
+        }
+        val richGuild = mockk<Guild> {
+            every { id } returns "10"
+            every { name } returns "Rich"
+            every { iconUrl } returns null
+            every { memberCount } returns 100
+            every { ownerIdLong } returns 1L
+            every { ownerId } returns "1"
+            every { getMemberById(1L) } returns mockk<Member> { every { effectiveName } returns "Owner" }
+            every { selfMember } returns self
+            every { timeCreated } returns OffsetDateTime.parse("2025-06-06T00:00:00Z") // ~365 days old
+            every { boostTier } returns Guild.BoostTier.TIER_2
+            every { boostCount } returns 14
+            every { locale } returns net.dv8tion.jda.api.interactions.DiscordLocale.ENGLISH_US
+            every { textChannels } returns listOf(mockk(), mockk())
+            every { voiceChannels } returns listOf(mockk())
+            every { roles } returns listOf(mockk(), mockk(), mockk())
+            every { features } returns setOf("COMMUNITY", "VERIFIED", "SOME_NOISY_FLAG")
+        }
+        stubGuilds(richGuild)
+        every { configService.listAllConfig() } returns emptyList()
+
+        val row = service.listInstalls().single()
+
+        assertEquals(2, row.boostTier)
+        assertEquals(14, row.boostCount)
+        assertEquals(3, row.channelCount) // 2 text + 1 voice
+        assertEquals(3, row.roleCount)
+        assertEquals(365L, row.serverAgeDays)
+        // Only the notable features surface, prettified; the noisy one is dropped.
+        assertTrue(row.features.contains("Community"))
+        assertTrue(row.features.contains("Verified"))
+        assertTrue(row.features.none { it.contains("Noisy") })
+    }
+
+    @Test
+    fun `buildStats summarises modes, members and recent installs from the clock window`() {
+        // now = 2026-06-06. last7 cutoff = 2026-05-30, last30 = 2026-05-07.
+        val justNow = Instant.parse("2026-06-05T00:00:00Z").toEpochMilli()       // within 7d
+        val twoWeeks = Instant.parse("2026-05-23T00:00:00Z").toEpochMilli()      // within 30d, not 7d
+        val ancient = Instant.parse("2024-01-01T00:00:00Z").toEpochMilli()       // outside both
+        val rows = listOf(
+            rowOf(mode = "express", installedAt = justNow, members = 100),
+            rowOf(mode = "custom", installedAt = twoWeeks, members = 50),
+            rowOf(mode = AdminInstallsService.LEGACY, installedAt = null, members = 30),
+            rowOf(mode = "express", installedAt = ancient, members = 20),
+        )
+        every { installEventService.countByType(InstallEventType.JOIN) } returns 10L
+        every { installEventService.countByType(InstallEventType.LEAVE) } returns 4L
+        every { installEventService.countByTypeSince(InstallEventType.JOIN, any()) } returns 3L
+        every { installEventService.countByTypeSince(InstallEventType.LEAVE, any()) } returns 1L
+
+        val stats = service.buildStats(rows)
+
+        assertEquals(4, stats.totalInstalls)
+        assertEquals(2, stats.expressCount)
+        assertEquals(1, stats.customCount)
+        assertEquals(1, stats.legacyCount)
+        assertEquals(200L, stats.totalMembers)
+        assertEquals(50L, stats.avgMembers)
+        assertEquals(1, stats.installsLast7Days)
+        assertEquals(2, stats.installsLast30Days)
+        assertEquals(10L, stats.lifetimeJoins)
+        assertEquals(4L, stats.lifetimeLeaves)
+        assertEquals(6L, stats.netGrowth)
+        assertEquals(3L, stats.joinsLast30Days)
+        assertEquals(1L, stats.leavesLast30Days)
+        assertTrue(stats.hasLedgerData)
+    }
+
+    @Test
+    fun `buildStats reports no ledger data when the ledger is empty`() {
+        every { installEventService.countByType(any()) } returns 0L
+        every { installEventService.countByTypeSince(any(), any()) } returns 0L
+
+        val stats = service.buildStats(emptyList())
+
+        assertEquals(0, stats.totalInstalls)
+        assertEquals(0L, stats.avgMembers)
+        assertEquals(false, stats.hasLedgerData)
+    }
+
+    private fun rowOf(mode: String, installedAt: Long?, members: Int): AdminInstallsService.InstallRow =
+        AdminInstallsService.InstallRow(
+            guildId = "g", guildName = "G", iconUrl = null, ownerId = "1", ownerName = null,
+            memberCount = members, installMode = mode, installedAtMillis = installedAt,
+            botJoinedAtMillis = null, serverCreatedMillis = null, boostTier = 0, boostCount = 0,
+            locale = null, channelCount = 0, roleCount = 0, features = emptyList(),
+            daysSinceInstall = null, serverAgeDays = null,
+        )
 }

--- a/web/src/test/kotlin/web/service/InstallChartsServiceTest.kt
+++ b/web/src/test/kotlin/web/service/InstallChartsServiceTest.kt
@@ -1,0 +1,115 @@
+package web.service
+
+import database.dto.activity.InstallEventDto
+import database.dto.activity.InstallEventType
+import database.service.activity.InstallEventService
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+
+class InstallChartsServiceTest {
+
+    private val now = Instant.parse("2026-06-15T00:00:00Z")
+    private val clock = Clock.fixed(now, ZoneOffset.UTC)
+
+    private lateinit var installEventService: InstallEventService
+    private lateinit var service: InstallChartsService
+
+    @BeforeEach
+    fun setup() {
+        installEventService = mockk(relaxed = true)
+        service = InstallChartsService(installEventService, clock)
+    }
+
+    private fun millis(iso: String): Long = Instant.parse(iso).toEpochMilli()
+
+    private fun row(installedAt: Long?): AdminInstallsService.InstallRow =
+        AdminInstallsService.InstallRow(
+            guildId = "g", guildName = "G", iconUrl = null, ownerId = "1", ownerName = null,
+            memberCount = 0, installMode = "express", installedAtMillis = installedAt,
+            botJoinedAtMillis = null, serverCreatedMillis = null, boostTier = 0, boostCount = 0,
+            locale = null, channelCount = 0, roleCount = 0, features = emptyList(),
+            daysSinceInstall = null, serverAgeDays = null,
+        )
+
+    private fun leave(iso: String) =
+        InstallEventDto(guildId = 1L, eventType = InstallEventType.LEAVE.name, occurredAt = Instant.parse(iso))
+
+    @Test
+    fun `buckets installs by month and removals from the ledger`() {
+        val rows = listOf(
+            row(millis("2026-06-01T00:00:00Z")),
+            row(millis("2026-06-20T00:00:00Z")),
+            row(millis("2026-05-10T00:00:00Z")),
+            row(null), // legacy, no date — excluded
+        )
+        every { installEventService.findSince(any()) } returns listOf(
+            leave("2026-06-05T00:00:00Z"),
+            // A JOIN row in the ledger must not be counted as a removal.
+            InstallEventDto(guildId = 2L, eventType = InstallEventType.JOIN.name, occurredAt = Instant.parse("2026-06-06T00:00:00Z")),
+        )
+
+        val view = service.build(rows)
+
+        assertEquals(12, view.buckets.size)
+        val june = view.buckets.last()
+        assertEquals("Jun 2026", june.label)
+        assertEquals(2, june.installs)
+        assertEquals(1, june.removals)
+        assertEquals(1, june.net)
+        val may = view.buckets[view.buckets.size - 2]
+        assertEquals(1, may.installs)
+        assertEquals(0, may.removals)
+        assertEquals(3, view.totalInstalls)
+        assertEquals(1, view.totalRemovals)
+        assertEquals(2, view.netTotal)
+        assertFalse(view.isEmpty)
+    }
+
+    @Test
+    fun `bar heights are scaled to the busiest month`() {
+        // June: 2 installs (the max anywhere) → 100%. May: 1 install → 50%.
+        val rows = listOf(
+            row(millis("2026-06-01T00:00:00Z")),
+            row(millis("2026-06-02T00:00:00Z")),
+            row(millis("2026-05-02T00:00:00Z")),
+        )
+        every { installEventService.findSince(any()) } returns emptyList()
+
+        val view = service.build(rows)
+
+        assertEquals(2, view.maxValue)
+        assertEquals(100, view.buckets.last().installsHeightPct)
+        assertEquals(50, view.buckets[view.buckets.size - 2].installsHeightPct)
+    }
+
+    @Test
+    fun `installs outside the trailing window are dropped`() {
+        // 2 years ago — well outside the 12-month window.
+        val rows = listOf(row(millis("2024-01-01T00:00:00Z")))
+        every { installEventService.findSince(any()) } returns emptyList()
+
+        val view = service.build(rows)
+
+        assertEquals(0, view.totalInstalls)
+        assertTrue(view.isEmpty)
+    }
+
+    @Test
+    fun `empty inputs produce an empty chart`() {
+        every { installEventService.findSince(any()) } returns emptyList()
+
+        val view = service.build(emptyList())
+
+        assertTrue(view.isEmpty)
+        assertEquals(0, view.maxValue)
+        assertEquals(12, view.buckets.size) // window still rendered, just all-zero
+    }
+}

--- a/web/src/test/kotlin/web/template/AdminInstallsTemplateRenderTest.kt
+++ b/web/src/test/kotlin/web/template/AdminInstallsTemplateRenderTest.kt
@@ -13,13 +13,15 @@ import org.thymeleaf.spring6.templateresolver.SpringResourceTemplateResolver
 import org.thymeleaf.templatemode.TemplateMode
 import org.thymeleaf.web.servlet.JakartaServletWebApplication
 import web.service.AdminInstallsService
+import web.service.InstallChartsService
 
 /**
  * Renders the real `templates/admin-installs.html` against a Spring-backed
- * Thymeleaf engine (same SpringEL dialect prod uses) so the per-row
- * expressions — the mode-badge `th:classappend` ternary, the
- * icon/placeholder branch, the owner-name fallback, and the installed-at
- * date column — are exercised, not just the controller wiring.
+ * Thymeleaf engine (same SpringEL dialect prod uses) so the stats strip,
+ * the CSS bar chart, and the per-row expressions — the mode-badge
+ * `th:classappend` ternary, the icon/placeholder branch, the owner-name
+ * fallback, the metric chips, and the installed-at column — are all
+ * exercised, not just the controller wiring.
  */
 class AdminInstallsTemplateRenderTest {
 
@@ -39,17 +41,48 @@ class AdminInstallsTemplateRenderTest {
         setTemplateResolver(resolver)
     }
 
-    private fun render(installs: List<AdminInstallsService.InstallRow>): String {
+    private fun render(
+        installs: List<AdminInstallsService.InstallRow>,
+        stats: AdminInstallsService.InstallStats = statsFor(installs),
+        chart: InstallChartsService.InstallChartView = emptyChart(),
+    ): String {
         val request = MockHttpServletRequest(servletContext)
         val response = MockHttpServletResponse()
         val exchange = webApp.buildExchange(request, response)
         val ctx = WebContext(exchange).apply {
             setVariable("installs", installs)
+            setVariable("stats", stats)
+            setVariable("chart", chart)
             setVariable("username", "operator")
             setVariable("isBotOwner", true)
         }
         return engine.process("admin-installs", ctx)
     }
+
+    private fun statsFor(installs: List<AdminInstallsService.InstallRow>) =
+        AdminInstallsService.InstallStats(
+            totalInstalls = installs.size,
+            expressCount = installs.count { it.installMode == "express" },
+            customCount = installs.count { it.installMode == "custom" },
+            legacyCount = installs.count { it.installMode == AdminInstallsService.LEGACY },
+            totalMembers = installs.sumOf { it.memberCount.toLong() },
+            avgMembers = if (installs.isEmpty()) 0 else installs.sumOf { it.memberCount.toLong() } / installs.size,
+            installsLast7Days = 1, installsLast30Days = 2,
+            lifetimeJoins = 0, lifetimeLeaves = 0, netGrowth = 0,
+            joinsLast30Days = 0, leavesLast30Days = 0, hasLedgerData = false,
+        )
+
+    private fun emptyChart() = InstallChartsService.InstallChartView(
+        buckets = emptyList(), maxValue = 0, totalInstalls = 0, totalRemovals = 0,
+    )
+
+    private fun chartWith(vararg buckets: InstallChartsService.MonthBucket) =
+        InstallChartsService.InstallChartView(
+            buckets = buckets.toList(),
+            maxValue = buckets.maxOfOrNull { maxOf(it.installs, it.removals) } ?: 0,
+            totalInstalls = buckets.sumOf { it.installs },
+            totalRemovals = buckets.sumOf { it.removals },
+        )
 
     private fun row(
         guildId: String,
@@ -59,30 +92,31 @@ class AdminInstallsTemplateRenderTest {
         icon: String? = null,
         mode: String = "express",
         installedAt: Long? = 1_700_000_000_000L,
+        boostTier: Int = 0,
+        features: List<String> = emptyList(),
+        daysSinceInstall: Long? = 42L,
+        serverAgeDays: Long? = 365L,
     ) = AdminInstallsService.InstallRow(
         guildId = guildId, guildName = name, iconUrl = icon,
         ownerId = ownerId, ownerName = ownerName, memberCount = 7,
         installMode = mode, installedAtMillis = installedAt,
+        botJoinedAtMillis = installedAt, serverCreatedMillis = 1_600_000_000_000L,
+        boostTier = boostTier, boostCount = if (boostTier > 0) 10 else 0,
+        locale = "English (US)", channelCount = 12, roleCount = 8,
+        features = features, daysSinceInstall = daysSinceInstall, serverAgeDays = serverAgeDays,
     )
 
     @Test
     fun `express and custom installs render their mode badges with the right modifier class`() {
-        val html = render(
-            listOf(
-                row("10", "Alpha", mode = "express"),
-                row("20", "Beta", mode = "custom"),
-            )
-        )
+        val html = render(listOf(row("10", "Alpha", mode = "express"), row("20", "Beta", mode = "custom")))
         assertTrue(html.contains("mode-express")) { "express badge class missing:\n$html" }
         assertTrue(html.contains("mode-custom")) { "custom badge class missing:\n$html" }
         assertTrue(html.contains("Alpha") && html.contains("Beta"))
-        // 2 installs counted in the header.
-        assertTrue(html.contains(">2<") || html.contains("2 total"))
     }
 
     @Test
     fun `legacy install renders the legacy badge and an em-dash for the missing date`() {
-        val html = render(listOf(row("30", "Gamma", mode = AdminInstallsService.LEGACY, installedAt = null)))
+        val html = render(listOf(row("30", "Gamma", mode = AdminInstallsService.LEGACY, installedAt = null, daysSinceInstall = null)))
         assertTrue(html.contains("mode-legacy")) { "legacy badge class missing:\n$html" }
         assertTrue(html.contains("legacy/unknown"))
         assertTrue(html.contains("&mdash;") || html.contains("—")) { "missing-date dash not rendered:\n$html" }
@@ -101,11 +135,38 @@ class AdminInstallsTemplateRenderTest {
     }
 
     @Test
+    fun `metric chips and stats strip render the deducible server info`() {
+        val html = render(listOf(row("60", "Foxtrot", boostTier = 2, features = listOf("Community", "Verified"))))
+        assertTrue(html.contains("Tier 2")) { "boost chip missing:\n$html" }
+        assertTrue(html.contains("Community") && html.contains("Verified")) { "feature chips missing:\n$html" }
+        assertTrue(html.contains("English (US)")) { "locale chip missing:\n$html" }
+        assertTrue(html.contains("Total installs")) { "stats strip missing:\n$html" }
+        assertTrue(html.contains("Net growth")) { "churn stat missing:\n$html" }
+    }
+
+    @Test
+    fun `chart renders month bars when data is present`() {
+        val html = render(
+            installs = listOf(row("70", "Golf")),
+            chart = chartWith(
+                InstallChartsService.MonthBucket("Jun 2026", installs = 3, removals = 1, net = 2, installsHeightPct = 100, removalsHeightPct = 33),
+            ),
+        )
+        assertTrue(html.contains("chart-bar-installs")) { "install bar missing:\n$html" }
+        assertTrue(html.contains("chart-bar-removals")) { "removal bar missing:\n$html" }
+        assertTrue(html.contains("Jun 2026")) { "month label missing:\n$html" }
+    }
+
+    @Test
+    fun `chart shows the empty state when there is no history`() {
+        val html = render(installs = listOf(row("80", "Hotel")), chart = emptyChart())
+        assertTrue(html.contains("Not enough history yet")) { "chart empty state missing:\n$html" }
+    }
+
+    @Test
     fun `empty install list renders the empty-state hero`() {
         val html = render(emptyList())
         assertTrue(html.contains("No installs yet")) { "empty hero missing:\n$html" }
-        // The CSS class name lives in the <style> block regardless; assert on the
-        // actual table element instead.
         assertFalse(html.contains("<table")) { "table should not render when there are no installs:\n$html" }
     }
 }


### PR DESCRIPTION
## Why

Follow-up to #662 (the operator `/admin/installs` page). That page listed *who* installed the bot; this adds the **metrics, server detail, and churn tracking** to actually reason about the install base — plus a UI polish pass.

## What

### Install-event ledger (new — database module)
The existing install tracking is a **current-state snapshot** (`INSTALL_MODE`/`INSTALLED_AT` config keys) — it can't see guilds that have since *left*, so churn was unmeasurable. This adds an append-only event log:
- **V48 migration** + `InstallEventDto` / persistence / `InstallEventService` recording a JOIN/LEAVE row per lifecycle transition.
- Recording wired into `InstallWelcomeHandler.onGuildJoin` and `GuildLeaveCleanupHandler.onGuildLeave`, each guarded with `runCatching` so a ledger write can never break the welcome flow or cache eviction.
- ⚠️ Only captures events **from this migration's deploy onward** — there's no retroactive history for guilds that joined earlier.

### Web dashboard
- **Summary stats strip** — total installs, members reached + average, setup-mode breakdown (express / custom / legacy), new installs in the last 7 / 30 days, lifetime net growth, and 30-day churn (joins vs leaves).
- **Monthly installs-vs-removals bar chart** — installs counted from wizard completion dates (historical), removals from the ledger (post-deploy). CSS bars with a graceful empty state; the source split is captioned on the page.
- **Richer per-row detail**, all deduced off the *cached* `Guild` (no Discord API calls): bot-join date, days-since-install, server age, boost tier + count, locale, channel/role counts, and notable feature flags (Community / Partnered / Verified / …). Read defensively so one guild with an odd cache state can't blank the page.
- **UI polish** — stat cards, mode/feature badges, metric chips, hover states, all on the existing design-system tokens (`--bg-elevated`, `--accent`, spacing/radius vars).

## Testing
- New/updated unit tests: `InstallEventServiceTest`; expanded `AdminInstallsServiceTest` (stats windows + deducible server detail); new `InstallChartsServiceTest` (monthly bucketing, scaling, windowing); updated `AdminControllerTest`; expanded `AdminInstallsTemplateRenderTest` (stats strip, chart bars, chips); and handler tests asserting JOIN/LEAVE recording.
- **Full `:web` (1512) and `:discord-bot` (1877) suites pass.** The `:application` `@SpringBootTest` integration tests (and any DB-backed persistence test for the new entity) need Docker/Testcontainers and can't run in this sandbox — the migration + entity follow the existing `message_daily_count` / `ubi_daily` patterns exactly.

## Notes
- Two intentional data sources on the chart: install dates live in config history (available retroactively), but a departed guild leaves no config trace, so removals can only come from the event ledger. The caption explains this; older months show zero removals.

https://claude.ai/code/session_01KZNzPZmpXZrhcqPHTF6K9t

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZNzPZmpXZrhcqPHTF6K9t)_