### PR TITLE
Surface "members reached" as live social proof on the homepage

### DIFF
--- a/application/src/test/kotlin/web/controller/HomeControllerTest.kt
+++ b/application/src/test/kotlin/web/controller/HomeControllerTest.kt
@@ -24,6 +24,7 @@ class HomeControllerTest {
     private val expectedInviteUrl = web.util.DiscordInvite.urlFor(clientId)
     private val sampleStats = HomeStatsService.HomeStats(
         serverCount = 7,
+        memberCount = 12_345L,
         commandCount = 42,
         gameCount = 19,
         minigameCount = 12,

--- a/web/src/main/kotlin/web/service/HomeStatsService.kt
+++ b/web/src/main/kotlin/web/service/HomeStatsService.kt
@@ -12,6 +12,8 @@ import java.util.concurrent.atomic.AtomicReference
 /**
  * Live numbers for the homepage. Counts:
  *  - **servers**: how many guilds the bot is currently in (JDA cache size)
+ *  - **members**: total members reached across every guild (sum of the
+ *    cached member counts) — the headline social-proof number
  *  - **commands**: total slash-command count across every category
  *  - **games / minigames**: derived from [GameCatalog] so the stats strip,
  *    hero text, and casino feature card all stay in lockstep when a game
@@ -31,6 +33,8 @@ class HomeStatsService(
 
     data class HomeStats(
         val serverCount: Int,
+        /** Total members reached across all guilds — public social proof. */
+        val memberCount: Long,
         val commandCount: Int,
         /** Grand total — casino + pvp. The numbers strip and hero stats
          *  strip "Games" tiles read this. */
@@ -61,8 +65,9 @@ class HomeStatsService(
         return fresh
     }
 
-    private fun compute(): HomeStats = HomeStats(
-        serverCount = jda.guildCache.size().toInt(),
+    private fun compute(): HomeStats = jda.guildCache.let { guildCache -> HomeStats(
+        serverCount = guildCache.size().toInt(),
+        memberCount = guildCache.sumOf { it.memberCount.toLong() },
         commandCount = commandManager.run {
             musicCommands.size +
                 dndCommands.size +
@@ -82,7 +87,7 @@ class HomeStatsService(
         configKeyCount = ConfigDto.Configurations.values().size,
         achievementCount = AchievementCatalog.all.count { !it.hidden },
         notificationKindCount = NotificationChannelKind.entries.size,
-    )
+    ) }
 
     companion object {
         private val TTL_NANOS = 60_000_000_000L

--- a/web/src/main/resources/templates/home.html
+++ b/web/src/main/resources/templates/home.html
@@ -18,7 +18,11 @@
             <h1 id="hero-title">Your server&rsquo;s <span>best companion</span></h1>
             <p>A live per-server coin economy, a [[${homeStats.casinoGameCount}]]-game casino with a shared jackpot pool,
                 [[${homeStats.pvpGameCount}]] head-to-head PvP matchups, music and intro songs, monthly leaderboards,
-                and a full browser-based admin &mdash; all in one Discord bot.</p>
+                and a full browser-based admin &mdash; all in one Discord bot.<span
+                    th:if="${homeStats.serverCount > 0}"
+                    th:text="' Already serving ' + ${#numbers.formatInteger(homeStats.memberCount, 1, 'COMMA')}
+                             + ' members across ' + ${#numbers.formatInteger(homeStats.serverCount, 1, 'COMMA')}
+                             + ' server' + (${homeStats.serverCount} == 1 ? '' : 's') + '.'"> Already serving members.</span></p>
             <div class="hero-actions">
                 <a th:href="${inviteUrl}" class="btn-primary">Invite to Server</a>
                 <a th:href="@{/commands/wiki}" class="btn-secondary">Browse all commands</a>
@@ -36,6 +40,10 @@
     <div class="stat">
         <span class="stat-value" data-count-up th:text="${homeStats.serverCount}">0</span>
         <span class="stat-label">Servers</span>
+    </div>
+    <div class="stat">
+        <span class="stat-value" data-count-up th:text="${#numbers.formatInteger(homeStats.memberCount, 1, 'COMMA')}">0</span>
+        <span class="stat-label">Members</span>
     </div>
     <div class="stat">
         <span class="stat-value" data-count-up th:text="${homeStats.commandCount}">0</span>
@@ -176,6 +184,10 @@
 <!-- By the numbers — surfaces the homeStats DTO as a visible craft signal. -->
 <section class="numbers-strip" aria-label="TobyBot by the numbers">
     <div class="numbers-strip-inner">
+        <div class="numbers-cell" data-reveal>
+            <span class="numbers-value" data-count-up th:text="${#numbers.formatInteger(homeStats.memberCount, 1, 'COMMA')}">0</span>
+            <span class="numbers-label">Members reached</span>
+        </div>
         <div class="numbers-cell" data-reveal>
             <span class="numbers-value" data-count-up th:text="${homeStats.casinoGameCount}">0</span>
             <span class="numbers-label">Casino games</span>

--- a/web/src/test/kotlin/web/service/HomeStatsServiceTest.kt
+++ b/web/src/test/kotlin/web/service/HomeStatsServiceTest.kt
@@ -47,6 +47,22 @@ class HomeStatsServiceTest {
     }
 
     @Test
+    fun `memberCount sums the member count of every cached guild`() {
+        @Suppress("UNCHECKED_CAST")
+        val guildCache = mockk<SnowflakeCacheView<Guild>>(relaxed = true)
+        every { jda.guildCache } returns guildCache
+        every { guildCache.size() } returns 3L
+        every { guildCache.iterator() } returns mutableListOf(
+            mockk<Guild> { every { memberCount } returns 1000 },
+            mockk<Guild> { every { memberCount } returns 250 },
+            mockk<Guild> { every { memberCount } returns 7 },
+        ).iterator()
+        service = HomeStatsService(jda, commandManager)
+
+        assertEquals(1257L, service.get().memberCount)
+    }
+
+    @Test
     fun `commandCount sums every category in CommandManager`() {
         // 17 + 3 + 18 + 6 + 34 + 17 + 3 = 98
         assertEquals(98, service.get().commandCount)

--- a/web/src/test/kotlin/web/template/HomeStatsRenderTest.kt
+++ b/web/src/test/kotlin/web/template/HomeStatsRenderTest.kt
@@ -1,0 +1,79 @@
+package web.template
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.context.support.GenericApplicationContext
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.mock.web.MockServletContext
+import org.thymeleaf.context.WebContext
+import org.thymeleaf.spring6.SpringTemplateEngine
+import org.thymeleaf.spring6.templateresolver.SpringResourceTemplateResolver
+import org.thymeleaf.templatemode.TemplateMode
+import org.thymeleaf.web.servlet.JakartaServletWebApplication
+import web.service.HomeStatsService
+
+/**
+ * Renders the real home.html through a Spring Thymeleaf engine to prove the
+ * live-stats expressions actually evaluate — the hero "members reached"
+ * tile, the woven-in hero subtitle clause, and the "by the numbers"
+ * members cell. HomeFeatureCardsTemplateTest only string-scans the raw
+ * template, so it can't catch a broken SpEL expression; this can.
+ */
+class HomeStatsRenderTest {
+
+    private val servletContext = MockServletContext()
+    private val webApp = JakartaServletWebApplication.buildApplication(servletContext)
+
+    private val engine: SpringTemplateEngine = SpringTemplateEngine().apply {
+        val appCtx = GenericApplicationContext().also { it.refresh() }
+        setTemplateResolver(SpringResourceTemplateResolver().apply {
+            setApplicationContext(appCtx)
+            prefix = "classpath:/templates/"
+            suffix = ".html"
+            templateMode = TemplateMode.HTML
+            characterEncoding = "UTF-8"
+            isCacheable = false
+        })
+    }
+
+    private fun stats(servers: Int, members: Long) = HomeStatsService.HomeStats(
+        serverCount = servers, memberCount = members, commandCount = 98, gameCount = 19,
+        minigameCount = 12, minigameNames = "slots, dice", casinoGameCount = 15,
+        pvpGameCount = 4, pvpGameNames = "duel, rps", configKeyCount = 58,
+        achievementCount = 15, notificationKindCount = 8,
+    )
+
+    private fun render(servers: Int, members: Long): String {
+        val exchange = webApp.buildExchange(MockHttpServletRequest(servletContext), MockHttpServletResponse())
+        val ctx = WebContext(exchange).apply {
+            setVariable("homeStats", stats(servers, members))
+            setVariable("inviteUrl", "https://invite")
+        }
+        return engine.process("home", ctx)
+    }
+
+    @Test
+    fun `hero strip, woven copy and numbers strip all surface the member count`() {
+        val html = render(servers = 1280, members = 2_500_000L)
+
+        // Hero stats tile + label.
+        assertTrue(html.contains("Members")) { "Members tile label missing" }
+        // Comma-formatted member count appears (hero tile / numbers strip / copy).
+        assertTrue(html.contains("2,500,000")) { "formatted member count missing:\n$html" }
+        // Woven hero subtitle clause with correct pluralisation.
+        assertTrue(html.contains("Already serving 2,500,000 members across 1,280 servers.")) {
+            "hero subtitle clause not rendered as expected:\n$html"
+        }
+        assertTrue(html.contains("Members reached")) { "numbers-strip members cell missing" }
+    }
+
+    @Test
+    fun `hero subtitle uses singular server and hides when no servers`() {
+        val singular = render(servers = 1, members = 42L)
+        assertTrue(singular.contains("across 1 server.")) { "singular 'server' not used:\n$singular" }
+
+        val none = render(servers = 0, members = 0L)
+        assertTrue(!none.contains("Already serving")) { "subtitle clause should hide when serverCount is 0" }
+    }
+}


### PR DESCRIPTION
## Why

You asked whether we could surface some of the install stats onto the public hero, more generically. The `/admin/installs` page tracks **members reached**, but the public homepage only advertised servers / commands / games. Members reached is the strongest, non-sensitive social-proof number — and it slots straight into the existing `HomeStatsService` that already powers the hero.

**Privacy line held:** only aggregate counts go public. Churn, health, dormancy, owners, install modes, and per-guild data stay operator-only on `/admin/installs`.

## What

- **`HomeStatsService`** — add `memberCount` (sum of every cached guild's member count). Reads `jda.guildCache` **once** (captured in a local) so the existing 60s-memoise + single-cache-read contract is preserved.
- **`home.html`** — three surfacings, per your picks:
  - a **"Members" tile** in the hero stats-strip (with count-up),
  - the number **woven into the hero subtitle** — *"Already serving N members across M servers."* (pluralised, and hidden when `serverCount == 0` so a fresh/dev instance doesn't say "0 members"),
  - a **"Members reached" cell** in the lower "by the numbers" strip.

## Testing
- `HomeStatsServiceTest` — member-count sums across the cache.
- **New `HomeStatsRenderTest`** — renders the *real* `home.html` through Thymeleaf to prove the woven-copy SpEL expression actually evaluates (the existing `HomeFeatureCardsTemplateTest` only string-scans the raw file, so it can't catch a broken expression). Covers the comma formatting, singular/plural, and the hidden-when-zero case.
- Updated the `HomeController` sample stats.
- Full **`:web` (1526)** + `HomeControllerTest` (14) green.

⚠️ Visual: couldn't screenshot here (no headless browser / app needs Postgres) — worth a glance at the hero, but it's the same `.stat`/`.numbers-cell` components already in use.

https://claude.ai/code/session_01KZNzPZmpXZrhcqPHTF6K9t

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZNzPZmpXZrhcqPHTF6K9t)_