### PR TITLE
Share + mobile-polish the two legacy guild-picker pages

### DIFF
--- a/web/src/main/resources/static/css/guild-picker.css
+++ b/web/src/main/resources/static/css/guild-picker.css
@@ -1,0 +1,101 @@
+/* Shared styles for the two legacy "pick a server" pickers that predate the
+ * lb-guild fragment system — the intro picker (guilds.html) and the
+ * moderation picker (moderation-guilds.html). Extracted out of per-page
+ * inline <style> blocks so both share one cacheable sheet and one set of
+ * responsive rules.
+ *
+ * (Most other pickers — casino/economy/lottery/etc. — render through
+ * fragments/guildListPage + leaderboard.css's .lb-guild-* classes; these
+ * two have bespoke card bodies, so they keep .guild-* but now share it.) */
+
+.guild-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
+    gap: var(--space-4);
+}
+.guild-card {
+    position: relative;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: var(--space-5);
+    text-align: center;
+    text-decoration: none;
+    color: var(--text);
+    transition: border-color 0.15s var(--ease-out, ease), transform 0.1s var(--ease-out, ease), box-shadow 0.15s var(--ease-out, ease);
+    display: block;
+}
+.guild-card:hover {
+    border-color: var(--accent);
+    transform: translateY(-2px);
+    color: var(--text);
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.25);
+}
+.guild-icon, .guild-icon-placeholder {
+    width: 64px; height: 64px; border-radius: 50%;
+    margin: 0 auto 12px; display: block;
+}
+.guild-icon-placeholder {
+    background: var(--accent);
+    color: #fff;
+    font-size: 1.5rem; font-weight: 700;
+    display: flex; align-items: center; justify-content: center;
+}
+.guild-name {
+    font-weight: 600; font-size: 0.95rem;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+
+/* Per-card count pill (intro picker: "2 / 3" intros used). */
+.guild-count {
+    position: absolute;
+    top: 10px; right: 10px;
+    background: var(--border);
+    color: var(--text-muted);
+    font-size: 0.7rem;
+    padding: 3px 8px;
+    border-radius: 999px;
+    font-weight: 600;
+}
+.guild-count.has-intros { background: var(--accent-soft); color: var(--accent); }
+.guild-count.full { background: rgba(231, 76, 60, 0.12); color: var(--danger); }
+
+/* Wrap holds the card + the floating "set default" star form. */
+.guild-card-wrap { position: relative; display: block; }
+.guild-card-wrap .default-guild-form {
+    position: absolute;
+    bottom: 8px; left: 50%;
+    transform: translateX(-50%);
+    margin: 0;
+    z-index: 2;
+}
+.guild-card-wrap .guild-card { padding-bottom: 44px; }
+
+.search-row {
+    display: flex;
+    gap: var(--space-3);
+    margin-bottom: var(--space-5);
+    align-items: center;
+}
+.search-row input { flex: 1; max-width: 420px; }
+
+.empty-hero {
+    background: var(--bg-elevated);
+    border: 1px dashed var(--border-strong);
+    border-radius: var(--radius-lg);
+    padding: 48px 24px;
+    text-align: center;
+    color: var(--text-muted);
+}
+.empty-hero h2 { color: var(--text); margin-bottom: 10px; }
+.empty-hero .emoji { font-size: 2.4rem; display: block; margin-bottom: 12px; }
+.no-results { color: var(--text-muted); padding: 24px; text-align: center; display: none; }
+
+@media (max-width: 480px) {
+    .guild-grid { grid-template-columns: 1fr; gap: 12px; }
+    .guild-card { padding: 14px 16px; }
+    .guild-card-wrap .guild-card { padding-bottom: 44px; }
+    .search-row { flex-direction: column; align-items: stretch; }
+    .search-row input { max-width: 100%; }
+    .empty-hero { padding: 32px 16px; }
+}

--- a/web/src/main/resources/templates/guilds.html
+++ b/web/src/main/resources/templates/guilds.html
@@ -1,92 +1,9 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="en">
-<head th:replace="~{fragments/head :: head('TobyBot - Select a Server', null)}"></head>
+<head th:replace="~{fragments/head :: head('TobyBot - Select a Server', '/css/guild-picker.css')}"></head>
 <body>
 <a href="#main" class="skip-link">Skip to content</a>
 <div th:replace="~{fragments/navbar :: navbar}"></div>
-
-<style>
-    .guild-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
-        gap: var(--space-4);
-    }
-    .guild-card {
-        position: relative;
-        background: var(--bg-elevated);
-        border: 1px solid var(--border);
-        border-radius: var(--radius-lg);
-        padding: var(--space-5);
-        text-align: center;
-        text-decoration: none;
-        color: var(--text);
-        transition: border-color 0.15s, transform 0.1s;
-        display: block;
-    }
-    .guild-card:hover { border-color: var(--accent); transform: translateY(-2px); color: var(--text); }
-    .guild-icon, .guild-icon-placeholder {
-        width: 64px; height: 64px; border-radius: 50%;
-        margin: 0 auto 12px; display: block;
-    }
-    .guild-icon-placeholder {
-        background: var(--accent);
-        color: #fff;
-        font-size: 1.5rem; font-weight: 700;
-        display: flex; align-items: center; justify-content: center;
-    }
-    .guild-name {
-        font-weight: 600; font-size: 0.95rem;
-        overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-    }
-    .guild-count {
-        position: absolute;
-        top: 10px; right: 10px;
-        background: var(--border);
-        color: var(--text-muted);
-        font-size: 0.7rem;
-        padding: 3px 8px;
-        border-radius: 999px;
-        font-weight: 600;
-    }
-    .guild-count.has-intros { background: var(--accent-soft); color: var(--accent); }
-    .guild-count.full { background: rgba(231, 76, 60, 0.12); color: var(--danger); }
-
-    .guild-card-wrap { position: relative; display: block; }
-    .guild-card-wrap .default-guild-form {
-        position: absolute;
-        bottom: 8px; left: 50%;
-        transform: translateX(-50%);
-        margin: 0;
-        z-index: 2;
-    }
-    .guild-card-wrap .guild-card { padding-bottom: 44px; }
-
-    .search-row {
-        display: flex;
-        gap: var(--space-3);
-        margin-bottom: var(--space-5);
-        align-items: center;
-    }
-    .search-row input { flex: 1; max-width: 420px; }
-    .empty-hero {
-        background: var(--bg-elevated);
-        border: 1px dashed var(--border-strong);
-        border-radius: var(--radius-lg);
-        padding: 48px 24px;
-        text-align: center;
-        color: var(--text-muted);
-    }
-    .empty-hero h2 { color: var(--text); margin-bottom: 10px; }
-    .empty-hero .emoji { font-size: 2.4rem; display: block; margin-bottom: 12px; }
-    .no-results { color: var(--text-muted); padding: 24px; text-align: center; display: none; }
-    @media (max-width: 480px) {
-        .guild-grid { grid-template-columns: 1fr; gap: 12px; }
-        .guild-card { padding: 14px 16px; }
-        .search-row { flex-direction: column; align-items: stretch; }
-        .search-row input { max-width: 100%; }
-        .empty-hero { padding: 32px 16px; }
-    }
-</style>
 
 <main id="main" class="container">
     <h1 class="mb-3">Select a Server</h1>
@@ -100,7 +17,7 @@
         <span class="muted" th:text="${#lists.size(guilds)} + ' server' + (${#lists.size(guilds)} == 1 ? '' : 's')">0 servers</span>
     </div>
 
-    <div class="guild-grid" th:if="${not #lists.isEmpty(guilds)}" id="guildGrid">
+    <div class="guild-grid" th:if="${not #lists.isEmpty(guilds)}" id="guildGrid" data-reveal>
         <div class="guild-card-wrap"
              th:each="guild : ${guilds}"
              th:attr="data-guild-name=${#strings.toLowerCase(guild.name)}">

--- a/web/src/main/resources/templates/moderation-guilds.html
+++ b/web/src/main/resources/templates/moderation-guilds.html
@@ -1,62 +1,9 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="en">
-<head th:replace="~{fragments/head :: head('TobyBot - Moderate a Server', null)}"></head>
+<head th:replace="~{fragments/head :: head('TobyBot - Moderate a Server', '/css/guild-picker.css')}"></head>
 <body>
 <a href="#main" class="skip-link">Skip to content</a>
 <div th:replace="~{fragments/navbar :: navbar}"></div>
-
-<style>
-    .guild-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
-        gap: var(--space-4);
-    }
-    .guild-card {
-        background: var(--bg-elevated);
-        border: 1px solid var(--border);
-        border-radius: var(--radius-lg);
-        padding: var(--space-5);
-        text-align: center;
-        text-decoration: none;
-        color: var(--text);
-        transition: border-color 0.15s, transform 0.1s;
-        display: block;
-    }
-    .guild-card:hover { border-color: var(--accent); transform: translateY(-2px); color: var(--text); }
-    .guild-icon, .guild-icon-placeholder {
-        width: 64px; height: 64px; border-radius: 50%;
-        margin: 0 auto 12px; display: block;
-    }
-    .guild-icon-placeholder {
-        background: var(--accent);
-        color: #fff;
-        font-size: 1.5rem; font-weight: 700;
-        display: flex; align-items: center; justify-content: center;
-    }
-    .guild-name {
-        font-weight: 600; font-size: 0.95rem;
-        overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-    }
-    .empty-hero {
-        background: var(--bg-elevated);
-        border: 1px dashed var(--border-strong);
-        border-radius: var(--radius-lg);
-        padding: 48px 24px;
-        text-align: center;
-        color: var(--text-muted);
-    }
-    .empty-hero h2 { color: var(--text); margin-bottom: 10px; }
-    .empty-hero .emoji { font-size: 2.4rem; display: block; margin-bottom: 12px; }
-    .guild-card-wrap { position: relative; display: block; }
-    .guild-card-wrap .default-guild-form {
-        position: absolute;
-        bottom: 8px; left: 50%;
-        transform: translateX(-50%);
-        margin: 0;
-        z-index: 2;
-    }
-    .guild-card-wrap .guild-card { padding-bottom: 44px; }
-</style>
 
 <main id="main" class="container">
     <h1 class="mb-3">Moderate a Server</h1>
@@ -66,7 +13,7 @@
 
     <div th:replace="~{fragments/alerts :: error}"></div>
 
-    <div class="guild-grid" th:if="${not #lists.isEmpty(guilds)}">
+    <div class="guild-grid" th:if="${not #lists.isEmpty(guilds)}" data-reveal>
         <div class="guild-card-wrap" th:each="guild : ${guilds}">
             <a class="guild-card"
                th:href="@{/moderation/{id}(id=${guild.id})}">

--- a/web/src/test/kotlin/web/template/GuildPickerTemplateRenderTest.kt
+++ b/web/src/test/kotlin/web/template/GuildPickerTemplateRenderTest.kt
@@ -1,0 +1,104 @@
+package web.template
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.context.support.GenericApplicationContext
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.mock.web.MockServletContext
+import org.thymeleaf.context.WebContext
+import org.thymeleaf.spring6.SpringTemplateEngine
+import org.thymeleaf.spring6.templateresolver.SpringResourceTemplateResolver
+import org.thymeleaf.templatemode.TemplateMode
+import org.thymeleaf.web.servlet.JakartaServletWebApplication
+
+/**
+ * Renders the two legacy "pick a server" pages (intro picker `guilds.html`
+ * and moderation picker `moderation-guilds.html`) through a real Spring
+ * Thymeleaf engine after their inline <style> blocks were extracted to the
+ * shared `/css/guild-picker.css`. Guards against a malformed
+ * head/extraCss wiring and confirms the card grid + empty state still
+ * render (these pages had no render coverage before).
+ */
+class GuildPickerTemplateRenderTest {
+
+    private val servletContext = MockServletContext()
+    private val webApp = JakartaServletWebApplication.buildApplication(servletContext)
+
+    private val engine: SpringTemplateEngine = SpringTemplateEngine().apply {
+        val appCtx = GenericApplicationContext().also { it.refresh() }
+        setTemplateResolver(SpringResourceTemplateResolver().apply {
+            setApplicationContext(appCtx)
+            prefix = "classpath:/templates/"
+            suffix = ".html"
+            templateMode = TemplateMode.HTML
+            characterEncoding = "UTF-8"
+            isCacheable = false
+        })
+    }
+
+    private fun render(view: String, vars: Map<String, Any?>): String {
+        val exchange = webApp.buildExchange(MockHttpServletRequest(servletContext), MockHttpServletResponse())
+        val ctx = WebContext(exchange).apply { vars.forEach { (k, v) -> setVariable(k, v) } }
+        return engine.process(view, ctx)
+    }
+
+    private fun guild(id: String, name: String, icon: String?) =
+        mapOf("id" to id, "name" to name, "iconUrl" to icon)
+
+    @Test
+    fun `moderation picker renders the shared stylesheet, card grid and reveal`() {
+        val html = render(
+            "moderation-guilds",
+            mapOf(
+                "guilds" to listOf(guild("1", "Alpha", "https://cdn/icon.png"), guild("2", "Beta", null)),
+                "defaultGuildId" to null,
+                "inviteUrl" to "https://invite",
+                "username" to "op",
+            ),
+        )
+        assertTrue(html.contains("/css/guild-picker.css")) { "shared stylesheet not linked:\n$html" }
+        assertTrue(html.contains("guild-grid") && html.contains("data-reveal")) { "grid/reveal missing" }
+        assertTrue(html.contains("Alpha") && html.contains("Beta"))
+        assertTrue(html.contains("guild-icon-placeholder")) { "icon placeholder for icon-less guild missing" }
+    }
+
+    @Test
+    fun `moderation picker renders the empty state with no guilds`() {
+        val html = render(
+            "moderation-guilds",
+            mapOf("guilds" to emptyList<Any>(), "defaultGuildId" to null, "inviteUrl" to "https://invite", "username" to "op"),
+        )
+        assertTrue(html.contains("not a moderator anywhere")) { "empty hero missing:\n$html" }
+    }
+
+    @Test
+    fun `intro picker renders the shared stylesheet, count pill and search`() {
+        val html = render(
+            "guilds",
+            mapOf(
+                "guilds" to listOf(guild("1", "Alpha", null)),
+                "introCounts" to mapOf("1" to 2),
+                "maxIntros" to 3,
+                "defaultGuildId" to 1L,
+                "inviteUrl" to "https://invite",
+                "username" to "op",
+            ),
+        )
+        assertTrue(html.contains("/css/guild-picker.css")) { "shared stylesheet not linked:\n$html" }
+        assertTrue(html.contains("guild-count")) { "intro count pill missing" }
+        assertTrue(html.contains("2 / 3")) { "count text missing:\n$html" }
+        assertTrue(html.contains("guildSearch")) { "search box missing" }
+        assertTrue(html.contains("data-reveal"))
+    }
+
+    @Test
+    fun `intro picker renders the empty state with no guilds`() {
+        val html = render(
+            "guilds",
+            mapOf("guilds" to emptyList<Any>(), "introCounts" to emptyMap<String, Int>(), "maxIntros" to 3,
+                "defaultGuildId" to null, "inviteUrl" to "https://invite", "username" to "op"),
+        )
+        assertTrue(html.contains("isn't in any of your servers")) { "empty hero missing:\n$html" }
+    }
+}


### PR DESCRIPTION
## Why

Follow-up to the install-page mobile polish (#665). You asked which other pages deserve the same treatment. After auditing the templates, **two** were genuine holdouts and **one** scope item turned out to already be done.

## What

### Polished: the two legacy guild-picker pages
The intro picker (`guilds.html`) and moderation picker (`moderation-guilds.html`) were the last pages still carrying **bespoke inline `<style>` blocks** with duplicated `.guild-*` card CSS — every other picker renders through the `lb-guild` fragment system.

- Extracted their shared styles into **`web/css/guild-picker.css`**, loaded via the head fragment's `extraCss` slot; dropped both inline `<style>` blocks.
- `moderation-guilds.html` now inherits the **`≤480px` breakpoint** (1-column grid, tighter padding) that only the intro picker previously had.
- Added **`data-reveal`** fade-in-on-scroll to both grids and a subtle **hover shadow** on cards — matching the homepage polish.
- New **`GuildPickerTemplateRenderTest`** renders both pages (populated + empty) — they had no render coverage before.

### No change needed: moderation data tables
The `.mod-table` tables (users / titles / leaderboard) were in scope, but they **already reflow into cards on mobile** — `moderation.css:819`, the exact pattern the install page copied. The templates already carry `data-label` on every `<td>`. My earlier "remaining weak spot" note was a misread (I'd only seen the `min-width:0` line and missed the full reflow block). So nothing to do there — correcting the record.

## Testing
Template + CSS only, no Kotlin change. Full **`:web` suite (1523)** green, including the 4 new render tests.

⚠️ As with #665, I couldn't attach a mobile screenshot (the app needs Postgres/Docker and there's no headless browser in this sandbox) — worth a quick eyeball at phone width on the preview.

https://claude.ai/code/session_01KZNzPZmpXZrhcqPHTF6K9t

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZNzPZmpXZrhcqPHTF6K9t)_