### PR TITLE
Polish the navbar default-server (star) chip

### DIFF
--- a/web/src/main/resources/static/css/nav.css
+++ b/web/src/main/resources/static/css/nav.css
@@ -140,21 +140,33 @@ body > nav::after {
 .nav-default-guild {
     display: inline-flex;
     align-items: center;
-    gap: 4px;
-    max-width: 160px;
-    padding: 4px 10px;
-    border: 1px solid var(--border-strong);
+    gap: 6px;
+    max-width: 180px;
+    padding: 4px 12px;
+    border: 1px solid var(--border);
     border-radius: 999px;
-    color: #c5c5d2;
+    color: var(--text-muted);
     font-size: 0.8rem;
+    line-height: 1.4;
     text-decoration: none;
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
+    transition: color 0.15s, background 0.15s, border-color 0.15s;
 }
-.nav-default-guild:hover { border-color: var(--heading); color: var(--heading); }
-.nav-default-guild-empty { color: var(--text-dim); }
-.nav-default-guild-empty:hover { color: #c5c5d2; border-color: var(--text-dim); }
+.nav-default-guild:hover {
+    background: var(--accent-soft);
+    border-color: var(--accent);
+    color: var(--heading);
+}
+/* Leading glyph (★ / ☆ / ⚙). Accent on an anchored server so the pill reads
+   as an active state at a glance; the label truncates, the glyph never does. */
+.nav-default-star { flex: 0 0 auto; color: var(--accent-light); font-size: 0.8rem; line-height: 1; }
+.nav-default-cog { flex: 0 0 auto; font-size: 0.8rem; line-height: 1; opacity: 0.85; }
+.nav-default-label { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+
+/* Nothing anchored yet — a dashed "add me" chip rather than a faint label. */
+.nav-default-guild-empty { color: var(--text-muted); border-style: dashed; }
+.nav-default-guild-empty .nav-default-star { color: var(--text-dim); }
+.nav-default-guild-empty:hover { color: var(--heading); border-color: var(--accent); border-style: solid; }
+.nav-default-guild-empty:hover .nav-default-star { color: var(--accent-light); }
 
 /* Hamburger toggle — hidden on desktop, swap glyph via [aria-expanded]
    so JS only flips the attribute. */

--- a/web/src/main/resources/templates/fragments/navbar.html
+++ b/web/src/main/resources/templates/fragments/navbar.html
@@ -58,21 +58,21 @@
                th:href="@{/preferences(pick=true)}"
                class="nav-default-guild"
                th:title="'Default server: ' + ${currentDefaultGuildName} + ' — click to change'">
-                <span aria-hidden="true">&#9733;</span>
-                <span th:text="${currentDefaultGuildName}">Server</span>
+                <span class="nav-default-star" aria-hidden="true">&#9733;</span>
+                <span class="nav-default-label" th:text="${currentDefaultGuildName}">Server</span>
             </a>
             <a th:unless="${currentDefaultGuildName != null}"
                th:href="@{/preferences(pick=true)}"
                class="nav-default-guild nav-default-guild-empty"
                title="Set a default server to skip the guild picker">
-                <span aria-hidden="true">&#9734;</span>
-                <span>Set default server</span>
+                <span class="nav-default-star" aria-hidden="true">&#9734;</span>
+                <span class="nav-default-label">Set default server</span>
             </a>
             <a href="/preferences"
                class="nav-default-guild"
                title="Account settings &amp; notification preferences">
-                <span aria-hidden="true">&#9881;&#65039;</span>
-                <span>Settings</span>
+                <span class="nav-default-cog" aria-hidden="true">&#9881;&#65039;</span>
+                <span class="nav-default-label">Settings</span>
             </a>
         </div>
 


### PR DESCRIPTION
## Why

The default-server "star" chip in the navbar identity area read **heavier and duller** than everything around it. Concretely, the CSS had:
- hardcoded `#c5c5d2` colours (not design tokens)
- a heavy `border-strong` outline vs the airy `.nav-item` links
- a plain `★`/`☆` glyph with no "active" affordance
- a washed-out `text-dim` empty state
- `text-overflow: ellipsis` declared on the **flex container**, so long server names hard-clipped instead of ellipsising

## What

- **Tokens** — `text-muted` / `border` / `accent-soft`, so the chip matches the `.nav-item` links and buttons beside it.
- **Active affordance** — the `★` goes accent-coloured when a server is anchored, so the chip reads as a *set* state at a glance; the `⚙ Settings` chip stays neutral so the two don't look identical.
- **Empty state** — a legible dashed "Set default server" chip instead of a faint `text-dim` label.
- **Hover** — now matches the rest of the nav (accent-soft fill + accent border) rather than a one-off white border.
- **Truncation** — moved onto a `.nav-default-label` span so long server names actually ellipsis.

navbar fragment + `nav.css` only.

## Testing
Full **`:web` suite (1519)** green — the navbar fragment is rendered by many full-page template tests, so a parse error would surface there.

⚠️ This is a subjective visual tweak and I **couldn't screenshot it** here (no headless browser / the app needs Postgres). Happy to iterate if the direction isn't quite right — e.g. drop the accent star, restyle the empty state differently, or collapse the server + Settings chips into one control.

https://claude.ai/code/session_01KZNzPZmpXZrhcqPHTF6K9t

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZNzPZmpXZrhcqPHTF6K9t)_