### PR TITLE
Reuse shared primitives on the music player (toasts, modal, member-cell)

### DIFF
--- a/web/src/main/resources/static/css/music-player.css
+++ b/web/src/main/resources/static/css/music-player.css
@@ -513,30 +513,20 @@
     flex-direction: column;
     gap: 0.35rem;
 }
+/* Voice members reuse the shared `.member-cell` + `.avatar` + `.lb-name`
+   projection (same primitives as the "Requested by" line and the
+   leaderboard standings). Only the row padding and the bot/status
+   accents stay music-specific. The `<li>` carries `member-cell voice-member`,
+   the image `.avatar`, the name `.lb-name`. */
 .voice-member {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
     padding: 0.25rem 0.4rem;
     border-radius: var(--radius-sm);
 }
-.voice-member-avatar {
-    width: 28px;
-    height: 28px;
-    border-radius: 50%;
-    object-fit: cover;
-    flex-shrink: 0;
-    background: rgba(255, 255, 255, 0.1);
-}
-.voice-member-name {
+.voice-member .lb-name {
     flex: 1;
-    min-width: 0;
-    font-size: 0.9rem;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    font-weight: 500;
 }
-.voice-member.is-bot .voice-member-name { color: var(--accent); font-weight: 600; }
+.voice-member.is-bot .lb-name { color: var(--accent); font-weight: 600; }
 .voice-member-mute,
 .voice-member-deaf {
     font-size: 0.85rem;

--- a/web/src/main/resources/static/js/music-player.js
+++ b/web/src/main/resources/static/js/music-player.js
@@ -86,6 +86,13 @@
     const post = (path, body) => sendJson('POST', path, body);
     const del = (path) => sendJson('DELETE', path);
 
+    // Feedback through the shared toast primitive (toasts.js is loaded
+    // globally) so the player matches the rest of the site instead of
+    // firing OS-native alert() dialogs. No-ops if the message is empty.
+    function toast(message, type) {
+        if (message && window.TobyToasts) window.TobyToasts.show(message, { type: type || 'info' });
+    }
+
     // ---- Rendering -----------------------------------------------------
 
     function formatMs(ms) {
@@ -406,9 +413,26 @@
             delBtn.type = 'button';
             delBtn.className = 'btn-tertiary btn-danger';
             delBtn.textContent = '🗑 Delete';
-            delBtn.addEventListener('click', () => {
-                if (!confirm('Delete playlist "' + pl.name + '"?')) return;
-                del('/playlists/' + pl.id).then(() => refreshPlaylists());
+            delBtn.addEventListener('click', async () => {
+                // Shared modal (modal.js) for the confirm; fall back to the
+                // native dialog if it somehow isn't loaded.
+                const ok = window.TobyModal
+                    ? await window.TobyModal.confirm({
+                        title: 'Delete playlist?',
+                        body: '“' + pl.name + '” will be removed permanently.',
+                        confirmLabel: 'Delete',
+                        cancelLabel: 'Cancel',
+                    })
+                    : window.confirm('Delete playlist "' + pl.name + '"?');
+                if (!ok) return;
+                del('/playlists/' + pl.id).then((res) => {
+                    if (res && res.ok === false) {
+                        toast(res.message || 'Could not delete playlist.', 'error');
+                        return;
+                    }
+                    toast('Playlist deleted.', 'success');
+                    refreshPlaylists();
+                });
             });
             actions.appendChild(delBtn);
 
@@ -434,17 +458,17 @@
         els.voiceMemberList.innerHTML = '';
         (voice.members || []).forEach((m) => {
             const li = document.createElement('li');
-            li.className = 'voice-member';
+            li.className = 'member-cell voice-member';
             if (m.isBot) li.classList.add('is-bot');
 
             const img = document.createElement('img');
-            img.className = 'voice-member-avatar';
+            img.className = 'avatar';
             img.alt = '';
             if (m.avatarUrl) img.src = m.avatarUrl;
             li.appendChild(img);
 
             const name = document.createElement('span');
-            name.className = 'voice-member-name';
+            name.className = 'lb-name';
             name.textContent = m.displayName + (m.isBot ? ' (bot)' : '');
             li.appendChild(name);
 
@@ -566,10 +590,11 @@
                     if (res && res.ok) {
                         clearSearchResults();
                         els.addInput.value = '';
+                        toast('Added to queue.', 'success');
                     } else {
                         queueBtn.disabled = false;
                         queueBtn.textContent = 'Queue';
-                        if (res && res.message) alert(res.message);
+                        toast((res && res.message) || 'Could not queue that track.', 'error');
                     }
                 });
             });
@@ -589,8 +614,9 @@
                 if (res && res.ok) {
                     els.addInput.value = '';
                     clearSearchResults();
-                } else if (res && res.message) {
-                    alert(res.message);
+                    toast('Added to queue.', 'success');
+                } else {
+                    toast((res && res.message) || 'Could not queue that link.', 'error');
                 }
             });
             return;
@@ -613,8 +639,9 @@
             if (res && res.ok) {
                 els.savePlaylistName.value = '';
                 refreshPlaylists();
-            } else if (res && res.message) {
-                alert(res.message);
+                toast('Playlist saved.', 'success');
+            } else {
+                toast((res && res.message) || 'Could not save playlist.', 'error');
             }
         });
     });

--- a/web/src/main/resources/templates/music-player.html
+++ b/web/src/main/resources/templates/music-player.html
@@ -113,7 +113,7 @@
      lists drive playback, and only one preview can be active at a time. -->
 <audio id="preview-audio" preload="none" hidden></audio>
 
-<script src="/js/api.js" defer></script>
+<script src="/js/modal.js" defer></script>
 <script src="/js/music-queue.js" defer></script>
 <script src="/js/music-player.js" defer></script>
 <footer th:replace="~{fragments/footer :: footer}"></footer>

--- a/web/src/test/kotlin/web/static/MusicPlayerCssTest.kt
+++ b/web/src/test/kotlin/web/static/MusicPlayerCssTest.kt
@@ -147,6 +147,24 @@ class MusicPlayerCssTest {
         )
     }
 
+    @Test
+    fun `voice list reuses the shared member-cell primitives`() {
+        // The voice-channel roster renders with `member-cell` + `.avatar` +
+        // `.lb-name` — the same member projection as the leaderboard and the
+        // "Requested by" line — rather than bespoke per-row classes. Guard
+        // that the row keeps only the music-specific contextual tweak and
+        // doesn't re-grow a parallel `.voice-member-name` / `-avatar` set.
+        assertTrue(
+            musicCss.contains(".voice-member .lb-name"),
+            "music-player.css should style the voice name via the shared `.lb-name`."
+        )
+        assertFalse(
+            musicCss.contains(".voice-member-name") || musicCss.contains(".voice-member-avatar"),
+            "music-player.css must not reintroduce bespoke `.voice-member-name` / " +
+                "`.voice-member-avatar` rules — the voice row reuses `.lb-name` + `.avatar`."
+        )
+    }
+
     /**
      * Returns the body of the first top-level `selector { ... }` rule, or
      * null. "Top-level" excludes occurrences nested inside an `@media`


### PR DESCRIPTION
Three consistency refactors so the music player leans on site-wide primitives instead of bespoke / native equivalents. (Independent of #677 — touches different file sections, so the two merge cleanly in either order.)

## 1. Feedback → shared toast + modal primitives
The player fired **OS-native `alert()`** in 4 spots and **`confirm()`** for the delete-playlist guard — the last unstyled, out-of-place chrome on the page.
- Errors now surface through `window.TobyToasts` (already loaded globally via the head fragment).
- The delete confirm uses `window.TobyModal.confirm({...})`, matching the **sibling `intros` page** which already does exactly this. Keeps a native `confirm` fallback if `modal.js` somehow isn't present.
- Added modest **success toasts** on the previously-silent queue / save / delete flows ("Added to queue.", "Playlist saved.", "Playlist deleted.").

## 2. Voice roster → shared `.member-cell` projection
The "Requested by" line already reuses `.member-cell` + `.avatar` + `.lb-name`, but the voice-channel roster re-implemented the same avatar+name row as bespoke `.voice-member-avatar` / `.voice-member-name`. Now it composes the shared primitives (same projection as the leaderboard standings); only the row padding + bot/mute/deaf accents stay music-specific. Drops ~3 CSS rules.

## 3. Drop the unused `api.js` include
`music-player.html` loaded `/js/api.js`, but `music-player.js` rolls its own CSRF/fetch helpers and never touched `window.TobyApi`. Removed the dead include and swapped in `/js/modal.js` (needed by #1).

## Tests
New `MusicPlayerCssTest` case pins the voice-row reuse (`.voice-member .lb-name` present; bespoke `.voice-member-name` / `-avatar` gone).

## Notes
- Verified `node --check` on the JS and CSS brace balance. The jest harness can't run here (no `node_modules`), but the existing music JS tests (`music-player-resync`, `music-preview`) don't exercise the changed paths or reference the removed classes, and the new toast/modal calls live inside event handlers (not module load), so boot stays clean.
- The `build` CI job runs the Kotlin tests.

https://claude.ai/code/session_01NYQi5HJe2Moi27bM9rNndY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NYQi5HJe2Moi27bM9rNndY)_