### PR TITLE
Improve first-time onboarding: in-Discord /help overview, value-forward copy, re-welcome on re-invite

### DIFF
--- a/application/src/test/kotlin/integration/bot/ButtonManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/ButtonManagerTest.kt
@@ -9,6 +9,7 @@ import bot.toby.install.button.InstallCustomButton
 import bot.toby.install.button.InstallExpressButton
 import bot.toby.install.button.InstallFeaturesButton
 import bot.toby.install.button.InstallFinishButton
+import bot.toby.install.button.InstallHelpButton
 import bot.toby.install.button.InstallSkipButton
 import bot.toby.install.button.InstallToggleButton
 import bot.toby.lavaplayer.GuildMusicManager
@@ -125,6 +126,7 @@ class ButtonManagerTest {
             InstallBackButton::class.java,
             InstallFeaturesButton::class.java,
             InstallToggleButton::class.java,
+            InstallHelpButton::class.java,
         )
 
         assertTrue(availableButtons.containsAll(buttonManager.buttons.map { it.javaClass }.toList()))

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/HelpCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/HelpCommand.kt
@@ -1,40 +1,104 @@
 package bot.toby.command.commands.misc
 
-import core.command.Command.Companion.replyAndDelete
+import bot.toby.command.commands.dnd.DnDCommand
+import bot.toby.command.commands.economy.EconomyCommand
+import bot.toby.command.commands.fetch.FetchCommand
+import bot.toby.command.commands.game.pvp.GameCommand
+import bot.toby.command.commands.moderation.ModerationCommand
+import bot.toby.command.commands.mtg.MtgCommand
+import bot.toby.command.commands.music.MusicCommand
+import core.command.Command
+import core.command.Command.Companion.replyEmbedAndDelete
 import core.command.Command.Companion.replyEphemeralAndDelete
 import core.command.CommandContext
 import database.dto.user.UserDto
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.interactions.commands.build.OptionData
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-class HelpCommand @Autowired constructor(private val commands: List<core.command.Command>) : MiscCommand {
+class HelpCommand @Autowired constructor(private val commands: List<Command>) : MiscCommand {
     companion object {
         private const val COMMAND = "command"
+        private const val WIKI_URL = "github.com/ml404/toby-bot/wiki/Commands"
+        private const val KOFI_URL = "ko-fi.com/fratlayton"
+
+        /**
+         * Display order + labels for the no-argument `/help` overview.
+         * Each command is filed under the first category whose marker
+         * interface it implements; anything that matches none falls through
+         * to the "Everything else" bucket. Keeping this list here (rather
+         * than a property on every Command) means new commands show up in
+         * the overview automatically, grouped by the interface they already
+         * implement — no per-command bookkeeping.
+         */
+        private val CATEGORIES: List<HelpCategory> = listOf(
+            HelpCategory("🎲 Casino & games") { it is GameCommand },
+            HelpCategory("🎵 Music") { it is MusicCommand },
+            HelpCategory("💰 Economy & coins") { it is EconomyCommand },
+            HelpCategory("🛡️ Moderation") { it is ModerationCommand },
+            HelpCategory("🎴 Magic: The Gathering") { it is MtgCommand },
+            HelpCategory("🐉 Dungeons & Dragons") { it is DnDCommand },
+            HelpCategory("🔎 Lookups & tools") { it is FetchCommand },
+            HelpCategory("✨ Profile & misc") { it is MiscCommand },
+        )
+        private const val OTHER_LABEL = "📦 Everything else"
+
+        private data class HelpCategory(val label: String, val matches: (Command) -> Boolean)
     }
+
     override val ephemeral: Boolean = true
 
     override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
-        val args = ctx.event.options
         val event = ctx.event
-        // If no specific command is provided, direct users to the general wiki page
-        if (args.isEmpty()) {
-            val helpMessage =
-                "For a list of all available commands, visit the [Toby Bot Commands Wiki](https://github.com/ml404/toby-bot/wiki/Commands).\n" +
-                "Enjoying the bot? You can support development on [Ko-fi](https://ko-fi.com/fratlayton)."
-            event.hook.replyAndDelete(helpMessage, deleteDelay)
+        // No argument → show the in-Discord command overview rather than
+        // punting to an external wiki. This is the surface a brand-new user
+        // hits first, so it should answer "what can this bot do?" inline and
+        // hand off a zero-setup first action.
+        if (event.options.isEmpty()) {
+            event.hook.replyEmbedAndDelete(overviewEmbed(), deleteDelay)
             return
         }
 
         val searchOptional = event.getOption(COMMAND)?.asString
         val command = getCommand(searchOptional!!)
         if (command == null) {
-            event.hook.replyAndDelete("Nothing found for command '$searchOptional'", deleteDelay)
+            event.hook.replyEphemeralAndDelete("Nothing found for command '$searchOptional'", deleteDelay)
             return
         }
-        event.hook.replyEphemeralAndDelete(command.description, deleteDelay)
+        event.hook.replyEphemeralAndDelete("**/${command.name}** — ${command.description}", deleteDelay)
+    }
+
+    /**
+     * Builds the categorized command overview. Commands are grouped by the
+     * marker interface they implement and listed by name; the description
+     * leads with a zero-setup "try this now" nudge so a curious member has
+     * something to do immediately.
+     */
+    private fun overviewEmbed(): MessageEmbed {
+        val buckets = LinkedHashMap<String, MutableList<String>>()
+        CATEGORIES.forEach { buckets[it.label] = mutableListOf() }
+        buckets[OTHER_LABEL] = mutableListOf()
+
+        commands.sortedBy { it.name }.forEach { cmd ->
+            val label = CATEGORIES.firstOrNull { it.matches(cmd) }?.label ?: OTHER_LABEL
+            buckets.getValue(label).add("`/${cmd.name}`")
+        }
+
+        val builder = EmbedBuilder()
+            .setTitle("Toby Bot — what I can do")
+            .setDescription(
+                "**👉 New here? Try `/blackjack solo` or `/play <song>` right now — no setup needed.**\n\n" +
+                    "Below is everything I offer, grouped by area. Run `/help <command>` for details on any one of them."
+            )
+        buckets.filterValues { it.isNotEmpty() }.forEach { (label, names) ->
+            builder.addField(label, names.joinToString(" · "), false)
+        }
+        builder.setFooter("Full docs: $WIKI_URL  ·  Enjoying the bot? Support dev at $KOFI_URL")
+        return builder.build()
     }
 
     private fun getCommand(searchOptional: String) = commands.find { it.name.lowercase() == searchOptional }
@@ -42,7 +106,7 @@ class HelpCommand @Autowired constructor(private val commands: List<core.command
     override val name: String
         get() = "help"
     override val description: String
-        get() = "get help with the command you give this command"
+        get() = "See everything the bot can do, or pass a command name for details on just that one."
     override val optionData: List<OptionData>
         get() = listOf(OptionData(OptionType.STRING, COMMAND, "Command you would like help with", false, true))
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/HelpCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/HelpCommand.kt
@@ -1,19 +1,10 @@
 package bot.toby.command.commands.misc
 
-import bot.toby.command.commands.dnd.DnDCommand
-import bot.toby.command.commands.economy.EconomyCommand
-import bot.toby.command.commands.fetch.FetchCommand
-import bot.toby.command.commands.game.pvp.GameCommand
-import bot.toby.command.commands.moderation.ModerationCommand
-import bot.toby.command.commands.mtg.MtgCommand
-import bot.toby.command.commands.music.MusicCommand
 import core.command.Command
 import core.command.Command.Companion.replyEmbedAndDelete
 import core.command.Command.Companion.replyEphemeralAndDelete
 import core.command.CommandContext
 import database.dto.user.UserDto
-import net.dv8tion.jda.api.EmbedBuilder
-import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.interactions.commands.build.OptionData
 import org.springframework.beans.factory.annotation.Autowired
@@ -23,31 +14,6 @@ import org.springframework.stereotype.Component
 class HelpCommand @Autowired constructor(private val commands: List<Command>) : MiscCommand {
     companion object {
         private const val COMMAND = "command"
-        private const val WIKI_URL = "github.com/ml404/toby-bot/wiki/Commands"
-        private const val KOFI_URL = "ko-fi.com/fratlayton"
-
-        /**
-         * Display order + labels for the no-argument `/help` overview.
-         * Each command is filed under the first category whose marker
-         * interface it implements; anything that matches none falls through
-         * to the "Everything else" bucket. Keeping this list here (rather
-         * than a property on every Command) means new commands show up in
-         * the overview automatically, grouped by the interface they already
-         * implement — no per-command bookkeeping.
-         */
-        private val CATEGORIES: List<HelpCategory> = listOf(
-            HelpCategory("🎲 Casino & games") { it is GameCommand },
-            HelpCategory("🎵 Music") { it is MusicCommand },
-            HelpCategory("💰 Economy & coins") { it is EconomyCommand },
-            HelpCategory("🛡️ Moderation") { it is ModerationCommand },
-            HelpCategory("🎴 Magic: The Gathering") { it is MtgCommand },
-            HelpCategory("🐉 Dungeons & Dragons") { it is DnDCommand },
-            HelpCategory("🔎 Lookups & tools") { it is FetchCommand },
-            HelpCategory("✨ Profile & misc") { it is MiscCommand },
-        )
-        private const val OTHER_LABEL = "📦 Everything else"
-
-        private data class HelpCategory(val label: String, val matches: (Command) -> Boolean)
     }
 
     override val ephemeral: Boolean = true
@@ -59,7 +25,7 @@ class HelpCommand @Autowired constructor(private val commands: List<Command>) : 
         // hits first, so it should answer "what can this bot do?" inline and
         // hand off a zero-setup first action.
         if (event.options.isEmpty()) {
-            event.hook.replyEmbedAndDelete(overviewEmbed(), deleteDelay)
+            event.hook.replyEmbedAndDelete(HelpOverview.embed(commands), deleteDelay)
             return
         }
 
@@ -70,35 +36,6 @@ class HelpCommand @Autowired constructor(private val commands: List<Command>) : 
             return
         }
         event.hook.replyEphemeralAndDelete("**/${command.name}** — ${command.description}", deleteDelay)
-    }
-
-    /**
-     * Builds the categorized command overview. Commands are grouped by the
-     * marker interface they implement and listed by name; the description
-     * leads with a zero-setup "try this now" nudge so a curious member has
-     * something to do immediately.
-     */
-    private fun overviewEmbed(): MessageEmbed {
-        val buckets = LinkedHashMap<String, MutableList<String>>()
-        CATEGORIES.forEach { buckets[it.label] = mutableListOf() }
-        buckets[OTHER_LABEL] = mutableListOf()
-
-        commands.sortedBy { it.name }.forEach { cmd ->
-            val label = CATEGORIES.firstOrNull { it.matches(cmd) }?.label ?: OTHER_LABEL
-            buckets.getValue(label).add("`/${cmd.name}`")
-        }
-
-        val builder = EmbedBuilder()
-            .setTitle("Toby Bot — what I can do")
-            .setDescription(
-                "**👉 New here? Try `/blackjack solo` or `/play <song>` right now — no setup needed.**\n\n" +
-                    "Below is everything I offer, grouped by area. Run `/help <command>` for details on any one of them."
-            )
-        buckets.filterValues { it.isNotEmpty() }.forEach { (label, names) ->
-            builder.addField(label, names.joinToString(" · "), false)
-        }
-        builder.setFooter("Full docs: $WIKI_URL  ·  Enjoying the bot? Support dev at $KOFI_URL")
-        return builder.build()
     }
 
     private fun getCommand(searchOptional: String) = commands.find { it.name.lowercase() == searchOptional }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/HelpOverview.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/HelpOverview.kt
@@ -25,6 +25,7 @@ import net.dv8tion.jda.api.entities.MessageEmbed
  */
 object HelpOverview {
 
+    private const val WEBSITE_URL = "https://www.toby-bot.co.uk/"
     private const val WIKI_URL = "github.com/ml404/toby-bot/wiki/Commands"
     private const val KOFI_URL = "ko-fi.com/fratlayton"
     private const val OTHER_LABEL = "📦 Everything else"
@@ -61,12 +62,13 @@ object HelpOverview {
             .setTitle("Toby Bot — what I can do")
             .setDescription(
                 "**👉 New here? Try `/blackjack solo` or `/play <song>` right now — no setup needed.**\n\n" +
-                    "Below is everything I offer, grouped by area. Run `/help <command>` for details on any one of them."
+                    "Below is everything I offer, grouped by area. Run `/help <command>` for details on any one of them, " +
+                    "or see the full feature tour at **[toby-bot.co.uk]($WEBSITE_URL)**."
             )
         buckets.filterValues { it.isNotEmpty() }.forEach { (label, names) ->
             builder.addField(label, names.joinToString(" · "), false)
         }
-        builder.setFooter("Full docs: $WIKI_URL  ·  Enjoying the bot? Support dev at $KOFI_URL")
+        builder.setFooter("Full command list: $WIKI_URL  ·  Enjoying the bot? Support dev at $KOFI_URL")
         return builder.build()
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/HelpOverview.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/HelpOverview.kt
@@ -1,0 +1,72 @@
+package bot.toby.command.commands.misc
+
+import bot.toby.command.commands.dnd.DnDCommand
+import bot.toby.command.commands.economy.EconomyCommand
+import bot.toby.command.commands.fetch.FetchCommand
+import bot.toby.command.commands.game.pvp.GameCommand
+import bot.toby.command.commands.moderation.ModerationCommand
+import bot.toby.command.commands.mtg.MtgCommand
+import bot.toby.command.commands.music.MusicCommand
+import core.command.Command
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.entities.MessageEmbed
+
+/**
+ * Single source of truth for the "what can this bot do?" overview embed,
+ * shared by the no-argument [HelpCommand] and the public
+ * [bot.toby.install.button.InstallHelpButton] on the install welcome
+ * message. Both surfaces answer the same first-time question — "what does
+ * this thing do, and what can I try right now?" — so they build from the
+ * same place.
+ *
+ * Commands are grouped by the marker interface they already implement, so
+ * a newly added command shows up in the overview automatically with no
+ * per-command bookkeeping.
+ */
+object HelpOverview {
+
+    private const val WIKI_URL = "github.com/ml404/toby-bot/wiki/Commands"
+    private const val KOFI_URL = "ko-fi.com/fratlayton"
+    private const val OTHER_LABEL = "📦 Everything else"
+
+    private data class HelpCategory(val label: String, val matches: (Command) -> Boolean)
+
+    private val CATEGORIES: List<HelpCategory> = listOf(
+        HelpCategory("🎲 Casino & games") { it is GameCommand },
+        HelpCategory("🎵 Music") { it is MusicCommand },
+        HelpCategory("💰 Economy & coins") { it is EconomyCommand },
+        HelpCategory("🛡️ Moderation") { it is ModerationCommand },
+        HelpCategory("🎴 Magic: The Gathering") { it is MtgCommand },
+        HelpCategory("🐉 Dungeons & Dragons") { it is DnDCommand },
+        HelpCategory("🔎 Lookups & tools") { it is FetchCommand },
+        HelpCategory("✨ Profile & misc") { it is MiscCommand },
+    )
+
+    /**
+     * Build the categorized overview embed for [commands]. Leads with a
+     * zero-setup "try this now" nudge so a curious member has an immediate
+     * action, then lists each command by name under its category.
+     */
+    fun embed(commands: List<Command>): MessageEmbed {
+        val buckets = LinkedHashMap<String, MutableList<String>>()
+        CATEGORIES.forEach { buckets[it.label] = mutableListOf() }
+        buckets[OTHER_LABEL] = mutableListOf()
+
+        commands.sortedBy { it.name }.forEach { cmd ->
+            val label = CATEGORIES.firstOrNull { it.matches(cmd) }?.label ?: OTHER_LABEL
+            buckets.getValue(label).add("`/${cmd.name}`")
+        }
+
+        val builder = EmbedBuilder()
+            .setTitle("Toby Bot — what I can do")
+            .setDescription(
+                "**👉 New here? Try `/blackjack solo` or `/play <song>` right now — no setup needed.**\n\n" +
+                    "Below is everything I offer, grouped by area. Run `/help <command>` for details on any one of them."
+            )
+        buckets.filterValues { it.isNotEmpty() }.forEach { (label, names) ->
+            builder.addField(label, names.joinToString(" · "), false)
+        }
+        builder.setFooter("Full docs: $WIKI_URL  ·  Enjoying the bot? Support dev at $KOFI_URL")
+        return builder.build()
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/HelpOverview.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/HelpOverview.kt
@@ -26,7 +26,9 @@ import net.dv8tion.jda.api.entities.MessageEmbed
 object HelpOverview {
 
     private const val WEBSITE_URL = "https://www.toby-bot.co.uk/"
-    private const val WIKI_URL = "github.com/ml404/toby-bot/wiki/Commands"
+    // The site's own polished, auto-generated commands page (categorized
+    // cards + search) — not the bare GitHub wiki.
+    private const val COMMANDS_URL = "toby-bot.co.uk/commands/wiki"
     private const val KOFI_URL = "ko-fi.com/fratlayton"
     private const val OTHER_LABEL = "📦 Everything else"
 
@@ -68,7 +70,7 @@ object HelpOverview {
         buckets.filterValues { it.isNotEmpty() }.forEach { (label, names) ->
             builder.addField(label, names.joinToString(" · "), false)
         }
-        builder.setFooter("Full command list: $WIKI_URL  ·  Enjoying the bot? Support dev at $KOFI_URL")
+        builder.setFooter("Full command list: $COMMANDS_URL  ·  Enjoying the bot? Support dev at $KOFI_URL")
         return builder.build()
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/SupportCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/SupportCommand.kt
@@ -22,7 +22,7 @@ class SupportCommand : MiscCommand {
             )
             .addField("Ko-fi", "[Support development](https://ko-fi.com/fratlayton)", false)
             .addField("GitHub", "[Source & issues](https://github.com/ml404/toby-bot)", false)
-            .addField("Commands wiki", "[Browse all commands](https://github.com/ml404/toby-bot/wiki/Commands)", false)
+            .addField("Commands", "[Browse all commands](https://www.toby-bot.co.uk/commands/wiki)", false)
             .build()
 
         event.hook.sendMessageEmbeds(embed)

--- a/discord-bot/src/main/kotlin/bot/toby/handler/GuildLeaveCleanupHandler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/handler/GuildLeaveCleanupHandler.kt
@@ -4,10 +4,12 @@ import bot.toby.notify.AntiAutoclickNotifier
 import bot.toby.voice.VoiceCompanyTracker
 import common.logging.DiscordLogger
 import database.blackjack.BlackjackTableRegistry
+import database.dto.guild.ConfigDto.Configurations
 import database.poker.CasinoHoldemTableRegistry
 import database.poker.PokerTableRegistry
 import database.service.activity.InstallEventService
 import database.service.casino.CasinoBotSuspicionService
+import database.service.guild.ConfigService
 import net.dv8tion.jda.api.events.guild.GuildLeaveEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
 import org.springframework.stereotype.Service
@@ -33,6 +35,7 @@ class GuildLeaveCleanupHandler(
     private val casinoBotSuspicionService: CasinoBotSuspicionService,
     private val voiceCompanyTracker: VoiceCompanyTracker,
     private val installEventService: InstallEventService,
+    private val configService: ConfigService,
 ) : ListenerAdapter() {
 
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
@@ -45,6 +48,14 @@ class GuildLeaveCleanupHandler(
         // means the metric is captured even if an evict call later throws).
         runCatching { installEventService.recordLeave(guildId) }
             .onFailure { logger.error { "Failed to record LEAVE for guild $guildId: ${it.message}" } }
+        // Clear the install *welcome-gate* (`INSTALL_MODE`) so that if the
+        // bot is re-invited the onboarding wizard re-opens instead of staying
+        // silent on the stale sentinel. `INSTALLED_AT` and all substantive
+        // per-guild config (casino rules, channels, etc.) are intentionally
+        // left intact so a returning server keeps its settings and gets the
+        // welcome-back greeting (see InstallWelcomeHandler).
+        runCatching { configService.deleteConfig(event.guild.id, Configurations.INSTALL_MODE.configValue) }
+            .onFailure { logger.error { "Failed to clear INSTALL_MODE for guild $guildId: ${it.message}" } }
         runCatching { pokerTableRegistry.evictGuild(guildId) }
         runCatching { blackjackTableRegistry.evictGuild(guildId) }
         runCatching { casinoHoldemTableRegistry.evictGuild(guildId) }

--- a/discord-bot/src/main/kotlin/bot/toby/install/InstallWelcomeHandler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/InstallWelcomeHandler.kt
@@ -57,12 +57,19 @@ class InstallWelcomeHandler(
             logger.info { "Skipping welcome — guild ${guild.id} already installed ($existingValue)" }
             return
         }
+        // `INSTALL_MODE` is cleared on guild-leave (see GuildLeaveCleanupHandler)
+        // so a genuine re-invite re-opens the wizard, but `INSTALLED_AT` is
+        // left intact as a "we've onboarded this guild before" marker. Its
+        // presence here means this is a returning server whose config survived
+        // — greet them with the welcome-back variant instead of a fresh pitch.
+        val returning = !configService.getConfigByName(Configurations.INSTALLED_AT.configValue, guild.id)?.value.isNullOrBlank()
+        val welcomeEmbed = if (returning) InstallWizard.welcomeBackEmbed(guild.name) else InstallWizard.welcomeEmbed(guild.name)
         val channel = pickWelcomeChannel(guild)
         if (channel != null) {
-            channel.sendMessageEmbeds(InstallWizard.welcomeEmbed(guild.name))
+            channel.sendMessageEmbeds(welcomeEmbed)
                 .addComponents(InstallWizard.wizardButtons())
                 .queue()
-            logger.info { "Posted install welcome to ${guild.id} in #${channel.name}" }
+            logger.info { "Posted install ${if (returning) "welcome-back" else "welcome"} to ${guild.id} in #${channel.name}" }
             return
         }
         // No writable channel — fall back to DMing the guild owner so the

--- a/discord-bot/src/main/kotlin/bot/toby/install/InstallWizard.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/InstallWizard.kt
@@ -67,8 +67,8 @@ object InstallWizard {
                 "flip anything on later with `/setconfig`.\n" +
                 "**▸ Custom setup** — tune audio, channels, casino rules, lottery & more before you start.\n" +
                 "**▸ Skip for now** — dismiss this; run `/install` whenever you're ready.\n\n" +
-                "💡 Once you're set up, anyone can run `/help`, deal a hand with `/blackjack`, or queue a " +
-                "track with `/play`.\n" +
+                "💡 **No waiting required** — even before setup, anyone can play `/blackjack solo`, spin " +
+                "`/roulette`, or queue music with `/play`. Run `/help` to see everything I can do.\n" +
                 "_Only the server owner can use these buttons._"
         )
         .build()
@@ -90,7 +90,8 @@ object InstallWizard {
                 "**▸ Express setup** — re-confirm the quick defaults.\n" +
                 "**▸ Custom setup** — jump back into the tuning menus.\n" +
                 "**▸ Skip for now** — keep everything as it is.\n\n" +
-                "💡 Or jump straight back in with `/help`, `/blackjack`, or `/play`.\n" +
+                "💡 Or jump straight back in — anyone can play `/blackjack solo`, spin `/roulette`, or queue " +
+                "`/play`. Run `/help` for the full list.\n" +
                 "_Only the server owner can use these buttons._"
         )
         .build()

--- a/discord-bot/src/main/kotlin/bot/toby/install/InstallWizard.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/InstallWizard.kt
@@ -36,6 +36,14 @@ object InstallWizard {
     const val BTN_EXPRESS = "install_express"
     const val BTN_CUSTOM = "install_custom"
     const val BTN_SKIP = "install_skip"
+
+    /**
+     * Public (non-owner) button on the welcome message — anyone can click
+     * it to get the `/help` overview ephemerally. Gives curious members an
+     * immediate, zero-setup action while the owner-only Express / Custom /
+     * Skip buttons stay gated.
+     */
+    const val BTN_HELP = "install_help"
     const val BTN_FINISH = "install_finish"
     const val BTN_BACK = "install_category_back"
     const val BTN_FEATURES = "install_features"
@@ -182,6 +190,9 @@ object InstallWizard {
         Button.success(BTN_EXPRESS, "Express setup"),
         Button.primary(BTN_CUSTOM, "Custom setup"),
         Button.secondary(BTN_SKIP, "Skip for now"),
+        // Non-owner-friendly: any member can click this to see what the bot
+        // does without waiting on the owner to finish setup.
+        Button.secondary(BTN_HELP, "✨ What can I do?"),
     )
 
     fun finishButtonRow(): ActionRow = ActionRow.of(

--- a/discord-bot/src/main/kotlin/bot/toby/install/InstallWizard.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/InstallWizard.kt
@@ -77,6 +77,7 @@ object InstallWizard {
                 "**▸ Skip for now** — dismiss this; run `/install` whenever you're ready.\n\n" +
                 "💡 **No waiting required** — even before setup, anyone can play `/blackjack solo`, spin " +
                 "`/roulette`, or queue music with `/play`. Run `/help` to see everything I can do.\n" +
+                "🌐 Want the full tour first? Everything's at **[toby-bot.co.uk](https://www.toby-bot.co.uk/)**.\n" +
                 "_Only the server owner can use these buttons._"
         )
         .build()

--- a/discord-bot/src/main/kotlin/bot/toby/install/InstallWizard.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/InstallWizard.kt
@@ -53,19 +53,44 @@ object InstallWizard {
     // ---- embed factories ----
 
     fun welcomeEmbed(guildName: String): MessageEmbed = EmbedBuilder()
-        .setTitle("Welcome to $guildName!")
+        .setTitle("Thanks for adding me to $guildName! 🎉")
         .setDescription(
-            "Pick how you'd like to set the bot up:\n\n" +
-                "**▸ Express setup** — accept all defaults and get going in one click. " +
-                "Defaults include:\n" +
-                "  • Audio at full volume, message auto-delete on\n" +
-                "  • Activity tracking **OFF** (no XP / leaderboards)\n" +
-                "  • Daily lottery **OFF**\n" +
-                "  • Casino games enabled with conservative stake bounds\n" +
-                "  • Jackpot pool wired up but moderate (10% loss-tribute, 1% win-chance)\n\n" +
-                "**▸ Custom setup** — pick categories to tune now (audio, channels, casino rules, lottery). " +
-                "Anything you skip falls back to the defaults above; `/setconfig` is available anytime for fine-tuning.\n\n" +
-                "**▸ Skip for now** — dismiss this prompt. Run `/install` anytime to come back.\n\n" +
+            "I'm **toby-bot** — here's what I bring to the table:\n\n" +
+                "🎲 **Casino** — blackjack, poker, roulette, slots, dice & more, all sharing a Toby Coin " +
+                "economy and a server jackpot\n" +
+                "🎵 **Music** — queue and play audio right in your voice channels\n" +
+                "📈 **Leveling** — optional XP, leaderboards & activity rewards\n" +
+                "🎟️ **Daily lottery** — an optional server-wide draw\n\n" +
+                "**Let's get you set up — pick a path below:**\n" +
+                "**▸ Express setup** — one click, sensible defaults, start playing right away. Express keeps " +
+                "**Activity tracking OFF**, the **Daily lottery OFF**, and uses conservative casino stakes — " +
+                "flip anything on later with `/setconfig`.\n" +
+                "**▸ Custom setup** — tune audio, channels, casino rules, lottery & more before you start.\n" +
+                "**▸ Skip for now** — dismiss this; run `/install` whenever you're ready.\n\n" +
+                "💡 Once you're set up, anyone can run `/help`, deal a hand with `/blackjack`, or queue a " +
+                "track with `/play`.\n" +
+                "_Only the server owner can use these buttons._"
+        )
+        .build()
+
+    /**
+     * Returning-server variant of [welcomeEmbed], shown when the bot is
+     * re-invited to a guild it was previously set up in (detected via a
+     * surviving `INSTALLED_AT` sentinel). Reassures the owner their prior
+     * configuration is intact and offers the same Express / Custom / Skip
+     * buttons in case they want to review it.
+     */
+    fun welcomeBackEmbed(guildName: String): MessageEmbed = EmbedBuilder()
+        .setTitle("Welcome back to $guildName! 👋")
+        .setDescription(
+            "Good to be back — **your previous settings are still saved**, so the casino, channels and " +
+                "everything you configured before are exactly as you left them. You don't need to do " +
+                "anything to keep them.\n\n" +
+                "If you'd like to review or change your setup:\n" +
+                "**▸ Express setup** — re-confirm the quick defaults.\n" +
+                "**▸ Custom setup** — jump back into the tuning menus.\n" +
+                "**▸ Skip for now** — keep everything as it is.\n\n" +
+                "💡 Or jump straight back in with `/help`, `/blackjack`, or `/play`.\n" +
                 "_Only the server owner can use these buttons._"
         )
         .build()
@@ -90,10 +115,13 @@ object InstallWizard {
         .build()
 
     fun expressDoneEmbed(): MessageEmbed = EmbedBuilder()
-        .setTitle("You're all set!")
+        .setTitle("You're all set! 🎉")
         .setDescription(
-            "The bot is running on defaults. Use `/setconfig <category>` anytime to fine-tune settings, " +
-                "or `/install` to re-open this wizard."
+            "Defaults are live and the casino is open. Here's how to get going:\n\n" +
+                "• `/help` — browse every command\n" +
+                "• `/blackjack` or `/roulette` — deal a quick game\n" +
+                "• `/play <song>` — queue music in a voice channel\n\n" +
+                "Owners: `/setconfig <category>` fine-tunes any setting, and `/install` reopens this wizard anytime."
         )
         .build()
 
@@ -137,8 +165,14 @@ object InstallWizard {
         .build()
 
     fun finishDoneEmbed(): MessageEmbed = EmbedBuilder()
-        .setTitle("Custom setup complete")
-        .setDescription("Your settings are saved. Use `/setconfig <category>` anytime to keep tuning.")
+        .setTitle("Custom setup complete ✅")
+        .setDescription(
+            "Your settings are saved. Time to play:\n\n" +
+                "• `/help` — browse every command\n" +
+                "• `/blackjack` or `/roulette` — deal a quick game\n" +
+                "• `/play <song>` — queue music in a voice channel\n\n" +
+                "Keep tuning anytime with `/setconfig <category>`, or reopen this wizard with `/install`."
+        )
         .build()
 
     // ---- component factories ----

--- a/discord-bot/src/main/kotlin/bot/toby/install/button/InstallHelpButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/button/InstallHelpButton.kt
@@ -1,0 +1,33 @@
+package bot.toby.install.button
+
+import bot.toby.command.commands.misc.HelpOverview
+import bot.toby.install.InstallWizard
+import core.button.Button
+import core.button.ButtonContext
+import core.command.Command
+import database.dto.user.UserDto
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+/**
+ * "✨ What can I do?" — the one welcome-message button that is NOT
+ * owner-gated. Anyone can click it to get the same categorized `/help`
+ * overview, ephemerally, so a curious member has an immediate zero-setup
+ * action instead of waiting on the owner to finish the install wizard.
+ *
+ * Uses the default [Button.defersReply] (ephemeral) ack from
+ * [bot.toby.managers.DefaultButtonManager], so the handler just sends the
+ * overview embed as a follow-up.
+ */
+@Component
+class InstallHelpButton @Autowired constructor(
+    private val commands: List<Command>,
+) : Button {
+
+    override val name: String = InstallWizard.BTN_HELP
+    override val description: String = "Show what the bot can do — usable by anyone, not just the owner."
+
+    override fun handle(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        ctx.event.hook.sendMessageEmbeds(HelpOverview.embed(commands)).queue()
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/misc/HelpCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/misc/HelpCommandTest.kt
@@ -7,8 +7,11 @@ import bot.toby.command.commands.music.player.PlayCommand
 import core.command.Command
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
+import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.interactions.commands.OptionMapping
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -25,38 +28,39 @@ internal class HelpCommandTest : CommandTest {
 
     @Test
     fun testHandleCommandWithNoArgs() {
-        // Mock user interaction with no arguments
-
-        // Mock the event's options to be empty
+        // No argument → an in-Discord overview embed (not an external link).
         every { event.options } returns emptyList()
         every { event.getOption("command") } returns null
 
-        // Test handle method
+        val embedSlot = slot<MessageEmbed>()
+        every { event.hook.sendMessageEmbeds(capture(embedSlot), *anyVararg()) } returns
+            CommandTest.webhookMessageCreateAction
+
         helpCommand.handle(DefaultCommandContext(event), mockk(), 0)
 
-        // Verify interactions
-        verify(exactly = 1) { event.hook.sendMessage(any<String>()) }
+        verify(exactly = 1) { event.hook.sendMessageEmbeds(any<MessageEmbed>(), *anyVararg()) }
+        // The overview must hand a brand-new user a zero-setup first action
+        // and group PlayCommand under Music.
+        val embed = embedSlot.captured
+        assertTrue(embed.description!!.contains("/blackjack solo"))
+        assertTrue(embed.fields.any { it.name!!.contains("Music") && it.value!!.contains("/play") })
     }
 
     @Test
     fun testHandleCommandWithCommandArg() {
         // Mock user interaction with a command argument
-
-        // Mock the event's options to include a command argument
         val optionMapping: OptionMapping = mockk()
         every { event.options } returns listOf(optionMapping)
 
-        // Mock the CommandManager's command
         val musicCommand: Command = mockk<PlayCommand>()
         every { event.getOption("command") } returns optionMapping
         every { optionMapping.asString } returns "play"
         every { musicCommand.description } returns ""
         every { musicCommand.name } returns "play"
 
-        // Test handle method
         helpCommand.handle(DefaultCommandContext(event), mockk(), 0)
 
-        // Verify interactions
+        // Detail lookups reply with text (ephemeral).
         verify(exactly = 1) { event.hook.sendMessage(any<String>()) }
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/handler/GuildLeaveCleanupHandlerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/handler/GuildLeaveCleanupHandlerTest.kt
@@ -5,8 +5,10 @@ import bot.toby.voice.VoiceCompanyTracker
 import database.blackjack.BlackjackTableRegistry
 import database.poker.CasinoHoldemTableRegistry
 import database.poker.PokerTableRegistry
+import database.dto.guild.ConfigDto.Configurations
 import database.service.activity.InstallEventService
 import database.service.casino.CasinoBotSuspicionService
+import database.service.guild.ConfigService
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -28,6 +30,7 @@ class GuildLeaveCleanupHandlerTest {
     private val casinoBotSuspicionService: CasinoBotSuspicionService = mockk(relaxed = true)
     private val voiceCompanyTracker: VoiceCompanyTracker = mockk(relaxed = true)
     private val installEventService: InstallEventService = mockk(relaxed = true)
+    private val configService: ConfigService = mockk(relaxed = true)
 
     private val handler = GuildLeaveCleanupHandler(
         pokerTableRegistry,
@@ -38,10 +41,14 @@ class GuildLeaveCleanupHandlerTest {
         casinoBotSuspicionService,
         voiceCompanyTracker,
         installEventService,
+        configService,
     )
 
     private fun leaveEvent(guildId: Long): GuildLeaveEvent {
-        val guild = mockk<Guild>(relaxed = true) { every { idLong } returns guildId }
+        val guild = mockk<Guild>(relaxed = true) {
+            every { idLong } returns guildId
+            every { id } returns guildId.toString()
+        }
         return mockk(relaxed = true) { every { this@mockk.guild } returns guild }
     }
 
@@ -57,6 +64,19 @@ class GuildLeaveCleanupHandlerTest {
         verify(exactly = 1) { antiAutoclickNotifier.evictGuild(42L) }
         verify(exactly = 1) { casinoBotSuspicionService.evictGuild(42L) }
         verify(exactly = 1) { voiceCompanyTracker.evictGuild(42L) }
+    }
+
+    @Test
+    fun `guild leave clears the INSTALL_MODE welcome-gate so a re-invite re-onboards`() {
+        // INSTALL_MODE is the sentinel InstallWelcomeHandler checks to decide
+        // whether to skip the welcome. Clearing it on leave is what lets a
+        // re-invited guild see the wizard again instead of silence.
+        handler.onGuildLeave(leaveEvent(42L))
+
+        verify(exactly = 1) { configService.deleteConfig("42", Configurations.INSTALL_MODE.configValue) }
+        // INSTALLED_AT and substantive config are preserved — never deleted here.
+        verify(exactly = 0) { configService.deleteConfig("42", Configurations.INSTALLED_AT.configValue) }
+        verify(exactly = 0) { configService.deleteAll(any()) }
     }
 
     @Test

--- a/discord-bot/src/test/kotlin/bot/toby/install/InstallCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/InstallCommandTest.kt
@@ -88,11 +88,12 @@ internal class InstallCommandTest : CommandTest {
         verify(exactly = 1) { replyCallbackAction.addComponents(any<ActionRow>()) }
         // Embed mentions the guild name.
         assertTrue(embedSlot.captured.description?.contains("Express") == true)
-        // Action row has exactly the three wizard buttons in order.
+        // Action row has the three owner buttons plus the public help button.
         val buttons = componentsSlot.captured.components.filterIsInstance<Button>()
-        assertEquals(3, buttons.size)
+        assertEquals(4, buttons.size)
         assertEquals(InstallWizard.BTN_EXPRESS, buttons[0].customId)
         assertEquals(InstallWizard.BTN_CUSTOM, buttons[1].customId)
         assertEquals(InstallWizard.BTN_SKIP, buttons[2].customId)
+        assertEquals(InstallWizard.BTN_HELP, buttons[3].customId)
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/install/InstallWelcomeHandlerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/InstallWelcomeHandlerTest.kt
@@ -8,6 +8,7 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
+import io.mockk.slot
 import io.mockk.verify
 import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.components.actionrow.ActionRow
@@ -23,6 +24,7 @@ import net.dv8tion.jda.api.events.guild.GuildJoinEvent
 import net.dv8tion.jda.api.requests.RestAction
 import net.dv8tion.jda.api.requests.restaction.CacheRestAction
 import net.dv8tion.jda.api.requests.restaction.MessageCreateAction
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -113,6 +115,44 @@ internal class InstallWelcomeHandlerTest {
         handler.onGuildJoin(event)
 
         verify(exactly = 0) { systemChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `posts the welcome-back variant when INSTALLED_AT survives a re-invite`() {
+        // INSTALL_MODE was cleared on the previous leave, but INSTALLED_AT
+        // survives — so this is a returning server and should get the
+        // welcome-back greeting, not the first-time pitch.
+        every { configService.getConfigByName(Configurations.INSTALL_MODE.configValue, "100") } returns null
+        every { configService.getConfigByName(Configurations.INSTALLED_AT.configValue, "100") } returns
+            ConfigDto(Configurations.INSTALLED_AT.configValue, "1700000000000", "100")
+        every { guild.systemChannel } returns systemChannel
+        every {
+            selfMember.hasPermission(systemChannel, Permission.VIEW_CHANNEL, Permission.MESSAGE_SEND)
+        } returns true
+
+        val embedSlot = slot<MessageEmbed>()
+        every { systemChannel.sendMessageEmbeds(capture(embedSlot)) } returns messageAction
+
+        handler.onGuildJoin(event)
+
+        verify(exactly = 1) { systemChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+        assertTrue(embedSlot.captured.title!!.contains("Welcome back"))
+    }
+
+    @Test
+    fun `posts the first-time welcome when there is no prior INSTALLED_AT`() {
+        every { configService.getConfigByName(any(), any()) } returns null
+        every { guild.systemChannel } returns systemChannel
+        every {
+            selfMember.hasPermission(systemChannel, Permission.VIEW_CHANNEL, Permission.MESSAGE_SEND)
+        } returns true
+
+        val embedSlot = slot<MessageEmbed>()
+        every { systemChannel.sendMessageEmbeds(capture(embedSlot)) } returns messageAction
+
+        handler.onGuildJoin(event)
+
+        assertTrue(embedSlot.captured.title!!.contains("Thanks for adding me"))
     }
 
     @Test

--- a/discord-bot/src/test/kotlin/bot/toby/install/InstallWizardTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/InstallWizardTest.kt
@@ -18,12 +18,14 @@ import common.casino.roulette.Roulette
 internal class InstallWizardTest {
 
     @Test
-    fun `wizardButtons returns the three welcome buttons in order`() {
+    fun `wizardButtons returns the owner buttons plus the public help button in order`() {
         val buttons = InstallWizard.wizardButtons().components.filterIsInstance<Button>()
-        assertEquals(3, buttons.size)
+        assertEquals(4, buttons.size)
         assertEquals(InstallWizard.BTN_EXPRESS, buttons[0].customId)
         assertEquals(InstallWizard.BTN_CUSTOM, buttons[1].customId)
         assertEquals(InstallWizard.BTN_SKIP, buttons[2].customId)
+        // The help button is the only non-owner-gated entry point on the welcome message.
+        assertEquals(InstallWizard.BTN_HELP, buttons[3].customId)
     }
 
     @Test

--- a/discord-bot/src/test/kotlin/bot/toby/install/InstallWizardTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/InstallWizardTest.kt
@@ -145,6 +145,7 @@ internal class InstallWizardTest {
     fun `every welcome embed factory returns a nonempty description`() {
         val embeds = listOf(
             InstallWizard.welcomeEmbed("Guild"),
+            InstallWizard.welcomeBackEmbed("Guild"),
             InstallWizard.dmWelcomeEmbed("Guild"),
             InstallWizard.expressDoneEmbed(),
             InstallWizard.customSectionEmbed(),
@@ -183,6 +184,26 @@ internal class InstallWizardTest {
     fun `welcome embed mentions the guild name`() {
         val embed = InstallWizard.welcomeEmbed("MyServer")
         assertTrue(embed.title!!.contains("MyServer"))
+    }
+
+    @Test
+    fun `welcomeBack embed names the guild and reassures settings are kept`() {
+        val embed = InstallWizard.welcomeBackEmbed("MyServer")
+        assertTrue(embed.title!!.contains("Welcome back"))
+        assertTrue(embed.title!!.contains("MyServer"))
+        // Returning owners should be told their prior config survived the re-invite.
+        assertTrue(embed.description!!.contains("still saved", ignoreCase = true))
+    }
+
+    @Test
+    fun `done embeds point owners at concrete first actions`() {
+        // Onboarding should hand off to something playable, not just /setconfig.
+        listOf(InstallWizard.expressDoneEmbed(), InstallWizard.finishDoneEmbed()).forEach { embed ->
+            val description = embed.description!!
+            assertTrue(description.contains("/help"))
+            assertTrue(description.contains("/blackjack"))
+            assertTrue(description.contains("/play"))
+        }
     }
 
     @Test

--- a/discord-bot/src/test/kotlin/bot/toby/install/button/InstallHelpButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/button/InstallHelpButtonTest.kt
@@ -1,0 +1,45 @@
+package bot.toby.install.button
+
+import bot.toby.command.commands.music.player.PlayCommand
+import bot.toby.install.InstallWizard
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.entities.MessageEmbed
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class InstallHelpButtonTest {
+
+    private lateinit var button: InstallHelpButton
+    private lateinit var fx: InstallButtonFixture
+
+    @BeforeEach
+    fun setUp() {
+        button = InstallHelpButton(listOf(PlayCommand()))
+        fx = InstallButtonFixture()
+    }
+
+    @Test
+    fun `name matches the public help button id`() {
+        assertEquals(InstallWizard.BTN_HELP, button.name)
+    }
+
+    @Test
+    fun `defersReply is true so the manager acks ephemerally`() {
+        // Unlike the owner-only install buttons (which defer an edit), the
+        // help button replies with a fresh ephemeral message.
+        assertEquals(true, button.defersReply)
+    }
+
+    @Test
+    fun `sends the overview embed to anyone with no owner gate`() {
+        // A non-owner must still get the overview — that's the whole point.
+        fx.asNonOwner()
+
+        button.handle(fx.ctx, mockk(relaxed = true), 0)
+
+        verify(exactly = 1) { fx.hook.sendMessageEmbeds(any<MessageEmbed>(), *anyVararg<MessageEmbed>()) }
+        verify(exactly = 0) { fx.event.reply(any<String>()) }
+    }
+}


### PR DESCRIPTION
## Why

Motivated by the all-too-common drop-off: a stranger adds the bot, can't quickly tell what it does or hits friction, and uninstalls. This PR attacks that on three fronts — discovery, framing, and one genuine bug — without changing any bot capability. (Casino games and music already work out-of-the-box on defaults; the gap was purely *discovery and framing*.)

## 1. `/help` with no argument → in-Discord command overview

Previously `/help` (no args) just posted a link to the GitHub wiki — the worst possible answer for the exact person trying to figure out what the bot does. Now it renders a categorized, scannable overview **inside Discord**:

- Grouped by area (🎲 Casino & games, 🎵 Music, 💰 Economy, 🛡️ Moderation, 🎴 MTG, 🐉 D&D, 🔎 Lookups, ✨ Profile & misc), built from the **marker interface each command already implements** — so new commands appear automatically with no per-command bookkeeping.
- Leads with a zero-setup nudge: *"👉 New here? Try `/blackjack solo` or `/play <song>` right now — no setup needed."*
- Points to `/help <command>` for per-command detail (now formatted as `**/name** — description`).

## 2. Value-forward welcome + explicit "try it now" hooks

- The join welcome embed now **leads with what the bot does** (casino, music, leveling, lottery) instead of opening on config jargon (loss-tribute %, stake bounds).
- Because the install-wizard buttons are **owner-only**, the welcome + welcome-back embeds now make the no-setup first action **member-facing**: anyone can play `/blackjack solo`, spin `/roulette`, or queue `/play` before any owner configuration.
- The Express / Custom "done" screens hand off to concrete first actions (`/help`, `/blackjack`, `/play`) rather than only pointing at `/setconfig`.

## 3. Bug: a re-invite was silent (kept in this PR)

`InstallWelcomeHandler` suppresses the welcome whenever the `INSTALL_MODE` sentinel is set, but `GuildLeaveCleanupHandler` never cleared it on leave — so re-inviting the bot produced **silence** on the stale sentinel.

- Leave now clears the `INSTALL_MODE` welcome-gate so a re-invite re-opens the wizard, while **preserving** `INSTALLED_AT` and all substantive config (casino rules, channels, lottery).
- A returning server is detected via the surviving `INSTALLED_AT` marker and gets a **welcome-back** greeting ("your previous settings are still saved").

## Safety notes

- The admin installs dashboard reads `INSTALL_MODE`/`INSTALLED_AT` only from `jda.guildCache` (currently-present guilds) and derives churn from the append-only `install_event` ledger, so clearing a *departed* guild's sentinel doesn't affect any metric. `INSTALLED_AT` is left intact, so install-date charts and the returning-server signal keep working.

## Tests

- `HelpCommandTest` — no-arg path renders an overview embed carrying the try-now action and groups `/play` under Music.
- `GuildLeaveCleanupHandlerTest` — `INSTALL_MODE` deleted on leave; `INSTALLED_AT`/`deleteAll` untouched.
- `InstallWelcomeHandlerTest` — welcome-back vs first-time selection by surviving `INSTALLED_AT`.
- `InstallWizardTest` — welcome-back copy + done-screens point at concrete first actions.

All affected suites pass locally (0 failures).

https://claude.ai/code/session_014NH9kNe3jj7NbEx4SswK7u