### PR TITLE
Second DRY/SOLID pass over the Magic features

### DIFF
--- a/common/src/main/kotlin/common/mtg/MtgNames.kt
+++ b/common/src/main/kotlin/common/mtg/MtgNames.kt
@@ -35,6 +35,21 @@ object MtgNames {
     fun lookupKey(name: String): String = name.trim().lowercase()
 
     /**
+     * Indexes [items] by every [matchKeys] form of their name (full name plus
+     * each face), so a pasted front-face name resolves to the full-name card
+     * Scryfall returns. The first item wins a contested key — matching how
+     * both the bot's `MtgPoolResolver` and the web's cube service tie a
+     * resolved list back to its entries, kept here so they can't diverge.
+     */
+    fun <T> index(items: Iterable<T>, nameOf: (T) -> String): Map<String, T> {
+        val byKey = HashMap<String, T>()
+        items.forEach { item ->
+            matchKeys(nameOf(item)).forEach { key -> byKey.putIfAbsent(key, item) }
+        }
+        return byKey
+    }
+
+    /**
      * The identifier to send to Scryfall's collection lookup for [name].
      * Scryfall matches a card by a single face, **not** by its full
      * `A // B` name, so a pasted full name (e.g.

--- a/common/src/test/kotlin/common/mtg/MtgNamesTest.kt
+++ b/common/src/test/kotlin/common/mtg/MtgNamesTest.kt
@@ -121,4 +121,31 @@ class MtgNamesTest {
         val fullNameKeys = MtgNames.matchKeys("Archangel Avacyn // Avacyn, the Purifier")
         assertTrue(fullNameKeys.contains(MtgNames.lookupKey(request)))
     }
+
+    // --- index ----------------------------------------------------------
+
+    @Test
+    fun `index keys an item under its full name and every face`() {
+        val dfc = "Huntmaster of the Fells // Ravager of the Fells"
+        val byKey = MtgNames.index(listOf(dfc)) { it }
+
+        // Resolvable by the pasted front face, the back face, or the full name.
+        assertEquals(dfc, byKey[MtgNames.lookupKey("Huntmaster of the Fells")])
+        assertEquals(dfc, byKey[MtgNames.lookupKey("Ravager of the Fells")])
+        assertEquals(dfc, byKey[MtgNames.lookupKey(dfc)])
+    }
+
+    @Test
+    fun `index lets the first item win a contested key`() {
+        // Two printings of the same name: the first one indexed is kept.
+        val byKey = MtgNames.index(listOf("Forest #1", "Forest #2")) { "Forest" }
+        assertEquals("Forest #1", byKey[MtgNames.lookupKey("Forest")])
+    }
+
+    @Test
+    fun `index maps over arbitrary item types via the name selector`() {
+        data class Card(val name: String, val id: Int)
+        val byKey = MtgNames.index(listOf(Card("Sol Ring", 7))) { it.name }
+        assertEquals(7, byKey[MtgNames.lookupKey("sol ring")]?.id)
+    }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/AbstractMtgCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/AbstractMtgCommand.kt
@@ -40,4 +40,13 @@ abstract class AbstractMtgCommand(
     protected fun reply(ctx: CommandContext, embed: MessageEmbed, deleteDelay: Int) {
         ctx.event.hook.sendMessageEmbeds(embed).queue(invokeDeleteOnMessageResponse(deleteDelay))
     }
+
+    /**
+     * Replies with the family's standard error embed — the most-repeated reply
+     * across the commands (a bad/missing option, nothing found, etc.), so it
+     * lives here rather than being re-spelled at every call site.
+     */
+    protected fun replyError(ctx: CommandContext, message: String, deleteDelay: Int) {
+        reply(ctx, CubeEmbeds.errorEmbed(message), deleteDelay)
+    }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CardCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CardCommand.kt
@@ -33,7 +33,7 @@ class CardCommand @Autowired constructor(
             SUB_LOOKUP -> launchHandling(ctx) { handleLookup(ctx, deleteDelay) }
             SUB_RULINGS -> launchHandling(ctx) { handleRulings(ctx, deleteDelay) }
             SUB_COMBOS -> launchHandling(ctx) { handleCombos(ctx, deleteDelay) }
-            else -> reply(ctx, CubeEmbeds.errorEmbed("Pick a subcommand: lookup, rulings or combos."), deleteDelay)
+            else -> replyError(ctx, "Pick a subcommand: lookup, rulings or combos.", deleteDelay)
         }
     }
 
@@ -41,17 +41,17 @@ class CardCommand @Autowired constructor(
     private suspend fun handleLookup(ctx: CommandContext, deleteDelay: Int) {
         val name = ctx.event.stringOption(OPT_NAME)?.trim()
         if (name.isNullOrEmpty()) {
-            reply(ctx, CubeEmbeds.errorEmbed("Give me a card `name` to look up."), deleteDelay)
+            replyError(ctx, "Give me a card `name` to look up.", deleteDelay)
             return
         }
         when (val res = fetcher.fetchByNames(listOf(MtgNames.requestName(name)))) {
             is ScryfallCubeFetcher.Result.Failure ->
-                reply(ctx, CubeEmbeds.errorEmbed("Couldn't find a card named `$name`."), deleteDelay)
+                replyError(ctx, "Couldn't find a card named `$name`.", deleteDelay)
             is ScryfallCubeFetcher.Result.Success -> {
                 // Prefer the card whose full/face name matches what was typed.
                 val card = res.cards.firstOrNull { MtgNames.matchKeys(it.name).contains(MtgNames.lookupKey(name)) }
                     ?: res.cards.firstOrNull()
-                if (card == null) reply(ctx, CubeEmbeds.errorEmbed("Couldn't find a card named `$name`."), deleteDelay)
+                if (card == null) replyError(ctx, "Couldn't find a card named `$name`.", deleteDelay)
                 else reply(ctx, CubeEmbeds.cardEmbed(card), deleteDelay)
             }
         }
@@ -61,11 +61,11 @@ class CardCommand @Autowired constructor(
     private suspend fun handleRulings(ctx: CommandContext, deleteDelay: Int) {
         val name = ctx.event.stringOption(OPT_NAME)?.trim()
         if (name.isNullOrEmpty()) {
-            reply(ctx, CubeEmbeds.errorEmbed("Give me a card `name` to look up rulings for."), deleteDelay)
+            replyError(ctx, "Give me a card `name` to look up rulings for.", deleteDelay)
             return
         }
         when (val rulings = fetcher.fetchRulings(name)) {
-            null -> reply(ctx, CubeEmbeds.errorEmbed("Couldn't find a card named `$name`."), deleteDelay)
+            null -> replyError(ctx, "Couldn't find a card named `$name`.", deleteDelay)
             else -> reply(ctx, CubeEmbeds.rulingsEmbed(rulings), deleteDelay)
         }
     }
@@ -74,11 +74,11 @@ class CardCommand @Autowired constructor(
     private suspend fun handleCombos(ctx: CommandContext, deleteDelay: Int) {
         val name = ctx.event.stringOption(OPT_NAME)?.trim()
         if (name.isNullOrEmpty()) {
-            reply(ctx, CubeEmbeds.errorEmbed("Give me a card `name` to find combos for."), deleteDelay)
+            replyError(ctx, "Give me a card `name` to find combos for.", deleteDelay)
             return
         }
         when (val combos = fetcher.fetchCombos(name)) {
-            null -> reply(ctx, CubeEmbeds.errorEmbed("Couldn't reach Commander Spellbook. Try again later."), deleteDelay)
+            null -> replyError(ctx, "Couldn't reach Commander Spellbook. Try again later.", deleteDelay)
             else -> reply(ctx, CubeEmbeds.combosEmbed(combos), deleteDelay)
         }
     }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeCommand.kt
@@ -51,7 +51,7 @@ class CubeCommand @Autowired constructor(
             SUB_PREVIEW -> launchHandling(ctx) { handlePreview(ctx, requestingUserDto, deleteDelay) }
             SUB_GENERATE -> launchHandling(ctx) { handleGenerate(ctx, requestingUserDto) }
             SUB_SAVED -> launchHandling(ctx) { handleSaved(ctx, requestingUserDto, deleteDelay) }
-            else -> reply(ctx, CubeEmbeds.errorEmbed("Pick a subcommand: asfan, preview, generate or saved."), deleteDelay)
+            else -> replyError(ctx, "Pick a subcommand: asfan, preview, generate or saved.", deleteDelay)
         }
     }
 
@@ -84,7 +84,7 @@ class CubeCommand @Autowired constructor(
     private suspend fun handlePreview(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
         val packSize = ctx.event.intOption(OPT_PACK_SIZE, DEFAULT_PACK_SIZE)
         when (val resolved = resolvePool(ctx, requestingUserDto)) {
-            is MtgPoolResolver.PoolResult.Failed -> reply(ctx, CubeEmbeds.errorEmbed(resolved.message), deleteDelay)
+            is MtgPoolResolver.PoolResult.Failed -> replyError(ctx, resolved.message, deleteDelay)
             is MtgPoolResolver.PoolResult.Ready -> {
                 val pool = resolved.pool
                 val currency = currencyFor(ctx)

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
@@ -199,16 +199,25 @@ internal object CubeEmbeds {
         setAuthor(AUTHOR)
         setTitle(card.name)
         card.imageUrl?.let { setImage(it) }
-        val facts = buildList {
-            if (card.typeLine.isNotBlank()) add("**Type** · ${card.typeLine}")
-            add("**Mana value** · ${formatMv(card.manaValue)}")
-            card.rarity?.let { add("**Rarity** · ${Rarity.parse(it).displayName}") }
-            add("**Colour identity** · ${colorIdentityLine(card)}")
-            priceLine(card)?.let { add("**Price** · $it") }
-            if (card.legalFormats.isNotEmpty()) add("**Legal** · ${card.legalFormats.joinToString(", ")}")
-        }.joinToString("\n")
+        val facts = cardFactLines(card, includeManaValue = true).joinToString("\n")
         val oracle = card.oracleText?.let { "\n\n${oracleBlock(it)}" }.orEmpty()
         setDescription(facts + oracle)
+    }
+
+    /**
+     * The fact lines on a card panel — type, (optionally) mana value, rarity,
+     * colour identity, price and legal formats — in display order, present
+     * fields only. Shared by [cardEmbed] (the `/mtgcard` lookup) and the inline
+     * `[[card]]` mentions so the two panels can't drift. The compact inline
+     * mention omits the mana value via [includeManaValue].
+     */
+    fun cardFactLines(card: CubeCard, includeManaValue: Boolean): List<String> = buildList {
+        if (card.typeLine.isNotBlank()) add("**Type** · ${card.typeLine}")
+        if (includeManaValue) add("**Mana value** · ${formatMv(card.manaValue)}")
+        card.rarity?.let { add("**Rarity** · ${Rarity.parse(it).displayName}") }
+        add("**Colour identity** · ${colorIdentityLine(card)}")
+        priceLine(card)?.let { add("**Price** · $it") }
+        if (card.legalFormats.isNotEmpty()) add("**Legal** · ${card.legalFormats.joinToString(", ")}")
     }
 
     /**

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/DeckCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/DeckCommand.kt
@@ -32,7 +32,7 @@ class DeckCommand @Autowired constructor(
         logger.setGuildAndMemberContext(ctx.guild, ctx.member)
         when (ctx.event.subcommandName) {
             SUB_LEGALITY -> launchHandling(ctx) { handleLegality(ctx, requestingUserDto, deleteDelay) }
-            else -> reply(ctx, CubeEmbeds.errorEmbed("Pick a subcommand: legality."), deleteDelay)
+            else -> replyError(ctx, "Pick a subcommand: legality.", deleteDelay)
         }
     }
 
@@ -41,12 +41,12 @@ class DeckCommand @Autowired constructor(
         val formatKey = ctx.event.stringOption(OPT_FORMAT)?.trim()?.lowercase()
         val format = CubeCard.FORMATS.firstOrNull { it.first == formatKey }
         if (format == null) {
-            reply(ctx, CubeEmbeds.errorEmbed("Pick a `format` to check against (e.g. Modern, Commander)."), deleteDelay)
+            replyError(ctx, "Pick a `format` to check against (e.g. Modern, Commander).", deleteDelay)
             return
         }
         val resolved = resolver.resolve(ctx.event.stringOption(OPT_SAVED), ctx.event.stringOption(OPT_QUERY), requestingUserDto.discordId)
         when (resolved) {
-            is MtgPoolResolver.PoolResult.Failed -> reply(ctx, CubeEmbeds.errorEmbed(resolved.message), deleteDelay)
+            is MtgPoolResolver.PoolResult.Failed -> replyError(ctx, resolved.message, deleteDelay)
             is MtgPoolResolver.PoolResult.Ready -> {
                 val report = DeckLegality.check(resolved.pool, format.first)
                 reply(ctx, CubeEmbeds.legalityEmbed(report, format.second, resolved.label, resolved.notFound), deleteDelay)

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/MtgPoolResolver.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/MtgPoolResolver.kt
@@ -45,10 +45,7 @@ class MtgPoolResolver @Autowired constructor(
             return when (val res = fetcher.fetchByNames(entries.map { MtgNames.requestName(it.name) })) {
                 is ScryfallCubeFetcher.Result.Failure -> PoolResult.Failed(res.message)
                 is ScryfallCubeFetcher.Result.Success -> {
-                    val byName = HashMap<String, CubeCard>()
-                    res.cards.forEach { card ->
-                        MtgNames.matchKeys(card.name).forEach { key -> byName.putIfAbsent(key, card) }
-                    }
+                    val byName = MtgNames.index(res.cards) { it.name }
                     val pool = entries.flatMap { entry ->
                         byName[MtgNames.lookupKey(entry.name)]?.let { card -> List(entry.count) { card } } ?: emptyList()
                     }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/MtgReferenceCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/MtgReferenceCommand.kt
@@ -31,7 +31,7 @@ class MtgReferenceCommand @Autowired constructor(
         when (ctx.event.subcommandName) {
             SUB_SET -> launchHandling(ctx) { handleSet(ctx, deleteDelay) }
             SUB_RULE -> handleRule(ctx, deleteDelay) // static glossary, no IO
-            else -> reply(ctx, CubeEmbeds.errorEmbed("Pick a subcommand: set or rule."), deleteDelay)
+            else -> replyError(ctx, "Pick a subcommand: set or rule.", deleteDelay)
         }
     }
 
@@ -39,11 +39,11 @@ class MtgReferenceCommand @Autowired constructor(
     private suspend fun handleSet(ctx: CommandContext, deleteDelay: Int) {
         val code = ctx.event.stringOption(OPT_CODE)?.trim()
         if (code.isNullOrEmpty()) {
-            reply(ctx, CubeEmbeds.errorEmbed("Give me a set `code` (e.g. vow, mh3)."), deleteDelay)
+            replyError(ctx, "Give me a set `code` (e.g. vow, mh3).", deleteDelay)
             return
         }
         when (val set = fetcher.fetchSet(code)) {
-            null -> reply(ctx, CubeEmbeds.errorEmbed("Couldn't find a set with code `$code`."), deleteDelay)
+            null -> replyError(ctx, "Couldn't find a set with code `$code`.", deleteDelay)
             else -> reply(ctx, CubeEmbeds.setEmbed(set), deleteDelay)
         }
     }
@@ -52,11 +52,11 @@ class MtgReferenceCommand @Autowired constructor(
     private fun handleRule(ctx: CommandContext, deleteDelay: Int) {
         val term = ctx.event.stringOption(OPT_TERM)?.trim()
         if (term.isNullOrEmpty()) {
-            reply(ctx, CubeEmbeds.errorEmbed("Give me a keyword (e.g. trample, deathtouch)."), deleteDelay)
+            replyError(ctx, "Give me a keyword (e.g. trample, deathtouch).", deleteDelay)
             return
         }
         when (val found = MtgGlossary.lookup(term)) {
-            null -> reply(ctx, CubeEmbeds.errorEmbed("No glossary entry for `$term`. Try an evergreen keyword like trample or flying."), deleteDelay)
+            null -> replyError(ctx, "No glossary entry for `$term`. Try an evergreen keyword like trample or flying.", deleteDelay)
             else -> reply(ctx, CubeEmbeds.ruleEmbed(found), deleteDelay)
         }
     }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/PriceWatchCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/PriceWatchCommand.kt
@@ -37,7 +37,7 @@ class PriceWatchCommand @Autowired constructor(
             SUB_ADD -> launchHandling(ctx) { handleAdd(ctx, requestingUserDto, deleteDelay) }
             SUB_LIST -> handleList(ctx, requestingUserDto, deleteDelay) // DB read, no network
             SUB_REMOVE -> handleRemove(ctx, requestingUserDto, deleteDelay)
-            else -> reply(ctx, CubeEmbeds.errorEmbed("Pick a subcommand: add, list or remove."), deleteDelay)
+            else -> replyError(ctx, "Pick a subcommand: add, list or remove.", deleteDelay)
         }
     }
 
@@ -48,18 +48,18 @@ class PriceWatchCommand @Autowired constructor(
         val price = ctx.event.getOption(OPT_PRICE)?.asDouble
         val currency = MtgCurrency.fromCode(ctx.event.stringOption(OPT_CURRENCY)) ?: MtgCurrency.DEFAULT
         if (name.isNullOrEmpty()) {
-            reply(ctx, CubeEmbeds.errorEmbed("Give me a card `name` to watch."), deleteDelay); return
+            replyError(ctx, "Give me a card `name` to watch.", deleteDelay); return
         }
         val direction = directionKey?.let { runCatching { CardPriceWatchDto.Direction.valueOf(it) }.getOrNull() }
         if (direction == null) {
-            reply(ctx, CubeEmbeds.errorEmbed("Pick a `direction`: below or above."), deleteDelay); return
+            replyError(ctx, "Pick a `direction`: below or above.", deleteDelay); return
         }
         if (price == null || price <= 0.0) {
-            reply(ctx, CubeEmbeds.errorEmbed("Give me a positive target `price`."), deleteDelay); return
+            replyError(ctx, "Give me a positive target `price`.", deleteDelay); return
         }
         val card = fetcher.fetchNamed(name)
         if (card == null) {
-            reply(ctx, CubeEmbeds.errorEmbed("Couldn't find a card named `$name`."), deleteDelay); return
+            replyError(ctx, "Couldn't find a card named `$name`.", deleteDelay); return
         }
         val currentPrice = card.price(currency)?.toDoubleOrNull()
         val created = priceWatchService.create(
@@ -72,7 +72,7 @@ class PriceWatchCommand @Autowired constructor(
             priceAtCreation = currentPrice,
         )
         if (created == null) {
-            reply(ctx, CubeEmbeds.errorEmbed("You've hit the watch limit (${priceWatchService.maxPerUser}). Remove one with `${MtgCommandRef.PRICEWATCH_REMOVE}` first."), deleteDelay)
+            replyError(ctx, "You've hit the watch limit (${priceWatchService.maxPerUser}). Remove one with `${MtgCommandRef.PRICEWATCH_REMOVE}` first.", deleteDelay)
         } else {
             reply(ctx, CubeEmbeds.watchAddedEmbed(created, card, currency, currentPrice), deleteDelay)
         }
@@ -88,7 +88,7 @@ class PriceWatchCommand @Autowired constructor(
     private fun handleRemove(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
         val id = ctx.event.getOption(OPT_WATCH_ID)?.asLong
         if (id == null) {
-            reply(ctx, CubeEmbeds.errorEmbed("Give me the watch `id` to remove (see `${MtgCommandRef.PRICEWATCH_LIST}`)."), deleteDelay); return
+            replyError(ctx, "Give me the watch `id` to remove (see `${MtgCommandRef.PRICEWATCH_LIST}`).", deleteDelay); return
         }
         val removed = priceWatchService.remove(id, requestingUserDto.discordId)
         reply(

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcher.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcher.kt
@@ -170,20 +170,30 @@ class ScryfallCubeFetcher @Autowired constructor(
         val trimmed = name.trim()
         if (trimmed.isEmpty()) return@withContext null
         val url = "$NAMED_ENDPOINT?fuzzy=" + URLEncoder.encode(trimmed, StandardCharsets.UTF_8)
+        getAndParse(url, "Scryfall named lookup failed for '$trimmed'") { parseCard(it) }
+    }
+
+    /**
+     * GETs [url] and maps the JSON body via [parse], or null when the response
+     * isn't 200, the body can't be parsed, or the request fails (logged under
+     * [context]). Coroutine cancellation is always rethrown. Shared by the
+     * single-object lookups ([fetchNamed], [fetchSet], [fetchCombos]) so they
+     * don't each re-spell the request, status check and error handling.
+     */
+    private suspend fun <T> getAndParse(url: String, context: String, parse: (JsonObject) -> T?): T? =
         try {
             val response = client.get(url) {
                 header(HttpHeaders.Accept, "application/json")
                 timeout { requestTimeoutMillis = TIMEOUT_MS }
             }
-            if (response.status.value != 200) return@withContext null
-            parseCard(JsonParser.parseString(response.bodyAsText()).asJsonObject)
+            if (response.status.value != 200) null
+            else parse(JsonParser.parseString(response.bodyAsText()).asJsonObject)
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            logger.error("Scryfall named lookup failed for '$trimmed': $e")
+            logger.error("$context: $e")
             null
         }
-    }
 
     /**
      * Resolves a card by (fuzzy) name and fetches its official rulings in two
@@ -246,18 +256,8 @@ class ScryfallCubeFetcher @Autowired constructor(
         // q=card:"Name" filters variants that use that exact card.
         val query = URLEncoder.encode("card:\"$trimmed\"", StandardCharsets.UTF_8)
         val url = "$SPELLBOOK_ENDPOINT?q=$query&limit=$MAX_COMBOS&ordering=-popularity"
-        try {
-            val response = client.get(url) {
-                header(HttpHeaders.Accept, "application/json")
-                timeout { requestTimeoutMillis = TIMEOUT_MS }
-            }
-            if (response.status.value != 200) return@withContext null
-            CardCombos(trimmed, parseCombos(JsonParser.parseString(response.bodyAsText()).asJsonObject))
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            logger.error("Commander Spellbook lookup failed for '$trimmed': $e")
-            null
+        getAndParse(url, "Commander Spellbook lookup failed for '$trimmed'") {
+            CardCombos(trimmed, parseCombos(it))
         }
     }
 
@@ -269,19 +269,7 @@ class ScryfallCubeFetcher @Autowired constructor(
         val trimmed = code.trim().lowercase()
         if (trimmed.isEmpty()) return@withContext null
         val url = "$SETS_ENDPOINT/" + URLEncoder.encode(trimmed, StandardCharsets.UTF_8)
-        try {
-            val response = client.get(url) {
-                header(HttpHeaders.Accept, "application/json")
-                timeout { requestTimeoutMillis = TIMEOUT_MS }
-            }
-            if (response.status.value != 200) return@withContext null
-            parseSet(JsonParser.parseString(response.bodyAsText()).asJsonObject)
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            logger.error("Scryfall set lookup failed for '$trimmed': $e")
-            null
-        }
+        getAndParse(url, "Scryfall set lookup failed for '$trimmed'") { parseSet(it) }
     }
 
     /** Maps a Scryfall set object to [MtgSet], or null without a code/name. */

--- a/discord-bot/src/main/kotlin/bot/toby/handler/CardMentionListener.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/handler/CardMentionListener.kt
@@ -5,7 +5,6 @@ import bot.toby.command.commands.mtg.ScryfallCubeFetcher
 import common.discord.embed
 import common.logging.DiscordLogger
 import common.mtg.CubeCard
-import common.mtg.Rarity
 import database.dto.guild.ConfigDto
 import database.service.guild.ConfigService
 import kotlinx.coroutines.CoroutineDispatcher
@@ -63,13 +62,8 @@ class CardMentionListener @Autowired constructor(
         val front = embed(color = CubeEmbeds.OK_COLOR) {
             setTitle(card.name)
             card.imageUrl?.let { setImage(it) }
-            val facts = buildList {
-                if (card.typeLine.isNotBlank()) add("**Type** · ${card.typeLine}")
-                card.rarity?.let { add("**Rarity** · ${Rarity.parse(it).displayName}") }
-                add("**Colour identity** · ${CubeEmbeds.colorIdentityLine(card)}")
-                CubeEmbeds.priceLine(card)?.let { add("**Price** · $it") }
-                if (card.legalFormats.isNotEmpty()) add("**Legal** · ${card.legalFormats.joinToString(", ")}")
-            }.joinToString("\n")
+            // Compact panel: same facts as /mtgcard lookup, minus the mana value.
+            val facts = CubeEmbeds.cardFactLines(card, includeManaValue = false).joinToString("\n")
             setDescription(facts + (card.oracleText?.let { "\n\n${CubeEmbeds.oracleBlock(it)}" }.orEmpty()))
         }
         val back = card.imageUrlBack?.let { url ->

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeEmbedsTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CubeEmbedsTest.kt
@@ -197,6 +197,21 @@ class CubeEmbedsTest {
     }
 
     @Test
+    fun `cardFactLines includes the mana value only when asked`() {
+        val card = CubeCard(
+            name = "Ragavan", colors = setOf(MtgColor.RED),
+            typeLine = "Legendary Creature", manaValue = 1.0, rarity = "mythic",
+        )
+        val withMv = CubeEmbeds.cardFactLines(card, includeManaValue = true)
+        val withoutMv = CubeEmbeds.cardFactLines(card, includeManaValue = false)
+
+        assertTrue(withMv.any { it.contains("Mana value") })
+        assertFalse(withoutMv.any { it.contains("Mana value") })
+        // The other facts (type, rarity, colour identity) are present either way.
+        assertTrue(withoutMv.any { it.contains("Type") } && withoutMv.any { it.contains("Colour identity") })
+    }
+
+    @Test
     fun `priceLine joins present currencies only and is null when unpriced`() {
         assertEquals("\$1.50", CubeEmbeds.priceLine(CubeCard(name = "A", priceUsd = "1.50")))
         assertEquals(

--- a/web/src/main/kotlin/web/service/CubeWebService.kt
+++ b/web/src/main/kotlin/web/service/CubeWebService.kt
@@ -659,10 +659,7 @@ class CubeWebService {
      * the Purifier"). Entries that don't resolve go into [MatchResult.notFound].
      */
     fun matchEntries(entries: List<ListEntry>, cards: List<ScryfallCard>): MatchResult {
-        val byKey = HashMap<String, ScryfallCard>()
-        cards.forEach { card ->
-            MtgNames.matchKeys(card.card.name).forEach { key -> byKey.putIfAbsent(key, card) }
-        }
+        val byKey = MtgNames.index(cards) { it.card.name }
         val pool = mutableListOf<ScryfallCard>()
         val notFound = mutableListOf<String>()
         for (entry in entries) {


### PR DESCRIPTION
## What & why

Follow-up to #670. That pass consolidated formatting/colour duplication; this one collapses the remaining repeated *control* patterns onto shared seams. All changes are behaviour-preserving — no test output strings changed.

## Changes

- **`AbstractMtgCommand.replyError(ctx, message, deleteDelay)`** — replaces the **25** hand-spelled `reply(ctx, CubeEmbeds.errorEmbed(…), deleteDelay)` sites across `CubeCommand`, `CardCommand`, `DeckCommand`, `MtgReferenceCommand`, and `PriceWatchCommand`. The standard error reply now lives in one place.
- **`MtgNames.index(items, nameOf)`** — centralises the multi-faced-card name → card indexing (`matchKeys` + first-wins `putIfAbsent`) that `MtgPoolResolver` and the web's `CubeWebService.matchEntries` each built by hand, so the bot and web resolvers can't diverge. Generic over the item type via a name selector.
- **`CubeEmbeds.cardFactLines(card, includeManaValue)`** — single source for a card panel's fact lines (type, mana value, rarity, colour identity, price, legal), shared by `/mtgcard lookup` and inline `[[card]]` mentions. The compact mention passes `includeManaValue = false`; everything else is identical, so the two panels can't drift.
- **`ScryfallCubeFetcher.getAndParse(url, context, parse)`** — folds the duplicated GET + 200-check + cancellation-aware `try/catch` of `fetchNamed`, `fetchSet`, and `fetchCombos` into one helper (parse stays inside the `try`, preserving the "malformed body → null" behaviour). `fetchRulings` keeps its bespoke two-request flow.

## Tests

Added unit tests for `MtgNames.index` (front/back/full-name resolution, first-wins on contested keys, arbitrary item types) and `CubeEmbeds.cardFactLines` (the mana-value toggle). Existing command/embed/listener tests already exercise the refactored paths.

## Verification

`:common:test :discord-bot:test :web:test` all green ✅. Net change: −78 / +129 lines (much of the addition is tests + doc comments; the production code shrinks).


---
_Generated by [Claude Code](https://claude.ai/code/session_01P3fQzKSFGJzzjwT54tzHXB)_