### PR TITLE
Fix music player horizontal overflow on mobile

### DIFF
--- a/web/src/main/resources/static/css/music-player.css
+++ b/web/src/main/resources/static/css/music-player.css
@@ -40,7 +40,15 @@
 
 @media (max-width: 768px) {
     .music-grid {
-        grid-template-columns: 1fr;
+        /* `minmax(0, 1fr)` not `1fr` — a bare `1fr` track is
+           `minmax(auto, 1fr)`, whose `auto` floor lets a grid item's
+           min-content (a long search-result title, the volume slider's
+           intrinsic width, etc.) push the single column wider than the
+           viewport. That blew every card's right edge — Search button,
+           result rows, Queue buttons — off-screen on phones. The `0`
+           floor lets the column shrink to the container so the inner
+           ellipsis/wrap rules can do their job. */
+        grid-template-columns: minmax(0, 1fr);
         gap: 1rem;
     }
 }
@@ -55,6 +63,11 @@
     padding: var(--space-4) var(--space-5);
     box-shadow: var(--shadow-sm);
     transition: border-color var(--dur-base) var(--ease-out), box-shadow var(--dur-base) var(--ease-out);
+    /* Grid items default to `min-width: auto`, which refuses to shrink
+       below their content's min-content — so a wide child would stretch
+       the card past the column. Pin to 0 so the cards always fit their
+       track and the inner truncation rules take over. */
+    min-width: 0;
 }
 
 /* Now-playing is the hero of the dashboard — give it an accent-tinted
@@ -208,6 +221,7 @@
 
 .progress-track {
     flex: 1;
+    min-width: 0;
     /* Hit-target larger than the visible bar; transparent padding around it
        gives finger-sized scrubbing on touch without making the bar chunky. */
     height: 18px;
@@ -275,9 +289,11 @@
     align-items: center;
     gap: 0.5rem;
     margin-left: auto;
+    min-width: 0;
 }
 .volume-label input[type=range] {
     width: 120px;
+    min-width: 0;
     height: 32px;
     touch-action: manipulation;
 }

--- a/web/src/test/kotlin/web/static/MusicPlayerCssTest.kt
+++ b/web/src/test/kotlin/web/static/MusicPlayerCssTest.kt
@@ -136,8 +136,10 @@ class MusicPlayerCssTest {
         // Grid items default to `min-width: auto`, which refuses to shrink
         // below content min-content. Without `min-width: 0` a wide child
         // stretches the card past its column even after the track collapses.
-        val cardBlock = topLevelRuleBody(musicCss, ".now-playing-card,")
-            ?: error("music-player.css must declare the shared card rule starting `.now-playing-card,`")
+        // `.voice-card` is the last selector in the shared card list, sitting
+        // directly before the `{`, so it uniquely anchors that block.
+        val cardBlock = topLevelRuleBody(musicCss, ".voice-card")
+            ?: error("music-player.css must declare the shared `.voice-card { ... }` card rule")
         assertTrue(
             cardBlock.contains("min-width: 0"),
             "the shared music card rule must set `min-width: 0` so the cards " +

--- a/web/src/test/kotlin/web/static/MusicPlayerCssTest.kt
+++ b/web/src/test/kotlin/web/static/MusicPlayerCssTest.kt
@@ -110,6 +110,41 @@ class MusicPlayerCssTest {
         )
     }
 
+    @Test
+    fun `mobile grid collapses with a zero-floor track to avoid horizontal overflow`() {
+        // The single-column phone grid must use `minmax(0, 1fr)`, never a
+        // bare `1fr`. A bare `1fr` is `minmax(auto, 1fr)`, whose `auto`
+        // floor lets a grid item's min-content stretch the column past the
+        // viewport — which pushed every card's right edge (Search button,
+        // result rows, Queue buttons) off-screen on phones.
+        val normalized = musicCss.replace("\\s+".toRegex(), " ")
+        assertTrue(
+            normalized.contains("grid-template-columns: minmax(0, 1fr);"),
+            "music-player.css must collapse .music-grid to `minmax(0, 1fr)` on " +
+                "phones so the single column can shrink to the viewport."
+        )
+        assertFalse(
+            normalized.contains(".music-grid { grid-template-columns: 1fr;") ||
+                normalized.contains("grid-template-columns: 1fr; gap: 1rem;"),
+            "music-player.css must not use a bare `1fr` track for the phone " +
+                ".music-grid — it reintroduces the off-screen overflow."
+        )
+    }
+
+    @Test
+    fun `dashboard cards can shrink inside their grid track`() {
+        // Grid items default to `min-width: auto`, which refuses to shrink
+        // below content min-content. Without `min-width: 0` a wide child
+        // stretches the card past its column even after the track collapses.
+        val cardBlock = topLevelRuleBody(musicCss, ".now-playing-card,")
+            ?: error("music-player.css must declare the shared card rule starting `.now-playing-card,`")
+        assertTrue(
+            cardBlock.contains("min-width: 0"),
+            "the shared music card rule must set `min-width: 0` so the cards " +
+                "fit their grid track instead of stretching it on mobile."
+        )
+    }
+
     /**
      * Returns the body of the first top-level `selector { ... }` rule, or
      * null. "Top-level" excludes occurrences nested inside an `@media`


### PR DESCRIPTION
## Problem

On phones the music dashboard scrolled sideways — every card's right edge spilled off-screen: the **Search** button, the search-result rows, the **Queue** buttons, the result titles all got clipped at the viewport edge (see the reported screenshot).

## Root cause

The single-column phone grid. `.music-grid` collapses to `grid-template-columns: 1fr` under 768px, but a bare `1fr` is `minmax(auto, 1fr)` — and that `auto` floor lets a grid item's **min-content** (a long search-result title, the volume slider's intrinsic width, etc.) stretch the single column wider than the viewport. The cards themselves are grid items with the default `min-width: auto`, so they couldn't shrink back either. Everything inside inherited the over-wide track, which is why the inner `text-overflow: ellipsis` rules truncated *off-screen* instead of at the card edge.

## Fix

- Collapse the phone grid with **`minmax(0, 1fr)`** so the column can shrink to the container.
- Give the dashboard cards **`min-width: 0`** so they fit their track rather than stretching it.
- Defensive **`min-width: 0`** on the flex `.progress-track` and the `.volume-label` / volume slider so neither row can force width on its own.

No markup or JS changes — purely the responsive CSS.

## Tests

Added two `MusicPlayerCssTest` cases:
- the phone `.music-grid` uses a zero-floor `minmax(0, 1fr)` track (and rejects a bare `1fr` regression),
- the shared card rule carries `min-width: 0`.

## Note

jsdom (the jest harness) has no layout engine, so it can't measure the overflow directly — the guards are CSS-content assertions. I couldn't run a real browser / Playwright here (no network for `node_modules`), but verified brace balance and that the normalized CSS matches the assertions. The `build` CI job will run the Kotlin tests + stylelint.

https://claude.ai/code/session_01NYQi5HJe2Moi27bM9rNndY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NYQi5HJe2Moi27bM9rNndY)_