### PR TITLE
Polish the web MTG combo lookup (chips, labels, numbered cards)

### DIFF
--- a/web/src/main/resources/static/css/magic.css
+++ b/web/src/main/resources/static/css/magic.css
@@ -1183,12 +1183,35 @@ details[open] > .cube-section-summary .cube-collapse-chevron {
     margin-top: var(--space-3);
 }
 
+.cube-combos-head {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    margin-bottom: var(--space-2);
+}
+
 .cube-combos-h {
-    margin: 0 0 var(--space-2);
+    margin: 0;
     color: var(--heading);
     font-size: 0.8rem;
     text-transform: uppercase;
     letter-spacing: 0.04em;
+}
+
+.cube-combos-count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.4rem;
+    height: 1.4rem;
+    padding: 0 6px;
+    border-radius: 999px;
+    background: var(--mtg-gold-soft);
+    box-shadow: inset 0 0 0 1px var(--mtg-gold-border);
+    color: var(--mtg-gold);
+    font-size: 0.75rem;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
 }
 
 .cube-combos-empty {
@@ -1207,21 +1230,94 @@ details[open] > .cube-section-summary .cube-collapse-chevron {
 }
 
 .cube-combo {
-    padding: var(--space-2);
+    position: relative;
+    display: flex;
+    gap: var(--space-3);
+    padding: var(--space-3);
+    padding-left: var(--space-2);
+    border: 1px solid var(--border);
     border-left: 3px solid var(--mtg-gold, #c7a14f);
+    border-radius: var(--radius-md);
     background: var(--surface-2, rgba(255, 255, 255, 0.03));
     font-size: 0.9rem;
+    transition: border-color 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease;
 }
 
+.cube-combo:hover {
+    border-color: var(--mtg-gold-border);
+    border-left-color: var(--mtg-gold);
+    transform: translateY(-1px);
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18);
+}
+
+.cube-combo-num {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.6rem;
+    height: 1.6rem;
+    border-radius: 999px;
+    background: var(--mtg-gold-soft);
+    box-shadow: inset 0 0 0 1px var(--mtg-gold-border);
+    color: var(--mtg-gold);
+    font-size: 0.78rem;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+}
+
+.cube-combo-body {
+    flex: 1 1 auto;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+}
+
+.cube-combo-uses,
 .cube-combo-produces {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px;
+}
+
+.cube-combo-label {
+    flex: 0 0 auto;
     color: var(--text-muted);
-    margin-top: 2px;
+    font-size: 0.68rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.cube-combo-piece,
+.cube-combo-result {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-size: 0.82rem;
+    line-height: 1.4;
+}
+
+.cube-combo-piece {
+    border: 1px solid var(--border-strong);
+    background: rgba(255, 255, 255, 0.03);
+    color: var(--heading);
+}
+
+.cube-combo-result {
+    background: var(--mtg-gold-soft);
+    box-shadow: inset 0 0 0 1px var(--mtg-gold-border);
+    color: var(--mtg-gold);
+    font-weight: 600;
 }
 
 .cube-combo-link {
-    display: inline-block;
-    margin-top: 4px;
+    align-self: flex-start;
+    margin-top: 2px;
     font-size: 0.8rem;
+    font-weight: 600;
 }
 
 /* Reference tab: set lookup + keyword glossary results. */

--- a/web/src/main/resources/static/js/magic.js
+++ b/web/src/main/resources/static/js/magic.js
@@ -573,11 +573,22 @@
     /** Renders a card's combos (pieces → produces, each linked), or a friendly empty state. */
     function renderCombos(container, data) {
         container.replaceChildren();
+        const combos = (data && data.combos) || [];
+
+        const head = document.createElement('div');
+        head.className = 'cube-combos-head';
         const h = document.createElement('h4');
         h.className = 'cube-combos-h';
         h.textContent = 'Combos';
-        container.appendChild(h);
-        const combos = (data && data.combos) || [];
+        head.appendChild(h);
+        if (combos.length) {
+            const count = document.createElement('span');
+            count.className = 'cube-combos-count';
+            count.textContent = String(combos.length);
+            head.appendChild(count);
+        }
+        container.appendChild(head);
+
         if (!combos.length) {
             const p = document.createElement('p');
             p.className = 'cube-combos-empty';
@@ -585,19 +596,40 @@
             container.appendChild(p);
             return container;
         }
+
+        // Renders a labelled row of card-name chips ("Needs …", "Makes …").
+        function chipRow(rowClass, label, names, chipClass) {
+            const row = document.createElement('div');
+            row.className = rowClass;
+            const tag = document.createElement('span');
+            tag.className = 'cube-combo-label';
+            tag.textContent = label;
+            row.appendChild(tag);
+            (names || []).forEach(function (name) {
+                const chip = document.createElement('span');
+                chip.className = chipClass;
+                chip.textContent = name;
+                row.appendChild(chip);
+            });
+            return row;
+        }
+
         const ul = document.createElement('ul');
         ul.className = 'cube-combos-list';
-        combos.forEach(function (combo) {
+        combos.forEach(function (combo, i) {
             const li = document.createElement('li');
             li.className = 'cube-combo';
-            const uses = document.createElement('div');
-            uses.className = 'cube-combo-uses';
-            uses.textContent = (combo.uses || []).join(', ');
-            const produces = document.createElement('div');
-            produces.className = 'cube-combo-produces';
-            produces.textContent = '→ ' + (combo.produces || []).join(', ');
-            li.appendChild(uses);
-            li.appendChild(produces);
+
+            const num = document.createElement('span');
+            num.className = 'cube-combo-num';
+            num.setAttribute('aria-hidden', 'true');
+            num.textContent = String(i + 1);
+            li.appendChild(num);
+
+            const body = document.createElement('div');
+            body.className = 'cube-combo-body';
+            body.appendChild(chipRow('cube-combo-uses', 'Needs', combo.uses, 'cube-combo-piece'));
+            body.appendChild(chipRow('cube-combo-produces', 'Makes', combo.produces, 'cube-combo-result'));
             if (combo.url) {
                 const a = document.createElement('a');
                 a.className = 'cube-combo-link';
@@ -605,8 +637,9 @@
                 a.target = '_blank';
                 a.rel = 'noopener';
                 a.textContent = 'View combo ↗';
-                li.appendChild(a);
+                body.appendChild(a);
             }
+            li.appendChild(body);
             ul.appendChild(li);
         });
         container.appendChild(ul);

--- a/web/src/test/js/magic.test.js
+++ b/web/src/test/js/magic.test.js
@@ -486,11 +486,42 @@ describe('combos (combosUrl / renderCombos)', () => {
         expect(items[0].querySelector('.cube-combo-link').getAttribute('href')).toBe('https://commanderspellbook.com/combo/7/');
     });
 
+    test('renderCombos renders each card piece as its own chip', () => {
+        const container = document.createElement('div');
+        Cube.renderCombos(container, {
+            combos: [
+                { id: '7', uses: ['Kiki-Jiki', 'Zealous Conscripts'], produces: ['Infinite haste creatures'], url: 'x' },
+            ],
+        });
+        const combo = container.querySelector('.cube-combo');
+        const pieces = combo.querySelectorAll('.cube-combo-piece');
+        expect(pieces).toHaveLength(2);
+        expect(pieces[0].textContent).toBe('Kiki-Jiki');
+        expect(pieces[1].textContent).toBe('Zealous Conscripts');
+        const results = combo.querySelectorAll('.cube-combo-result');
+        expect(results).toHaveLength(1);
+        expect(results[0].textContent).toBe('Infinite haste creatures');
+    });
+
+    test('renderCombos numbers each combo and shows the total in the header', () => {
+        const container = document.createElement('div');
+        Cube.renderCombos(container, {
+            combos: [
+                { id: '1', uses: ['A'], produces: ['X'], url: 'x' },
+                { id: '2', uses: ['B'], produces: ['Y'], url: 'y' },
+            ],
+        });
+        expect(container.querySelector('.cube-combos-count').textContent).toBe('2');
+        const nums = container.querySelectorAll('.cube-combo-num');
+        expect(Array.from(nums).map(function (n) { return n.textContent; })).toEqual(['1', '2']);
+    });
+
     test('renderCombos shows an empty state when there are none', () => {
         const container = document.createElement('div');
         Cube.renderCombos(container, { combos: [] });
         expect(container.querySelector('.cube-combos-empty').textContent).toContain('No combos found');
         expect(container.querySelectorAll('.cube-combo')).toHaveLength(0);
+        expect(container.querySelector('.cube-combos-count')).toBeNull();
     });
 });
 


### PR DESCRIPTION
## What & why

The combo lookup already exists in the web Magic toolkit — it lives under the **Card lookup** tab, where a "Show combos" button fetches a card's combos from Commander Spellbook on demand. But the rendering was plain: each combo was a flat line of comma-joined card names, a `→ produces` line, and a bare link.

This PR gives the combos panel the same care as the rest of the Magic toolkit, with no change to the underlying data or fetch flow.

## Changes

- **Card pieces are now chips** — each card in a combo renders as its own pill, with `Needs` / `Makes` labels instead of comma soup.
- **Payoffs use gold accent chips** (`--mtg-gold`), so the result reads at a glance and is visually distinct from the pieces.
- **Numbered combos + a count badge** — each combo card gets a numbered badge, and the header shows how many combos were found.
- **Combo cards** get a border, rounded corners and a subtle hover lift, matching the toolkit's card aesthetic.

Pure presentation: same `/magic/api/combos` endpoint, same on-demand fetch, same `CardCombos` data.

## Before / after

| Before | After |
| --- | --- |
| Flat comma-joined names + bare link | Chips, Needs/Makes labels, gold payoffs, numbered cards, count badge, hover lift |

## Testing

- `web` Jest suite — **121 passing**, including new `renderCombos` cases for chips, numbering and the header count.
- `stylelint` on `magic.css` — clean.

https://claude.ai/code/session_011wR6WMh1a44DBYjGjZryAD

---
_Generated by [Claude Code](https://claude.ai/code/session_011wR6WMh1a44DBYjGjZryAD)_