### PR TITLE
Polish music player to match other web surfaces

### DIFF
--- a/web/src/main/resources/static/css/base.css
+++ b/web/src/main/resources/static/css/base.css
@@ -193,6 +193,35 @@ a:hover { color: var(--accent-hover); }
 .btn-primary[hidden],
 .btn-secondary[hidden] { display: none; }
 
+/* Tertiary — the quietest button in the family. Lower emphasis than
+   `.btn-secondary`: filled with the input surface, muted label, subtle
+   border, lifting to an accent-soft wash on hover. Used for "← All
+   servers" back links, playlist Load, search Clear, etc. Defined here
+   (above `.btn-danger`) so the `.btn-tertiary.btn-danger` combo on the
+   playlist Delete button still resolves to the danger palette by source
+   order. */
+.btn-tertiary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-2);
+    background: var(--bg-input);
+    color: var(--text-muted);
+    border: 1px solid var(--border-strong);
+    padding: 8px 14px;
+    border-radius: var(--radius-md);
+    font-size: 0.9rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s, border-color 0.15s, color 0.15s, transform 0.05s;
+    text-decoration: none;
+    font-family: inherit;
+}
+.btn-tertiary:hover:not(:disabled) { background: var(--accent-soft); border-color: var(--accent); color: var(--text); }
+.btn-tertiary:active:not(:disabled) { transform: translateY(1px); }
+.btn-tertiary:disabled { opacity: 0.55; cursor: not-allowed; }
+.btn-tertiary[hidden] { display: none; }
+
 /* Green accent variant for confirm-style actions (blackjack's Stand,
    future "Lock in" / "Confirm" controls). Same shape as `.btn-primary`,
    different colour token. */

--- a/web/src/main/resources/static/css/music-player.css
+++ b/web/src/main/resources/static/css/music-player.css
@@ -19,6 +19,12 @@
     flex-wrap: wrap;
 }
 
+.music-header-titles {
+    min-width: 0;
+}
+.music-header-titles .section-eyebrow {
+    margin-bottom: 2px;
+}
 .music-header h1 {
     margin: 0;
     font-size: 1.5rem;
@@ -43,16 +49,42 @@
 .queue-card,
 .playlists-card,
 .voice-card {
-    background: var(--bg-elevated, #1e2026);
-    border: 1px solid var(--border, #2c2e35);
-    border-radius: 12px;
-    padding: 1rem 1.25rem;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: var(--space-4) var(--space-5);
+    box-shadow: var(--shadow-sm);
+    transition: border-color var(--dur-base) var(--ease-out), box-shadow var(--dur-base) var(--ease-out);
+}
+
+/* Now-playing is the hero of the dashboard — give it an accent-tinted
+   aurora wash + a soft glow so it reads as the focal card, matching the
+   elevated-hero treatment the home/economy/casino surfaces use. The
+   ::before paints the gradient behind the content without tinting the
+   card border. */
+.now-playing-card {
+    position: relative;
+    overflow: hidden;
+    border-color: var(--border-strong);
+}
+.now-playing-card::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: var(--gradient-hero);
+    opacity: 0.6;
+    pointer-events: none;
+}
+.now-playing-card > * { position: relative; }
+.now-playing-card.is-playing {
+    border-color: var(--accent);
+    box-shadow: var(--shadow-md), var(--glow-accent);
 }
 
 .now-playing-empty {
     text-align: center;
     padding: 2rem 0;
-    color: var(--muted, #888);
+    color: var(--text-muted);
 }
 .now-playing-empty .emoji {
     font-size: 3rem;
@@ -71,9 +103,10 @@
     width: 120px;
     height: 120px;
     object-fit: cover;
-    border-radius: 8px;
+    border-radius: var(--radius-md);
     background: #000;
     flex-shrink: 0;
+    box-shadow: var(--shadow-md);
 }
 
 .now-playing-meta {
@@ -83,13 +116,48 @@
 
 .source-badge {
     display: inline-block;
-    padding: 2px 8px;
+    padding: 2px 10px;
     border-radius: 999px;
-    font-size: 0.75rem;
+    font-size: 0.72rem;
+    font-weight: 700;
     color: var(--heading);
     margin-bottom: 0.25rem;
     text-transform: uppercase;
-    letter-spacing: 0.04em;
+    letter-spacing: 0.05em;
+    box-shadow: var(--shadow-sm);
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.35);
+}
+
+/* CSS-only equalizer — three bars that bounce while a track is playing.
+   Sits next to the title; JS toggles `.is-playing` on the card and the
+   bars freeze (flat) when paused. Mirrors the casino flourish vocabulary
+   — a small living detail, killed entirely under reduced-motion. */
+.now-playing-eq {
+    display: none;
+    align-items: flex-end;
+    gap: 2px;
+    height: 14px;
+    margin: 0.25rem 0;
+}
+.now-playing-card.is-playing .now-playing-eq { display: inline-flex; }
+.now-playing-eq span {
+    display: block;
+    width: 3px;
+    height: 100%;
+    background: var(--accent-light);
+    border-radius: 2px;
+    transform-origin: bottom;
+    animation: eq-bounce 0.9s var(--ease-in-out) infinite;
+}
+.now-playing-eq span:nth-child(2) { animation-delay: 0.15s; }
+.now-playing-eq span:nth-child(3) { animation-delay: 0.3s; }
+.now-playing-eq span:nth-child(4) { animation-delay: 0.45s; }
+@keyframes eq-bounce {
+    0%, 100% { transform: scaleY(0.35); }
+    50% { transform: scaleY(1); }
+}
+@media (prefers-reduced-motion: reduce) {
+    .now-playing-eq span { animation: none; transform: scaleY(0.6); }
 }
 
 .now-playing-title {
@@ -107,7 +175,7 @@
 
 .now-playing-author {
     margin: 0 0 0.5rem;
-    color: var(--muted, #aaa);
+    color: var(--text-muted);
 }
 
 .now-playing-requester {
@@ -117,7 +185,7 @@
     flex-wrap: wrap;
     margin: 0 0 0.5rem;
     font-size: 0.85rem;
-    color: var(--muted, #888);
+    color: var(--text-muted);
 }
 .now-playing-requester-label {
     flex-shrink: 0;
@@ -128,7 +196,7 @@
 }
 .now-playing-requester .lb-name {
     font-size: 0.85rem;
-    color: var(--text, #fff);
+    color: var(--text);
 }
 
 .progress-row {
@@ -155,16 +223,19 @@
 .progress-fill {
     height: 100%;
     width: 0;
-    background: var(--accent, #5865f2);
+    background: var(--gradient-accent);
     border-radius: 3px;
     transition: width 0.4s linear;
+}
+.progress-track:hover .progress-fill {
+    box-shadow: 0 0 8px rgba(88, 101, 242, 0.5);
 }
 
 .time-current,
 .time-total {
     font-variant-numeric: tabular-nums;
     font-size: 0.85rem;
-    color: var(--muted, #aaa);
+    color: var(--text-muted);
     min-width: 3em;
     text-align: center;
 }
@@ -179,17 +250,23 @@
 .btn-transport {
     background: rgba(255, 255, 255, 0.05);
     color: inherit;
-    border: 1px solid var(--border, #2c2e35);
-    border-radius: 8px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
     min-width: var(--tap-min);
     min-height: var(--tap-min);
     padding: 0.5rem 0.75rem;
     font-size: 1.2rem;
     cursor: pointer;
     touch-action: manipulation;
+    transition: background var(--dur-fast) var(--ease-out), border-color var(--dur-fast) var(--ease-out), transform 0.05s;
 }
 .btn-transport:hover { background: rgba(255, 255, 255, 0.1); }
-.btn-transport.active { background: var(--accent, #5865f2); border-color: var(--accent, #5865f2); }
+.btn-transport:active { transform: translateY(1px); }
+.btn-transport.active {
+    background: var(--accent);
+    border-color: var(--accent);
+    box-shadow: var(--glow-accent);
+}
 .btn-transport.btn-danger { color: #f25865; }
 .btn-transport.btn-danger:hover { background: rgba(242, 88, 101, 0.1); }
 
@@ -226,8 +303,8 @@
     min-width: 0;
     padding: 0.5rem 0.75rem;
     background: rgba(0, 0, 0, 0.25);
-    border: 1px solid var(--border, #2c2e35);
-    border-radius: 6px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
     color: inherit;
 }
 .add-track-hint {
@@ -241,7 +318,7 @@
     padding: 0.5rem;
     background: rgba(88, 101, 242, 0.06);
     border: 1px solid rgba(88, 101, 242, 0.25);
-    border-radius: 8px;
+    border-radius: var(--radius-md);
 }
 .search-results-header {
     display: flex;
@@ -269,7 +346,7 @@
     gap: 0.5rem;
     padding: 0.5rem;
     background: rgba(255, 255, 255, 0.04);
-    border-radius: 6px;
+    border-radius: var(--radius-sm);
 }
 .search-result-meta { flex: 1; min-width: 0; }
 .search-result-title {
@@ -280,7 +357,7 @@
 }
 .search-result-author {
     font-size: 0.75rem;
-    color: var(--muted, #888);
+    color: var(--text-muted);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -302,16 +379,16 @@
     padding: 0.5rem;
     background: rgba(255, 255, 255, 0.03);
     border: 1px solid transparent;
-    border-radius: 6px;
+    border-radius: var(--radius-sm);
     cursor: grab;
     min-height: var(--tap-min);
 }
 .queue-item:hover { background: rgba(255, 255, 255, 0.06); }
 .queue-item.dragging { opacity: 0.4; }
-.queue-item.drop-target { border-color: var(--accent, #5865f2); }
+.queue-item.drop-target { border-color: var(--accent); }
 
 .queue-drag-handle {
-    color: var(--muted, #888);
+    color: var(--text-muted);
     cursor: grab;
     user-select: none;
 }
@@ -328,7 +405,7 @@
 }
 .queue-author {
     font-size: 0.75rem;
-    color: var(--muted, #888);
+    color: var(--text-muted);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -336,7 +413,7 @@
 
 .queue-remove {
     background: transparent;
-    color: var(--muted, #888);
+    color: var(--text-muted);
     border: none;
     cursor: pointer;
     font-size: 1.1rem;
@@ -352,20 +429,21 @@
    (Queue) and .queue-remove (✕) without inheriting the larger transport
    sizing. */
 .btn-preview {
-    background: rgba(88, 101, 242, 0.12);
-    color: var(--accent, #5865f2);
+    background: var(--accent-soft);
+    color: var(--accent);
     border: 1px solid rgba(88, 101, 242, 0.3);
-    border-radius: 6px;
+    border-radius: var(--radius-sm);
     cursor: pointer;
     font-size: 0.95rem;
     min-width: var(--tap-min);
     min-height: var(--tap-min);
     padding: 0 0.6rem;
     touch-action: manipulation;
+    transition: background var(--dur-fast) var(--ease-out);
 }
 .btn-preview:hover { background: rgba(88, 101, 242, 0.2); }
 .btn-preview[aria-pressed="true"] {
-    background: var(--accent, #5865f2);
+    background: var(--accent);
     color: var(--heading);
 }
 
@@ -386,7 +464,7 @@
     gap: 0.5rem;
     padding: 0.5rem;
     background: rgba(255, 255, 255, 0.03);
-    border-radius: 6px;
+    border-radius: var(--radius-sm);
     flex-wrap: wrap;
     min-height: var(--tap-min);
 }
@@ -405,10 +483,10 @@
 .voice-channel-name {
     margin: 0 0 0.5rem;
     font-size: 0.85rem;
-    color: var(--muted, #aaa);
+    color: var(--text-muted);
 }
 .voice-channel-empty {
-    color: var(--muted, #888);
+    color: var(--text-muted);
     font-size: 0.85rem;
 }
 .voice-member-list {
@@ -424,7 +502,7 @@
     align-items: center;
     gap: 0.5rem;
     padding: 0.25rem 0.4rem;
-    border-radius: 6px;
+    border-radius: var(--radius-sm);
 }
 .voice-member-avatar {
     width: 28px;
@@ -442,7 +520,7 @@
     overflow: hidden;
     text-overflow: ellipsis;
 }
-.voice-member.is-bot .voice-member-name { color: var(--accent, #5865f2); font-weight: 600; }
+.voice-member.is-bot .voice-member-name { color: var(--accent); font-weight: 600; }
 .voice-member-mute,
 .voice-member-deaf {
     font-size: 0.85rem;
@@ -456,18 +534,20 @@
     gap: 1rem;
 }
 .music-guild-card {
-    background: var(--bg-elevated, #1e2026);
-    border: 1px solid var(--border, #2c2e35);
-    border-radius: 12px;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
     padding: 1rem;
     display: flex;
     flex-direction: column;
     gap: 0.75rem;
-    transition: transform 0.15s ease, border-color 0.15s ease;
+    box-shadow: var(--shadow-sm);
+    transition: transform 0.1s var(--ease-out), border-color 0.15s var(--ease-out), box-shadow 0.15s var(--ease-out);
 }
 .music-guild-card:hover {
-    border-color: var(--accent, #5865f2);
+    border-color: var(--accent);
     transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.25);
 }
 .music-guild-card-head {
     display: flex;
@@ -477,7 +557,7 @@
 .music-guild-icon {
     width: 48px;
     height: 48px;
-    border-radius: 12px;
+    border-radius: var(--radius-lg);
     object-fit: cover;
     background: rgba(255, 255, 255, 0.05);
     flex-shrink: 0;
@@ -499,13 +579,13 @@
     gap: 0.5rem;
     min-height: 2.5em;
     padding: 0.5rem 0.6rem;
-    border-radius: 8px;
+    border-radius: var(--radius-md);
     background: rgba(255, 255, 255, 0.03);
     font-size: 0.85rem;
-    color: var(--muted, #aaa);
+    color: var(--text-muted);
 }
 .music-guild-status.is-playing {
-    background: rgba(88, 101, 242, 0.12);
+    background: var(--accent-soft);
     color: inherit;
 }
 .music-guild-status-icon {
@@ -546,7 +626,7 @@
     .playlists-card,
     .voice-card {
         padding: 0.875rem 1rem;
-        border-radius: 10px;
+        border-radius: var(--radius-lg);
     }
     .now-playing-empty {
         padding: 1.25rem 0;

--- a/web/src/main/resources/static/js/music-player.js
+++ b/web/src/main/resources/static/js/music-player.js
@@ -13,6 +13,7 @@
     const $ = (id) => document.getElementById(id);
 
     const els = {
+        card: $('now-playing-card'),
         emptyState: $('now-playing-empty'),
         content: $('now-playing-content'),
         art: $('now-playing-art'),
@@ -51,6 +52,13 @@
 
     let lastPaused = false;
     let lastDurationMs = 0;
+
+    // Toggles the accent glow + bouncing equalizer on the now-playing
+    // hero card. Active only when a track is loaded AND not paused, so the
+    // flourish always mirrors what the listener is actually hearing.
+    function setPlayingFlourish(active) {
+        if (els.card) els.card.classList.toggle('is-playing', !!active);
+    }
 
     // ---- HTTP helpers --------------------------------------------------
 
@@ -149,6 +157,7 @@
         if (!track) {
             els.content.hidden = true;
             els.emptyState.hidden = false;
+            setPlayingFlourish(false);
             els.title.textContent = '—';
             els.author.textContent = '—';
             els.requester.textContent = '';
@@ -186,6 +195,7 @@
         els.timeTotal.textContent = track.isStream ? 'LIVE' : formatMs(lastDurationMs);
         lastPaused = !!paused;
         els.btnPause.textContent = paused ? '▶️' : '⏸️';
+        setPlayingFlourish(!paused);
     }
 
     function renderProgress(positionMs) {
@@ -639,6 +649,9 @@
             const payload = JSON.parse(ev.data);
             lastPaused = !!payload.paused;
             els.btnPause.textContent = lastPaused ? '▶️' : '⏸️';
+            // Only flip the flourish when a track is actually loaded — a
+            // pause event with the empty state showing shouldn't light up.
+            setPlayingFlourish(!lastPaused && !els.content.hidden);
         });
         eventSource.addEventListener('volumeChanged', (ev) => {
             const payload = JSON.parse(ev.data);

--- a/web/src/main/resources/templates/music-guilds.html
+++ b/web/src/main/resources/templates/music-guilds.html
@@ -14,7 +14,7 @@
     <div th:replace="~{fragments/alerts :: error}"></div>
 
     <div class="music-guild-grid" th:if="${not #lists.isEmpty(guilds)}">
-        <article class="music-guild-card" th:each="g : ${guilds}">
+        <article class="music-guild-card" data-reveal th:each="g : ${guilds}">
             <header class="music-guild-card-head">
                 <img class="music-guild-icon"
                      th:if="${g.iconUrl != null}"

--- a/web/src/main/resources/templates/music-player.html
+++ b/web/src/main/resources/templates/music-player.html
@@ -8,7 +8,10 @@
 <main id="main" class="container music-dashboard">
 
     <header class="music-header">
-        <h1>🎵 <span th:text="${guildName}">Server</span></h1>
+        <div class="music-header-titles">
+            <span class="section-eyebrow">Music player</span>
+            <h1>🎵 <span th:text="${guildName}">Server</span></h1>
+        </div>
         <a class="btn-tertiary" href="/music-player/guilds?pick=true">← All servers</a>
     </header>
 
@@ -17,7 +20,7 @@
     <section class="music-grid">
 
         <!-- Now Playing -->
-        <article class="now-playing-card" aria-labelledby="now-playing-heading">
+        <article class="now-playing-card" id="now-playing-card" data-reveal aria-labelledby="now-playing-heading">
             <h2 id="now-playing-heading" class="sr-only">Now playing</h2>
             <div class="now-playing-empty" id="now-playing-empty">
                 <span class="emoji" aria-hidden="true">⏸️</span>
@@ -27,6 +30,7 @@
                 <img class="now-playing-art" id="now-playing-art" alt="">
                 <div class="now-playing-meta">
                     <span class="source-badge" id="source-badge">Music</span>
+                    <div class="now-playing-eq" aria-hidden="true"><span></span><span></span><span></span><span></span></div>
                     <h3 class="now-playing-title" id="now-playing-title">—</h3>
                     <p class="now-playing-author" id="now-playing-author">—</p>
                     <div class="now-playing-requester" id="now-playing-requester" hidden>
@@ -56,7 +60,7 @@
         </article>
 
         <!-- Add Track / Queue -->
-        <article class="queue-card" aria-labelledby="queue-heading">
+        <article class="queue-card" data-reveal aria-labelledby="queue-heading">
             <h2 id="queue-heading">Up next</h2>
             <form id="add-track-form" class="add-track-form" autocomplete="off">
                 <input id="add-track-input" type="text" placeholder="URL or search term — Spotify / YouTube / SoundCloud / Bandcamp / Apple Music / Deezer" required>
@@ -80,7 +84,7 @@
         </article>
 
         <!-- Playlists -->
-        <article class="playlists-card" aria-labelledby="playlists-heading">
+        <article class="playlists-card" data-reveal aria-labelledby="playlists-heading">
             <h2 id="playlists-heading">Saved playlists</h2>
             <form id="save-playlist-form" class="save-playlist-form" autocomplete="off">
                 <input id="save-playlist-name" type="text" maxlength="80" placeholder="Name your playlist" required>
@@ -91,7 +95,7 @@
         </article>
 
         <!-- Voice channel members -->
-        <article class="voice-card" aria-labelledby="voice-heading">
+        <article class="voice-card" data-reveal aria-labelledby="voice-heading">
             <h2 id="voice-heading">🔈 In the voice channel</h2>
             <p id="voice-channel-name" class="voice-channel-name" hidden></p>
             <p id="voice-channel-empty" class="voice-channel-empty">

--- a/web/src/test/kotlin/web/static/MusicPlayerCssTest.kt
+++ b/web/src/test/kotlin/web/static/MusicPlayerCssTest.kt
@@ -1,0 +1,130 @@
+package web.static
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins the music-player polish contract so the dashboard keeps pace with
+ * the rest of the web surfaces. Three concrete regressions this guards:
+ *
+ * 1. **`.btn-tertiary` loses its styling.** The "← All servers" back link,
+ *    the playlist Load button and the search Clear button all use
+ *    `.btn-tertiary`. That class was referenced across the music templates
+ *    but only ever had a touch min-height rule — so the buttons rendered
+ *    as raw browser-default chrome. The real ruleset now lives in
+ *    `base.css` (with the rest of the button family); if it regresses to a
+ *    bare touch rule the buttons go back to looking unstyled.
+ *
+ * 2. **The music sheet drifts back off the design tokens.** It used to
+ *    reference a non-existent `--muted` custom property (which silently
+ *    fell back to a hardcoded grey) instead of the real `--text-muted`
+ *    token. This test fails if `--muted` reappears.
+ *
+ * 3. **The now-playing flourish is dropped.** The hero card lights up
+ *    (`.is-playing`) with an accent glow + a CSS equalizer while audio is
+ *    playing, and the equalizer animation must be killed under
+ *    prefers-reduced-motion.
+ */
+class MusicPlayerCssTest {
+
+    private val baseCss: String by lazy { readCss("static/css/base.css") }
+    private val musicCss: String by lazy { readCss("static/css/music-player.css") }
+
+    private fun readCss(path: String): String =
+        javaClass.classLoader
+            .getResourceAsStream(path)
+            ?.bufferedReader()
+            ?.readText()
+            ?: error("$path is not on the classpath")
+
+    @Test
+    fun `btn-tertiary has a real ruleset in base css`() {
+        // The standalone declaration block (not the touch-block min-height
+        // one-liner) must set the visual properties that make it look like
+        // a button: background, colour and border.
+        val block = topLevelRuleBody(baseCss, ".btn-tertiary")
+            ?: error("base.css must declare a top-level `.btn-tertiary { ... }` rule")
+        listOf("background", "color", "border").forEach { prop ->
+            assertTrue(
+                block.contains("$prop:"),
+                "base.css `.btn-tertiary` must set `$prop` so the back-link / " +
+                    "Load / Clear buttons render as styled buttons, not raw browser chrome."
+            )
+        }
+    }
+
+    @Test
+    fun `btn-tertiary is defined before btn-danger so the danger combo wins`() {
+        // The playlist Delete button is `btn-tertiary btn-danger`. Both are
+        // single-class selectors (equal specificity), so source order
+        // decides the combined look — `.btn-danger` must come AFTER
+        // `.btn-tertiary` for the delete button to stay red.
+        val tertiaryAt = baseCss.indexOf(".btn-tertiary {")
+        val dangerAt = baseCss.indexOf(".btn-danger {")
+        assertTrue(
+            tertiaryAt in 0 until dangerAt,
+            "base.css must define `.btn-tertiary` before `.btn-danger` so the " +
+                "`.btn-tertiary.btn-danger` Delete button keeps the danger palette."
+        )
+    }
+
+    @Test
+    fun `music css uses design tokens, not the phantom --muted property`() {
+        assertFalse(
+            musicCss.contains("--muted"),
+            "music-player.css must use the real `--text-muted` token — `--muted` " +
+                "is not defined in base.css and silently falls back to a hardcoded grey."
+        )
+        assertTrue(
+            musicCss.contains("var(--text-muted)"),
+            "music-player.css should reference the shared `--text-muted` token."
+        )
+    }
+
+    @Test
+    fun `now-playing hero has the accent flourish`() {
+        assertTrue(
+            musicCss.contains(".now-playing-card.is-playing"),
+            "music-player.css must light up the now-playing card via `.is-playing`."
+        )
+        assertTrue(
+            musicCss.contains(".now-playing-eq") && musicCss.contains("@keyframes eq-bounce"),
+            "music-player.css must define the now-playing equalizer + its keyframes."
+        )
+    }
+
+    @Test
+    fun `equalizer animation is disabled under reduced motion`() {
+        assertTrue(
+            musicCss.contains("prefers-reduced-motion: reduce"),
+            "music-player.css must respect prefers-reduced-motion."
+        )
+        // Collapse whitespace so the assertion isn't sensitive to formatting,
+        // then require the equalizer bars to have their animation cancelled.
+        val normalized = musicCss.replace("\\s+".toRegex(), " ")
+        assertTrue(
+            normalized.contains(".now-playing-eq span { animation: none"),
+            "music-player.css must set `animation: none` on the equalizer bars " +
+                "under prefers-reduced-motion so motion-sensitive users see static bars."
+        )
+    }
+
+    /**
+     * Returns the body of the first top-level `selector { ... }` rule, or
+     * null. "Top-level" excludes occurrences nested inside an `@media`
+     * block (those open with the selector after a `{` that is itself inside
+     * the media query) — but for `.btn-tertiary` the standalone rule is at
+     * column 0, while the touch-block reference is indented inside a media
+     * query, so a simple `\nselector {` anchor distinguishes them.
+     */
+    private fun topLevelRuleBody(css: String, selector: String): String? {
+        val anchor = "\n$selector {"
+        val start = css.indexOf(anchor)
+        if (start < 0) return null
+        val open = css.indexOf('{', start)
+        val close = css.indexOf('}', open)
+        if (open < 0 || close < 0) return null
+        return css.substring(open + 1, close)
+    }
+}


### PR DESCRIPTION
## Why

The music dashboard was functional but looked barebones next to the rest of the site — it leaned on hardcoded colours/radii and a couple of unstyled primitives instead of the shared design-token system the other surfaces use.

## What changed

**Fixed the unstyled `.btn-tertiary` (the big one)**
`.btn-tertiary` is used across the music templates — the "← All servers" back link, the playlist **Load**/**Delete** buttons, and the search **Clear** button — but it only ever had a touch `min-height` rule. Those buttons were rendering as raw browser-default chrome. It now has a proper ruleset in `base.css` alongside the rest of the button family (quiet filled button, accent-soft hover). It's placed **before** `.btn-danger` so the combined `.btn-tertiary.btn-danger` Delete button still resolves to the danger palette by source order.

**Moved `music-player.css` onto the design tokens**
- Dropped the phantom `--muted` custom property (it isn't defined in `base.css`, so every `var(--muted, …)` silently fell back to a hardcoded grey) in favour of the real `--text-muted`.
- Replaced ad-hoc hex fallbacks, radii and spacing with the shared `--radius-*` / `--space-*` / `--shadow-*` / `--accent-soft` / motion tokens.

**Visual polish, in line with home/economy/casino**
- Card elevation (shadow + token radii).
- Now-playing **hero treatment**: accent aurora wash, a glow + a bouncing CSS equalizer while audio is playing (`.is-playing`), all killed under `prefers-reduced-motion`.
- Reveal-on-scroll (`data-reveal`) on the dashboard cards and the guild-picker cards.
- Section eyebrow on the header, gradient progress fill with hover glow, and a hover lift + shadow on the guild cards to match the shared picker chrome.

**Tests**
Added `MusicPlayerCssTest` pinning the `.btn-tertiary` fix (real ruleset + ordering before `.btn-danger`), the token usage (no `--muted`), and the now-playing flourish (equalizer + reduced-motion).

## Notes
- `.btn-tertiary` is only referenced by the music surfaces, so styling it is scoped to this feature.
- The JS toggles `.is-playing` on the now-playing card based on real playback/pause state; the existing `music-player-resync` JS test fixture has no `#now-playing-card`, so the new flourish hook safely no-ops there.
- Couldn't run Gradle/Stylelint in this environment (no network for the foojay plugin / `node_modules`); verified CSS brace balance, JS `node --check`, and the test invariants against the source directly.

https://claude.ai/code/session_01NYQi5HJe2Moi27bM9rNndY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NYQi5HJe2Moi27bM9rNndY)_