### PR TITLE
Add health, liveness, feature-adoption and audience insights to /admin/installs

### DIFF
--- a/database/src/main/kotlin/database/dto/activity/MessageDailyCountDto.kt
+++ b/database/src/main/kotlin/database/dto/activity/MessageDailyCountDto.kt
@@ -33,6 +33,10 @@ import java.time.LocalDate
         query = "select m from MessageDailyCountDto m " +
                 "where m.guildId = :guildId and m.dayStart = :dayStart"
     ),
+    NamedQuery(
+        name = "MessageDailyCountDto.lastActiveByGuild",
+        query = "select m.guildId, max(m.dayStart) from MessageDailyCountDto m group by m.guildId"
+    ),
 )
 @Entity
 @Table(name = "message_daily_count", schema = "public")

--- a/database/src/main/kotlin/database/persistence/activity/MessageDailyCountPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/activity/MessageDailyCountPersistence.kt
@@ -19,4 +19,12 @@ interface MessageDailyCountPersistence {
      * delta. `updatedAt` is bumped on every call.
      */
     fun increment(guildId: Long, dayStart: LocalDate, delta: Long)
+
+    /**
+     * Most recent message-activity day per guild, across all guilds, in a
+     * single grouped query. Powers the operator dashboard's active-vs-quiet
+     * liveness split — guilds absent from the result have never recorded a
+     * message day.
+     */
+    fun findLastActiveByGuild(): Map<Long, LocalDate>
 }

--- a/database/src/main/kotlin/database/persistence/activity/impl/DefaultMessageDailyCountPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/activity/impl/DefaultMessageDailyCountPersistence.kt
@@ -53,4 +53,16 @@ class DefaultMessageDailyCountPersistence : MessageDailyCountPersistence {
         query.setParameter("dayStart", dayStart)
         return query.resultList.firstOrNull()
     }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun findLastActiveByGuild(): Map<Long, LocalDate> {
+        val rows = entityManager
+            .createNamedQuery("MessageDailyCountDto.lastActiveByGuild")
+            .resultList as List<Array<Any?>>
+        return rows.mapNotNull { row ->
+            val guildId = (row[0] as? Number)?.toLong() ?: return@mapNotNull null
+            val day = row[1] as? LocalDate ?: return@mapNotNull null
+            guildId to day
+        }.toMap()
+    }
 }

--- a/database/src/test/kotlin/database/service/MessageActivityBufferTest.kt
+++ b/database/src/test/kotlin/database/service/MessageActivityBufferTest.kt
@@ -126,6 +126,8 @@ class MessageActivityBufferTest {
             }
             increments.add(Triple(guildId, dayStart, delta))
         }
+
+        override fun findLastActiveByGuild(): Map<Long, LocalDate> = emptyMap()
     }
 
     private fun noopScheduler(): ScheduledExecutorService =

--- a/web/src/main/kotlin/web/controller/admin/AdminController.kt
+++ b/web/src/main/kotlin/web/controller/admin/AdminController.kt
@@ -45,6 +45,7 @@ class AdminController(
         val rows = adminInstallsService.listInstalls()
         model.addAttribute("installs", rows)
         model.addAttribute("stats", adminInstallsService.buildStats(rows))
+        model.addAttribute("insights", adminInstallsService.buildInsights(rows))
         model.addAttribute("chart", installChartsService.build(rows))
         model.addAttribute("username", user.displayName())
         return "admin-installs"

--- a/web/src/main/kotlin/web/service/AdminInstallsService.kt
+++ b/web/src/main/kotlin/web/service/AdminInstallsService.kt
@@ -2,9 +2,11 @@ package web.service
 
 import database.dto.activity.InstallEventType
 import database.dto.guild.ConfigDto
+import database.persistence.activity.MessageDailyCountPersistence
 import database.service.activity.InstallEventService
 import database.service.guild.ConfigService
 import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.entities.Guild
 import org.springframework.stereotype.Service
 import java.time.Clock
@@ -15,27 +17,29 @@ import java.time.temporal.ChronoUnit
 
 /**
  * Assembles the bot-operator "who installed me" view for `/admin/installs`:
- * the per-guild rows, the headline summary stats, and the churn numbers.
+ * the per-guild rows, the headline summary stats, the churn numbers, and
+ * the deeper insights (health, liveness, feature adoption, audience).
  *
- * Two data sources, deliberately kept distinct:
- *  - **Current state** — JDA's guild cache (every guild the bot is in right
- *    now) joined to the install *wizard* sentinel
- *    ([ConfigDto.Configurations.INSTALL_MODE] / `INSTALLED_AT`). This is a
- *    snapshot; it has no notion of guilds that have since left.
+ * Three data sources, deliberately kept distinct:
+ *  - **Current state** — JDA's guild cache joined to the install *wizard*
+ *    sentinel ([ConfigDto.Configurations.INSTALL_MODE] / `INSTALLED_AT`).
  *  - **Lifecycle ledger** — [InstallEventService] records every JOIN/LEAVE
- *    from deploy onward, so churn (removals, net growth) can be reported
- *    even though the config snapshot can't see departed guilds.
+ *    from deploy onward, so churn can be reported even though the snapshot
+ *    can't see departed guilds.
+ *  - **Activity liveness** — [MessageDailyCountPersistence] gives the last
+ *    message-activity day per guild so installs can be split active vs quiet.
  *
- * Per-guild detail (boost tier, locale, channel/role counts, age, feature
- * flags) is read straight off the cached [Guild] — all in-memory, no
- * Discord API round-trips — and wrapped defensively so one guild with an
- * odd cache state can't blank the whole page.
+ * Per-guild detail (permissions, boost tier, locale, channel/role counts,
+ * age, feature flags) is read straight off the cached [Guild] — all
+ * in-memory, no Discord API round-trips — and wrapped defensively so one
+ * guild with an odd cache state can't blank the whole page.
  */
 @Service
 class AdminInstallsService(
     private val jda: JDA,
     private val configService: ConfigService,
     private val installEventService: InstallEventService,
+    private val messageDailyCounts: MessageDailyCountPersistence,
     private val clock: Clock = Clock.systemUTC(),
 ) {
 
@@ -44,13 +48,10 @@ class AdminInstallsService(
         val guildName: String,
         val iconUrl: String?,
         val ownerId: String,
-        /** Owner display name when the member is cached; null → template shows the id. */
         val ownerName: String?,
         val memberCount: Int,
-        /** "express" | "custom" | [LEGACY]. */
         val installMode: String,
         val installedAtMillis: Long?,
-        // --- deducible server info (all best-effort, off the cached Guild) ---
         val botJoinedAtMillis: Long?,
         val serverCreatedMillis: Long?,
         val boostTier: Int,
@@ -61,15 +62,20 @@ class AdminInstallsService(
         val features: List<String>,
         val daysSinceInstall: Long?,
         val serverAgeDays: Long?,
+        /** Permission/reachability problems, e.g. "Can't post". Empty = healthy. */
+        val healthIssues: List<String>,
+        val lastActiveMillis: Long?,
+        /** No message activity within [DORMANT_DAYS] (or none ever recorded). */
+        val isDormant: Boolean,
     ) {
-        /** True when the owner completed the wizard (vs. legacy/skipped). */
         val wizardCompleted: Boolean get() = installMode != LEGACY
+        val isHealthy: Boolean get() = healthIssues.isEmpty()
         val installedAtDisplay: String get() = formatMillis(installedAtMillis)
         val botJoinedAtDisplay: String get() = formatMillis(botJoinedAtMillis)
         val serverCreatedDisplay: String get() = formatMillis(serverCreatedMillis)
+        val lastActiveDisplay: String get() = formatMillis(lastActiveMillis)
     }
 
-    /** Headline numbers for the stats strip. */
     data class InstallStats(
         val totalInstalls: Int,
         val expressCount: Int,
@@ -79,38 +85,47 @@ class AdminInstallsService(
         val avgMembers: Long,
         val installsLast7Days: Int,
         val installsLast30Days: Int,
-        // churn — from the lifecycle ledger (post-deploy only)
         val lifetimeJoins: Long,
         val lifetimeLeaves: Long,
         val netGrowth: Long,
         val joinsLast30Days: Long,
         val leavesLast30Days: Long,
-        /** False until the ledger has accrued at least one event. */
         val hasLedgerData: Boolean,
+        // --- health + liveness ---
+        val brokenInstalls: Int,
+        val activeInstalls: Int,
+        val dormantInstalls: Int,
+    )
+
+    data class LabeledCount(val label: String, val count: Int) {
+        /** Bar width as a percentage of [outOf]; clamped to [0, 100]. */
+        fun pct(outOf: Int): Int = if (outOf <= 0) 0 else ((count.toDouble() / outOf) * 100).toInt().coerceIn(0, 100)
+    }
+
+    /** Aggregate breakdowns rendered as the page's "insights" panels. */
+    data class InstallInsights(
+        val total: Int,
+        val featureAdoption: List<LabeledCount>,
+        val sizeBuckets: List<LabeledCount>,
+        val localeDistribution: List<LabeledCount>,
+        val boostDistribution: List<LabeledCount>,
     )
 
     fun listInstalls(): List<InstallRow> {
         val nowMillis = clock.millis()
-        // One bulk read of every config row (cached, @Cacheable["configs"]),
-        // not N per-guild getConfigByName calls. Index by guild → key → value,
-        // skipping the global "all" pseudo-guild.
-        val configByGuild: Map<String, Map<String, String>> =
-            configService.listAllConfig().orEmpty()
-                .filterNotNull()
-                .filter { it.guildId != null && it.guildId != GLOBAL_GUILD && it.name != null }
-                .groupBy { it.guildId!! }
-                .mapValues { (_, rows) -> rows.associate { it.name!! to (it.value ?: "") } }
+        val dormantCutoff = clock.instant().minus(DORMANT_DAYS, ChronoUnit.DAYS).toEpochMilli()
+        val configByGuild = configByGuild()
+        val lastActiveByGuild = runCatching { messageDailyCounts.findLastActiveByGuild() }.getOrDefault(emptyMap())
 
         return jda.guildCache.mapNotNull { guild ->
             val cfg = configByGuild[guild.id].orEmpty()
             val mode = cfg[ConfigDto.Configurations.INSTALL_MODE.configValue]
                 ?.takeIf { it.isNotBlank() } ?: LEGACY
             val installedAt = cfg[ConfigDto.Configurations.INSTALLED_AT.configValue]?.toLongOrNull()
-            // Cache-only owner lookup. retrieveOwner() would be a network
-            // round-trip per guild — unacceptable across the whole list, so
-            // an uncached owner just shows as its id.
             val ownerName = guild.getMemberById(guild.ownerIdLong)?.effectiveName
             val detail = guildDetail(guild)
+            val lastActive = lastActiveByGuild[guild.idLong]
+                ?.atStartOfDay(ZoneOffset.UTC)?.toInstant()?.toEpochMilli()
 
             InstallRow(
                 guildId = guild.id,
@@ -131,9 +146,11 @@ class AdminInstallsService(
                 features = detail.features,
                 daysSinceInstall = installedAt?.let { daysBetween(it, nowMillis) },
                 serverAgeDays = detail.serverCreatedMillis?.let { daysBetween(it, nowMillis) },
+                healthIssues = healthIssues(guild),
+                lastActiveMillis = lastActive,
+                isDormant = lastActive == null || lastActive < dormantCutoff,
             )
         }.sortedWith(
-            // Newest installs first; legacy/unknown (null date) sink to the bottom.
             compareByDescending<InstallRow> { it.installedAtMillis ?: Long.MIN_VALUE }
                 .thenBy { it.guildName.lowercase() }
         )
@@ -165,8 +182,56 @@ class AdminInstallsService(
             joinsLast30Days = joins30,
             leavesLast30Days = leaves30,
             hasLedgerData = (lifetimeJoins + lifetimeLeaves) > 0L,
+            brokenInstalls = rows.count { !it.isHealthy },
+            activeInstalls = rows.count { !it.isDormant },
+            dormantInstalls = rows.count { it.isDormant },
         )
     }
+
+    fun buildInsights(rows: List<InstallRow>): InstallInsights {
+        val configByGuild = configByGuild()
+        // Restrict feature-adoption to guilds we actually have rows for so
+        // stale config from a since-departed guild doesn't inflate counts.
+        val liveGuildIds = rows.map { it.guildId }.toSet()
+        val liveConfig = configByGuild.filterKeys { it in liveGuildIds }
+
+        val featureAdoption = FEATURE_PREDICATES.map { (label, predicate) ->
+            LabeledCount(label, liveConfig.values.count(predicate))
+        }.sortedByDescending { it.count }
+
+        val sizeBuckets = listOf(
+            LabeledCount("Small (<50)", rows.count { it.memberCount < 50 }),
+            LabeledCount("Medium (50–499)", rows.count { it.memberCount in 50..499 }),
+            LabeledCount("Large (500–4999)", rows.count { it.memberCount in 500..4999 }),
+            LabeledCount("Huge (5000+)", rows.count { it.memberCount >= 5000 }),
+        )
+
+        val localeDistribution = rows
+            .mapNotNull { it.locale }
+            .groupingBy { it }.eachCount()
+            .map { (label, count) -> LabeledCount(label, count) }
+            .sortedByDescending { it.count }
+            .take(6)
+
+        val boostDistribution = (0..3).map { tier ->
+            LabeledCount(if (tier == 0) "No boost" else "Tier $tier", rows.count { it.boostTier == tier })
+        }.filter { it.count > 0 }
+
+        return InstallInsights(
+            total = rows.size,
+            featureAdoption = featureAdoption,
+            sizeBuckets = sizeBuckets,
+            localeDistribution = localeDistribution,
+            boostDistribution = boostDistribution,
+        )
+    }
+
+    private fun configByGuild(): Map<String, Map<String, String>> =
+        configService.listAllConfig().orEmpty()
+            .filterNotNull()
+            .filter { it.guildId != null && it.guildId != GLOBAL_GUILD && it.name != null }
+            .groupBy { it.guildId!! }
+            .mapValues { (_, rows) -> rows.associate { it.name!! to (it.value ?: "") } }
 
     private data class GuildDetail(
         val botJoinedAtMillis: Long? = null,
@@ -179,7 +244,6 @@ class AdminInstallsService(
         val features: List<String> = emptyList(),
     )
 
-    /** Best-effort detail straight off the cached guild; never throws. */
     private fun guildDetail(guild: Guild): GuildDetail = runCatching {
         GuildDetail(
             botJoinedAtMillis = guild.selfMember.timeJoined.toInstant().toEpochMilli(),
@@ -189,21 +253,45 @@ class AdminInstallsService(
             locale = guild.locale.languageName,
             channelCount = guild.textChannels.size + guild.voiceChannels.size,
             roleCount = guild.roles.size,
-            features = NOTABLE_FEATURES
-                .filter { it in guild.features }
-                .map { prettyFeature(it) },
+            features = NOTABLE_FEATURES.filter { it in guild.features }.map { prettyFeature(it) },
         )
     }.getOrDefault(GuildDetail())
 
+    /** Permission/reachability problems for the bot in [guild]; never throws. */
+    private fun healthIssues(guild: Guild): List<String> = runCatching {
+        val self = guild.selfMember
+        // Administrator subsumes everything we'd flag — short-circuit.
+        if (self.hasPermission(Permission.ADMINISTRATOR)) return@runCatching emptyList()
+        val issues = mutableListOf<String>()
+        val canPost = guild.systemChannel
+            ?.let { self.hasPermission(it, Permission.VIEW_CHANNEL, Permission.MESSAGE_SEND) } == true ||
+            guild.textChannels.any { self.hasPermission(it, Permission.VIEW_CHANNEL, Permission.MESSAGE_SEND) }
+        if (!canPost) issues.add("Can't post")
+        if (!self.hasPermission(Permission.MANAGE_ROLES)) issues.add("No Manage Roles")
+        issues
+    }.getOrDefault(emptyList())
+
     companion object {
         const val LEGACY = "legacy/unknown"
+        const val DORMANT_DAYS = 30L
         private const val GLOBAL_GUILD = "all"
         private val DATE_FORMAT: DateTimeFormatter =
             DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm 'UTC'")
 
-        /** Discord guild feature flags worth surfacing as badges (ignore the noisy rest). */
         private val NOTABLE_FEATURES: List<String> = listOf(
             "COMMUNITY", "PARTNERED", "VERIFIED", "DISCOVERABLE", "BANNER", "VANITY_URL",
+        )
+
+        /** Optional features we can detect from the per-guild config map. */
+        private val FEATURE_PREDICATES: List<Pair<String, (Map<String, String>) -> Boolean>> = listOf(
+            "Activity tracking" to { c -> c[ConfigDto.Configurations.ACTIVITY_TRACKING.configValue] == "true" },
+            "Daily lottery" to { c -> c[ConfigDto.Configurations.LOTTERY_DAILY_ENABLED.configValue] == "true" },
+            "Welcome messages" to { c -> c[ConfigDto.Configurations.WELCOME_ENABLED.configValue] == "true" },
+            "Goodbye messages" to { c -> c[ConfigDto.Configurations.GOODBYE_ENABLED.configValue] == "true" },
+            "Leaderboard channel" to { c -> c[ConfigDto.Configurations.LEADERBOARD_CHANNEL.configValue].orEmpty().isNotBlank() },
+            "Level-up channel" to { c -> c[ConfigDto.Configurations.LEVEL_UP_CHANNEL.configValue].orEmpty().isNotBlank() },
+            "UBI payouts" to { c -> (c[ConfigDto.Configurations.UBI_DAILY_AMOUNT.configValue]?.toIntOrNull() ?: 0) > 0 },
+            "Lottery channel" to { c -> c[ConfigDto.Configurations.LOTTERY_CHANNEL.configValue].orEmpty().isNotBlank() },
         )
 
         private fun prettyFeature(raw: String): String =

--- a/web/src/main/resources/templates/admin-installs.html
+++ b/web/src/main/resources/templates/admin-installs.html
@@ -55,6 +55,26 @@
     }
     .chart-caption { font-size: 0.78rem; color: var(--text-muted); margin-top: var(--space-5); }
 
+    /* ---- insights panels ---- */
+    .insights-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+        gap: var(--space-4);
+        margin-bottom: var(--space-6);
+    }
+    .insight-card {
+        background: var(--bg-elevated); border: 1px solid var(--border);
+        border-radius: var(--radius-lg); padding: var(--space-5);
+    }
+    .insight-card h3 { font-size: 0.95rem; margin: 0 0 var(--space-4); }
+    .bar-row { display: grid; grid-template-columns: 130px 1fr 32px; align-items: center; gap: var(--space-3); margin-bottom: 8px; }
+    .bar-row:last-child { margin-bottom: 0; }
+    .bar-label { font-size: 0.8rem; color: var(--text-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .bar-track { background: var(--bg); border-radius: 999px; height: 8px; overflow: hidden; }
+    .bar-fill { height: 100%; background: var(--accent); border-radius: 999px; min-width: 2px; }
+    .bar-count { font-size: 0.8rem; font-variant-numeric: tabular-nums; text-align: right; }
+    .insight-empty { font-size: 0.82rem; color: var(--text-muted); }
+
     /* ---- table ---- */
     .installs-scroll { overflow-x: auto; }
     .installs-table {
@@ -90,6 +110,8 @@
     }
     .chip-boost { color: #ff73fa; border-color: rgba(255,115,250,0.4); }
     .chip-feature { color: var(--accent); border-color: rgba(88,166,255,0.4); }
+    .chip-warn { color: #f85149; border-color: rgba(248,81,73,0.45); background: rgba(248,81,73,0.08); }
+    .chip-quiet { color: #d29922; border-color: rgba(210,153,34,0.45); }
     .mode-badge {
         display: inline-block; padding: 2px 10px; border-radius: 999px;
         font-size: 0.76rem; font-weight: 600; text-transform: capitalize; white-space: nowrap;
@@ -160,6 +182,21 @@
             </div>
             <div class="stat-sub">joined · left in last 30 days</div>
         </div>
+        <div class="stat-card">
+            <div class="stat-eyebrow">Activity</div>
+            <div class="stat-value">
+                <span class="stat-pos" th:text="${stats.activeInstalls}">0</span>
+                <span class="muted" style="font-size:1rem;">/ <span th:text="${stats.totalInstalls}">0</span></span>
+            </div>
+            <div class="stat-sub"><span th:text="${stats.dormantInstalls}">0</span> quiet (no messages in 30d)</div>
+        </div>
+        <div class="stat-card">
+            <div class="stat-eyebrow">Health</div>
+            <div class="stat-value"
+                 th:classappend="${stats.brokenInstalls > 0 ? 'stat-neg' : 'stat-pos'}"
+                 th:text="${stats.brokenInstalls}">0</div>
+            <div class="stat-sub" th:text="${stats.brokenInstalls > 0 ? 'installs with permission issues' : 'all installs healthy'}">ok</div>
+        </div>
     </div>
 
     <!-- ===================== growth + churn chart ===================== -->
@@ -196,6 +233,45 @@
             removals come from the live JOIN/LEAVE event ledger, which only records events from
             its deploy onward — so removals for older months read as zero.
         </p>
+    </div>
+
+    <!-- ===================== insights panels ===================== -->
+    <div class="insights-grid">
+        <div class="insight-card">
+            <h3>Feature adoption</h3>
+            <div th:if="${#lists.isEmpty(insights.featureAdoption)}" class="insight-empty">No installs yet.</div>
+            <div class="bar-row" th:each="f : ${insights.featureAdoption}">
+                <span class="bar-label" th:text="${f.label}" th:title="${f.label}">Feature</span>
+                <span class="bar-track"><span class="bar-fill" th:style="'width:' + ${f.pct(insights.total)} + '%'"></span></span>
+                <span class="bar-count" th:text="${f.count}">0</span>
+            </div>
+        </div>
+        <div class="insight-card">
+            <h3>Server size</h3>
+            <div class="bar-row" th:each="b : ${insights.sizeBuckets}">
+                <span class="bar-label" th:text="${b.label}" th:title="${b.label}">Size</span>
+                <span class="bar-track"><span class="bar-fill" th:style="'width:' + ${b.pct(insights.total)} + '%'"></span></span>
+                <span class="bar-count" th:text="${b.count}">0</span>
+            </div>
+        </div>
+        <div class="insight-card">
+            <h3>Top locales</h3>
+            <div th:if="${#lists.isEmpty(insights.localeDistribution)}" class="insight-empty">No locale data.</div>
+            <div class="bar-row" th:each="l : ${insights.localeDistribution}">
+                <span class="bar-label" th:text="${l.label}" th:title="${l.label}">Locale</span>
+                <span class="bar-track"><span class="bar-fill" th:style="'width:' + ${l.pct(insights.total)} + '%'"></span></span>
+                <span class="bar-count" th:text="${l.count}">0</span>
+            </div>
+        </div>
+        <div class="insight-card">
+            <h3>Boost tier</h3>
+            <div th:if="${#lists.isEmpty(insights.boostDistribution)}" class="insight-empty">No boost data.</div>
+            <div class="bar-row" th:each="t : ${insights.boostDistribution}">
+                <span class="bar-label" th:text="${t.label}" th:title="${t.label}">Tier</span>
+                <span class="bar-track"><span class="bar-fill" th:style="'width:' + ${t.pct(insights.total)} + '%'"></span></span>
+                <span class="bar-count" th:text="${t.count}">0</span>
+            </div>
+        </div>
     </div>
 
     <!-- ===================== per-install table ===================== -->
@@ -245,9 +321,13 @@
                     <span th:unless="${row.installedAtMillis != null}" class="muted">&mdash;</span>
                     <div class="installs-sub" th:if="${row.daysSinceInstall != null}"
                          th:text="${row.daysSinceInstall + ' days ago'}">x days ago</div>
+                    <div class="installs-sub" th:if="${row.lastActiveMillis != null}"
+                         th:text="'active ' + ${row.lastActiveDisplay}" th:title="'Last message activity'">active date</div>
                 </td>
                 <td>
                     <div class="meta-chips">
+                        <span class="chip chip-warn" th:each="h : ${row.healthIssues}" th:text="${h}">issue</span>
+                        <span class="chip chip-quiet" th:if="${row.isDormant}" title="No message activity in the last 30 days">quiet</span>
                         <span class="chip" th:if="${row.serverAgeDays != null}"
                               th:title="'Server created ' + ${row.serverCreatedDisplay}"
                               th:text="'age ' + ${#numbers.formatInteger(row.serverAgeDays, 1, 'COMMA')} + 'd'">age</span>

--- a/web/src/test/kotlin/web/controller/admin/AdminControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/admin/AdminControllerTest.kt
@@ -45,6 +45,7 @@ class AdminControllerTest {
                 botJoinedAtMillis = null, serverCreatedMillis = null, boostTier = 0, boostCount = 0,
                 locale = null, channelCount = 0, roleCount = 0, features = emptyList(),
                 daysSinceInstall = null, serverAgeDays = null,
+                healthIssues = emptyList(), lastActiveMillis = null, isDormant = false,
             )
         )
         every { adminInstallsService.listInstalls() } returns rows
@@ -55,6 +56,7 @@ class AdminControllerTest {
         assertEquals("admin-installs", view)
         verify { model.addAttribute("installs", rows) }
         verify { adminInstallsService.buildStats(rows) }
+        verify { adminInstallsService.buildInsights(rows) }
         verify { installChartsService.build(rows) }
     }
 

--- a/web/src/test/kotlin/web/service/AdminInstallsServiceTest.kt
+++ b/web/src/test/kotlin/web/service/AdminInstallsServiceTest.kt
@@ -2,6 +2,7 @@ package web.service
 
 import database.dto.activity.InstallEventType
 import database.dto.guild.ConfigDto
+import database.persistence.activity.MessageDailyCountPersistence
 import database.service.activity.InstallEventService
 import database.service.guild.ConfigService
 import io.mockk.every
@@ -30,6 +31,7 @@ class AdminInstallsServiceTest {
     private lateinit var jda: JDA
     private lateinit var configService: ConfigService
     private lateinit var installEventService: InstallEventService
+    private lateinit var messageDailyCounts: MessageDailyCountPersistence
     private lateinit var service: AdminInstallsService
 
     @BeforeEach
@@ -37,7 +39,9 @@ class AdminInstallsServiceTest {
         jda = mockk(relaxed = true)
         configService = mockk(relaxed = true)
         installEventService = mockk(relaxed = true)
-        service = AdminInstallsService(jda, configService, installEventService, clock)
+        messageDailyCounts = mockk(relaxed = true)
+        every { messageDailyCounts.findLastActiveByGuild() } returns emptyMap()
+        service = AdminInstallsService(jda, configService, installEventService, messageDailyCounts, clock)
     }
 
     /** Strict guild mock — detail accessors are intentionally left unstubbed
@@ -52,6 +56,7 @@ class AdminInstallsServiceTest {
         icon: String? = null,
     ): Guild = mockk {
         every { this@mockk.id } returns id
+        every { idLong } returns id.toLong()
         every { this@mockk.name } returns name
         every { iconUrl } returns icon
         every { memberCount } returns members
@@ -160,6 +165,7 @@ class AdminInstallsServiceTest {
         }
         val richGuild = mockk<Guild> {
             every { id } returns "10"
+            every { idLong } returns 10L
             every { name } returns "Rich"
             every { iconUrl } returns null
             every { memberCount } returns 100
@@ -239,12 +245,126 @@ class AdminInstallsServiceTest {
         assertEquals(false, stats.hasLedgerData)
     }
 
-    private fun rowOf(mode: String, installedAt: Long?, members: Int): AdminInstallsService.InstallRow =
+    private fun rowOf(
+        mode: String = "express",
+        installedAt: Long? = null,
+        members: Int = 0,
+        locale: String? = null,
+        boostTier: Int = 0,
+        healthIssues: List<String> = emptyList(),
+        isDormant: Boolean = false,
+    ): AdminInstallsService.InstallRow =
         AdminInstallsService.InstallRow(
             guildId = "g", guildName = "G", iconUrl = null, ownerId = "1", ownerName = null,
             memberCount = members, installMode = mode, installedAtMillis = installedAt,
-            botJoinedAtMillis = null, serverCreatedMillis = null, boostTier = 0, boostCount = 0,
-            locale = null, channelCount = 0, roleCount = 0, features = emptyList(),
+            botJoinedAtMillis = null, serverCreatedMillis = null, boostTier = boostTier, boostCount = 0,
+            locale = locale, channelCount = 0, roleCount = 0, features = emptyList(),
             daysSinceInstall = null, serverAgeDays = null,
+            healthIssues = healthIssues, lastActiveMillis = null, isDormant = isDormant,
         )
+
+    @Test
+    fun `health issues are flagged when the bot lacks post and manage-roles perms`() {
+        val self = mockk<net.dv8tion.jda.api.entities.SelfMember> {
+            every { hasPermission(net.dv8tion.jda.api.Permission.ADMINISTRATOR) } returns false
+            every { hasPermission(net.dv8tion.jda.api.Permission.MANAGE_ROLES) } returns false
+            every { hasPermission(any<net.dv8tion.jda.api.entities.channel.middleman.GuildChannel>(), *anyVararg()) } returns false
+        }
+        val g = mockk<Guild> {
+            every { id } returns "10"; every { idLong } returns 10L; every { name } returns "Locked"; every { iconUrl } returns null
+            every { memberCount } returns 5; every { ownerIdLong } returns 1L; every { ownerId } returns "1"
+            every { getMemberById(1L) } returns null
+            every { selfMember } returns self
+            every { systemChannel } returns null
+            every { textChannels } returns emptyList()
+            // detail accessors left to throw → defaults
+            every { timeCreated } throws RuntimeException("n/a")
+        }
+        stubGuilds(g)
+        every { configService.listAllConfig() } returns emptyList()
+
+        val row = service.listInstalls().single()
+
+        assertTrue(row.healthIssues.contains("Can't post"))
+        assertTrue(row.healthIssues.contains("No Manage Roles"))
+        assertEquals(false, row.isHealthy)
+    }
+
+    @Test
+    fun `administrator permission short-circuits all health checks`() {
+        val self = mockk<net.dv8tion.jda.api.entities.SelfMember> {
+            every { hasPermission(net.dv8tion.jda.api.Permission.ADMINISTRATOR) } returns true
+        }
+        val g = mockk<Guild> {
+            every { id } returns "10"; every { idLong } returns 10L; every { name } returns "Admin"; every { iconUrl } returns null
+            every { memberCount } returns 5; every { ownerIdLong } returns 1L; every { ownerId } returns "1"
+            every { getMemberById(1L) } returns null
+            every { selfMember } returns self
+            every { timeCreated } throws RuntimeException("n/a")
+        }
+        stubGuilds(g)
+        every { configService.listAllConfig() } returns emptyList()
+
+        assertTrue(service.listInstalls().single().isHealthy)
+    }
+
+    @Test
+    fun `guild with recent message activity is not dormant`() {
+        stubGuilds(guild("10", "Alpha", ownerId = 1L, ownerName = "A"))
+        every { configService.listAllConfig() } returns emptyList()
+        // clock is 2026-06-06; 3 days ago is well within the 30-day window.
+        every { messageDailyCounts.findLastActiveByGuild() } returns mapOf(10L to java.time.LocalDate.of(2026, 6, 3))
+
+        val row = service.listInstalls().single()
+
+        assertEquals(false, row.isDormant)
+        assertEquals(
+            java.time.LocalDate.of(2026, 6, 3).atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli(),
+            row.lastActiveMillis,
+        )
+    }
+
+    @Test
+    fun `guild with stale or missing activity is dormant`() {
+        stubGuilds(
+            guild("10", "Stale", ownerId = 1L, ownerName = "A"),
+            guild("20", "Never", ownerId = 2L, ownerName = "B"),
+        )
+        every { configService.listAllConfig() } returns emptyList()
+        every { messageDailyCounts.findLastActiveByGuild() } returns mapOf(10L to java.time.LocalDate.of(2026, 1, 1))
+
+        val byName = service.listInstalls().associateBy { it.guildName }
+        assertTrue(byName.getValue("Stale").isDormant)  // 5 months ago
+        assertTrue(byName.getValue("Never").isDormant)  // no row at all
+    }
+
+    @Test
+    fun `buildInsights counts feature adoption, size buckets and locale distribution`() {
+        every { configService.listAllConfig() } returns listOf(
+            cfg(ConfigDto.Configurations.ACTIVITY_TRACKING.configValue, "true", "10"),
+            cfg(ConfigDto.Configurations.LOTTERY_DAILY_ENABLED.configValue, "true", "10"),
+            cfg(ConfigDto.Configurations.WELCOME_ENABLED.configValue, "true", "20"),
+            // config for a guild not in the row set must be ignored
+            cfg(ConfigDto.Configurations.ACTIVITY_TRACKING.configValue, "true", "999"),
+        )
+        val rows = listOf(
+            rowOf(members = 10, locale = "English (US)", boostTier = 0).copy(guildId = "10"),
+            rowOf(members = 200, locale = "English (US)", boostTier = 2).copy(guildId = "20"),
+            rowOf(members = 9000, locale = "German", boostTier = 0).copy(guildId = "30"),
+        )
+
+        val insights = service.buildInsights(rows)
+
+        assertEquals(3, insights.total)
+        val activity = insights.featureAdoption.first { it.label == "Activity tracking" }
+        assertEquals(1, activity.count) // guild 10 only (999 ignored, no row)
+        assertEquals(1, insights.featureAdoption.first { it.label == "Welcome messages" }.count)
+        assertEquals(1, insights.sizeBuckets.first { it.label.startsWith("Small") }.count)
+        assertEquals(1, insights.sizeBuckets.first { it.label.startsWith("Medium") }.count)
+        assertEquals(1, insights.sizeBuckets.first { it.label.startsWith("Huge") }.count)
+        assertEquals("English (US)", insights.localeDistribution.first().label)
+        assertEquals(2, insights.localeDistribution.first().count)
+        assertEquals(2, insights.boostDistribution.first { it.label == "No boost" }.count)
+        assertEquals(1, insights.boostDistribution.first { it.label == "Tier 2" }.count)
+    }
 }

--- a/web/src/test/kotlin/web/service/InstallChartsServiceTest.kt
+++ b/web/src/test/kotlin/web/service/InstallChartsServiceTest.kt
@@ -37,6 +37,7 @@ class InstallChartsServiceTest {
             botJoinedAtMillis = null, serverCreatedMillis = null, boostTier = 0, boostCount = 0,
             locale = null, channelCount = 0, roleCount = 0, features = emptyList(),
             daysSinceInstall = null, serverAgeDays = null,
+            healthIssues = emptyList(), lastActiveMillis = null, isDormant = false,
         )
 
     private fun leave(iso: String) =

--- a/web/src/test/kotlin/web/template/AdminInstallsTemplateRenderTest.kt
+++ b/web/src/test/kotlin/web/template/AdminInstallsTemplateRenderTest.kt
@@ -44,6 +44,7 @@ class AdminInstallsTemplateRenderTest {
     private fun render(
         installs: List<AdminInstallsService.InstallRow>,
         stats: AdminInstallsService.InstallStats = statsFor(installs),
+        insights: AdminInstallsService.InstallInsights = insightsFor(installs),
         chart: InstallChartsService.InstallChartView = emptyChart(),
     ): String {
         val request = MockHttpServletRequest(servletContext)
@@ -52,6 +53,7 @@ class AdminInstallsTemplateRenderTest {
         val ctx = WebContext(exchange).apply {
             setVariable("installs", installs)
             setVariable("stats", stats)
+            setVariable("insights", insights)
             setVariable("chart", chart)
             setVariable("username", "operator")
             setVariable("isBotOwner", true)
@@ -70,6 +72,18 @@ class AdminInstallsTemplateRenderTest {
             installsLast7Days = 1, installsLast30Days = 2,
             lifetimeJoins = 0, lifetimeLeaves = 0, netGrowth = 0,
             joinsLast30Days = 0, leavesLast30Days = 0, hasLedgerData = false,
+            brokenInstalls = installs.count { !it.isHealthy },
+            activeInstalls = installs.count { !it.isDormant },
+            dormantInstalls = installs.count { it.isDormant },
+        )
+
+    private fun insightsFor(installs: List<AdminInstallsService.InstallRow>) =
+        AdminInstallsService.InstallInsights(
+            total = installs.size,
+            featureAdoption = listOf(AdminInstallsService.LabeledCount("Activity tracking", 1)),
+            sizeBuckets = listOf(AdminInstallsService.LabeledCount("Small (<50)", installs.size)),
+            localeDistribution = listOf(AdminInstallsService.LabeledCount("English (US)", installs.size)),
+            boostDistribution = listOf(AdminInstallsService.LabeledCount("No boost", installs.size)),
         )
 
     private fun emptyChart() = InstallChartsService.InstallChartView(
@@ -96,6 +110,8 @@ class AdminInstallsTemplateRenderTest {
         features: List<String> = emptyList(),
         daysSinceInstall: Long? = 42L,
         serverAgeDays: Long? = 365L,
+        healthIssues: List<String> = emptyList(),
+        isDormant: Boolean = false,
     ) = AdminInstallsService.InstallRow(
         guildId = guildId, guildName = name, iconUrl = icon,
         ownerId = ownerId, ownerName = ownerName, memberCount = 7,
@@ -104,6 +120,7 @@ class AdminInstallsTemplateRenderTest {
         boostTier = boostTier, boostCount = if (boostTier > 0) 10 else 0,
         locale = "English (US)", channelCount = 12, roleCount = 8,
         features = features, daysSinceInstall = daysSinceInstall, serverAgeDays = serverAgeDays,
+        healthIssues = healthIssues, lastActiveMillis = installedAt, isDormant = isDormant,
     )
 
     @Test
@@ -155,6 +172,29 @@ class AdminInstallsTemplateRenderTest {
         assertTrue(html.contains("chart-bar-installs")) { "install bar missing:\n$html" }
         assertTrue(html.contains("chart-bar-removals")) { "removal bar missing:\n$html" }
         assertTrue(html.contains("Jun 2026")) { "month label missing:\n$html" }
+    }
+
+    @Test
+    fun `health issues and quiet badge render on the row`() {
+        val html = render(listOf(
+            row("90", "India", healthIssues = listOf("Cannot post", "No Manage Roles"), isDormant = true),
+        ))
+        assertTrue(html.contains("Cannot post")) { "health chip missing:\n$html" }
+        assertTrue(html.contains("No Manage Roles")) { "manage-roles chip missing:\n$html" }
+        assertTrue(html.contains("chip-warn")) { "warn chip class missing:\n$html" }
+        assertTrue(html.contains(">quiet<")) { "quiet badge missing:\n$html" }
+    }
+
+    @Test
+    fun `insights panels render feature adoption, size, locale and boost bars`() {
+        val html = render(listOf(row("a1", "J")))
+        assertTrue(html.contains("Feature adoption")) { "feature panel missing:\n$html" }
+        assertTrue(html.contains("Server size")) { "size panel missing:\n$html" }
+        assertTrue(html.contains("Top locales")) { "locale panel missing:\n$html" }
+        assertTrue(html.contains("Boost tier")) { "boost panel missing:\n$html" }
+        assertTrue(html.contains("bar-fill")) { "bar fill missing:\n$html" }
+        // health + activity stat cards
+        assertTrue(html.contains("Health") && html.contains("Activity")) { "health/activity stat cards missing:\n$html" }
     }
 
     @Test


### PR DESCRIPTION
## Why

Follow-up to #662 / #663. Those built the operator `/admin/installs` page and its growth/churn metrics. This squeezes four more signals out of **data we already have** — the JDA guild cache and existing tables — with **no new data collection**.

## What

- **Install health flags** — per-guild permission/reachability checks read off the *cached* `Guild` (no API calls): can't post anywhere, missing Manage Roles. `Administrator` short-circuits. Surfaced as red row chips + a **"broken installs"** stat card. Catches silently-misconfigured installs.
- **Active vs quiet** — one grouped query (`MessageDailyCount.lastActiveByGuild`) gives each guild's last message-activity day. Installs with nothing in 30 days are flagged **quiet**; the page shows an active/total stat card and a per-row "active *date*" line + quiet badge. Turns "N installs" into "how many are alive."
- **Feature-adoption funnel** — counts, from the config we already bulk-read, how many installs turned on each optional feature (activity tracking, daily lottery, welcome/goodbye, leaderboard / level-up / lottery channels, UBI). Rendered as a bar list.
- **Audience rollups** — server-size buckets, top locales, and boost-tier distribution as bar-list insight panels.

All deduced in-memory and defensively (one odd guild can't blank the page). `buildInsights` restricts feature counts to **live** guilds so stale config from a departed guild can't inflate them.

## Notes / honest limits
- **Liveness uses message activity** as the proxy — a purely voice-active server with no chat would read as "quiet." The badge/caption says "no messages in 30 days" rather than "dead."
- The new `findLastActiveByGuild` is a single grouped query (`select guild_id, max(day_start) … group by guild_id`), not N per-guild lookups.

## Testing
- Expanded `AdminInstallsServiceTest` (health flags, Administrator short-circuit, dormancy, feature/size/locale/boost insights), updated `AdminControllerTest` and `AdminInstallsTemplateRenderTest` (health chips, quiet badge, insight panels), plus the new persistence method.
- **Full `:web` (1519) and `:database` (856) suites pass.** The `:application` integration tests need Docker/Testcontainers (unavailable here); the new query follows the existing `message_daily_count` named-query pattern.

https://claude.ai/code/session_01KZNzPZmpXZrhcqPHTF6K9t

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZNzPZmpXZrhcqPHTF6K9t)_