### PR TITLE
Polish /admin/installs for mobile (card-per-row layout + reveal/count-up)

### DIFF
--- a/web/src/main/resources/static/css/installs.css
+++ b/web/src/main/resources/static/css/installs.css
@@ -1,0 +1,194 @@
+/* Operator /admin/installs dashboard.
+ *
+ * Loaded via the head fragment's `extraCss` slot (like home.css, economy.css
+ * etc.) instead of an inline <style> block so the page gets the same
+ * cacheable, media-query-friendly treatment as the rest of the site.
+ *
+ * Desktop is a dense table; at <=600px every install row reshapes into a
+ * stacked card (thead hidden, td label via data-label::before) so nothing
+ * relies on horizontal scrolling. The stats/insight grids and the bar chart
+ * each get their own small-screen handling further down. */
+
+/* ---- headline ---- */
+.installs-title { font-size: clamp(1.6rem, 4vw, 2.1rem); margin-bottom: var(--space-2); }
+
+/* ---- stats strip ---- */
+.installs-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: var(--space-4);
+    margin-bottom: var(--space-6);
+}
+.stat-card {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: var(--space-4) var(--space-5);
+    transition: border-color var(--dur-base, .15s) var(--ease-out, ease), transform var(--dur-base, .15s) var(--ease-out, ease);
+}
+.stat-card:hover { border-color: var(--border-strong); transform: translateY(-2px); }
+.stat-eyebrow {
+    font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.06em;
+    color: var(--text-muted); margin-bottom: 6px;
+}
+.stat-value { font-size: clamp(1.6rem, 4.5vw, 1.9rem); font-weight: 700; line-height: 1.1; font-variant-numeric: tabular-nums; }
+.stat-sub { font-size: 0.82rem; color: var(--text-muted); margin-top: 4px; }
+.stat-pos { color: #3fb950; }
+.stat-neg { color: #f85149; }
+
+/* ---- chart ---- */
+.chart-card {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: var(--space-5);
+    margin-bottom: var(--space-6);
+}
+.chart-head { display: flex; justify-content: space-between; align-items: baseline; flex-wrap: wrap; gap: var(--space-3); margin-bottom: var(--space-4); }
+.chart-legend { display: flex; gap: var(--space-4); font-size: 0.82rem; color: var(--text-muted); }
+.legend-dot { display: inline-block; width: 10px; height: 10px; border-radius: 2px; margin-right: 6px; vertical-align: middle; }
+.legend-installs { background: #3fb950; }
+.legend-removals { background: #f85149; }
+.chart-scroll { overflow-x: auto; -webkit-overflow-scrolling: touch; }
+.chart-bars { display: flex; align-items: flex-end; gap: var(--space-2); }
+.chart-col { flex: 1 1 0; display: flex; flex-direction: column; align-items: center; min-width: 0; }
+.chart-col-bars { display: flex; align-items: flex-end; gap: 3px; height: 130px; width: 100%; justify-content: center; }
+.chart-bar { width: 14px; max-width: 45%; border-radius: 3px 3px 0 0; transition: opacity .15s; min-height: 2px; }
+.chart-bar:hover { opacity: 0.75; }
+.chart-bar-installs { background: #3fb950; }
+.chart-bar-removals { background: #f85149; }
+.chart-bar-empty { background: var(--border); min-height: 0; }
+.chart-col-label {
+    font-size: 0.68rem; color: var(--text-muted); margin-top: 14px;
+    white-space: nowrap; transform: rotate(-35deg); transform-origin: top center; height: 20px;
+}
+.chart-caption { font-size: 0.78rem; color: var(--text-muted); margin-top: var(--space-5); }
+.chart-empty { text-align: center; color: var(--text-muted); padding: 32px 16px; font-size: 0.9rem; }
+
+/* ---- insights panels ---- */
+.insights-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: var(--space-4);
+    margin-bottom: var(--space-6);
+}
+.insight-card {
+    background: var(--bg-elevated); border: 1px solid var(--border);
+    border-radius: var(--radius-lg); padding: var(--space-5);
+}
+.insight-card h3 { font-size: 0.95rem; margin: 0 0 var(--space-4); }
+.bar-row { display: grid; grid-template-columns: minmax(0, 130px) 1fr 32px; align-items: center; gap: var(--space-3); margin-bottom: 8px; }
+.bar-row:last-child { margin-bottom: 0; }
+.bar-label { font-size: 0.8rem; color: var(--text-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.bar-track { background: var(--bg); border-radius: 999px; height: 8px; overflow: hidden; }
+.bar-fill { height: 100%; background: var(--accent); border-radius: 999px; min-width: 2px; }
+.bar-count { font-size: 0.8rem; font-variant-numeric: tabular-nums; text-align: right; }
+.insight-empty { font-size: 0.82rem; color: var(--text-muted); }
+
+/* ---- table (desktop) ---- */
+.installs-scroll { overflow-x: auto; }
+.installs-table {
+    width: 100%; border-collapse: collapse;
+    background: var(--bg-elevated); border: 1px solid var(--border);
+    border-radius: var(--radius-lg); overflow: hidden;
+}
+.installs-table th, .installs-table td {
+    padding: var(--space-3) var(--space-4); text-align: left;
+    border-bottom: 1px solid var(--border); vertical-align: top;
+}
+.installs-table th {
+    font-size: 0.74rem; text-transform: uppercase; letter-spacing: 0.04em;
+    color: var(--text-muted); white-space: nowrap;
+}
+.installs-table tr:last-child td { border-bottom: none; }
+.installs-table tbody tr:hover { background: rgba(255,255,255,0.02); }
+.installs-guild { display: flex; align-items: center; gap: var(--space-3); }
+.installs-icon, .installs-icon-placeholder { width: 36px; height: 36px; border-radius: 50%; flex: 0 0 auto; }
+.installs-icon-placeholder {
+    background: var(--accent); color: #fff; font-weight: 700; font-size: 0.95rem;
+    display: flex; align-items: center; justify-content: center;
+}
+.installs-name { font-weight: 600; }
+.installs-sub { font-size: 0.75rem; color: var(--text-muted); }
+.installs-owner-id { color: var(--text-muted); font-size: 0.85rem; }
+.installs-num { text-align: right; font-variant-numeric: tabular-nums; white-space: nowrap; }
+.meta-chips { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 6px; }
+.chip {
+    display: inline-block; padding: 1px 8px; border-radius: 999px;
+    font-size: 0.7rem; background: var(--bg); border: 1px solid var(--border);
+    color: var(--text-muted); white-space: nowrap;
+}
+.chip-boost { color: #ff73fa; border-color: rgba(255,115,250,0.4); }
+.chip-feature { color: var(--accent); border-color: rgba(88,166,255,0.4); }
+.chip-warn { color: #f85149; border-color: rgba(248,81,73,0.45); background: rgba(248,81,73,0.08); }
+.chip-quiet { color: #d29922; border-color: rgba(210,153,34,0.45); }
+.mode-badge {
+    display: inline-block; padding: 2px 10px; border-radius: 999px;
+    font-size: 0.76rem; font-weight: 600; text-transform: capitalize; white-space: nowrap;
+}
+.mode-express { background: rgba(46, 160, 67, 0.18); color: #3fb950; }
+.mode-custom  { background: rgba(88, 166, 255, 0.18); color: #58a6ff; }
+.mode-legacy  { background: var(--bg); color: var(--text-muted); border: 1px dashed var(--border-strong); }
+
+.empty-hero {
+    background: var(--bg-elevated); border: 1px dashed var(--border-strong);
+    border-radius: var(--radius-lg); padding: 48px 24px; text-align: center; color: var(--text-muted);
+}
+.empty-hero h2 { color: var(--text); margin-bottom: 10px; }
+.empty-hero .emoji { font-size: 2.4rem; display: block; margin-bottom: 12px; }
+
+/* =========================================================================
+   Mobile (<=600px): each install row becomes a self-contained card.
+   ========================================================================= */
+@media (max-width: 600px) {
+    .installs-stats { grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: var(--space-3); }
+    .stat-card { padding: var(--space-3) var(--space-4); }
+
+    /* Bar-list label column shrinks so the bar itself stays readable. */
+    .bar-row { grid-template-columns: minmax(0, 96px) 1fr 26px; gap: var(--space-2); }
+
+    /* Keep all 12 month bars legible by letting the strip scroll. */
+    .chart-bars { min-width: 520px; }
+    .chart-scroll { margin: 0 calc(var(--space-5) * -1); padding: 0 var(--space-5); }
+
+    /* Table → cards. */
+    .installs-scroll { overflow-x: visible; }
+    .installs-table,
+    .installs-table tbody,
+    .installs-table tr,
+    .installs-table td { display: block; width: 100%; }
+    .installs-table thead { display: none; }
+    .installs-table { border: 0; background: transparent; border-radius: 0; overflow: visible; }
+    .installs-table tr {
+        background: var(--bg-elevated);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        margin-bottom: var(--space-4);
+        padding: var(--space-4);
+    }
+    .installs-table tbody tr:hover { background: var(--bg-elevated); }
+    .installs-table td { border-bottom: none; padding: 6px 0; }
+
+    /* Label : value rows for the simple cells. */
+    .installs-table td.cell-kv {
+        display: flex; align-items: baseline; justify-content: space-between;
+        gap: var(--space-3); padding: 7px 0; border-top: 1px solid var(--border);
+    }
+    .installs-table td.cell-kv::before {
+        content: attr(data-label);
+        color: var(--text-muted); font-size: 0.72rem; text-transform: uppercase;
+        letter-spacing: 0.04em; flex: 0 0 auto;
+    }
+    .installs-table td.cell-kv.installs-num { text-align: right; }
+
+    /* Server cell is the card header — icon + name, no label, no rule. */
+    .installs-table td.cell-server { padding: 0 0 var(--space-3); }
+
+    /* Stacked cells (Installed dates, Details chips): label on its own line. */
+    .installs-table td.cell-stack { padding: 7px 0; border-top: 1px solid var(--border); }
+    .installs-table td.cell-stack::before {
+        content: attr(data-label); display: block; margin-bottom: 4px;
+        color: var(--text-muted); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.04em;
+    }
+    .meta-chips { margin-top: 0; }
+}

--- a/web/src/main/resources/templates/admin-installs.html
+++ b/web/src/main/resources/templates/admin-installs.html
@@ -1,136 +1,12 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="en">
-<head th:replace="~{fragments/head :: head('TobyBot - Installs', null)}"></head>
+<head th:replace="~{fragments/head :: head('TobyBot - Installs', '/css/installs.css')}"></head>
 <body>
 <a href="#main" class="skip-link">Skip to content</a>
 <div th:replace="~{fragments/navbar :: navbar}"></div>
 
-<style>
-    /* ---- stats strip ---- */
-    .installs-stats {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-        gap: var(--space-4);
-        margin-bottom: var(--space-6);
-    }
-    .stat-card {
-        background: var(--bg-elevated);
-        border: 1px solid var(--border);
-        border-radius: var(--radius-lg);
-        padding: var(--space-4) var(--space-5);
-    }
-    .stat-eyebrow {
-        font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.06em;
-        color: var(--text-muted); margin-bottom: 6px;
-    }
-    .stat-value { font-size: 1.9rem; font-weight: 700; line-height: 1.1; }
-    .stat-sub { font-size: 0.82rem; color: var(--text-muted); margin-top: 4px; }
-    .stat-pos { color: #3fb950; }
-    .stat-neg { color: #f85149; }
-
-    /* ---- chart ---- */
-    .chart-card {
-        background: var(--bg-elevated);
-        border: 1px solid var(--border);
-        border-radius: var(--radius-lg);
-        padding: var(--space-5);
-        margin-bottom: var(--space-6);
-    }
-    .chart-head { display: flex; justify-content: space-between; align-items: baseline; flex-wrap: wrap; gap: var(--space-3); margin-bottom: var(--space-4); }
-    .chart-legend { display: flex; gap: var(--space-4); font-size: 0.82rem; color: var(--text-muted); }
-    .legend-dot { display: inline-block; width: 10px; height: 10px; border-radius: 2px; margin-right: 6px; vertical-align: middle; }
-    .legend-installs { background: #3fb950; }
-    .legend-removals { background: #f85149; }
-    .chart-bars { display: flex; align-items: flex-end; gap: var(--space-2); }
-    .chart-col { flex: 1 1 0; display: flex; flex-direction: column; align-items: center; min-width: 0; }
-    .chart-col-bars { display: flex; align-items: flex-end; gap: 3px; height: 130px; width: 100%; justify-content: center; }
-    .chart-bar { width: 14px; max-width: 45%; border-radius: 3px 3px 0 0; transition: opacity .15s; min-height: 2px; }
-    .chart-bar:hover { opacity: 0.75; }
-    .chart-bar-installs { background: #3fb950; }
-    .chart-bar-removals { background: #f85149; }
-    .chart-bar-empty { background: var(--border); min-height: 0; }
-    .chart-col-label {
-        font-size: 0.68rem; color: var(--text-muted); margin-top: 14px;
-        white-space: nowrap; transform: rotate(-35deg); transform-origin: top center; height: 20px;
-    }
-    .chart-caption { font-size: 0.78rem; color: var(--text-muted); margin-top: var(--space-5); }
-
-    /* ---- insights panels ---- */
-    .insights-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-        gap: var(--space-4);
-        margin-bottom: var(--space-6);
-    }
-    .insight-card {
-        background: var(--bg-elevated); border: 1px solid var(--border);
-        border-radius: var(--radius-lg); padding: var(--space-5);
-    }
-    .insight-card h3 { font-size: 0.95rem; margin: 0 0 var(--space-4); }
-    .bar-row { display: grid; grid-template-columns: 130px 1fr 32px; align-items: center; gap: var(--space-3); margin-bottom: 8px; }
-    .bar-row:last-child { margin-bottom: 0; }
-    .bar-label { font-size: 0.8rem; color: var(--text-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-    .bar-track { background: var(--bg); border-radius: 999px; height: 8px; overflow: hidden; }
-    .bar-fill { height: 100%; background: var(--accent); border-radius: 999px; min-width: 2px; }
-    .bar-count { font-size: 0.8rem; font-variant-numeric: tabular-nums; text-align: right; }
-    .insight-empty { font-size: 0.82rem; color: var(--text-muted); }
-
-    /* ---- table ---- */
-    .installs-scroll { overflow-x: auto; }
-    .installs-table {
-        width: 100%; border-collapse: collapse;
-        background: var(--bg-elevated); border: 1px solid var(--border);
-        border-radius: var(--radius-lg); overflow: hidden;
-    }
-    .installs-table th, .installs-table td {
-        padding: var(--space-3) var(--space-4); text-align: left;
-        border-bottom: 1px solid var(--border); vertical-align: top;
-    }
-    .installs-table th {
-        font-size: 0.74rem; text-transform: uppercase; letter-spacing: 0.04em;
-        color: var(--text-muted); white-space: nowrap;
-    }
-    .installs-table tr:last-child td { border-bottom: none; }
-    .installs-table tbody tr:hover { background: rgba(255,255,255,0.02); }
-    .installs-guild { display: flex; align-items: center; gap: var(--space-3); }
-    .installs-icon, .installs-icon-placeholder { width: 36px; height: 36px; border-radius: 50%; flex: 0 0 auto; }
-    .installs-icon-placeholder {
-        background: var(--accent); color: #fff; font-weight: 700; font-size: 0.95rem;
-        display: flex; align-items: center; justify-content: center;
-    }
-    .installs-name { font-weight: 600; }
-    .installs-sub { font-size: 0.75rem; color: var(--text-muted); }
-    .installs-owner-id { color: var(--text-muted); font-size: 0.85rem; }
-    .installs-num { text-align: right; font-variant-numeric: tabular-nums; white-space: nowrap; }
-    .meta-chips { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 6px; }
-    .chip {
-        display: inline-block; padding: 1px 8px; border-radius: 999px;
-        font-size: 0.7rem; background: var(--bg); border: 1px solid var(--border);
-        color: var(--text-muted); white-space: nowrap;
-    }
-    .chip-boost { color: #ff73fa; border-color: rgba(255,115,250,0.4); }
-    .chip-feature { color: var(--accent); border-color: rgba(88,166,255,0.4); }
-    .chip-warn { color: #f85149; border-color: rgba(248,81,73,0.45); background: rgba(248,81,73,0.08); }
-    .chip-quiet { color: #d29922; border-color: rgba(210,153,34,0.45); }
-    .mode-badge {
-        display: inline-block; padding: 2px 10px; border-radius: 999px;
-        font-size: 0.76rem; font-weight: 600; text-transform: capitalize; white-space: nowrap;
-    }
-    .mode-express { background: rgba(46, 160, 67, 0.18); color: #3fb950; }
-    .mode-custom  { background: rgba(88, 166, 255, 0.18); color: #58a6ff; }
-    .mode-legacy  { background: var(--bg); color: var(--text-muted); border: 1px dashed var(--border-strong); }
-
-    .empty-hero {
-        background: var(--bg-elevated); border: 1px dashed var(--border-strong);
-        border-radius: var(--radius-lg); padding: 48px 24px; text-align: center; color: var(--text-muted);
-    }
-    .empty-hero h2 { color: var(--text); margin-bottom: 10px; }
-    .empty-hero .emoji { font-size: 2.4rem; display: block; margin-bottom: 12px; }
-    .chart-empty { text-align: center; color: var(--text-muted); padding: 32px 16px; font-size: 0.9rem; }
-</style>
-
-<main id="main" class="container">
-    <h1 class="mb-3">Installs</h1>
+<main id="main" class="container-wide">
+    <h1 class="installs-title">Installs</h1>
     <p class="muted mb-5">
         Every server TobyBot is currently in, with adoption and churn metrics.
     </p>
@@ -138,20 +14,20 @@
     <div th:replace="~{fragments/alerts :: error}"></div>
 
     <!-- ===================== summary stats strip ===================== -->
-    <div class="installs-stats">
+    <div class="installs-stats" data-reveal>
         <div class="stat-card">
             <div class="stat-eyebrow">Total installs</div>
-            <div class="stat-value" th:text="${stats.totalInstalls}">0</div>
+            <div class="stat-value" data-count-up th:text="${stats.totalInstalls}">0</div>
             <div class="stat-sub">servers right now</div>
         </div>
         <div class="stat-card">
             <div class="stat-eyebrow">Members reached</div>
-            <div class="stat-value" th:text="${#numbers.formatInteger(stats.totalMembers, 1, 'COMMA')}">0</div>
+            <div class="stat-value" data-count-up th:text="${#numbers.formatInteger(stats.totalMembers, 1, 'COMMA')}">0</div>
             <div class="stat-sub"><span th:text="${#numbers.formatInteger(stats.avgMembers, 1, 'COMMA')}">0</span> avg / server</div>
         </div>
         <div class="stat-card">
             <div class="stat-eyebrow">Setup mode</div>
-            <div class="stat-value" th:text="${stats.expressCount + stats.customCount}">0</div>
+            <div class="stat-value" data-count-up th:text="${stats.expressCount + stats.customCount}">0</div>
             <div class="stat-sub">
                 <span th:text="${stats.expressCount}">0</span> express ·
                 <span th:text="${stats.customCount}">0</span> custom ·
@@ -160,7 +36,7 @@
         </div>
         <div class="stat-card">
             <div class="stat-eyebrow">New installs</div>
-            <div class="stat-value" th:text="${stats.installsLast30Days}">0</div>
+            <div class="stat-value" data-count-up th:text="${stats.installsLast30Days}">0</div>
             <div class="stat-sub"><span th:text="${stats.installsLast7Days}">0</span> in last 7 days · 30-day total</div>
         </div>
         <div class="stat-card">
@@ -200,7 +76,7 @@
     </div>
 
     <!-- ===================== growth + churn chart ===================== -->
-    <div class="chart-card">
+    <div class="chart-card" data-reveal>
         <div class="chart-head">
             <strong>Installs &amp; removals per month</strong>
             <div class="chart-legend">
@@ -213,7 +89,7 @@
             Not enough history yet — install dates and removal events will populate this chart over time.
         </div>
 
-        <div th:unless="${chart.isEmpty}">
+        <div th:unless="${chart.isEmpty}" class="chart-scroll">
             <div class="chart-bars">
                 <div class="chart-col" th:each="b : ${chart.buckets}">
                     <div class="chart-col-bars"
@@ -236,7 +112,7 @@
     </div>
 
     <!-- ===================== insights panels ===================== -->
-    <div class="insights-grid">
+    <div class="insights-grid" data-reveal>
         <div class="insight-card">
             <h3>Feature adoption</h3>
             <div th:if="${#lists.isEmpty(insights.featureAdoption)}" class="insight-empty">No installs yet.</div>
@@ -275,7 +151,7 @@
     </div>
 
     <!-- ===================== per-install table ===================== -->
-    <div class="installs-scroll" th:if="${not #lists.isEmpty(installs)}">
+    <div class="installs-scroll" th:if="${not #lists.isEmpty(installs)}" data-reveal>
         <table class="installs-table">
             <thead>
             <tr>
@@ -289,7 +165,7 @@
             </thead>
             <tbody>
             <tr th:each="row : ${installs}">
-                <td>
+                <td class="cell-server">
                     <div class="installs-guild">
                         <img th:if="${row.iconUrl != null}"
                              th:src="${row.iconUrl}"
@@ -306,17 +182,17 @@
                         </div>
                     </div>
                 </td>
-                <td>
+                <td class="cell-kv" data-label="Owner">
                     <span th:if="${row.ownerName != null}" th:text="${row.ownerName}">Owner</span>
                     <span th:unless="${row.ownerName != null}" class="installs-owner-id" th:text="${row.ownerId}">000</span>
                 </td>
-                <td class="installs-num" th:text="${#numbers.formatInteger(row.memberCount, 1, 'COMMA')}">0</td>
-                <td>
+                <td class="cell-kv installs-num" data-label="Members" th:text="${#numbers.formatInteger(row.memberCount, 1, 'COMMA')}">0</td>
+                <td class="cell-kv" data-label="Mode">
                     <span class="mode-badge"
                           th:classappend="${row.installMode == 'express' ? 'mode-express' : (row.installMode == 'custom' ? 'mode-custom' : 'mode-legacy')}"
                           th:text="${row.installMode}">mode</span>
                 </td>
-                <td>
+                <td class="cell-stack" data-label="Installed">
                     <span th:if="${row.installedAtMillis != null}" th:text="${row.installedAtDisplay}">date</span>
                     <span th:unless="${row.installedAtMillis != null}" class="muted">&mdash;</span>
                     <div class="installs-sub" th:if="${row.daysSinceInstall != null}"
@@ -324,7 +200,7 @@
                     <div class="installs-sub" th:if="${row.lastActiveMillis != null}"
                          th:text="'active ' + ${row.lastActiveDisplay}" th:title="'Last message activity'">active date</div>
                 </td>
-                <td>
+                <td class="cell-stack" data-label="Details">
                     <div class="meta-chips">
                         <span class="chip chip-warn" th:each="h : ${row.healthIssues}" th:text="${h}">issue</span>
                         <span class="chip chip-quiet" th:if="${row.isDormant}" title="No message activity in the last 30 days">quiet</span>


### PR DESCRIPTION
## Why

The `/admin/installs` page shipped with a bespoke inline `<style>` block and a 6-column table that just scrolled sideways on phones — out of step with the rest of the site, which uses per-page stylesheets and reflowing layouts. This brings it up to the homepage's level of polish, especially on mobile.

## What

- **Dedicated stylesheet** — moved all styles out of the inline `<style>` into `web/css/installs.css`, loaded via the head fragment's `extraCss` slot (same pattern as `home.css` / `economy.css`). Cacheable and media-query-friendly.
- **Mobile (`≤600px`): table → cards.** Each install row reshapes into a self-contained card — `thead` hidden, cells stacked with `data-label`/`::before` captions, the **Server** cell as the card header, **Installed**/**Details** stacked. No more horizontal scrolling of a wide table.
- **Responsive everywhere else** — stats grid tightens to 2-up on phones; insight bar-rows shrink their label column; the 12-month bar chart gets a horizontal-scroll wrapper so bars stay legible instead of crushed.
- **Homepage polish primitives** (both already global): `data-reveal` fade-in-on-scroll on each section, `data-count-up` on the headline stat numbers, a subtle hover-lift on stat cards, and fluid `clamp()` type. Page now uses `container-wide` for more desktop breathing room.

## Testing
- `AdminInstallsTemplateRenderTest` (10) and the full **`:web` suite (1519)** pass. Template-only + new CSS — no Kotlin change.
- ⚠️ I couldn't attach a mobile screenshot from this environment (the app needs Postgres/Docker to run, and no headless browser is available here). The change is purely presentational; worth a quick eyeball on the deploy/preview at a phone width.

https://claude.ai/code/session_01KZNzPZmpXZrhcqPHTF6K9t

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZNzPZmpXZrhcqPHTF6K9t)_