### PR TITLE
Fix shared /magic?q= links landing on the hidden Card lookup tab

### DIFF
--- a/web/src/main/resources/static/js/magic.js
+++ b/web/src/main/resources/static/js/magic.js
@@ -1051,6 +1051,20 @@
         }
     }
 
+    /**
+     * A server-rendered shared cube (/magic/c/<token>) arrives pre-loaded in
+     * the list box, or — for a bad token — with a "not found" notice there.
+     * Either lives in the shared "Your cube" source, which is hidden on the
+     * default Card lookup tab, so switch to the list source and a cube tab
+     * (Preview) to reveal it. Returns true when a shared cube/miss was present.
+     */
+    function revealSharedCube(doc) {
+        if (!doc.querySelector('[data-shared-banner], [data-shared-missing]')) return false;
+        setSource(doc, 'list');
+        activateTab(doc, 'preview');
+        return true;
+    }
+
     /** Disables the form's submit button while a request is in flight. */
     function withBusy(form, busy) {
         const btn = form.querySelector('button[type="submit"]');
@@ -2028,9 +2042,8 @@
         wireShare(doc);
         wireCardAutocomplete(doc);
         prefillFromUrl(doc);
-        // A shared cube arrives pre-loaded in the list box — show that source
-        // (this wins over a ?q= / ?list= prefill).
-        if (doc.querySelector('[data-shared-banner]')) setSource(doc, 'list');
+        // A server-rendered shared cube wins over a ?q= / ?list= prefill.
+        revealSharedCube(doc);
         wireCardCount(doc);
         wireCopyQuery(doc);
         wireExamples(doc);
@@ -2063,6 +2076,7 @@
         queryShareUrl: queryShareUrl,
         readUrlPrefill: readUrlPrefill,
         prefillFromUrl: prefillFromUrl,
+        revealSharedCube: revealSharedCube,
         countCards: countCards,
         scryfallAutocompleteUrl: scryfallAutocompleteUrl,
         currentLineInfo: currentLineInfo,

--- a/web/src/main/resources/static/js/magic.js
+++ b/web/src/main/resources/static/js/magic.js
@@ -1027,9 +1027,16 @@
         });
     }
 
-    /** Pre-loads the source from ?q= / ?list= so a shared link lands ready. */
+    /**
+     * Pre-loads the source from ?q= / ?list= so a shared link lands ready.
+     * A prefill targets the shared "Your cube" source, which only shows on the
+     * cube tabs — but the page defaults to Card lookup, where it's hidden. So a
+     * prefill also lands on a cube tab (Preview) to reveal it, unless an
+     * explicit #hash deep-link already chose one.
+     */
     function prefillFromUrl(doc) {
         const pre = readUrlPrefill(root.location && root.location.search);
+        const hasPrefill = pre.q != null || pre.list != null;
         if (pre.q != null) {
             const input = doc.querySelector('[data-source-panel="search"] input[name="query"]');
             if (input) input.value = pre.q;
@@ -1038,6 +1045,9 @@
             const textarea = doc.querySelector('textarea[name="list"]');
             if (textarea) textarea.value = pre.list;
             setSource(doc, 'list');
+        }
+        if (hasPrefill && !tabIdFromHash(root.location && root.location.hash)) {
+            activateTab(doc, 'preview');
         }
     }
 
@@ -2052,6 +2062,7 @@
         absoluteUrl: absoluteUrl,
         queryShareUrl: queryShareUrl,
         readUrlPrefill: readUrlPrefill,
+        prefillFromUrl: prefillFromUrl,
         countCards: countCards,
         scryfallAutocompleteUrl: scryfallAutocompleteUrl,
         currentLineInfo: currentLineInfo,

--- a/web/src/main/resources/templates/magic.html
+++ b/web/src/main/resources/templates/magic.html
@@ -86,7 +86,7 @@
             <div data-source-panel="list" hidden>
                 <p class="cube-shared-banner" th:if="${sharedName}" data-shared-banner
                    th:text="'📥 Loaded shared cube: ' + ${sharedName}">Loaded shared cube</p>
-                <p class="cube-shared-missing" th:if="${sharedMissing}">
+                <p class="cube-shared-missing" th:if="${sharedMissing}" data-shared-missing>
                     That shared cube link wasn't found — it may have been mistyped.
                 </p>
                 <div class="cube-listlabel" id="cube-list-label">Your card list

--- a/web/src/test/js/magic.test.js
+++ b/web/src/test/js/magic.test.js
@@ -1106,6 +1106,73 @@ describe('readUrlPrefill', () => {
     });
 });
 
+describe('prefillFromUrl lands a shared link on a cube tab', () => {
+    // A ?q= / ?list= share link prefills the shared "Your cube" source, which
+    // only shows on the cube tabs — but the page defaults to Card lookup, where
+    // it's hidden. These prove the prefill switches to a cube tab to reveal it.
+    let host;
+    afterEach(() => {
+        window.history.replaceState(null, '', '/magic');
+        window.location.hash = '';
+        if (host && host.parentNode) host.parentNode.removeChild(host);
+        host = null;
+    });
+
+    function setUp() {
+        host = document.createElement('div');
+        host.innerHTML =
+            '<section class="cube-source-card" data-needs-cube hidden></section>' +
+            '<div data-source-tab="search" aria-selected="false"></div>' +
+            '<div data-source-tab="list" aria-selected="false"></div>' +
+            '<div data-source-panel="search"><input name="query"></div>' +
+            '<div data-source-panel="list" hidden><textarea name="list"></textarea></div>' +
+            '<button role="tab" data-tab="card" aria-selected="true"></button>' +
+            '<button role="tab" data-tab="preview" aria-selected="false"></button>' +
+            '<section data-panel="card"></section>' +
+            '<section data-panel="preview" hidden></section>';
+        document.body.appendChild(host);
+    }
+
+    test('a ?q= link fills the search box and switches to the preview tab', () => {
+        setUp();
+        window.history.replaceState(null, '', '/magic?q=cube%3Avintage');
+        Cube.prefillFromUrl(document);
+
+        expect(document.querySelector('[data-source-panel="search"] input[name="query"]').value).toBe('cube:vintage');
+        expect(document.querySelector('[data-tab="preview"]').getAttribute('aria-selected')).toBe('true');
+        expect(document.querySelector('[data-panel="preview"]').hidden).toBe(false);
+        expect(document.querySelector('[data-needs-cube]').hidden).toBe(false);
+    });
+
+    test('a ?list= link fills the list box and switches to the preview tab', () => {
+        setUp();
+        window.history.replaceState(null, '', '/magic?list=Bolt%0AForest');
+        Cube.prefillFromUrl(document);
+
+        expect(document.querySelector('textarea[name="list"]').value).toBe('Bolt\nForest');
+        expect(document.querySelector('[data-tab="preview"]').getAttribute('aria-selected')).toBe('true');
+    });
+
+    test('an explicit #hash deep-link wins over the prefill default', () => {
+        setUp();
+        window.history.replaceState(null, '', '/magic?q=cube%3Avintage#card');
+        Cube.prefillFromUrl(document);
+
+        // The query is still prefilled, but the chosen tab is left to wireTabs.
+        expect(document.querySelector('[data-source-panel="search"] input[name="query"]').value).toBe('cube:vintage');
+        expect(document.querySelector('[data-tab="preview"]').getAttribute('aria-selected')).toBe('false');
+    });
+
+    test('no prefill leaves the tabs untouched', () => {
+        setUp();
+        window.history.replaceState(null, '', '/magic');
+        Cube.prefillFromUrl(document);
+
+        expect(document.querySelector('[data-tab="preview"]').getAttribute('aria-selected')).toBe('false');
+        expect(document.querySelector('[data-panel="preview"]').hidden).toBe(true);
+    });
+});
+
 describe('countCards', () => {
     test('counts non-blank, non-comment lines', () => {
         expect(Cube.countCards('Bolt\nForest\n\n# comment\n// also\n3 Island')).toBe(3);

--- a/web/src/test/js/magic.test.js
+++ b/web/src/test/js/magic.test.js
@@ -1173,6 +1173,59 @@ describe('prefillFromUrl lands a shared link on a cube tab', () => {
     });
 });
 
+describe('revealSharedCube lands a /magic/c/<token> link on a cube tab', () => {
+    // A server-rendered shared cube pre-loads the list box (or, for a bad token,
+    // a "not found" notice) inside the shared "Your cube" source — hidden on the
+    // default Card lookup tab. These prove it switches to the list source on a
+    // cube tab so the loaded list / notice is actually visible.
+    let host;
+    afterEach(() => {
+        if (host && host.parentNode) host.parentNode.removeChild(host);
+        host = null;
+    });
+
+    function setUp(extra) {
+        host = document.createElement('div');
+        host.innerHTML =
+            '<section class="cube-source-card" data-needs-cube hidden></section>' +
+            '<div data-source-tab="search" aria-selected="true"></div>' +
+            '<div data-source-tab="list" aria-selected="false"></div>' +
+            '<div data-source-panel="search"></div>' +
+            '<div data-source-panel="list" hidden>' + (extra || '') + '</div>' +
+            '<button role="tab" data-tab="card" aria-selected="true"></button>' +
+            '<button role="tab" data-tab="preview" aria-selected="false"></button>' +
+            '<section data-panel="card"></section>' +
+            '<section data-panel="preview" hidden></section>';
+        document.body.appendChild(host);
+    }
+
+    test('a loaded shared cube switches to the list source on the preview tab', () => {
+        setUp('<p data-shared-banner>Loaded shared cube: Vintage</p>');
+        expect(Cube.revealSharedCube(document)).toBe(true);
+
+        expect(document.querySelector('[data-source-tab="list"]').getAttribute('aria-selected')).toBe('true');
+        expect(document.querySelector('[data-source-panel="list"]').hidden).toBe(false);
+        expect(document.querySelector('[data-tab="preview"]').getAttribute('aria-selected')).toBe('true');
+        expect(document.querySelector('[data-needs-cube]').hidden).toBe(false);
+    });
+
+    test('a not-found shared link still reveals the notice on a cube tab', () => {
+        setUp('<p data-shared-missing>That shared cube link wasn\'t found</p>');
+        expect(Cube.revealSharedCube(document)).toBe(true);
+
+        expect(document.querySelector('[data-tab="preview"]').getAttribute('aria-selected')).toBe('true');
+        expect(document.querySelector('[data-source-panel="list"]').hidden).toBe(false);
+    });
+
+    test('no shared cube is a no-op', () => {
+        setUp('');
+        expect(Cube.revealSharedCube(document)).toBe(false);
+
+        expect(document.querySelector('[data-tab="preview"]').getAttribute('aria-selected')).toBe('false');
+        expect(document.querySelector('[data-panel="preview"]').hidden).toBe(true);
+    });
+});
+
 describe('countCards', () => {
     test('counts non-blank, non-comment lines', () => {
         expect(Cube.countCards('Bolt\nForest\n\n# comment\n// also\n3 Island')).toBe(3);


### PR DESCRIPTION
## Problem

The cube share link `https://www.toby-bot.co.uk/magic?q=cube:vintage` (and `?list=...`) appeared to do nothing.

The `?q=` / `?list=` params prefill the shared **"Your cube"** source, but that source is gated behind `data-needs-cube` and only shows on the cube tabs. Since the magic page now **defaults to the Card lookup tab** (`DEFAULT_TAB = 'card'`, which is in `NO_SHARED_SOURCE`), the prefilled query was hidden and the link silently landed on an unrelated tool.

## Fix

`prefillFromUrl` now switches to the **Preview** cube tab whenever a `?q=` / `?list=` prefill is present — so a shared link lands on a tab that actually shows the prefilled cube. An explicit `#hash` deep-link (e.g. `/magic?q=...#generate`) still wins, and a plain `/magic` with no prefill is untouched (stays on Card lookup).

## Tests

Added 4 Jest cases under `prefillFromUrl lands a shared link on a cube tab`:
- a `?q=` link fills the search box and switches to Preview (source section becomes visible)
- a `?list=` link fills the list box and switches to Preview
- an explicit `#hash` wins over the prefill default
- no prefill leaves the tabs untouched

All 116 magic JS tests pass.

https://claude.ai/code/session_01AUojxAQA1eERqncUSw5kMf

---
_Generated by [Claude Code](https://claude.ai/code/session_01AUojxAQA1eERqncUSw5kMf)_