### PR TITLE
Build and edit playlists in the web UI without playing

### DIFF
--- a/database/src/main/kotlin/database/service/music/MusicPlaylistService.kt
+++ b/database/src/main/kotlin/database/service/music/MusicPlaylistService.kt
@@ -27,6 +27,39 @@ interface MusicPlaylistService {
         items: List<PlaylistItemInput>,
     ): MusicPlaylistDto
 
+    /**
+     * Create an empty playlist so it can be curated track-by-track from the
+     * web UI without ever touching the live queue. Same name validation /
+     * uniqueness rules as [create].
+     */
+    fun createEmpty(
+        guildId: Long,
+        ownerDiscordId: Long,
+        name: String,
+    ): MusicPlaylistDto
+
+    /** Append a track to the end of the playlist. Returns null if it doesn't exist. */
+    fun addItem(playlistId: Long, item: PlaylistItemInput): MusicPlaylistDto?
+
+    /**
+     * Remove the item with [itemId] from the playlist and re-sequence the
+     * remaining positions. Returns null if the playlist or item doesn't exist.
+     */
+    fun removeItem(playlistId: Long, itemId: Long): MusicPlaylistDto?
+
+    /**
+     * Move the item at [fromIndex] to [toIndex] (positions re-sequenced).
+     * Returns null if the playlist is missing or either index is out of range.
+     */
+    fun reorderItems(playlistId: Long, fromIndex: Int, toIndex: Int): MusicPlaylistDto?
+
+    /**
+     * Rename the playlist. Throws [PlaylistNameTakenException] if the owner
+     * already has another playlist with that name in the guild. Returns null
+     * if the playlist doesn't exist.
+     */
+    fun rename(playlistId: Long, newName: String): MusicPlaylistDto?
+
     fun deleteById(id: Long)
 
     class PlaylistNameTakenException(message: String) : RuntimeException(message)

--- a/database/src/main/kotlin/database/service/music/impl/DefaultMusicPlaylistService.kt
+++ b/database/src/main/kotlin/database/service/music/impl/DefaultMusicPlaylistService.kt
@@ -27,14 +27,9 @@ class DefaultMusicPlaylistService(
         name: String,
         items: List<PlaylistItemInput>,
     ): MusicPlaylistDto {
-        val trimmed = name.trim()
-        require(trimmed.isNotEmpty()) { "Playlist name cannot be blank" }
-        require(trimmed.length <= 80) { "Playlist name must be at most 80 characters" }
         require(items.isNotEmpty()) { "Playlist must contain at least one track" }
-
-        if (persistence.getByGuildOwnerAndName(guildId, ownerDiscordId, trimmed) != null) {
-            throw PlaylistNameTakenException("A playlist named '$trimmed' already exists for this user in this guild")
-        }
+        val trimmed = validatedName(name)
+        requireNameFree(guildId, ownerDiscordId, trimmed)
 
         val playlist = MusicPlaylistDto(
             guildId = guildId,
@@ -42,21 +37,98 @@ class DefaultMusicPlaylistService(
             name = trimmed,
         )
         items.forEachIndexed { index, input ->
-            val item = MusicPlaylistItemDto(
-                playlist = playlist,
-                position = index,
-                identifier = input.identifier,
-                title = input.title,
-                author = input.author,
-                durationMs = input.durationMs,
-                sourceName = input.sourceName,
-            )
-            playlist.items.add(item)
+            playlist.items.add(input.toItem(playlist, index))
         }
         return persistence.save(playlist)
+    }
+
+    override fun createEmpty(
+        guildId: Long,
+        ownerDiscordId: Long,
+        name: String,
+    ): MusicPlaylistDto {
+        val trimmed = validatedName(name)
+        requireNameFree(guildId, ownerDiscordId, trimmed)
+        return persistence.save(
+            MusicPlaylistDto(guildId = guildId, ownerDiscordId = ownerDiscordId, name = trimmed),
+        )
+    }
+
+    override fun addItem(playlistId: Long, item: PlaylistItemInput): MusicPlaylistDto? {
+        val playlist = persistence.getById(playlistId) ?: return null
+        playlist.items.add(item.toItem(playlist, playlist.items.size))
+        resequence(playlist)
+        return persistence.update(playlist)
+    }
+
+    override fun removeItem(playlistId: Long, itemId: Long): MusicPlaylistDto? {
+        val playlist = persistence.getById(playlistId) ?: return null
+        val removed = playlist.items.removeIf { it.id == itemId }
+        if (!removed) return null
+        resequence(playlist)
+        return persistence.update(playlist)
+    }
+
+    override fun reorderItems(playlistId: Long, fromIndex: Int, toIndex: Int): MusicPlaylistDto? {
+        val playlist = persistence.getById(playlistId) ?: return null
+        val ordered = playlist.items.sortedBy { it.position }.toMutableList()
+        if (fromIndex !in ordered.indices || toIndex !in ordered.indices) return null
+        if (fromIndex != toIndex) {
+            ordered.add(toIndex, ordered.removeAt(fromIndex))
+        }
+        // Reassign positions on the existing item entities — we deliberately
+        // don't clear()/re-add the collection, which under orphanRemoval would
+        // delete then re-insert every row. Only the position column changes.
+        ordered.forEachIndexed { index, item -> item.position = index }
+        return persistence.update(playlist)
+    }
+
+    override fun rename(playlistId: Long, newName: String): MusicPlaylistDto? {
+        val playlist = persistence.getById(playlistId) ?: return null
+        val trimmed = validatedName(newName)
+        val clash = persistence.getByGuildOwnerAndName(playlist.guildId, playlist.ownerDiscordId, trimmed)
+        if (clash != null && clash.id != playlist.id) {
+            throw PlaylistNameTakenException(
+                "A playlist named '$trimmed' already exists for this user in this guild",
+            )
+        }
+        playlist.name = trimmed
+        return persistence.update(playlist)
     }
 
     override fun deleteById(id: Long) {
         persistence.deleteById(id)
     }
+
+    private fun validatedName(name: String): String {
+        val trimmed = name.trim()
+        require(trimmed.isNotEmpty()) { "Playlist name cannot be blank" }
+        require(trimmed.length <= 80) { "Playlist name must be at most 80 characters" }
+        return trimmed
+    }
+
+    private fun requireNameFree(guildId: Long, ownerDiscordId: Long, name: String) {
+        if (persistence.getByGuildOwnerAndName(guildId, ownerDiscordId, name) != null) {
+            throw PlaylistNameTakenException(
+                "A playlist named '$name' already exists for this user in this guild",
+            )
+        }
+    }
+
+    /** Re-number positions 0..n by current position order, without
+        reordering the JPA collection itself (avoids orphan churn). */
+    private fun resequence(playlist: MusicPlaylistDto) {
+        playlist.items.sortedBy { it.position }.forEachIndexed { index, item -> item.position = index }
+    }
+
+    private fun PlaylistItemInput.toItem(playlist: MusicPlaylistDto, position: Int) =
+        MusicPlaylistItemDto(
+            playlist = playlist,
+            position = position,
+            identifier = identifier,
+            title = title,
+            author = author,
+            durationMs = durationMs,
+            sourceName = sourceName,
+        )
 }

--- a/database/src/test/kotlin/database/service/impl/DefaultMusicPlaylistServiceTest.kt
+++ b/database/src/test/kotlin/database/service/impl/DefaultMusicPlaylistServiceTest.kt
@@ -1,6 +1,7 @@
 package database.service.impl
 
 import database.dto.music.MusicPlaylistDto
+import database.dto.music.MusicPlaylistItemDto
 import database.persistence.music.MusicPlaylistPersistence
 import database.service.music.MusicPlaylistService.PlaylistItemInput
 import database.service.music.MusicPlaylistService.PlaylistNameTakenException
@@ -12,6 +13,7 @@ import io.mockk.slot
 import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
@@ -111,6 +113,132 @@ class DefaultMusicPlaylistServiceTest {
         val expected = MusicPlaylistDto(id = 1L, name = "x")
         every { persistence.getById(1L) } returns expected
         assertSame(expected, service.getById(1L))
+    }
+
+    // ---- Curation: empty create + item mutation + rename --------------
+
+    @Test
+    fun `createEmpty persists a playlist with no items`() {
+        every { persistence.getByGuildOwnerAndName(any(), any(), any()) } returns null
+        val captured = slot<MusicPlaylistDto>()
+        every { persistence.save(capture(captured)) } answers { captured.captured }
+        service.createEmpty(guildId, ownerId, "Empty")
+        assertEquals("Empty", captured.captured.name)
+        assertEquals(0, captured.captured.items.size)
+    }
+
+    @Test
+    fun `createEmpty rejects blank name`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            service.createEmpty(guildId, ownerId, "   ")
+        }
+    }
+
+    @Test
+    fun `createEmpty throws PlaylistNameTakenException on duplicate`() {
+        every { persistence.getByGuildOwnerAndName(guildId, ownerId, "Mix") } returns
+            MusicPlaylistDto(id = 1L, guildId = guildId, ownerDiscordId = ownerId, name = "Mix")
+        assertThrows(PlaylistNameTakenException::class.java) {
+            service.createEmpty(guildId, ownerId, "Mix")
+        }
+    }
+
+    @Test
+    fun `addItem appends at the next position`() {
+        val playlist = playlistWith("a")
+        every { persistence.getById(5L) } returns playlist
+        val captured = slot<MusicPlaylistDto>()
+        every { persistence.update(capture(captured)) } answers { captured.captured }
+        service.addItem(5L, item("b"))
+        val items = captured.captured.items.sortedBy { it.position }
+        assertEquals(2, items.size)
+        assertEquals("b", items[1].identifier)
+        assertEquals(1, items[1].position)
+    }
+
+    @Test
+    fun `addItem returns null when the playlist is missing`() {
+        every { persistence.getById(5L) } returns null
+        assertNull(service.addItem(5L, item("b")))
+    }
+
+    @Test
+    fun `removeItem drops the item and re-sequences positions`() {
+        val playlist = playlistWith("a", "b", "c") // item ids 1,2,3
+        every { persistence.getById(5L) } returns playlist
+        val captured = slot<MusicPlaylistDto>()
+        every { persistence.update(capture(captured)) } answers { captured.captured }
+        service.removeItem(5L, 2L)
+        val items = captured.captured.items.sortedBy { it.position }
+        assertEquals(listOf("a", "c"), items.map { it.identifier })
+        assertEquals(listOf(0, 1), items.map { it.position })
+    }
+
+    @Test
+    fun `removeItem returns null when the item is absent`() {
+        every { persistence.getById(5L) } returns playlistWith("a")
+        assertNull(service.removeItem(5L, 999L))
+    }
+
+    @Test
+    fun `reorderItems moves an item and re-sequences positions`() {
+        val playlist = playlistWith("a", "b", "c")
+        every { persistence.getById(5L) } returns playlist
+        val captured = slot<MusicPlaylistDto>()
+        every { persistence.update(capture(captured)) } answers { captured.captured }
+        service.reorderItems(5L, 0, 2) // a -> end
+        val items = captured.captured.items.sortedBy { it.position }
+        assertEquals(listOf("b", "c", "a"), items.map { it.identifier })
+        assertEquals(listOf(0, 1, 2), items.map { it.position })
+    }
+
+    @Test
+    fun `reorderItems returns null for an out-of-range index`() {
+        every { persistence.getById(5L) } returns playlistWith("a", "b")
+        assertNull(service.reorderItems(5L, 0, 9))
+    }
+
+    @Test
+    fun `rename throws when another playlist already has the name`() {
+        every { persistence.getById(5L) } returns
+            MusicPlaylistDto(id = 5L, guildId = guildId, ownerDiscordId = ownerId, name = "Old")
+        every { persistence.getByGuildOwnerAndName(guildId, ownerId, "New") } returns
+            MusicPlaylistDto(id = 9L, guildId = guildId, ownerDiscordId = ownerId, name = "New")
+        assertThrows(PlaylistNameTakenException::class.java) {
+            service.rename(5L, "New")
+        }
+    }
+
+    @Test
+    fun `rename succeeds when the only name clash is the playlist itself`() {
+        val playlist = MusicPlaylistDto(id = 5L, guildId = guildId, ownerDiscordId = ownerId, name = "Mix")
+        every { persistence.getById(5L) } returns playlist
+        every { persistence.getByGuildOwnerAndName(guildId, ownerId, "Mix") } returns playlist
+        val captured = slot<MusicPlaylistDto>()
+        every { persistence.update(capture(captured)) } answers { captured.captured }
+        service.rename(5L, "Mix")
+        assertEquals("Mix", captured.captured.name)
+    }
+
+    @Test
+    fun `rename returns null when the playlist is missing`() {
+        every { persistence.getById(5L) } returns null
+        assertNull(service.rename(5L, "New"))
+    }
+
+    private fun playlistWith(vararg identifiers: String): MusicPlaylistDto {
+        val playlist = MusicPlaylistDto(id = 5L, guildId = guildId, ownerDiscordId = ownerId, name = "Mix")
+        identifiers.forEachIndexed { index, id ->
+            playlist.items.add(
+                MusicPlaylistItemDto(
+                    id = (index + 1).toLong(),
+                    playlist = playlist,
+                    position = index,
+                    identifier = id,
+                ),
+            )
+        }
+        return playlist
     }
 
     private fun item(id: String) = PlaylistItemInput(

--- a/web/src/main/kotlin/web/controller/MusicWebController.kt
+++ b/web/src/main/kotlin/web/controller/MusicWebController.kt
@@ -1,6 +1,7 @@
 package web.controller
 
 import core.music.MusicControlGateway
+import database.service.music.MusicPlaylistService.PlaylistItemInput
 import database.service.music.MusicPlaylistService.PlaylistNameTakenException
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.http.ResponseEntity
@@ -43,8 +44,21 @@ class MusicWebController(
     data class SeekRequest(val positionMs: Long = 0)
     data class LoopRequest(val looping: Boolean = false)
     data class ReorderRequest(val from: Int = 0, val to: Int = 0)
-    data class SavePlaylistRequest(val name: String = "")
+    data class SavePlaylistRequest(val name: String = "", val fromQueue: Boolean = true)
     data class SavePlaylistResponse(val ok: Boolean, val id: Long? = null, val message: String? = null)
+    data class RenamePlaylistRequest(val name: String = "")
+    data class AddPlaylistItemRequest(
+        val identifier: String = "",
+        val title: String? = null,
+        val author: String? = null,
+        val durationMs: Long? = null,
+        val sourceName: String? = null,
+    )
+    data class PlaylistDetailResponse(
+        val ok: Boolean,
+        val detail: MusicWebService.PlaylistDetail? = null,
+        val message: String? = null,
+    )
 
     @GetMapping("/guilds")
     fun guildList(
@@ -272,7 +286,11 @@ class MusicWebController(
                     .body(SavePlaylistResponse(false, null, "Name is required"))
             }
             try {
-                val id = musicWebService.saveCurrentQueueAsPlaylist(guildId, discordId, body.name)
+                val id = if (body.fromQueue) {
+                    musicWebService.saveCurrentQueueAsPlaylist(guildId, discordId, body.name)
+                } else {
+                    musicWebService.createEmptyPlaylist(guildId, discordId, body.name)
+                }
                 ResponseEntity.ok(SavePlaylistResponse(true, id, null))
             } catch (e: PlaylistNameTakenException) {
                 ResponseEntity.status(409).body(SavePlaylistResponse(false, null, e.message))
@@ -294,6 +312,94 @@ class MusicWebController(
         if (result.ok) ResponseEntity.ok(ApiResult(true, "Loaded ${result.tracksLoaded} tracks (${result.tracksFailed} failed)"))
         else ResponseEntity.status(404).body(ApiResult(false, result.message ?: "Failed to load playlist"))
     }
+
+    @GetMapping("/{guildId}/playlists/{playlistId}")
+    @ResponseBody
+    fun playlistDetail(
+        @PathVariable guildId: Long,
+        @PathVariable playlistId: Long,
+        @AuthenticationPrincipal user: OAuth2User?,
+    ): ResponseEntity<PlaylistDetailResponse> =
+        guarded(user, guildId, { PlaylistDetailResponse(false, null, "Unauthorized") }) { discordId ->
+            val detail = musicWebService.getPlaylistDetail(guildId, playlistId, discordId)
+                ?: return@guarded ResponseEntity.status(404).body(PlaylistDetailResponse(false, null, "Playlist not found"))
+            ResponseEntity.ok(PlaylistDetailResponse(true, detail))
+        }
+
+    @PostMapping("/{guildId}/playlists/{playlistId}/items")
+    @ResponseBody
+    fun addPlaylistItem(
+        @PathVariable guildId: Long,
+        @PathVariable playlistId: Long,
+        @AuthenticationPrincipal user: OAuth2User?,
+        @RequestBody body: AddPlaylistItemRequest,
+    ): ResponseEntity<PlaylistDetailResponse> = guardedDetail(user, guildId) { discordId ->
+        val result = musicWebService.addTrackToPlaylist(
+            guildId, playlistId, discordId,
+            PlaylistItemInput(
+                identifier = body.identifier,
+                title = body.title,
+                author = body.author,
+                durationMs = body.durationMs,
+                sourceName = body.sourceName,
+            ),
+        )
+        playlistResult(result)
+    }
+
+    @DeleteMapping("/{guildId}/playlists/{playlistId}/items/{itemId}")
+    @ResponseBody
+    fun removePlaylistItem(
+        @PathVariable guildId: Long,
+        @PathVariable playlistId: Long,
+        @PathVariable itemId: Long,
+        @AuthenticationPrincipal user: OAuth2User?,
+    ): ResponseEntity<PlaylistDetailResponse> = guardedDetail(user, guildId) { discordId ->
+        playlistResult(musicWebService.removeTrackFromPlaylist(guildId, playlistId, discordId, itemId))
+    }
+
+    @PostMapping("/{guildId}/playlists/{playlistId}/items/reorder")
+    @ResponseBody
+    fun reorderPlaylist(
+        @PathVariable guildId: Long,
+        @PathVariable playlistId: Long,
+        @AuthenticationPrincipal user: OAuth2User?,
+        @RequestBody body: ReorderRequest,
+    ): ResponseEntity<PlaylistDetailResponse> = guardedDetail(user, guildId) { discordId ->
+        if (body.from < 0 || body.to < 0) {
+            return@guardedDetail ResponseEntity.badRequest()
+                .body(PlaylistDetailResponse(false, null, "indices must be >= 0"))
+        }
+        playlistResult(musicWebService.reorderPlaylist(guildId, playlistId, discordId, body.from, body.to))
+    }
+
+    @PostMapping("/{guildId}/playlists/{playlistId}/rename")
+    @ResponseBody
+    fun renamePlaylist(
+        @PathVariable guildId: Long,
+        @PathVariable playlistId: Long,
+        @AuthenticationPrincipal user: OAuth2User?,
+        @RequestBody body: RenamePlaylistRequest,
+    ): ResponseEntity<PlaylistDetailResponse> = guardedDetail(user, guildId) { discordId ->
+        if (body.name.isBlank()) {
+            return@guardedDetail ResponseEntity.badRequest()
+                .body(PlaylistDetailResponse(false, null, "Name is required"))
+        }
+        try {
+            playlistResult(musicWebService.renamePlaylist(guildId, playlistId, discordId, body.name))
+        } catch (e: PlaylistNameTakenException) {
+            ResponseEntity.status(409).body(PlaylistDetailResponse(false, null, e.message))
+        }
+    }
+
+    /** Maps a service [MusicWebService.PlaylistMutation] to a response: 200 on
+        success, 404 otherwise (owner/missing failures carry their message). */
+    private fun playlistResult(result: MusicWebService.PlaylistMutation): ResponseEntity<PlaylistDetailResponse> =
+        if (result.ok) {
+            ResponseEntity.ok(PlaylistDetailResponse(true, result.detail))
+        } else {
+            ResponseEntity.status(404).body(PlaylistDetailResponse(false, null, result.message))
+        }
 
     @DeleteMapping("/{guildId}/playlists/{playlistId}")
     @ResponseBody
@@ -350,4 +456,13 @@ class MusicWebController(
         guildId: Long,
         block: (discordId: Long) -> ResponseEntity<ApiResult>,
     ): ResponseEntity<ApiResult> = guardedWrite(user, guildId, { ApiResult(false, "Unauthorized") }, block)
+
+    /** Write-flavoured guard for the playlist-editor endpoints, which return a
+        [PlaylistDetailResponse] rather than the bare [ApiResult]. */
+    private inline fun guardedDetail(
+        user: OAuth2User?,
+        guildId: Long,
+        block: (discordId: Long) -> ResponseEntity<PlaylistDetailResponse>,
+    ): ResponseEntity<PlaylistDetailResponse> =
+        guardedWrite(user, guildId, { PlaylistDetailResponse(false, null, "Unauthorized") }, block)
 }

--- a/web/src/main/kotlin/web/service/MusicWebService.kt
+++ b/web/src/main/kotlin/web/service/MusicWebService.kt
@@ -34,6 +34,27 @@ class MusicWebService(
         val trackCount: Int,
     )
 
+    data class PlaylistItemView(
+        val id: Long,
+        val title: String?,
+        val author: String?,
+        val durationMs: Long?,
+        val sourceName: String?,
+        val uri: String?,
+    )
+
+    /** Full playlist contents for the web editor. [canEdit] is true only for
+        the owner — other guild members can view a playlist but not change it. */
+    data class PlaylistDetail(
+        val id: Long,
+        val name: String,
+        val ownerDiscordId: Long,
+        val canEdit: Boolean,
+        val items: List<PlaylistItemView>,
+    )
+
+    data class PlaylistMutation(val ok: Boolean, val detail: PlaylistDetail? = null, val message: String? = null)
+
     fun getGuildName(guildId: Long): String? = jda.getGuildById(guildId)?.name
 
     fun listGuildsForUser(accessToken: String, discordId: Long): List<GuildCardView> {
@@ -122,6 +143,89 @@ class MusicWebService(
         val saved = playlistService.create(guildId, discordId, name, items)
         return saved.id ?: -1L
     }
+
+    /** Create an empty playlist so it can be curated track-by-track without
+        playing anything. Returns the new playlist's id. */
+    fun createEmptyPlaylist(guildId: Long, discordId: Long, name: String): Long =
+        playlistService.createEmpty(guildId, discordId, name).id ?: -1L
+
+    /**
+     * Full contents of a playlist for the editor. Any guild member may view;
+     * `canEdit` flags whether the requester owns it. Returns null when the
+     * playlist is missing or belongs to another guild.
+     */
+    fun getPlaylistDetail(guildId: Long, playlistId: Long, discordId: Long): PlaylistDetail? {
+        val playlist = playlistService.getById(playlistId) ?: return null
+        if (playlist.guildId != guildId) return null
+        return playlist.toDetail(discordId)
+    }
+
+    /** Append a resolved track to a playlist the requester owns. */
+    fun addTrackToPlaylist(
+        guildId: Long,
+        playlistId: Long,
+        discordId: Long,
+        input: PlaylistItemInput,
+    ): PlaylistMutation {
+        ownedPlaylistOrError(guildId, playlistId, discordId)?.let { return it }
+        if (input.identifier.isBlank()) return PlaylistMutation(false, message = "Track is missing an identifier.")
+        val updated = playlistService.addItem(playlistId, input) ?: return notFound()
+        return PlaylistMutation(true, updated.toDetail(discordId))
+    }
+
+    fun removeTrackFromPlaylist(guildId: Long, playlistId: Long, discordId: Long, itemId: Long): PlaylistMutation {
+        ownedPlaylistOrError(guildId, playlistId, discordId)?.let { return it }
+        val updated = playlistService.removeItem(playlistId, itemId)
+            ?: return PlaylistMutation(false, message = "Track not found in playlist.")
+        return PlaylistMutation(true, updated.toDetail(discordId))
+    }
+
+    fun reorderPlaylist(guildId: Long, playlistId: Long, discordId: Long, from: Int, to: Int): PlaylistMutation {
+        ownedPlaylistOrError(guildId, playlistId, discordId)?.let { return it }
+        val updated = playlistService.reorderItems(playlistId, from, to)
+            ?: return PlaylistMutation(false, message = "Invalid track positions.")
+        return PlaylistMutation(true, updated.toDetail(discordId))
+    }
+
+    /** May throw [MusicPlaylistService.PlaylistNameTakenException]. */
+    fun renamePlaylist(guildId: Long, playlistId: Long, discordId: Long, name: String): PlaylistMutation {
+        ownedPlaylistOrError(guildId, playlistId, discordId)?.let { return it }
+        val updated = playlistService.rename(playlistId, name) ?: return notFound()
+        return PlaylistMutation(true, updated.toDetail(discordId))
+    }
+
+    /**
+     * Returns a failure [PlaylistMutation] when the playlist is missing, in a
+     * different guild, or not owned by [discordId]; null when the requester
+     * may edit it.
+     */
+    private fun ownedPlaylistOrError(guildId: Long, playlistId: Long, discordId: Long): PlaylistMutation? {
+        val playlist = playlistService.getById(playlistId) ?: return notFound()
+        if (playlist.guildId != guildId) return notFound()
+        if (playlist.ownerDiscordId != discordId) {
+            return PlaylistMutation(false, message = "Only the owner can edit this playlist.")
+        }
+        return null
+    }
+
+    private fun notFound() = PlaylistMutation(false, message = "Playlist not found.")
+
+    private fun database.dto.music.MusicPlaylistDto.toDetail(viewerDiscordId: Long) = PlaylistDetail(
+        id = id ?: -1L,
+        name = name,
+        ownerDiscordId = ownerDiscordId,
+        canEdit = ownerDiscordId == viewerDiscordId,
+        items = items.sortedBy { it.position }.map {
+            PlaylistItemView(
+                id = it.id ?: -1L,
+                title = it.title,
+                author = it.author,
+                durationMs = it.durationMs,
+                sourceName = it.sourceName,
+                uri = it.identifier,
+            )
+        },
+    )
 
     /**
      * Re-load each track in the saved playlist via the gateway. Errors on

--- a/web/src/main/resources/static/css/music-player.css
+++ b/web/src/main/resources/static/css/music-player.css
@@ -359,12 +359,85 @@
 .search-result {
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
     gap: 0.5rem;
     padding: 0.5rem;
     background: rgba(255, 255, 255, 0.04);
     border-radius: var(--radius-sm);
 }
 .search-result-meta { flex: 1; min-width: 0; }
+
+/* Add-to-playlist picker — the menu drops onto its own full-width row
+   below the result controls (no absolute positioning, so it can't clip
+   off-screen on phones). */
+.add-to-playlist { position: relative; }
+.btn-add-playlist {
+    background: rgba(255, 255, 255, 0.05);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    font-size: 0.85rem;
+    min-height: var(--tap-min);
+    padding: 0 0.6rem;
+    white-space: nowrap;
+    touch-action: manipulation;
+    transition: background var(--dur-fast) var(--ease-out), border-color var(--dur-fast) var(--ease-out);
+}
+.btn-add-playlist:hover { background: var(--accent-soft); border-color: var(--accent); }
+.btn-add-playlist[aria-expanded="true"] { background: var(--accent-soft); border-color: var(--accent); }
+.add-to-playlist-menu {
+    flex-basis: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    margin-top: 0.25rem;
+    padding: 0.5rem;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-md);
+}
+.add-to-playlist-menu[hidden] { display: none; }
+.add-to-playlist-option {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    background: rgba(255, 255, 255, 0.03);
+    color: inherit;
+    border: 1px solid transparent;
+    border-radius: var(--radius-sm);
+    padding: 0.4rem 0.6rem;
+    cursor: pointer;
+    font-size: 0.85rem;
+    min-height: 36px;
+    text-align: left;
+}
+.add-to-playlist-option:hover { background: var(--accent-soft); border-color: var(--accent); }
+.add-to-playlist-option-name {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.add-to-playlist-option-count { flex-shrink: 0; font-size: 0.75rem; }
+.add-to-playlist-empty { margin: 0.1rem 0; font-size: 0.8rem; }
+.add-to-playlist-new {
+    display: flex;
+    gap: 0.4rem;
+    border-top: 1px solid var(--border);
+    padding-top: 0.4rem;
+}
+.add-to-playlist-new input {
+    flex: 1;
+    min-width: 0;
+    padding: 0.4rem 0.6rem;
+    background: rgba(0, 0, 0, 0.25);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    color: inherit;
+}
 .search-result-title {
     font-size: 0.9rem;
     white-space: nowrap;
@@ -474,22 +547,114 @@
 }
 
 .playlist-item {
+    background: rgba(255, 255, 255, 0.03);
+    border-radius: var(--radius-sm);
+}
+
+/* Header row: expand toggle on the left, Load/Delete on the right. */
+.playlist-row {
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 0.5rem;
     padding: 0.5rem;
-    background: rgba(255, 255, 255, 0.03);
-    border-radius: var(--radius-sm);
     flex-wrap: wrap;
     min-height: var(--tap-min);
 }
-
-.playlist-meta { min-width: 0; flex: 1; }
-.playlist-name { font-size: 0.9rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.playlist-count { font-size: 0.75rem; }
+.playlist-toggle {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex: 1;
+    min-width: 0;
+    background: transparent;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+    padding: 0.25rem 0;
+    text-align: left;
+    font: inherit;
+}
+.playlist-caret {
+    flex-shrink: 0;
+    color: var(--text-muted);
+    font-size: 0.8rem;
+}
+.playlist-name { font-size: 0.9rem; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.playlist-count { flex-shrink: 0; font-size: 0.75rem; }
 
 .playlist-actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+/* Inline editor revealed under an expanded playlist. */
+.playlist-editor {
+    padding: 0 0.5rem 0.5rem;
+}
+.playlist-editor[hidden] { display: none; }
+.pl-loading, .pl-empty { font-size: 0.8rem; margin: 0.25rem 0; }
+
+.playlist-rename-form {
+    display: flex;
+    gap: 0.4rem;
+    margin-bottom: 0.5rem;
+}
+.playlist-rename-input {
+    flex: 1;
+    min-width: 0;
+    padding: 0.4rem 0.6rem;
+    background: rgba(0, 0, 0, 0.25);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    color: inherit;
+}
+
+.pl-track-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+.pl-track {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.4rem 0.5rem;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid transparent;
+    border-radius: var(--radius-sm);
+}
+.pl-track[draggable="true"] { cursor: grab; }
+.pl-track:hover { background: rgba(255, 255, 255, 0.06); }
+.pl-track.dragging { opacity: 0.4; }
+.pl-track.drop-target { border-color: var(--accent); }
+.pl-track-handle {
+    flex-shrink: 0;
+    color: var(--text-muted);
+    cursor: grab;
+    user-select: none;
+}
+.pl-track-meta { flex: 1; min-width: 0; }
+.pl-track-title { font-size: 0.85rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.pl-track-sub { font-size: 0.72rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.pl-track-remove {
+    flex-shrink: 0;
+    background: transparent;
+    color: var(--text-muted);
+    border: none;
+    cursor: pointer;
+    font-size: 1rem;
+    min-width: var(--tap-min);
+    min-height: var(--tap-min);
+    touch-action: manipulation;
+}
+.pl-track-remove:hover { color: #f25865; }
+
+.save-playlist-actions {
     display: flex;
     gap: 0.5rem;
     flex-wrap: wrap;
@@ -700,17 +865,13 @@
         flex-direction: column;
     }
     .add-track-form button,
-    .save-playlist-form button {
+    .save-playlist-form .btn-primary {
         width: 100%;
     }
-    .playlist-item {
-        flex-direction: column;
-        align-items: stretch;
+    .save-playlist-actions {
+        width: 100%;
     }
-    .playlist-actions {
-        justify-content: stretch;
-    }
-    .playlist-actions button {
+    .save-playlist-actions button {
         flex: 1;
     }
 }

--- a/web/src/main/resources/static/js/music-player.js
+++ b/web/src/main/resources/static/js/music-player.js
@@ -45,10 +45,19 @@
         playlistsEmpty: $('playlists-empty'),
         savePlaylistForm: $('save-playlist-form'),
         savePlaylistName: $('save-playlist-name'),
+        saveQueueBtn: $('save-queue-btn'),
         voiceChannelName: $('voice-channel-name'),
         voiceChannelEmpty: $('voice-channel-empty'),
         voiceMemberList: $('voice-member-list'),
     };
+
+    // Current user — lets us show edit affordances only on playlists they own.
+    const myDiscordId = body.dataset.discordId || '';
+    // Cache of the last-rendered playlist summaries + which one is expanded in
+    // the inline editor, so SSE-less refreshes (save / delete / visibility)
+    // can re-open the same editor without the user losing their place.
+    let playlistsCache = [];
+    let expandedPlaylistId = null;
 
     let lastPaused = false;
     let lastDurationMs = 0;
@@ -375,69 +384,221 @@
         previewController.clearIfRemoved(tracks.map((t) => t.uri || t.identifier));
     }
 
+    // Small DOM helper to keep the playlist-editor builders readable.
+    function makeEl(tag, className, text) {
+        const el = document.createElement(tag);
+        if (className) el.className = className;
+        if (text != null) el.textContent = text;
+        return el;
+    }
+
+    function ownsPlaylist(pl) {
+        return myDiscordId !== '' && String(pl.ownerDiscordId) === myDiscordId;
+    }
+
+    function trackCountLabel(n) {
+        return n + ' track' + (n === 1 ? '' : 's');
+    }
+
     function renderPlaylists(playlists) {
+        playlistsCache = playlists || [];
         els.playlistList.innerHTML = '';
-        if (!playlists || playlists.length === 0) {
+        if (playlistsCache.length === 0) {
             els.playlistsEmpty.hidden = false;
             return;
         }
         els.playlistsEmpty.hidden = true;
-        playlists.forEach((pl) => {
-            const li = document.createElement('li');
-            li.className = 'playlist-item';
+        playlistsCache.forEach((pl) => {
+            const li = makeEl('li', 'playlist-item');
+            li.dataset.playlistId = String(pl.id);
+            const owned = ownsPlaylist(pl);
 
-            const meta = document.createElement('div');
-            meta.className = 'playlist-meta';
-            const name = document.createElement('div');
-            name.className = 'playlist-name';
-            name.textContent = pl.name;
-            const count = document.createElement('div');
-            count.className = 'playlist-count muted';
-            count.textContent = pl.trackCount + ' track' + (pl.trackCount === 1 ? '' : 's');
-            meta.appendChild(name);
-            meta.appendChild(count);
-            li.appendChild(meta);
+            // Header row: expand toggle (name + count) then Load / Delete.
+            const row = makeEl('div', 'playlist-row');
 
-            const actions = document.createElement('div');
-            actions.className = 'playlist-actions';
-            const loadBtn = document.createElement('button');
+            const toggle = makeEl('button', 'playlist-toggle');
+            toggle.type = 'button';
+            toggle.setAttribute('aria-expanded', 'false');
+            const caret = makeEl('span', 'playlist-caret', '▸');
+            caret.setAttribute('aria-hidden', 'true');
+            const name = makeEl('span', 'playlist-name', pl.name);
+            const count = makeEl('span', 'playlist-count muted', trackCountLabel(pl.trackCount));
+            toggle.appendChild(caret);
+            toggle.appendChild(name);
+            toggle.appendChild(count);
+            row.appendChild(toggle);
+
+            const actions = makeEl('div', 'playlist-actions');
+            const loadBtn = makeEl('button', 'btn-tertiary', '⏵ Load');
             loadBtn.type = 'button';
-            loadBtn.className = 'btn-tertiary';
-            loadBtn.textContent = '⏵ Load';
+            loadBtn.title = 'Add this playlist to the queue';
             loadBtn.addEventListener('click', () => {
-                post('/playlists/' + pl.id + '/load');
+                loadBtn.disabled = true;
+                post('/playlists/' + pl.id + '/load').then((res) => {
+                    loadBtn.disabled = false;
+                    if (res && res.ok) toast(res.message || 'Playlist loaded.', 'success');
+                    else toast((res && res.message) || 'Could not load playlist.', 'error');
+                });
             });
             actions.appendChild(loadBtn);
 
-            const delBtn = document.createElement('button');
-            delBtn.type = 'button';
-            delBtn.className = 'btn-tertiary btn-danger';
-            delBtn.textContent = '🗑 Delete';
-            delBtn.addEventListener('click', async () => {
-                // Shared modal (modal.js) for the confirm; fall back to the
-                // native dialog if it somehow isn't loaded.
-                const ok = window.TobyModal
-                    ? await window.TobyModal.confirm({
-                        title: 'Delete playlist?',
-                        body: '“' + pl.name + '” will be removed permanently.',
-                        confirmLabel: 'Delete',
-                        cancelLabel: 'Cancel',
-                    })
-                    : window.confirm('Delete playlist "' + pl.name + '"?');
-                if (!ok) return;
-                del('/playlists/' + pl.id).then((res) => {
-                    if (res && res.ok === false) {
-                        toast(res.message || 'Could not delete playlist.', 'error');
-                        return;
+            if (owned) {
+                const delBtn = makeEl('button', 'btn-tertiary btn-danger', '🗑');
+                delBtn.type = 'button';
+                delBtn.title = 'Delete playlist';
+                delBtn.setAttribute('aria-label', 'Delete playlist');
+                delBtn.addEventListener('click', () => deletePlaylist(pl));
+                actions.appendChild(delBtn);
+            }
+            row.appendChild(actions);
+            li.appendChild(row);
+
+            const panel = makeEl('div', 'playlist-editor');
+            panel.hidden = true;
+            li.appendChild(panel);
+
+            toggle.addEventListener('click', () => togglePlaylist(pl, toggle, panel));
+
+            els.playlistList.appendChild(li);
+
+            // Re-open the editor that was open before this re-render.
+            if (String(pl.id) === String(expandedPlaylistId)) {
+                openPlaylist(pl, toggle, panel);
+            }
+        });
+    }
+
+    function togglePlaylist(pl, toggle, panel) {
+        if (toggle.getAttribute('aria-expanded') === 'true') {
+            expandedPlaylistId = null;
+            toggle.setAttribute('aria-expanded', 'false');
+            toggle.querySelector('.playlist-caret').textContent = '▸';
+            panel.hidden = true;
+        } else {
+            openPlaylist(pl, toggle, panel);
+        }
+    }
+
+    function openPlaylist(pl, toggle, panel) {
+        expandedPlaylistId = pl.id;
+        toggle.setAttribute('aria-expanded', 'true');
+        toggle.querySelector('.playlist-caret').textContent = '▾';
+        panel.hidden = false;
+        panel.innerHTML = '<p class="muted pl-loading">Loading…</p>';
+        getJson('/playlists/' + pl.id)
+            .then((res) => {
+                if (res && res.ok && res.detail) renderPlaylistEditor(panel, res.detail);
+                else panel.innerHTML = '<p class="muted">Could not load this playlist.</p>';
+            })
+            .catch(() => { panel.innerHTML = '<p class="muted">Could not load this playlist.</p>'; });
+    }
+
+    function renderPlaylistEditor(panel, detail) {
+        panel.innerHTML = '';
+
+        if (detail.canEdit) {
+            const renameForm = makeEl('form', 'playlist-rename-form');
+            renameForm.autocomplete = 'off';
+            const renameInput = makeEl('input', 'playlist-rename-input');
+            renameInput.type = 'text';
+            renameInput.maxLength = 80;
+            renameInput.value = detail.name;
+            renameInput.setAttribute('aria-label', 'Playlist name');
+            const renameBtn = makeEl('button', 'btn-tertiary', 'Rename');
+            renameBtn.type = 'submit';
+            renameForm.appendChild(renameInput);
+            renameForm.appendChild(renameBtn);
+            renameForm.addEventListener('submit', (e) => {
+                e.preventDefault();
+                const newName = renameInput.value.trim();
+                if (!newName || newName === detail.name) return;
+                post('/playlists/' + detail.id + '/rename', { name: newName }).then((res) => {
+                    if (res && res.ok && res.detail) {
+                        toast('Playlist renamed.', 'success');
+                        renderPlaylistEditor(panel, res.detail);
+                        refreshPlaylists();
+                    } else {
+                        toast((res && res.message) || 'Could not rename playlist.', 'error');
                     }
-                    toast('Playlist deleted.', 'success');
-                    refreshPlaylists();
                 });
             });
-            actions.appendChild(delBtn);
+            panel.appendChild(renameForm);
+        }
 
-            li.appendChild(actions);
-            els.playlistList.appendChild(li);
+        if (!detail.items || detail.items.length === 0) {
+            panel.appendChild(makeEl('p', 'muted pl-empty',
+                detail.canEdit
+                    ? 'No tracks yet — find tracks in search and use “＋ Playlist”.'
+                    : 'This playlist is empty.'));
+            return;
+        }
+
+        const list = makeEl('ol', 'pl-track-list');
+        detail.items.forEach((track, i) => {
+            const item = makeEl('li', 'pl-track');
+            item.dataset.index = String(i);
+            if (detail.canEdit) {
+                item.draggable = true;
+                const handle = makeEl('span', 'pl-track-handle', '⋮⋮');
+                handle.setAttribute('aria-hidden', 'true');
+                item.appendChild(handle);
+            }
+            const meta = makeEl('div', 'pl-track-meta');
+            meta.appendChild(makeEl('div', 'pl-track-title', track.title || '(untitled)'));
+            const sub = [track.author || '', track.durationMs ? formatMs(track.durationMs) : '']
+                .filter(Boolean).join(' • ');
+            meta.appendChild(makeEl('div', 'pl-track-sub muted', sub));
+            item.appendChild(meta);
+
+            if (detail.canEdit) {
+                const remove = makeEl('button', 'pl-track-remove', '✕');
+                remove.type = 'button';
+                remove.setAttribute('aria-label', 'Remove track');
+                remove.addEventListener('click', () => {
+                    del('/playlists/' + detail.id + '/items/' + track.id).then((res) => {
+                        if (res && res.ok && res.detail) {
+                            renderPlaylistEditor(panel, res.detail);
+                            refreshPlaylists();
+                        } else {
+                            toast((res && res.message) || 'Could not remove track.', 'error');
+                        }
+                    });
+                });
+                item.appendChild(remove);
+            }
+            list.appendChild(item);
+        });
+        panel.appendChild(list);
+
+        if (detail.canEdit && window.TobyMusicQueue && typeof window.TobyMusicQueue.attach === 'function') {
+            window.TobyMusicQueue.attach(list, (from, to) => {
+                post('/playlists/' + detail.id + '/items/reorder', { from: from, to: to }).then((res) => {
+                    if (res && res.ok && res.detail) renderPlaylistEditor(panel, res.detail);
+                    else toast((res && res.message) || 'Could not reorder.', 'error');
+                });
+            }, 'li.pl-track');
+        }
+    }
+
+    async function deletePlaylist(pl) {
+        // Shared modal (modal.js) for the confirm; fall back to native if absent.
+        const ok = window.TobyModal
+            ? await window.TobyModal.confirm({
+                title: 'Delete playlist?',
+                body: '“' + pl.name + '” will be removed permanently.',
+                confirmLabel: 'Delete',
+                cancelLabel: 'Cancel',
+            })
+            : window.confirm('Delete playlist "' + pl.name + '"?');
+        if (!ok) return;
+        del('/playlists/' + pl.id).then((res) => {
+            if (res && res.ok === false) {
+                toast(res.message || 'Could not delete playlist.', 'error');
+                return;
+            }
+            if (String(pl.id) === String(expandedPlaylistId)) expandedPlaylistId = null;
+            toast('Playlist deleted.', 'success');
+            refreshPlaylists();
         });
     }
 
@@ -549,6 +710,111 @@
         els.searchQueryLabel.textContent = '';
     }
 
+    // ---- Add-to-playlist picker (search results) -----------------------
+    // Curating a playlist never queues or plays the track — it POSTs the
+    // resolved metadata straight to /playlists/{id}/items.
+
+    function closeAllPlaylistMenus(except) {
+        els.searchList.querySelectorAll('.add-to-playlist-menu').forEach((m) => {
+            if (m !== except) m.hidden = true;
+        });
+    }
+    // One document-level listener closes any open picker on an outside click.
+    document.addEventListener('click', (e) => {
+        if (!e.target.closest('.add-to-playlist')) closeAllPlaylistMenus(null);
+    });
+
+    function addTrackToPlaylist(playlistId, track) {
+        return post('/playlists/' + playlistId + '/items', {
+            identifier: track.uri || track.identifier,
+            title: track.title,
+            author: track.author,
+            durationMs: track.durationMs,
+            sourceName: track.sourceName,
+        }).then((res) => {
+            if (res && res.ok) {
+                toast('Added to playlist.', 'success');
+                refreshPlaylists();
+            } else {
+                toast((res && res.message) || 'Could not add to playlist.', 'error');
+            }
+            return res;
+        });
+    }
+
+    function buildPlaylistMenu(track, menu) {
+        menu.innerHTML = '';
+        const owned = playlistsCache.filter(ownsPlaylist);
+        if (owned.length > 0) {
+            owned.forEach((pl) => {
+                const opt = makeEl('button', 'add-to-playlist-option');
+                opt.type = 'button';
+                opt.appendChild(makeEl('span', 'add-to-playlist-option-name', pl.name));
+                opt.appendChild(makeEl('span', 'add-to-playlist-option-count muted', trackCountLabel(pl.trackCount)));
+                opt.addEventListener('click', () => {
+                    menu.hidden = true;
+                    addTrackToPlaylist(pl.id, track);
+                });
+                menu.appendChild(opt);
+            });
+        } else {
+            menu.appendChild(makeEl('p', 'add-to-playlist-empty muted', 'No playlists yet — name one below.'));
+        }
+
+        // Inline "create + add" so a playlist can be born from a search hit.
+        const newForm = makeEl('form', 'add-to-playlist-new');
+        newForm.autocomplete = 'off';
+        const input = makeEl('input', 'add-to-playlist-new-input');
+        input.type = 'text';
+        input.maxLength = 80;
+        input.placeholder = 'New playlist…';
+        const addBtn = makeEl('button', 'btn-tertiary', '＋ Add');
+        addBtn.type = 'submit';
+        newForm.appendChild(input);
+        newForm.appendChild(addBtn);
+        newForm.addEventListener('submit', (e) => {
+            e.preventDefault();
+            const name = input.value.trim();
+            if (!name) return;
+            addBtn.disabled = true;
+            post('/playlists', { name: name, fromQueue: false }).then((res) => {
+                if (res && res.ok && res.id) {
+                    menu.hidden = true;
+                    addTrackToPlaylist(res.id, track);
+                } else {
+                    addBtn.disabled = false;
+                    toast((res && res.message) || 'Could not create playlist.', 'error');
+                }
+            });
+        });
+        menu.appendChild(newForm);
+    }
+
+    function makeAddToPlaylistControl(track) {
+        const wrap = makeEl('div', 'add-to-playlist');
+        const btn = makeEl('button', 'btn-add-playlist', '＋ Playlist');
+        btn.type = 'button';
+        btn.setAttribute('aria-haspopup', 'true');
+        btn.setAttribute('aria-expanded', 'false');
+        btn.title = 'Add to a playlist without playing';
+        const menu = makeEl('div', 'add-to-playlist-menu');
+        menu.hidden = true;
+        btn.addEventListener('click', () => {
+            const opening = menu.hidden;
+            closeAllPlaylistMenus(menu);
+            if (opening) {
+                buildPlaylistMenu(track, menu);
+                menu.hidden = false;
+            } else {
+                menu.hidden = true;
+            }
+            btn.setAttribute('aria-expanded', String(opening));
+        });
+        wrap.appendChild(btn);
+        wrap.appendChild(menu);
+        return wrap;
+    }
+
     function renderSearchResults(query, results) {
         els.searchSection.hidden = false;
         els.searchQueryLabel.textContent = '"' + query + '"';
@@ -578,6 +844,8 @@
 
             const previewBtn = makePreviewBtn(track);
             if (previewBtn) li.appendChild(previewBtn);
+
+            li.appendChild(makeAddToPlaylistControl(track));
 
             const queueBtn = document.createElement('button');
             queueBtn.type = 'button';
@@ -631,20 +899,30 @@
 
     els.searchCloseBtn.addEventListener('click', clearSearchResults);
 
-    els.savePlaylistForm.addEventListener('submit', (e) => {
-        e.preventDefault();
+    // Two ways to create: the form submit (“＋ New”) makes an empty playlist
+    // to curate from search; “💾 Save queue” snapshots the live queue.
+    function createPlaylist(fromQueue) {
         const name = els.savePlaylistName.value.trim();
         if (!name) return;
-        post('/playlists', { name: name }).then((res) => {
+        post('/playlists', { name: name, fromQueue: fromQueue }).then((res) => {
             if (res && res.ok) {
                 els.savePlaylistName.value = '';
+                if (res.id != null) expandedPlaylistId = res.id;
                 refreshPlaylists();
-                toast('Playlist saved.', 'success');
+                toast(fromQueue ? 'Queue saved as playlist.' : 'Playlist created.', 'success');
             } else {
-                toast((res && res.message) || 'Could not save playlist.', 'error');
+                toast((res && res.message) || 'Could not create playlist.', 'error');
             }
         });
+    }
+
+    els.savePlaylistForm.addEventListener('submit', (e) => {
+        e.preventDefault();
+        createPlaylist(false);
     });
+    if (els.saveQueueBtn) {
+        els.saveQueueBtn.addEventListener('click', () => createPlaylist(true));
+    }
 
     // ---- SSE -----------------------------------------------------------
 

--- a/web/src/main/resources/static/js/music-queue.js
+++ b/web/src/main/resources/static/js/music-queue.js
@@ -5,15 +5,18 @@
 (function () {
     'use strict';
 
-    function attach(listEl, onReorder) {
-        // Re-binding cleanly each time renderQueue rebuilds the list.
+    // `itemSelector` lets the same drag logic drive the live queue
+    // (`li.queue-item`) and the playlist-editor track rows (`li.pl-track`).
+    function attach(listEl, onReorder, itemSelector) {
+        const selector = itemSelector || 'li.queue-item';
+        // Re-binding cleanly each time the list is rebuilt.
         if (listEl.dataset.dndBound === '1') return;
         listEl.dataset.dndBound = '1';
 
         let draggingIdx = null;
 
         listEl.addEventListener('dragstart', (e) => {
-            const li = e.target.closest('li.queue-item');
+            const li = e.target.closest(selector);
             if (!li) return;
             draggingIdx = Number(li.dataset.index);
             li.classList.add('dragging');
@@ -28,24 +31,24 @@
             if (draggingIdx == null) return;
             e.preventDefault();
             if (e.dataTransfer) e.dataTransfer.dropEffect = 'move';
-            const li = e.target.closest('li.queue-item');
+            const li = e.target.closest(selector);
             if (li) li.classList.add('drop-target');
         });
 
         listEl.addEventListener('dragleave', (e) => {
-            const li = e.target.closest('li.queue-item');
+            const li = e.target.closest(selector);
             if (li) li.classList.remove('drop-target');
         });
 
         listEl.addEventListener('drop', (e) => {
             e.preventDefault();
             if (draggingIdx == null) return;
-            const li = e.target.closest('li.queue-item');
+            const li = e.target.closest(selector);
             if (!li) return;
             const toIdx = Number(li.dataset.index);
             if (toIdx === draggingIdx) return;
             // Optimistic DOM swap: move the dragged node before/after the drop target.
-            const allItems = Array.from(listEl.querySelectorAll('li.queue-item'));
+            const allItems = Array.from(listEl.querySelectorAll(selector));
             const dragged = allItems[draggingIdx];
             const target = allItems[toIdx];
             if (dragged && target) {

--- a/web/src/main/resources/templates/music-player.html
+++ b/web/src/main/resources/templates/music-player.html
@@ -87,9 +87,14 @@
         <article class="playlists-card" data-reveal aria-labelledby="playlists-heading">
             <h2 id="playlists-heading">Saved playlists</h2>
             <form id="save-playlist-form" class="save-playlist-form" autocomplete="off">
-                <input id="save-playlist-name" type="text" maxlength="80" placeholder="Name your playlist" required>
-                <button class="btn-secondary" type="submit">💾 Save current queue</button>
+                <input id="save-playlist-name" type="text" maxlength="80" placeholder="New playlist name" required>
+                <div class="save-playlist-actions">
+                    <button class="btn-primary" type="submit">＋ New</button>
+                    <button class="btn-secondary" type="button" id="save-queue-btn"
+                            title="Snapshot the current queue into a new playlist">💾 Save queue</button>
+                </div>
             </form>
+            <p class="add-track-hint muted">Create an empty playlist, then add tracks from search — building a playlist never plays anything.</p>
             <ul id="playlist-list" class="playlist-list" aria-live="polite"></ul>
             <p id="playlists-empty" class="muted">No saved playlists yet.</p>
         </article>

--- a/web/src/test/js/music-playlist-builder.test.js
+++ b/web/src/test/js/music-playlist-builder.test.js
@@ -1,0 +1,151 @@
+// Verifies the "build playlists without playing" promise on the client:
+// adding a search result to a playlist POSTs the resolved metadata to the
+// playlist-items endpoint and NEVER hits /load (which would queue/play it).
+
+class MockEventSource {
+    constructor(url) {
+        this.url = url;
+        this.handlers = {};
+        MockEventSource.instances.push(this);
+    }
+    addEventListener(name, handler) { this.handlers[name] = handler; }
+    close() {}
+    fire(name, payload) {
+        const handler = this.handlers[name];
+        if (handler) handler({ data: JSON.stringify(payload) });
+    }
+}
+MockEventSource.instances = [];
+
+function flush() {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function json(body) {
+    return Promise.resolve({ ok: true, json: () => Promise.resolve(body) });
+}
+
+function idleState() {
+    return {
+        guildId: 42, nowPlaying: null, positionMs: 0, paused: false,
+        volume: 100, looping: false, queue: [], voiceChannelId: null, voiceChannel: null,
+    };
+}
+
+function track() {
+    return {
+        identifier: 'id-1', title: 'Numb', author: 'Linkin Park',
+        durationMs: 185000, uri: 'https://youtu.be/x', previewUrl: null, sourceName: 'youtube',
+    };
+}
+
+function setUpDashboardDom() {
+    document.head.innerHTML = '';
+    document.body.innerHTML = `
+        <div id="now-playing-empty"></div>
+        <div id="now-playing-content" hidden>
+            <span id="source-badge"></span><h3 id="now-playing-title"></h3>
+            <p id="now-playing-author"></p>
+            <div id="now-playing-requester" hidden><span id="now-playing-requester-cell"></span></div>
+            <span id="time-current"></span><span id="time-total"></span>
+            <div id="progress-track"><div id="progress-fill"></div></div>
+        </div>
+        <button id="btn-pause"></button><button id="btn-skip"></button>
+        <button id="btn-stop"></button><button id="btn-loop" aria-pressed="false"></button>
+        <input id="volume-slider" type="range" min="0" max="150" value="100" />
+        <span id="volume-value">100</span>
+        <form id="add-track-form"><input id="add-track-input" /><button>Search</button></form>
+        <section id="search-results-section" hidden>
+            <span id="search-results-query"></span>
+            <button id="search-results-close"></button>
+            <ol id="search-results-list"></ol>
+            <p id="search-results-empty" hidden></p>
+        </section>
+        <ol id="queue-list"></ol><p id="queue-empty"></p>
+        <ul id="playlist-list"></ul><p id="playlists-empty"></p>
+        <form id="save-playlist-form">
+            <input id="save-playlist-name" />
+            <div class="save-playlist-actions">
+                <button type="submit">＋ New</button>
+                <button type="button" id="save-queue-btn">Save queue</button>
+            </div>
+        </form>
+        <p id="voice-channel-name" hidden></p><p id="voice-channel-empty"></p>
+        <ul id="voice-member-list"></ul>
+    `;
+    document.body.dataset.musicPage = '1';
+    document.body.dataset.guildId = '42';
+    document.body.dataset.discordId = '100';
+}
+
+describe('music-player.js — build playlists without playing', () => {
+    let fetchMock;
+    let visibilitySpy;
+
+    beforeEach(() => {
+        jest.resetModules();
+        MockEventSource.instances.length = 0;
+        setUpDashboardDom();
+        window.EventSource = MockEventSource;
+
+        fetchMock = jest.fn().mockImplementation((url) => {
+            if (url.endsWith('/state')) return json({ state: idleState() });
+            if (url.endsWith('/playlists')) return json([]);
+            return json({});
+        });
+        window.fetch = fetchMock;
+        visibilitySpy = jest.spyOn(document, 'visibilityState', 'get');
+        visibilitySpy.mockReturnValue('visible');
+
+        require('../../main/resources/static/js/music-player');
+    });
+
+    afterEach(() => visibilitySpy.mockRestore());
+
+    function methodRouter(url, init) {
+        const method = (init && init.method) || 'GET';
+        if (url.endsWith('/state')) return json({ state: idleState() });
+        if (url.includes('/search')) return json([track()]);
+        if (url.endsWith('/playlists') && method === 'GET') return json([]);
+        if (url.endsWith('/playlists') && method === 'POST') return json({ ok: true, id: 5 });
+        if (url.endsWith('/playlists/5/items') && method === 'POST') {
+            return json({ ok: true, detail: { id: 5, name: 'My Mix', ownerDiscordId: 100, canEdit: true, items: [] } });
+        }
+        return json({});
+    }
+
+    test('adding a search hit to a new playlist posts items and never calls /load', async () => {
+        await flush();
+        fetchMock.mockImplementation(methodRouter);
+
+        // Run a free-text search so the results panel renders.
+        document.getElementById('add-track-input').value = 'numb';
+        document.getElementById('add-track-form').dispatchEvent(new Event('submit', { cancelable: true }));
+        await flush();
+
+        const addBtn = document.querySelector('#search-results-list .btn-add-playlist');
+        expect(addBtn).not.toBeNull();
+
+        addBtn.click();
+        const menu = document.querySelector('.add-to-playlist-menu');
+        expect(menu.hidden).toBe(false);
+
+        // Create-and-add via the inline "new playlist" form in the menu.
+        menu.querySelector('.add-to-playlist-new-input').value = 'My Mix';
+        menu.querySelector('.add-to-playlist-new').dispatchEvent(new Event('submit', { cancelable: true }));
+        await flush();
+        await flush();
+
+        const calls = fetchMock.mock.calls;
+        const createCall = calls.find(([u, i]) => u.endsWith('/playlists') && i && i.method === 'POST');
+        expect(createCall).toBeTruthy();
+        expect(JSON.parse(createCall[1].body).fromQueue).toBe(false);
+
+        const addCall = calls.find(([u, i]) => u.endsWith('/playlists/5/items') && i && i.method === 'POST');
+        expect(addCall).toBeTruthy();
+        expect(JSON.parse(addCall[1].body).identifier).toBe('https://youtu.be/x');
+
+        // The whole point: curating never queues/plays the track.
+        expect(calls.some(([u]) => u.endsWith('/load'))).toBe(false);
+    });
+});

--- a/web/src/test/kotlin/web/controller/MusicWebControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/MusicWebControllerTest.kt
@@ -102,6 +102,10 @@ class MusicWebControllerTest {
             "playlists POST"   to { controller.createPlaylist(guildId, user, MusicWebController.SavePlaylistRequest("x")).statusCode.value() },
             "playlists/{id}/load" to { controller.loadPlaylist(guildId, 1L, user).statusCode.value() },
             "playlists/{id} DELETE" to { controller.deletePlaylist(guildId, 1L, user).statusCode.value() },
+            "playlists/{id}/items POST" to { controller.addPlaylistItem(guildId, 1L, user, MusicWebController.AddPlaylistItemRequest("u")).statusCode.value() },
+            "playlists/{id}/items DELETE" to { controller.removePlaylistItem(guildId, 1L, 2L, user).statusCode.value() },
+            "playlists/{id}/items/reorder" to { controller.reorderPlaylist(guildId, 1L, user, MusicWebController.ReorderRequest(0, 1)).statusCode.value() },
+            "playlists/{id}/rename" to { controller.renamePlaylist(guildId, 1L, user, MusicWebController.RenamePlaylistRequest("x")).statusCode.value() },
         )
         writes.forEach { (label, run) ->
             assertEquals(403, run(), "Expected $label to 403 when musicPermission revoked")
@@ -118,6 +122,8 @@ class MusicWebControllerTest {
             )
         every { musicWebService.search(guildId, any(), any()) } returns emptyList()
         every { musicWebService.listPlaylistsForGuild(guildId) } returns emptyList()
+        every { musicWebService.getPlaylistDetail(guildId, 1L, discordId) } returns
+            MusicWebService.PlaylistDetail(1L, "Mix", discordId, canEdit = true, items = emptyList())
         every { sseService.register(guildId) } returns mockk(relaxed = true)
 
         val reads: List<Pair<String, () -> Int>> = listOf(
@@ -125,6 +131,7 @@ class MusicWebControllerTest {
             "events"           to { controller.stream(guildId, user).statusCode.value() },
             "search"           to { controller.search(guildId, "linkin park", user).statusCode.value() },
             "playlists GET"    to { controller.listPlaylists(guildId, user).statusCode.value() },
+            "playlists/{id} GET" to { controller.playlistDetail(guildId, 1L, user).statusCode.value() },
         )
         reads.forEach { (label, run) ->
             assertEquals(200, run(), "Expected $label to 200 even when musicPermission revoked")
@@ -400,6 +407,74 @@ class MusicWebControllerTest {
         assertEquals(200, response.statusCode.value())
         assertTrue(response.body!!.ok)
         assertEquals(42L, response.body!!.id)
+    }
+
+    @Test
+    fun `create empty playlist routes to createEmptyPlaylist when fromQueue is false`() {
+        every { musicWebService.createEmptyPlaylist(guildId, discordId, "Fresh") } returns 7L
+        val response = controller.createPlaylist(
+            guildId, user, MusicWebController.SavePlaylistRequest("Fresh", fromQueue = false),
+        )
+        assertEquals(200, response.statusCode.value())
+        assertEquals(7L, response.body!!.id)
+        verify(exactly = 1) { musicWebService.createEmptyPlaylist(guildId, discordId, "Fresh") }
+        verify(exactly = 0) { musicWebService.saveCurrentQueueAsPlaylist(any(), any(), any()) }
+    }
+
+    @Test
+    fun `playlist detail returns 404 when missing`() {
+        every { musicWebService.getPlaylistDetail(guildId, 1L, discordId) } returns null
+        assertEquals(404, controller.playlistDetail(guildId, 1L, user).statusCode.value())
+    }
+
+    @Test
+    fun `add playlist item returns 200 with the updated detail`() {
+        val detail = MusicWebService.PlaylistDetail(1L, "Mix", discordId, canEdit = true, items = emptyList())
+        every { musicWebService.addTrackToPlaylist(guildId, 1L, discordId, any()) } returns
+            MusicWebService.PlaylistMutation(true, detail)
+        val response = controller.addPlaylistItem(
+            guildId, 1L, user, MusicWebController.AddPlaylistItemRequest(identifier = "uri-1", title = "Song"),
+        )
+        assertEquals(200, response.statusCode.value())
+        assertTrue(response.body!!.ok)
+        assertNotNull(response.body!!.detail)
+    }
+
+    @Test
+    fun `add playlist item returns 404 when the service refuses`() {
+        every { musicWebService.addTrackToPlaylist(guildId, 1L, discordId, any()) } returns
+            MusicWebService.PlaylistMutation(false, message = "Only the owner can edit this playlist.")
+        val response = controller.addPlaylistItem(
+            guildId, 1L, user, MusicWebController.AddPlaylistItemRequest(identifier = "uri-1"),
+        )
+        assertEquals(404, response.statusCode.value())
+        assertFalse(response.body!!.ok)
+    }
+
+    @Test
+    fun `reorder playlist rejects negative indices with 400`() {
+        val response = controller.reorderPlaylist(
+            guildId, 1L, user, MusicWebController.ReorderRequest(-1, 0),
+        )
+        assertEquals(400, response.statusCode.value())
+    }
+
+    @Test
+    fun `rename playlist returns 409 on a name clash`() {
+        every { musicWebService.renamePlaylist(guildId, 1L, discordId, "Taken") } throws
+            PlaylistNameTakenException("taken")
+        val response = controller.renamePlaylist(
+            guildId, 1L, user, MusicWebController.RenamePlaylistRequest("Taken"),
+        )
+        assertEquals(409, response.statusCode.value())
+    }
+
+    @Test
+    fun `rename playlist rejects blank name with 400`() {
+        val response = controller.renamePlaylist(
+            guildId, 1L, user, MusicWebController.RenamePlaylistRequest("  "),
+        )
+        assertEquals(400, response.statusCode.value())
     }
 
     @Test

--- a/web/src/test/kotlin/web/service/MusicWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/MusicWebServiceTest.kt
@@ -183,6 +183,101 @@ class MusicWebServiceTest {
         assertFalse(ok)
     }
 
+    // ---- Curation (build playlists without playing) --------------------
+
+    @Test
+    fun `createEmptyPlaylist delegates to playlist service and returns id`() {
+        every { playlistService.createEmpty(guildId, discordId, "Empty") } returns
+            MusicPlaylistDto(id = 7L, guildId = guildId, ownerDiscordId = discordId, name = "Empty")
+        assertEquals(7L, service.createEmptyPlaylist(guildId, discordId, "Empty"))
+    }
+
+    @Test
+    fun `getPlaylistDetail maps items and flags canEdit for owner`() {
+        val playlist = MusicPlaylistDto(id = 1L, guildId = guildId, ownerDiscordId = discordId, name = "Mix")
+        playlist.items.add(
+            MusicPlaylistItemDto(
+                id = 10L, position = 0, identifier = "uri-1",
+                title = "Song", author = "Artist", durationMs = 1234L, sourceName = "youtube",
+            ),
+        )
+        every { playlistService.getById(1L) } returns playlist
+        val detail = service.getPlaylistDetail(guildId, 1L, discordId)
+        assertNotNull(detail)
+        assertTrue(detail!!.canEdit)
+        assertEquals(1, detail.items.size)
+        assertEquals(10L, detail.items[0].id)
+        assertEquals("uri-1", detail.items[0].uri)
+    }
+
+    @Test
+    fun `getPlaylistDetail flags canEdit false for a non-owner viewer`() {
+        every { playlistService.getById(1L) } returns
+            MusicPlaylistDto(id = 1L, guildId = guildId, ownerDiscordId = 9999L, name = "Mix")
+        assertFalse(service.getPlaylistDetail(guildId, 1L, discordId)!!.canEdit)
+    }
+
+    @Test
+    fun `getPlaylistDetail returns null for a cross-guild playlist`() {
+        every { playlistService.getById(1L) } returns
+            MusicPlaylistDto(id = 1L, guildId = 999L, ownerDiscordId = discordId, name = "Mix")
+        assertNull(service.getPlaylistDetail(guildId, 1L, discordId))
+    }
+
+    @Test
+    fun `addTrackToPlaylist appends for the owner`() {
+        val playlist = MusicPlaylistDto(id = 1L, guildId = guildId, ownerDiscordId = discordId, name = "Mix")
+        every { playlistService.getById(1L) } returns playlist
+        every { playlistService.addItem(1L, any()) } returns playlist
+        val result = service.addTrackToPlaylist(guildId, 1L, discordId, item("uri-1"))
+        assertTrue(result.ok)
+        assertNotNull(result.detail)
+        verify(exactly = 1) { playlistService.addItem(1L, any()) }
+    }
+
+    @Test
+    fun `addTrackToPlaylist refuses a non-owner and never mutates`() {
+        every { playlistService.getById(1L) } returns
+            MusicPlaylistDto(id = 1L, guildId = guildId, ownerDiscordId = 9999L, name = "Mix")
+        val result = service.addTrackToPlaylist(guildId, 1L, discordId, item("uri-1"))
+        assertFalse(result.ok)
+        verify(exactly = 0) { playlistService.addItem(any(), any()) }
+    }
+
+    @Test
+    fun `removeTrackFromPlaylist refuses a non-owner`() {
+        every { playlistService.getById(1L) } returns
+            MusicPlaylistDto(id = 1L, guildId = guildId, ownerDiscordId = 9999L, name = "Mix")
+        val result = service.removeTrackFromPlaylist(guildId, 1L, discordId, 5L)
+        assertFalse(result.ok)
+        verify(exactly = 0) { playlistService.removeItem(any(), any()) }
+    }
+
+    @Test
+    fun `reorderPlaylist delegates for the owner`() {
+        val playlist = MusicPlaylistDto(id = 1L, guildId = guildId, ownerDiscordId = discordId, name = "Mix")
+        every { playlistService.getById(1L) } returns playlist
+        every { playlistService.reorderItems(1L, 0, 1) } returns playlist
+        assertTrue(service.reorderPlaylist(guildId, 1L, discordId, 0, 1).ok)
+    }
+
+    @Test
+    fun `renamePlaylist refuses a non-owner`() {
+        every { playlistService.getById(1L) } returns
+            MusicPlaylistDto(id = 1L, guildId = guildId, ownerDiscordId = 9999L, name = "Mix")
+        val result = service.renamePlaylist(guildId, 1L, discordId, "New")
+        assertFalse(result.ok)
+        verify(exactly = 0) { playlistService.rename(any(), any()) }
+    }
+
+    private fun item(id: String) = PlaylistItemInput(
+        identifier = id,
+        title = "title-$id",
+        author = "author-$id",
+        durationMs = 1000L,
+        sourceName = "youtube",
+    )
+
     @Test
     fun `isMember delegates to GuildMembership`() {
         every { membership.isMember(discordId, guildId) } returns true


### PR DESCRIPTION
Lets you **build and edit playlists entirely from the web UI without playing anything**. Before this, the only way to fill a playlist was to snapshot the live queue — so curating meant playing the tracks first. This decouples curation from playback end-to-end.

Scope chosen: **full editor** (add / remove / drag-reorder / rename + create-empty) with an **"add to playlist" picker on search results**.

## How it works
- **Search → "＋ Playlist"**: every search result gets a picker. Pick one of your playlists (or create one inline) and the resolved track metadata is POSTed straight to the playlist — `/search` already resolves without playing, and we never call `/load`. Nothing hits the voice channel.
- **Saved playlists are expandable editors**: open one to rename it, drag-reorder its tracks, and remove tracks. **＋ New** creates an empty playlist to curate; **💾 Save queue** keeps the old snapshot behaviour.

## Backend
- `MusicPlaylistService`: `createEmpty`, `addItem`, `removeItem`, `reorderItems`, `rename` (with position re-sequencing). `reorderItems` reassigns positions on the existing entities rather than `clear()`/re-add, which under `orphanRemoval` would churn rows. **No DB migration** — the existing tables already model items.
- `MusicWebService`: owner-gated `addTrackToPlaylist` / `removeTrackFromPlaylist` / `reorderPlaylist` / `renamePlaylist`, plus `getPlaylistDetail` (any guild member can view; `canEdit` only for the owner).
- Controller: item GET/POST/DELETE, `items/reorder`, `rename` (409 on name clash), and `POST /playlists` gains a `fromQueue` flag (defaults `true`, preserving existing callers). All mutations go through the same `musicPermission` write gate.

## Tests
- DB-service: empty create, append/remove/re-sequence, reorder bounds, rename clash/self/missing.
- Web-service: owner gating (add/remove/rename refuse non-owners and never mutate), detail mapping + `canEdit`, cross-guild null.
- Controller: new endpoints added to the auth matrices; `fromQueue=false` routing, 404/409/400 paths.
- Jest: adding a search hit to a new playlist posts `/playlists` (`fromQueue:false`) then `/playlists/{id}/items`, and **never calls `/load`**.

## Notes
- Couldn't run Gradle/jest/stylelint here (no network for `node_modules`/foojay), so I verified `node --check` on the JS, CSS brace balance + breakpoint allowlist, and that the existing music jest tests don't touch the changed paths. The `build` job runs stylelint + jest + the Kotlin suite.

https://claude.ai/code/session_01NYQi5HJe2Moi27bM9rNndY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NYQi5HJe2Moi27bM9rNndY)_