### PR TITLE
Unify Scryfall card parsing across the bot and web

### DIFF
--- a/common/src/main/kotlin/common/mtg/scryfall/JsonAccessor.kt
+++ b/common/src/main/kotlin/common/mtg/scryfall/JsonAccessor.kt
@@ -1,0 +1,34 @@
+package common.mtg.scryfall
+
+/**
+ * A tiny read-only view over a parsed JSON object — just enough of it for
+ * [ScryfallCardMapper] to read a Scryfall card without caring which JSON
+ * library produced the tree.
+ *
+ * The bot parses Scryfall responses with Gson and the web with Jackson; each
+ * supplies a thin adapter implementing this interface so the card-mapping
+ * rules (which fields, how double-faced cards fall back to their front face)
+ * live in `common` once, instead of being re-spelled per surface where they
+ * could drift.
+ *
+ * All accessors are forgiving by design — a missing, null, or wrong-typed
+ * value reads as absent (null / empty / the supplied default) rather than
+ * throwing, so a stray value in an API payload can't break card parsing.
+ */
+interface JsonAccessor {
+
+    /** The string at [key], or null when absent, JSON null, or blank. */
+    fun string(key: String): String?
+
+    /** The number at [key] as a Double, or [default] when absent or non-numeric. */
+    fun double(key: String, default: Double = 0.0): Double
+
+    /** The non-blank string elements of the array at [key], or empty when absent/not an array. */
+    fun stringList(key: String): List<String>
+
+    /** The object at [key] as a nested accessor, or null when absent/not an object. */
+    fun child(key: String): JsonAccessor?
+
+    /** The object elements of the array at [key] as accessors, or empty when absent/not an array. */
+    fun children(key: String): List<JsonAccessor>
+}

--- a/common/src/main/kotlin/common/mtg/scryfall/ScryfallCardMapper.kt
+++ b/common/src/main/kotlin/common/mtg/scryfall/ScryfallCardMapper.kt
@@ -1,0 +1,102 @@
+package common.mtg.scryfall
+
+import common.mtg.CubeCard
+import common.mtg.MtgColor
+
+/**
+ * Maps a Scryfall card object (seen through a [JsonAccessor]) into a [CubeCard],
+ * the one place the field-by-field mapping lives. The bot and the web both feed
+ * their own JSON tree through here so the two surfaces can't drift on which
+ * fields a card carries or how a double-faced card is read.
+ *
+ * Double-faced cards (transform / modal / split / adventure) put their mana
+ * cost and front image on the **first face** and their rules text on **each**
+ * face; the helpers below encode those fallbacks once.
+ */
+object ScryfallCardMapper {
+
+    /**
+     * Builds a [CubeCard] from [node], or null when it has no usable name.
+     * Colour comes from `color_identity` (the cube-sorting convention) and land
+     * status from the front-face type line.
+     *
+     * [decorateFaceName] formats a double-faced card's face name when combining
+     * the two faces' rules text — the only surface-specific choice (Discord
+     * bolds it with markdown; the web shows it plain), kept as a parameter so
+     * both keep their exact output. [frontImageUrl] is the front image the
+     * caller wants on the card (the bot stores the `normal` size here; the web
+     * keeps its images in a separate view and passes null).
+     */
+    fun toCubeCard(
+        node: JsonAccessor,
+        decorateFaceName: (String) -> String = { it },
+        frontImageUrl: String? = null,
+    ): CubeCard? {
+        val name = node.string("name") ?: return null
+        val typeLine = node.string("type_line") ?: ""
+        return CubeCard(
+            name = name,
+            colors = MtgColor.parse(node.stringList("color_identity")),
+            isLand = CubeCard.isLandType(typeLine),
+            typeLine = typeLine,
+            manaValue = node.double("cmc"),
+            imageUrl = frontImageUrl,
+            rarity = node.string("rarity"),
+            manaCost = manaCost(node),
+            oracleText = oracleText(node, decorateFaceName),
+            imageUrlBack = backImageUrl(node),
+            priceUsd = price(node, "usd"),
+            priceEur = price(node, "eur"),
+            priceTix = price(node, "tix"),
+            legalFormats = CubeCard.legalFormatsOf { legality(node, it) },
+            legalities = CubeCard.legalitiesOf { legality(node, it) },
+        )
+    }
+
+    /**
+     * The card's image at the given Scryfall [size] (`small`, `normal`, …), or
+     * null. Single-faced cards carry `image_uris` directly; double-faced cards
+     * put it on the first face.
+     */
+    fun frontImageUrl(node: JsonAccessor, size: String): String? =
+        node.child("image_uris")?.string(size)
+            ?: node.children("card_faces").firstOrNull()?.child("image_uris")?.string(size)
+
+    /**
+     * The back-face `normal` image for a double-faced card (transform / modal
+     * DFC), or null. Only true two-faced cards carry per-face `image_uris`;
+     * split / adventure cards share one image, so they correctly return null.
+     */
+    fun backImageUrl(node: JsonAccessor): String? =
+        node.children("card_faces").takeIf { it.size >= 2 }
+            ?.get(1)?.child("image_uris")?.string("normal")
+
+    /** The card's `mana_cost`, falling back to the first face's, or null. */
+    private fun manaCost(node: JsonAccessor): String? =
+        node.string("mana_cost")
+            ?: node.children("card_faces").firstOrNull()?.string("mana_cost")
+
+    /** A Scryfall `prices` entry (e.g. "usd"), or null when absent/blank. */
+    private fun price(node: JsonAccessor, key: String): String? =
+        node.child("prices")?.string(key)
+
+    /** A Scryfall `legalities` status for a format code, or null when absent. */
+    private fun legality(node: JsonAccessor, format: String): String? =
+        node.child("legalities")?.string(format)
+
+    /**
+     * The card's rules text, or null. Single-faced cards carry `oracle_text`
+     * directly; double-faced cards put it on each face, combined (newline-
+     * separated) with each face's [decorateFaceName]-formatted name.
+     */
+    private fun oracleText(node: JsonAccessor, decorateFaceName: (String) -> String): String? {
+        node.string("oracle_text")?.let { return it }
+        val faces = node.children("card_faces")
+        if (faces.isEmpty()) return null
+        val parts = faces.mapNotNull { face ->
+            val text = face.string("oracle_text") ?: return@mapNotNull null
+            face.string("name")?.let { "${decorateFaceName(it)}\n$text" } ?: text
+        }
+        return parts.joinToString("\n\n").takeIf { it.isNotBlank() }
+    }
+}

--- a/common/src/test/kotlin/common/mtg/scryfall/ScryfallCardMapperTest.kt
+++ b/common/src/test/kotlin/common/mtg/scryfall/ScryfallCardMapperTest.kt
@@ -1,0 +1,156 @@
+package common.mtg.scryfall
+
+import common.mtg.MtgColor
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests the shared card mapping in isolation, through a tiny in-memory
+ * [JsonAccessor] so `common` needs no JSON library. The bot's and web's
+ * real-JSON parser tests cover their Gson/Jackson adapters end-to-end.
+ */
+class ScryfallCardMapperTest {
+
+    /** A [JsonAccessor] over nested Kotlin maps/lists, mirroring the tolerant adapter contract. */
+    @Suppress("UNCHECKED_CAST")
+    private class MapAccessor(private val m: Map<String, Any?>) : JsonAccessor {
+        override fun string(key: String) = (m[key] as? String)?.takeIf { it.isNotBlank() }
+        override fun double(key: String, default: Double) = (m[key] as? Number)?.toDouble() ?: default
+        override fun stringList(key: String) =
+            (m[key] as? List<*>)?.mapNotNull { (it as? String)?.takeIf { s -> s.isNotBlank() } } ?: emptyList()
+        override fun child(key: String) = (m[key] as? Map<String, Any?>)?.let(::MapAccessor)
+        override fun children(key: String) =
+            (m[key] as? List<*>)?.mapNotNull { (it as? Map<String, Any?>)?.let(::MapAccessor) } ?: emptyList()
+    }
+
+    private fun node(vararg pairs: Pair<String, Any?>) = MapAccessor(mapOf(*pairs))
+
+    @Test
+    fun `maps a single-faced card's core fields`() {
+        val card = ScryfallCardMapper.toCubeCard(
+            node(
+                "name" to "Lightning Bolt",
+                "color_identity" to listOf("R"),
+                "type_line" to "Instant",
+                "cmc" to 1.0,
+                "rarity" to "common",
+                "mana_cost" to "{R}",
+                "oracle_text" to "Deal 3 damage to any target.",
+                "prices" to mapOf("usd" to "1.50", "eur" to "1.20", "tix" to "0.03"),
+                "legalities" to mapOf("modern" to "legal", "vintage" to "legal", "standard" to "not_legal"),
+            ),
+        )!!
+
+        assertEquals("Lightning Bolt", card.name)
+        assertEquals(setOf(MtgColor.RED), card.colors)
+        assertFalse(card.isLand)
+        assertEquals(1.0, card.manaValue)
+        assertEquals("common", card.rarity)
+        assertEquals("{R}", card.manaCost)
+        assertEquals("Deal 3 damage to any target.", card.oracleText)
+        assertEquals("1.50", card.priceUsd)
+        assertEquals("1.20", card.priceEur)
+        assertEquals("0.03", card.priceTix)
+        assertEquals(listOf("Modern", "Vintage"), card.legalFormats)
+        assertEquals("legal", card.legalities["modern"])
+        assertEquals("not_legal", card.legalities["standard"])
+    }
+
+    @Test
+    fun `returns null without a usable name`() {
+        assertNull(ScryfallCardMapper.toCubeCard(node("type_line" to "Instant")))
+        assertNull(ScryfallCardMapper.toCubeCard(node("name" to "  ", "type_line" to "Instant")))
+    }
+
+    @Test
+    fun `detects a land from the front face only`() {
+        assertTrue(ScryfallCardMapper.toCubeCard(node("name" to "Forest", "type_line" to "Basic Land — Forest"))!!.isLand)
+        // Front face is a spell; the back being a land doesn't make it a land.
+        assertFalse(
+            ScryfallCardMapper.toCubeCard(
+                node("name" to "Legion's Landing", "type_line" to "Legendary Enchantment // Legendary Land"),
+            )!!.isLand,
+        )
+    }
+
+    @Test
+    fun `unpriced and unknown fields are null or empty`() {
+        val card = ScryfallCardMapper.toCubeCard(node("name" to "Token", "type_line" to "Token"))!!
+        assertNull(card.rarity)
+        assertNull(card.manaCost)
+        assertNull(card.oracleText)
+        assertNull(card.priceUsd)
+        assertNull(card.imageUrl)
+        assertNull(card.imageUrlBack)
+        assertTrue(card.legalFormats.isEmpty())
+        assertTrue(card.legalities.isEmpty())
+    }
+
+    @Test
+    fun `a double-faced card pulls mana cost and front image from the first face`() {
+        val front = mapOf(
+            "name" to "Delver of Secrets",
+            "mana_cost" to "{U}",
+            "oracle_text" to "Look at the top card.",
+            "image_uris" to mapOf("small" to "front-small.jpg", "normal" to "front.jpg"),
+        )
+        val back = mapOf(
+            "name" to "Insectile Aberration",
+            "oracle_text" to "Flying.",
+            "image_uris" to mapOf("normal" to "back.jpg"),
+        )
+        val node = node(
+            "name" to "Delver of Secrets // Insectile Aberration",
+            "type_line" to "Creature — Human Wizard // Creature — Human Insect",
+            "card_faces" to listOf(front, back),
+        )
+
+        val card = ScryfallCardMapper.toCubeCard(node)!!
+        assertEquals("{U}", card.manaCost)
+        assertEquals("back.jpg", card.imageUrlBack)
+        assertEquals("front-small.jpg", ScryfallCardMapper.frontImageUrl(node, "small"))
+        assertEquals("front.jpg", ScryfallCardMapper.frontImageUrl(node, "normal"))
+    }
+
+    @Test
+    fun `oracle text combines both faces, decorating face names per surface`() {
+        val node = node(
+            "name" to "A // B",
+            "card_faces" to listOf(
+                mapOf("name" to "A", "oracle_text" to "Do A."),
+                mapOf("name" to "B", "oracle_text" to "Do B."),
+            ),
+        )
+        // Default: plain face names (the web).
+        assertEquals("A\nDo A.\n\nB\nDo B.", ScryfallCardMapper.toCubeCard(node)!!.oracleText)
+        // Discord: face names bolded with markdown.
+        assertEquals(
+            "**A**\nDo A.\n\n**B**\nDo B.",
+            ScryfallCardMapper.toCubeCard(node, decorateFaceName = { "**$it**" })!!.oracleText,
+        )
+    }
+
+    @Test
+    fun `a split card with one shared image has no back image`() {
+        // Split / adventure cards have two faces but no per-face image_uris.
+        val node = node(
+            "name" to "Fire // Ice",
+            "card_faces" to listOf(
+                mapOf("name" to "Fire", "oracle_text" to "Deal 2 damage."),
+                mapOf("name" to "Ice", "oracle_text" to "Tap target."),
+            ),
+        )
+        assertNull(ScryfallCardMapper.backImageUrl(node))
+    }
+
+    @Test
+    fun `colours come back in canonical WUBRG order regardless of input order`() {
+        val card = ScryfallCardMapper.toCubeCard(
+            node("name" to "Niv-Mizzet", "type_line" to "Creature", "color_identity" to listOf("R", "U")),
+        )!!
+        assertEquals(setOf(MtgColor.BLUE, MtgColor.RED), card.colors)
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/GsonAccessor.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/GsonAccessor.kt
@@ -1,0 +1,31 @@
+package bot.toby.command.commands.mtg
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+import common.mtg.scryfall.JsonAccessor
+
+/**
+ * [JsonAccessor] over a Gson [JsonObject], so the bot's Scryfall parsing can
+ * share [common.mtg.scryfall.ScryfallCardMapper] with the web (which uses
+ * Jackson). Absent / null / wrong-typed values read as absent rather than
+ * throwing, matching the rest of the bot's tolerant parsing.
+ */
+class GsonAccessor(private val obj: JsonObject) : JsonAccessor {
+
+    override fun string(key: String): String? =
+        obj.get(key)?.takeIf { it.isJsonPrimitive }?.asString?.takeIf { it.isNotBlank() }
+
+    override fun double(key: String, default: Double): Double =
+        obj.get(key)?.takeIf { it.isJsonPrimitive }?.asDouble ?: default
+
+    override fun stringList(key: String): List<String> =
+        (obj.get(key) as? JsonArray)
+            ?.mapNotNull { it.takeIf { e -> e.isJsonPrimitive }?.asString?.takeIf { s -> s.isNotBlank() } }
+            ?: emptyList()
+
+    override fun child(key: String): JsonAccessor? =
+        (obj.get(key) as? JsonObject)?.let(::GsonAccessor)
+
+    override fun children(key: String): List<JsonAccessor> =
+        (obj.get(key) as? JsonArray)?.mapNotNull { (it as? JsonObject)?.let(::GsonAccessor) } ?: emptyList()
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcher.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/ScryfallCubeFetcher.kt
@@ -8,8 +8,8 @@ import common.logging.DiscordLogger
 import common.mtg.CardCombos
 import common.mtg.CardRulings
 import common.mtg.CubeCard
-import common.mtg.MtgColor
 import common.mtg.MtgSet
+import common.mtg.scryfall.ScryfallCardMapper
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.timeout
 import io.ktor.client.request.get
@@ -336,86 +336,14 @@ class ScryfallCubeFetcher @Autowired constructor(
      * status from the type line.
      */
     fun parseCard(card: JsonObject): CubeCard? {
-        val name = card.get("name")?.asString?.takeIf { it.isNotBlank() } ?: return null
-        val identity = card.getAsJsonArray("color_identity")
-            ?.map { it.asString }
-            ?: emptyList()
-        val typeLine = card.get("type_line")?.asString ?: ""
-        val manaValue = card.get("cmc")?.asDouble ?: 0.0
-        return CubeCard(
-            name = name,
-            colors = MtgColor.parse(identity),
-            isLand = CubeCard.isLandType(typeLine),
-            typeLine = typeLine,
-            manaValue = manaValue,
-            imageUrl = imageUrl(card),
-            rarity = card.get("rarity")?.asString?.takeIf { it.isNotBlank() },
-            manaCost = manaCost(card),
-            oracleText = oracleText(card),
-            imageUrlBack = backImageUrl(card),
-            priceUsd = price(card, "usd"),
-            priceEur = price(card, "eur"),
-            priceTix = price(card, "tix"),
-            legalFormats = CubeCard.legalFormatsOf { fmt -> legality(card, fmt) },
-            legalities = CubeCard.legalitiesOf { fmt -> legality(card, fmt) },
+        val node = GsonAccessor(card)
+        // The bot renders in Discord, so a DFC's face names are bolded with
+        // markdown; the card carries the `normal` image for its panel.
+        return ScryfallCardMapper.toCubeCard(
+            node,
+            decorateFaceName = { "**$it**" },
+            frontImageUrl = ScryfallCardMapper.frontImageUrl(node, "normal"),
         )
-    }
-
-    /** A Scryfall `legalities` status for a format code, or null when absent. */
-    fun legality(card: JsonObject, format: String): String? =
-        card.getAsJsonObject("legalities")?.get(format)?.takeIf { !it.isJsonNull }?.asString
-
-    /** A Scryfall `prices` entry (e.g. "usd"), or null when absent/blank. */
-    fun price(card: JsonObject, key: String): String? =
-        card.getAsJsonObject("prices")?.get(key)?.takeIf { !it.isJsonNull }?.asString?.takeIf { it.isNotBlank() }
-
-    /**
-     * The card's rules text, or null. Single-faced cards carry `oracle_text`
-     * directly; double-faced cards put it on each face, so both are combined
-     * with their face names.
-     */
-    fun oracleText(card: JsonObject): String? {
-        card.get("oracle_text")?.asString?.takeIf { it.isNotBlank() }?.let { return it }
-        val faces = card.getAsJsonArray("card_faces") ?: return null
-        val parts = faces.mapNotNull { face ->
-            val obj = face.asJsonObject
-            val text = obj.get("oracle_text")?.asString?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
-            obj.get("name")?.asString?.let { "**$it**\n$text" } ?: text
-        }
-        return parts.joinToString("\n\n").takeIf { it.isNotBlank() }
-    }
-
-    /** The back-face `normal` image for a double-faced card, or null. */
-    fun backImageUrl(card: JsonObject): String? {
-        val faces = card.getAsJsonArray("card_faces") ?: return null
-        if (faces.size() < 2) return null
-        return faces[1].asJsonObject.getAsJsonObject("image_uris")?.get("normal")?.asString?.takeIf { it.isNotBlank() }
-    }
-
-    /**
-     * The card's `mana_cost`, or null. Single-faced cards carry it directly;
-     * double-faced cards put it on the first face.
-     */
-    fun manaCost(card: JsonObject): String? {
-        fun costOf(obj: JsonObject?): String? =
-            obj?.get("mana_cost")?.asString?.takeIf { it.isNotBlank() }
-
-        costOf(card)?.let { return it }
-        val firstFace = card.getAsJsonArray("card_faces")?.firstOrNull()?.asJsonObject
-        return costOf(firstFace)
-    }
-
-    /**
-     * The card's `normal` image link, or null. Single-faced cards carry
-     * `image_uris` directly; double-faced cards put it on the first face.
-     */
-    fun imageUrl(card: JsonObject): String? {
-        fun normalOf(obj: JsonObject?): String? =
-            obj?.getAsJsonObject("image_uris")?.get("normal")?.asString?.takeIf { it.isNotBlank() }
-
-        normalOf(card)?.let { return it }
-        val firstFace = card.getAsJsonArray("card_faces")?.firstOrNull()?.asJsonObject
-        return normalOf(firstFace)
     }
 
     private fun searchUrl(query: String): String {

--- a/web/src/main/kotlin/web/service/CubeWebService.kt
+++ b/web/src/main/kotlin/web/service/CubeWebService.kt
@@ -16,6 +16,7 @@ import common.mtg.MtgNames
 import common.mtg.MtgColor
 import common.mtg.PackGenerator
 import common.mtg.Rarity
+import common.mtg.scryfall.ScryfallCardMapper
 import org.springframework.stereotype.Service
 import java.io.IOException
 import java.net.URI
@@ -463,94 +464,17 @@ class CubeWebService {
 
     /** Maps one Scryfall card object to a [ScryfallCard], or null if it has no name. */
     fun cardOf(node: JsonNode): ScryfallCard? {
-        val name = node.path("name").asText("").takeIf { it.isNotBlank() } ?: return null
-        val identity = node.path("color_identity").mapNotNull { it.asText(null) }
-        val typeLine = node.path("type_line").asText("")
+        val accessor = JacksonAccessor(node)
+        // The web renders oracle text as plain HTML, so DFC face names stay
+        // undecorated (no markdown). It keeps both image sizes for the page.
+        val card = ScryfallCardMapper.toCubeCard(accessor) ?: return null
         return ScryfallCard(
-            card = CubeCard(
-                name = name,
-                colors = MtgColor.parse(identity),
-                isLand = CubeCard.isLandType(typeLine),
-                typeLine = typeLine,
-                manaValue = node.path("cmc").asDouble(0.0),
-                rarity = node.path("rarity").asText("").takeIf { it.isNotBlank() },
-                manaCost = manaCostOf(node),
-                oracleText = oracleTextOf(node),
-                imageUrlBack = backImageOf(node),
-                priceUsd = priceOf(node, "usd"),
-                priceEur = priceOf(node, "eur"),
-                priceTix = priceOf(node, "tix"),
-                legalFormats = CubeCard.legalFormatsOf { node.path("legalities").path(it).asText(null) },
-                legalities = CubeCard.legalitiesOf { node.path("legalities").path(it).asText(null) },
-            ),
-            imageUrl = imageOf(node, "small"),
-            imageUrlLarge = imageOf(node, "normal"),
-            imageUrlBack = backImageOf(node),
-            manaCost = manaCostOf(node),
+            card = card,
+            imageUrl = ScryfallCardMapper.frontImageUrl(accessor, "small"),
+            imageUrlLarge = ScryfallCardMapper.frontImageUrl(accessor, "normal"),
+            imageUrlBack = card.imageUrlBack,
+            manaCost = card.manaCost,
         )
-    }
-
-    /**
-     * A card image at the given Scryfall [size] (`small` ≈ 146×204 thumb,
-     * `normal` ≈ 488×680 for the hover zoom), or null if Scryfall has none.
-     * Single-faced cards carry `image_uris` directly; double-faced cards
-     * put images on the first face instead.
-     */
-    private fun imageOf(node: JsonNode, size: String): String? {
-        node.path("image_uris").path(size).asText("").takeIf { it.isNotBlank() }?.let { return it }
-        val faces = node.path("card_faces")
-        if (faces.isArray && faces.size() > 0) {
-            faces[0].path("image_uris").path(size).asText("").takeIf { it.isNotBlank() }?.let { return it }
-        }
-        return null
-    }
-
-    /**
-     * The back-face `normal` image for a double-faced card (transform / modal
-     * DFC), or null. Only true two-faced cards carry per-face `image_uris`;
-     * split, adventure and aftermath cards share one image, so they correctly
-     * return null here (no spurious "flip" affordance).
-     */
-    private fun backImageOf(node: JsonNode): String? {
-        val faces = node.path("card_faces")
-        if (faces.isArray && faces.size() > 1) {
-            faces[1].path("image_uris").path("normal").asText("").takeIf { it.isNotBlank() }?.let { return it }
-        }
-        return null
-    }
-
-    /**
-     * The card's mana cost string (e.g. `{1}{R}{R}`). Single-faced cards carry
-     * it directly; double-faced cards put it on the front face. Null when the
-     * card has none (most lands).
-     */
-    private fun manaCostOf(node: JsonNode): String? {
-        node.path("mana_cost").asText("").takeIf { it.isNotBlank() }?.let { return it }
-        val faces = node.path("card_faces")
-        if (faces.isArray && faces.size() > 0) {
-            faces[0].path("mana_cost").asText("").takeIf { it.isNotBlank() }?.let { return it }
-        }
-        return null
-    }
-
-    /** A Scryfall `prices` entry (e.g. "usd"), or null when absent/blank. */
-    private fun priceOf(node: JsonNode, key: String): String? =
-        node.path("prices").path(key).asText("").takeIf { it.isNotBlank() }
-
-    /**
-     * The card's rules text, or null. Single-faced cards carry `oracle_text`
-     * directly; double-faced cards put it on each face, combined with the
-     * face names.
-     */
-    private fun oracleTextOf(node: JsonNode): String? {
-        node.path("oracle_text").asText("").takeIf { it.isNotBlank() }?.let { return it }
-        val faces = node.path("card_faces")
-        if (!faces.isArray) return null
-        val parts = faces.mapNotNull { face ->
-            val text = face.path("oracle_text").asText("").takeIf { it.isNotBlank() } ?: return@mapNotNull null
-            face.path("name").asText("").takeIf { it.isNotBlank() }?.let { "$it\n$text" } ?: text
-        }
-        return parts.joinToString("\n\n").takeIf { it.isNotBlank() }
     }
 
     private fun fetchPool(query: String): CubeResult<List<ScryfallCard>> {

--- a/web/src/main/kotlin/web/service/JacksonAccessor.kt
+++ b/web/src/main/kotlin/web/service/JacksonAccessor.kt
@@ -1,0 +1,28 @@
+package web.service
+
+import com.fasterxml.jackson.databind.JsonNode
+import common.mtg.scryfall.JsonAccessor
+
+/**
+ * [JsonAccessor] over a Jackson [JsonNode], so the web's Scryfall parsing can
+ * share [common.mtg.scryfall.ScryfallCardMapper] with the bot (which uses
+ * Gson). Mirrors the web service's previous tolerant `path(...).asText("")`
+ * extraction, so a missing/null/wrong-typed value reads as absent.
+ */
+class JacksonAccessor(private val node: JsonNode) : JsonAccessor {
+
+    override fun string(key: String): String? =
+        node.path(key).asText("").takeIf { it.isNotBlank() }
+
+    override fun double(key: String, default: Double): Double =
+        node.path(key).asDouble(default)
+
+    override fun stringList(key: String): List<String> =
+        node.path(key).mapNotNull { it.asText("").takeIf { s -> s.isNotBlank() } }
+
+    override fun child(key: String): JsonAccessor? =
+        node.path(key).takeIf { it.isObject }?.let(::JacksonAccessor)
+
+    override fun children(key: String): List<JsonAccessor> =
+        node.path(key).let { if (it.isArray) it.filter { e -> e.isObject }.map(::JacksonAccessor) else emptyList() }
+}


### PR DESCRIPTION
## What & why

Third pass on the Magic features, tackling the biggest remaining duplication the earlier analysis flagged: the bot (Gson) and the web (Jackson) each carried their **own** copy of the Scryfall card → `CubeCard` mapping — same fields, same double-faced front-face fallbacks — free to drift apart. This collapses them onto a single mapper in `common`.

## How

- **`common/mtg/scryfall/JsonAccessor`** — a ~5-method read-only abstraction (`string`, `double`, `stringList`, `child`, `children`) over a parsed JSON object, so the mapping can live in `common` without depending on a JSON library.
- **`common/mtg/scryfall/ScryfallCardMapper`** — the one card mapping. The single genuine per-surface difference — double-faced **oracle face names** (Discord bolds them with markdown; the web renders plain text via `textContent`) — is a `decorateFaceName` strategy, and the front image size is a parameter. So **both surfaces keep their exact previous output** (verified: no test string changed).
- **`GsonAccessor`** (bot) and **`JacksonAccessor`** (web) — thin adapters that mirror each surface's prior tolerant extraction semantics.
- `ScryfallCubeFetcher.parseCard` and `CubeWebService.cardOf` now delegate to the mapper; their duplicated field helpers (`oracleText`/`manaCost`/`imageUrl`/`backImageUrl`/`price`/`legality` and the web's `*Of` equivalents) are deleted.

Net: **−166 / +369** (the addition is the shared mapper + adapters + a new test suite; the two parsers shrink substantially).

## Tests

- New `ScryfallCardMapperTest` exercises the mapping in isolation through an in-memory `JsonAccessor` (single-faced fields, DFC mana/image/oracle fallbacks, the face-name decoration strategy, split-card back-image absence, WUBRG colour ordering, empty/unknown fields).
- The existing real-JSON `ScryfallCubeFetcherTest` and `CubeWebServiceTest` guard the Gson/Jackson adapters end-to-end — both unchanged and green.

## Verification

`:common:test :discord-bot:test :web:test` all green ✅.

> Note: this branch was developed on top of #671 and rebased onto `main` after #671 merged, so the diff is the mapper change only. (Unrelated heads-up: #671's post-merge `main` build hit a flaky Gradle plugin-resolution error — `foojay-resolver-convention` not resolvable — unrelated to its code; I've re-run that job.)


---
_Generated by [Claude Code](https://claude.ai/code/session_01P3fQzKSFGJzzjwT54tzHXB)_