### PR TITLE
Make toby-bot's value land in the first 30 seconds for new installers

### DIFF
--- a/application/src/test/kotlin/integration/bot/ButtonManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/ButtonManagerTest.kt
@@ -5,6 +5,7 @@ import bot.configuration.*
 import bot.toby.button.buttons.*
 import bot.toby.helpers.*
 import bot.toby.install.button.InstallBackButton
+import bot.toby.install.button.InstallClaimDailyButton
 import bot.toby.install.button.InstallCustomButton
 import bot.toby.install.button.InstallExpressButton
 import bot.toby.install.button.InstallFeaturesButton
@@ -127,6 +128,7 @@ class ButtonManagerTest {
             InstallFeaturesButton::class.java,
             InstallToggleButton::class.java,
             InstallHelpButton::class.java,
+            InstallClaimDailyButton::class.java,
         )
 
         assertTrue(availableButtons.containsAll(buttonManager.buttons.map { it.javaClass }.toList()))

--- a/database/src/main/kotlin/database/achievement/AchievementCatalog.kt
+++ b/database/src/main/kotlin/database/achievement/AchievementCatalog.kt
@@ -42,6 +42,18 @@ object AchievementCatalog {
      * the moment the relevant trigger calls `progress(...)`/`unlock(...)`.
      */
     val all: List<AchievementSpec> = listOf(
+        // Milestone — fired once when the server owner completes the install
+        // wizard (InstallCompletionService). Visible from day one so a fresh
+        // server has something on the board immediately.
+        AchievementSpec(
+            code = "install_complete",
+            name = "Welcome Aboard",
+            description = "Finish setting up toby-bot in your server.",
+            category = "milestone",
+            icon = "🎉",
+            xpReward = 100,
+            creditReward = 500,
+        ),
         // Streak achievements — fired by AchievementEventHandler on StreakClaimedEvent.
         AchievementSpec(
             code = "streak_first",

--- a/database/src/test/kotlin/database/achievement/AchievementCatalogTest.kt
+++ b/database/src/test/kotlin/database/achievement/AchievementCatalogTest.kt
@@ -28,7 +28,7 @@ class AchievementCatalogTest {
 
     @Test
     fun `every catalog entry uses a known category`() {
-        val known = setOf("streak", "level", "casino", "social", "music", "voice", "consolation")
+        val known = setOf("streak", "level", "casino", "social", "music", "voice", "consolation", "milestone")
         val unknown = AchievementCatalog.all.filterNot { it.category in known }
         assertTrue(unknown.isEmpty(), "achievements with unknown category: ${unknown.map { it.code to it.category }}")
     }
@@ -132,6 +132,10 @@ class AchievementCatalogTest {
             "baccarat_first_win",
             "casino_holdem_first_win",
             "highlow_first_streak",
+            // Unlocked directly by InstallCompletionService when the owner
+            // finishes the install wizard — wired, just not via the
+            // AchievementEventHandler event path.
+            "install_complete",
         )
         val visible = AchievementCatalog.all.filterNot { it.hidden }.map { it.code }.toSet()
         val orphaned = visible - wired

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/DailyCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/DailyCommand.kt
@@ -4,7 +4,6 @@ import core.command.Command.Companion.replyEphemeralEmbedAndDelete
 import core.command.CommandContext
 import database.dto.user.UserDto
 import database.service.social.LoginStreakService
-import database.service.social.LoginStreakService.ClaimResult
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.entities.MessageEmbed
 import org.springframework.beans.factory.annotation.Autowired
@@ -36,36 +35,7 @@ class DailyCommand @Autowired constructor(
             guildId = guild.idLong,
             channelId = event.channel.idLong
         )
-        event.hook.replyEphemeralEmbedAndDelete(buildEmbed(result), deleteDelay)
-    }
-
-    private fun buildEmbed(result: ClaimResult): MessageEmbed = when (result) {
-        is ClaimResult.Granted -> {
-            val title = if (result.isNewBest) "🔥 New personal best — Day ${result.currentStreak}!"
-                        else "✅ Daily claimed — Day ${result.currentStreak}"
-            EmbedBuilder()
-                .setTitle(title)
-                .setDescription(buildString {
-                    append("**+").append(result.xpGranted).append(" XP**")
-                    if (result.creditsGranted > 0) {
-                        append("  ·  **+").append(result.creditsGranted).append(" credits**")
-                    }
-                    append('\n')
-                    append("Current streak: ").append(result.currentStreak)
-                    append("  ·  Best: ").append(result.longestStreak)
-                    append("\n\nCome back tomorrow to keep the streak alive.")
-                })
-                .setColor(Color(0x4ADE80))
-                .build()
-        }
-        is ClaimResult.AlreadyClaimed -> EmbedBuilder()
-            .setTitle("Already claimed today")
-            .setDescription(
-                "You're at Day **${result.currentStreak}** (best: ${result.longestStreak}). " +
-                "Come back after midnight UTC to keep the streak going."
-            )
-            .setColor(Color(0x60A5FA))
-            .build()
+        event.hook.replyEphemeralEmbedAndDelete(DailyEmbeds.claimResult(result), deleteDelay)
     }
 
     private fun errorEmbed(message: String): MessageEmbed = EmbedBuilder()

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/DailyEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/DailyEmbeds.kt
@@ -1,0 +1,45 @@
+package bot.toby.command.commands.misc
+
+import database.service.social.LoginStreakService.ClaimResult
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.entities.MessageEmbed
+import java.awt.Color
+
+/**
+ * Shared renderer for a daily-claim outcome, used by both [DailyCommand]
+ * and the install wizard's one-click "Claim daily" launcher
+ * ([bot.toby.install.button.InstallClaimDailyButton]) so the slash command
+ * and the button stay pixel-identical.
+ */
+object DailyEmbeds {
+
+    fun claimResult(result: ClaimResult): MessageEmbed = when (result) {
+        is ClaimResult.Granted -> {
+            val title = if (result.isNewBest) "🔥 New personal best — Day ${result.currentStreak}!"
+            else "✅ Daily claimed — Day ${result.currentStreak}"
+            EmbedBuilder()
+                .setTitle(title)
+                .setDescription(buildString {
+                    append("**+").append(result.xpGranted).append(" XP**")
+                    if (result.creditsGranted > 0) {
+                        append("  ·  **+").append(result.creditsGranted).append(" credits**")
+                    }
+                    append('\n')
+                    append("Current streak: ").append(result.currentStreak)
+                    append("  ·  Best: ").append(result.longestStreak)
+                    append("\n\nCome back tomorrow to keep the streak alive.")
+                })
+                .setColor(Color(0x4ADE80))
+                .build()
+        }
+
+        is ClaimResult.AlreadyClaimed -> EmbedBuilder()
+            .setTitle("Already claimed today")
+            .setDescription(
+                "You're at Day **${result.currentStreak}** (best: ${result.longestStreak}). " +
+                    "Come back after midnight UTC to keep the streak going."
+            )
+            .setColor(Color(0x60A5FA))
+            .build()
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/install/InstallCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/InstallCommand.kt
@@ -24,7 +24,7 @@ class InstallCommand : ModerationCommand {
             event.reply("This command can only be used in a server.").setEphemeral(true).queue()
             return
         }
-        event.replyEmbeds(InstallWizard.welcomeEmbed(guild.name))
+        event.replyEmbeds(InstallWizard.welcomeEmbed(guild.name, event.jda.guildCache.size().toInt()))
             .addComponents(InstallWizard.wizardButtons())
             .queue()
     }

--- a/discord-bot/src/main/kotlin/bot/toby/install/InstallCompletionService.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/InstallCompletionService.kt
@@ -1,0 +1,67 @@
+package bot.toby.install
+
+import common.logging.DiscordLogger
+import database.dto.guild.ConfigDto.Configurations
+import database.service.economy.JackpotService
+import database.service.guild.AchievementService
+import database.service.guild.ConfigService
+import net.dv8tion.jda.api.entities.Guild
+import org.springframework.stereotype.Service
+
+/**
+ * The "install just completed" hook, shared by the Express and Custom
+ * (Finish) buttons. Beyond stamping the install sentinel, it makes the
+ * payoff *immediate and visible* for a freshly-onboarded server:
+ *
+ *  - unlocks the owner's "Welcome Aboard" achievement (which fires the
+ *    full DM / channel / web-push notification pipeline), so the very
+ *    first thing the owner sees is the bot's reward machinery working; and
+ *  - seeds the server jackpot with a starting pot so the casino opens with
+ *    a live, non-zero number instead of looking dead on the first game.
+ *
+ * Both side-effects are best-effort: a failure in either is logged and
+ * swallowed so it can never break the install UX (mirroring the defensive
+ * posture in [InstallWelcomeHandler]).
+ */
+@Service
+class InstallCompletionService(
+    private val configService: ConfigService,
+    private val jackpotService: JackpotService,
+    private val achievementService: AchievementService,
+) {
+
+    private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
+
+    fun complete(guild: Guild, mode: String, channelId: Long?) {
+        // First-EVER install for this guild? INSTALLED_AT survives a
+        // guild-leave (only INSTALL_MODE is cleared on leave), so its
+        // absence — read BEFORE writeIfFresh stamps it — is the one true
+        // "never onboarded before" signal. The jackpot seed is gated on
+        // this so a leave/re-invite cycle can't farm the pool.
+        val firstEverInstall = configService
+            .getConfigByName(Configurations.INSTALLED_AT.configValue, guild.id)?.value
+            .isNullOrBlank()
+
+        InstallSentinel.writeIfFresh(configService, guild.id, mode)
+
+        // Celebratory unlock for the owner. unlock() is idempotent — it
+        // publishes no event and re-awards nothing once owned — so a second
+        // /install never re-notifies or double-pays.
+        runCatching {
+            achievementService.unlock(guild.ownerIdLong, guild.idLong, INSTALL_ACHIEVEMENT_CODE, channelId)
+        }.onFailure { logger.error { "Install achievement grant failed for guild ${guild.id}: ${it.message}" } }
+
+        if (firstEverInstall) {
+            runCatching { jackpotService.addToPool(guild.idLong, JACKPOT_SEED_AMOUNT) }
+                .onFailure { logger.error { "Jackpot seed failed for guild ${guild.id}: ${it.message}" } }
+        }
+    }
+
+    companion object {
+        /** Must match the `code` of the milestone achievement in `AchievementCatalog`. */
+        const val INSTALL_ACHIEVEMENT_CODE: String = "install_complete"
+
+        /** Starting jackpot pot (credits) so the casino opens with a live number. */
+        const val JACKPOT_SEED_AMOUNT: Long = 1000L
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/install/InstallWelcomeHandler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/InstallWelcomeHandler.kt
@@ -63,7 +63,8 @@ class InstallWelcomeHandler(
         // presence here means this is a returning server whose config survived
         // — greet them with the welcome-back variant instead of a fresh pitch.
         val returning = !configService.getConfigByName(Configurations.INSTALLED_AT.configValue, guild.id)?.value.isNullOrBlank()
-        val welcomeEmbed = if (returning) InstallWizard.welcomeBackEmbed(guild.name) else InstallWizard.welcomeEmbed(guild.name)
+        val welcomeEmbed = if (returning) InstallWizard.welcomeBackEmbed(guild.name)
+            else InstallWizard.welcomeEmbed(guild.name, guild.jda.guildCache.size().toInt())
         val channel = pickWelcomeChannel(guild)
         if (channel != null) {
             channel.sendMessageEmbeds(welcomeEmbed)

--- a/discord-bot/src/main/kotlin/bot/toby/install/InstallWizard.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/InstallWizard.kt
@@ -44,6 +44,14 @@ object InstallWizard {
      * Skip buttons stay gated.
      */
     const val BTN_HELP = "install_help"
+
+    /**
+     * Public (non-owner) launcher on the post-install "done" message —
+     * anyone can click it to claim their daily reward in one tap, no
+     * command typing. Handled by
+     * [bot.toby.install.button.InstallClaimDailyButton].
+     */
+    const val BTN_CLAIM_DAILY = "install_claim_daily"
     const val BTN_FINISH = "install_finish"
     const val BTN_BACK = "install_category_back"
     const val BTN_FEATURES = "install_features"
@@ -157,7 +165,9 @@ object InstallWizard {
     fun expressDoneEmbed(): MessageEmbed = EmbedBuilder()
         .setTitle("You're all set! 🎉")
         .setDescription(
-            "Defaults are live and the casino is open. Here's how to get going:\n\n" +
+            "Defaults are live and the casino is open. **Tap a button below to start right now** — " +
+                "claim your daily credits, or take the tour. No typing needed.\n\n" +
+                "Prefer commands? Here's how to get going:\n" +
                 "• `/daily` — claim free credits to play with (new players start with some already)\n" +
                 "• `/blackjack` or `/roulette` — deal a quick game\n" +
                 "• `/play <song>` — queue music in a voice channel\n" +
@@ -208,7 +218,9 @@ object InstallWizard {
     fun finishDoneEmbed(): MessageEmbed = EmbedBuilder()
         .setTitle("Custom setup complete ✅")
         .setDescription(
-            "Your settings are saved. Time to play:\n\n" +
+            "Your settings are saved. **Tap a button below to start right now** — claim your daily " +
+                "credits, or take the tour. No typing needed.\n\n" +
+                "Prefer commands? Time to play:\n" +
                 "• `/daily` — claim free credits to play with (new players start with some already)\n" +
                 "• `/blackjack` or `/roulette` — deal a quick game\n" +
                 "• `/play <song>` — queue music in a voice channel\n" +
@@ -230,6 +242,18 @@ object InstallWizard {
 
     fun finishButtonRow(): ActionRow = ActionRow.of(
         Button.success(BTN_FINISH, "Finish"),
+    )
+
+    /**
+     * One-click launcher row left on the post-install "done" message so the
+     * owner's (or any member's) very first action is a tap, not a typed
+     * slash command: claim daily credits, or open the full feature tour.
+     * Both buttons are non-owner-gated — the welcome message doubles as a
+     * shared launcher for everyone in the channel.
+     */
+    fun launcherRow(): ActionRow = ActionRow.of(
+        Button.success(BTN_CLAIM_DAILY, "🎁 Claim daily credits"),
+        Button.secondary(BTN_HELP, "✨ What can I do?"),
     )
 
     fun backButtonRow(): ActionRow = ActionRow.of(

--- a/discord-bot/src/main/kotlin/bot/toby/install/InstallWizard.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/InstallWizard.kt
@@ -58,9 +58,37 @@ object InstallWizard {
 
     fun sectionDetailMenuId(sectionId: String): String = "$MENU_SECTION_DETAIL_PREFIX:$sectionId"
 
+    /**
+     * Floor below which the "trusted by N servers" social-proof line is
+     * suppressed — a tiny number reads as a liability, not a credential, so
+     * fresh / self-hosted deployments simply omit the line until it's
+     * flattering.
+     */
+    const val MIN_SERVERS_FOR_SOCIAL_PROOF = 25
+
+    /**
+     * Honest, never-overstated social-proof line for the welcome pitch:
+     * floors the live guild count down to the nearest 10 and renders it as
+     * "N+", so the number shown is always ≤ the real one. Returns an empty
+     * string (no line) when [serverCount] is null/unknown or below
+     * [MIN_SERVERS_FOR_SOCIAL_PROOF].
+     */
+    fun socialProofLine(serverCount: Int?): String {
+        if (serverCount == null || serverCount < MIN_SERVERS_FOR_SOCIAL_PROOF) return ""
+        val rounded = (serverCount / 10) * 10
+        return "🏆 Already trusted by **$rounded+** Discord servers.\n"
+    }
+
     // ---- embed factories ----
 
-    fun welcomeEmbed(guildName: String): MessageEmbed = EmbedBuilder()
+    /**
+     * The guild-join / `/install` welcome pitch. [serverCount] (the bot's
+     * live guild count) is threaded through only to render the optional
+     * social-proof line via [socialProofLine] — pass null to omit it (e.g.
+     * when the count is unknown or unflattering). Defaulting to null keeps
+     * every existing caller and test source-compatible.
+     */
+    fun welcomeEmbed(guildName: String, serverCount: Int? = null): MessageEmbed = EmbedBuilder()
         .setTitle("Thanks for adding me to $guildName! 🎉")
         .setDescription(
             "I'm **toby-bot** — here's what I bring to the table:\n\n" +
@@ -69,6 +97,7 @@ object InstallWizard {
                 "🎵 **Music** — queue and play audio right in your voice channels\n" +
                 "📈 **Leveling** — optional XP, leaderboards & activity rewards\n" +
                 "🎟️ **Daily lottery** — an optional server-wide draw\n\n" +
+                socialProofLine(serverCount) +
                 "**Let's get you set up — pick a path below:**\n" +
                 "**▸ Express setup** — one click, sensible defaults, start playing right away. Express keeps " +
                 "**Activity tracking OFF**, the **Daily lottery OFF**, and uses conservative casino stakes — " +

--- a/discord-bot/src/main/kotlin/bot/toby/install/button/InstallClaimDailyButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/button/InstallClaimDailyButton.kt
@@ -1,0 +1,41 @@
+package bot.toby.install.button
+
+import bot.toby.command.commands.misc.DailyEmbeds
+import bot.toby.install.InstallWizard
+import core.button.Button
+import core.button.ButtonContext
+import database.dto.user.UserDto
+import database.service.social.LoginStreakService
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+/**
+ * "🎁 Claim daily credits" — the non-owner launcher button left on the
+ * post-install "done" message. Anyone in the channel can tap it to claim
+ * their own daily reward without typing `/daily`, turning the very first
+ * post-setup action into a single click.
+ *
+ * Reuses [LoginStreakService.claim] (the same entry point as
+ * [bot.toby.command.commands.misc.DailyCommand]) and renders the outcome
+ * via the shared [DailyEmbeds], so the button and the slash command behave
+ * identically. Uses the default ephemeral [Button.defersReply] ack, so the
+ * handler just sends the result as a per-clicker follow-up.
+ */
+@Component
+class InstallClaimDailyButton @Autowired constructor(
+    private val loginStreakService: LoginStreakService,
+) : Button {
+
+    override val name: String = InstallWizard.BTN_CLAIM_DAILY
+    override val description: String =
+        "Claim your daily reward straight from the welcome message — usable by anyone, not just the owner."
+
+    override fun handle(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val result = loginStreakService.claim(
+            discordId = requestingUserDto.discordId,
+            guildId = ctx.guild.idLong,
+            channelId = ctx.event.channel.idLong,
+        )
+        ctx.event.hook.sendMessageEmbeds(DailyEmbeds.claimResult(result)).queue()
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/install/button/InstallExpressButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/button/InstallExpressButton.kt
@@ -1,11 +1,10 @@
 package bot.toby.install.button
 
 import bot.toby.install.InstallAuth
-import bot.toby.install.InstallSentinel
+import bot.toby.install.InstallCompletionService
 import bot.toby.install.InstallWizard
 import core.button.ButtonContext
 import database.dto.user.UserDto
-import database.service.guild.ConfigService
 import org.springframework.stereotype.Component
 
 /**
@@ -20,7 +19,7 @@ import org.springframework.stereotype.Component
  */
 @Component
 class InstallExpressButton(
-    private val configService: ConfigService,
+    private val installCompletionService: InstallCompletionService,
 ) : OwnerOnlyInstallButton() {
 
     override val name: String = InstallWizard.BTN_EXPRESS
@@ -30,7 +29,7 @@ class InstallExpressButton(
     override fun handleAsOwner(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
         val event = ctx.event
         event.deferEdit().queue()
-        InstallSentinel.writeIfFresh(configService, ctx.guild.id, mode = "express")
+        installCompletionService.complete(ctx.guild, mode = "express", channelId = event.channel.idLong)
         event.hook.editOriginalEmbeds(InstallWizard.expressDoneEmbed())
             .setComponents()
             .queue()

--- a/discord-bot/src/main/kotlin/bot/toby/install/button/InstallExpressButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/button/InstallExpressButton.kt
@@ -31,7 +31,7 @@ class InstallExpressButton(
         event.deferEdit().queue()
         installCompletionService.complete(ctx.guild, mode = "express", channelId = event.channel.idLong)
         event.hook.editOriginalEmbeds(InstallWizard.expressDoneEmbed())
-            .setComponents()
+            .setComponents(InstallWizard.launcherRow())
             .queue()
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/install/button/InstallFinishButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/button/InstallFinishButton.kt
@@ -29,7 +29,7 @@ class InstallFinishButton(
         event.deferEdit().queue()
         installCompletionService.complete(ctx.guild, mode = "custom", channelId = event.channel.idLong)
         event.hook.editOriginalEmbeds(InstallWizard.finishDoneEmbed())
-            .setComponents()
+            .setComponents(InstallWizard.launcherRow())
             .queue()
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/install/button/InstallFinishButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/button/InstallFinishButton.kt
@@ -1,11 +1,10 @@
 package bot.toby.install.button
 
 import bot.toby.install.InstallAuth
-import bot.toby.install.InstallSentinel
+import bot.toby.install.InstallCompletionService
 import bot.toby.install.InstallWizard
 import core.button.ButtonContext
 import database.dto.user.UserDto
-import database.service.guild.ConfigService
 import org.springframework.stereotype.Component
 
 /**
@@ -18,7 +17,7 @@ import org.springframework.stereotype.Component
  */
 @Component
 class InstallFinishButton(
-    private val configService: ConfigService,
+    private val installCompletionService: InstallCompletionService,
 ) : OwnerOnlyInstallButton() {
 
     override val name: String = InstallWizard.BTN_FINISH
@@ -28,7 +27,7 @@ class InstallFinishButton(
     override fun handleAsOwner(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
         val event = ctx.event
         event.deferEdit().queue()
-        InstallSentinel.writeIfFresh(configService, ctx.guild.id, mode = "custom")
+        installCompletionService.complete(ctx.guild, mode = "custom", channelId = event.channel.idLong)
         event.hook.editOriginalEmbeds(InstallWizard.finishDoneEmbed())
             .setComponents()
             .queue()

--- a/discord-bot/src/test/kotlin/bot/toby/install/InstallCompletionServiceTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/InstallCompletionServiceTest.kt
@@ -1,0 +1,96 @@
+package bot.toby.install
+
+import database.achievement.AchievementCatalog
+import database.dto.guild.ConfigDto
+import database.dto.guild.ConfigDto.Configurations
+import database.service.economy.JackpotService
+import database.service.guild.AchievementService
+import database.service.guild.ConfigService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.entities.Guild
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class InstallCompletionServiceTest {
+
+    private lateinit var configService: ConfigService
+    private lateinit var jackpotService: JackpotService
+    private lateinit var achievementService: AchievementService
+    private lateinit var service: InstallCompletionService
+    private lateinit var guild: Guild
+
+    @BeforeEach
+    fun setUp() {
+        configService = mockk(relaxed = true)
+        jackpotService = mockk(relaxed = true)
+        achievementService = mockk(relaxed = true)
+        service = InstallCompletionService(configService, jackpotService, achievementService)
+        guild = mockk(relaxed = true) {
+            every { id } returns "g1"
+            every { idLong } returns 1L
+            every { ownerIdLong } returns 99L
+        }
+    }
+
+    private fun stubInstalledAt(value: String?) {
+        every {
+            configService.getConfigByName(Configurations.INSTALLED_AT.configValue, "g1")
+        } returns value?.let { ConfigDto(Configurations.INSTALLED_AT.configValue, it, "g1") }
+    }
+
+    @Test
+    fun `first-ever install seeds jackpot, unlocks owner achievement, and stamps the sentinel`() {
+        stubInstalledAt(null)
+
+        service.complete(guild, mode = "express", channelId = 5L)
+
+        verify(exactly = 1) {
+            jackpotService.addToPool(1L, InstallCompletionService.JACKPOT_SEED_AMOUNT)
+        }
+        verify(exactly = 1) {
+            achievementService.unlock(99L, 1L, InstallCompletionService.INSTALL_ACHIEVEMENT_CODE, 5L)
+        }
+        verify(exactly = 1) { configService.upsertAll("g1", any()) }
+    }
+
+    @Test
+    fun `returning server (INSTALLED_AT survives) does not reseed the jackpot but still unlocks`() {
+        stubInstalledAt("1700000000000")
+
+        service.complete(guild, mode = "express", channelId = null)
+
+        verify(exactly = 0) { jackpotService.addToPool(any(), any()) }
+        verify(exactly = 1) {
+            achievementService.unlock(99L, 1L, InstallCompletionService.INSTALL_ACHIEVEMENT_CODE, null)
+        }
+    }
+
+    @Test
+    fun `achievement failure is swallowed and the jackpot is still seeded`() {
+        stubInstalledAt(null)
+        every { achievementService.unlock(any(), any(), any(), any()) } throws RuntimeException("boom")
+
+        service.complete(guild, mode = "custom", channelId = 5L)
+
+        verify(exactly = 1) {
+            jackpotService.addToPool(1L, InstallCompletionService.JACKPOT_SEED_AMOUNT)
+        }
+    }
+
+    @Test
+    fun `jackpot failure is swallowed`() {
+        stubInstalledAt(null)
+        every { jackpotService.addToPool(any(), any()) } throws RuntimeException("boom")
+
+        // Must not propagate — the install UX completes regardless.
+        service.complete(guild, mode = "express", channelId = 5L)
+    }
+
+    @Test
+    fun `the install achievement code exists in the catalog`() {
+        assertNotNull(AchievementCatalog.byCode(InstallCompletionService.INSTALL_ACHIEVEMENT_CODE))
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/install/InstallWizardTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/InstallWizardTest.kt
@@ -189,6 +189,28 @@ internal class InstallWizardTest {
     }
 
     @Test
+    fun `socialProofLine is empty below the floor or when unknown`() {
+        assertEquals("", InstallWizard.socialProofLine(null))
+        assertEquals("", InstallWizard.socialProofLine(0))
+        assertEquals("", InstallWizard.socialProofLine(InstallWizard.MIN_SERVERS_FOR_SOCIAL_PROOF - 1))
+    }
+
+    @Test
+    fun `socialProofLine floors the count to the nearest ten and never overstates`() {
+        // 47 → "40+" (always rounded down so the shown number is <= the real one).
+        val line = InstallWizard.socialProofLine(47)
+        assertTrue(line.contains("40+"), "expected floored '40+' but was: $line")
+        assertEquals(false, line.contains("47"))
+        assertEquals(false, line.contains("50+"))
+    }
+
+    @Test
+    fun `welcome embed omits social proof when count is unknown but includes it when flattering`() {
+        assertEquals(false, InstallWizard.welcomeEmbed("G").description!!.contains("trusted by", ignoreCase = true))
+        assertTrue(InstallWizard.welcomeEmbed("G", 130).description!!.contains("130+"))
+    }
+
+    @Test
     fun `welcomeBack embed names the guild and reassures settings are kept`() {
         val embed = InstallWizard.welcomeBackEmbed("MyServer")
         assertTrue(embed.title!!.contains("Welcome back"))

--- a/discord-bot/src/test/kotlin/bot/toby/install/InstallWizardTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/InstallWizardTest.kt
@@ -36,6 +36,15 @@ internal class InstallWizardTest {
     }
 
     @Test
+    fun `launcherRow has the non-owner claim-daily and help buttons`() {
+        val buttons = InstallWizard.launcherRow().components.filterIsInstance<Button>()
+        assertEquals(2, buttons.size)
+        assertEquals(InstallWizard.BTN_CLAIM_DAILY, buttons[0].customId)
+        assertEquals(ButtonStyle.SUCCESS, buttons[0].style)
+        assertEquals(InstallWizard.BTN_HELP, buttons[1].customId)
+    }
+
+    @Test
     fun `backButtonRow contains the back button only`() {
         val buttons = InstallWizard.backButtonRow().components.filterIsInstance<Button>()
         assertEquals(1, buttons.size)

--- a/discord-bot/src/test/kotlin/bot/toby/install/button/InstallClaimDailyButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/button/InstallClaimDailyButtonTest.kt
@@ -1,0 +1,58 @@
+package bot.toby.install.button
+
+import bot.toby.install.InstallWizard
+import database.dto.user.UserDto
+import database.service.social.LoginStreakService
+import database.service.social.LoginStreakService.ClaimResult
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.entities.MessageEmbed
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class InstallClaimDailyButtonTest {
+
+    private lateinit var loginStreakService: LoginStreakService
+    private lateinit var button: InstallClaimDailyButton
+    private lateinit var fx: InstallButtonFixture
+
+    @BeforeEach
+    fun setUp() {
+        loginStreakService = mockk(relaxed = true)
+        button = InstallClaimDailyButton(loginStreakService)
+        fx = InstallButtonFixture()
+    }
+
+    @Test
+    fun `name matches the launcher claim-daily id`() {
+        assertEquals(InstallWizard.BTN_CLAIM_DAILY, button.name)
+    }
+
+    @Test
+    fun `defersReply is true so each clicker gets an ephemeral result`() {
+        assertEquals(true, button.defersReply)
+    }
+
+    @Test
+    fun `claims the clicking user's daily and replies, with no owner gate`() {
+        // A non-owner must still be able to claim their own reward.
+        fx.asNonOwner()
+        val requestingUser = mockk<UserDto> { every { discordId } returns 42L }
+        every { loginStreakService.claim(42L, any(), any(), any()) } returns
+            ClaimResult.Granted(
+                currentStreak = 1,
+                longestStreak = 1,
+                xpGranted = 25L,
+                creditsGranted = 50L,
+                isNewBest = true,
+            )
+
+        button.handle(fx.ctx, requestingUser, 0)
+
+        verify(exactly = 1) { loginStreakService.claim(42L, any(), any(), any()) }
+        verify(exactly = 1) { fx.hook.sendMessageEmbeds(any<MessageEmbed>(), *anyVararg<MessageEmbed>()) }
+        verify(exactly = 0) { fx.event.reply(any<String>()) }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/install/button/InstallExpressButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/button/InstallExpressButtonTest.kt
@@ -1,15 +1,11 @@
 package bot.toby.install.button
 
-import bot.toby.install.InstallWizard
+import bot.toby.install.InstallCompletionService
 import core.button.ButtonContext
-import database.dto.guild.ConfigDto
-import database.dto.guild.ConfigDto.Configurations
-import database.service.guild.ConfigService
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
-import io.mockk.slot
 import io.mockk.verify
 import net.dv8tion.jda.api.components.MessageTopLevelComponent
 import net.dv8tion.jda.api.entities.Guild
@@ -20,13 +16,12 @@ import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
 import net.dv8tion.jda.api.interactions.InteractionHook
 import net.dv8tion.jda.api.requests.restaction.WebhookMessageEditAction
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 internal class InstallExpressButtonTest {
 
-    private lateinit var configService: ConfigService
+    private lateinit var installCompletionService: InstallCompletionService
     private lateinit var button: InstallExpressButton
     private lateinit var ctx: ButtonContext
     private lateinit var event: ButtonInteractionEvent
@@ -37,8 +32,8 @@ internal class InstallExpressButtonTest {
 
     @BeforeEach
     fun setUp() {
-        configService = mockk(relaxed = true)
-        button = InstallExpressButton(configService)
+        installCompletionService = mockk(relaxed = true)
+        button = InstallExpressButton(installCompletionService)
 
         hook = mockk(relaxed = true)
         member = mockk(relaxed = true) { every { isOwner } returns true }
@@ -71,38 +66,22 @@ internal class InstallExpressButtonTest {
     }
 
     @Test
-    fun `non-owner is rejected ephemerally with no DB writes or edits`() {
+    fun `non-owner is rejected ephemerally with no completion or edits`() {
         every { member.isOwner } returns false
 
         button.handle(ctx, mockk(relaxed = true), 0)
 
         verify(exactly = 1) { event.reply(any<String>()) }
-        verify(exactly = 0) { configService.upsertAll(any(), any()) }
-        verify(exactly = 0) {
-            configService.upsertConfig(any<String>(), any<String>(), any<String>())
-        }
+        verify(exactly = 0) { installCompletionService.complete(any(), any(), any()) }
         verify(exactly = 0) { hook.editOriginalEmbeds(any<MessageEmbed>()) }
         verify(exactly = 0) { event.deferEdit() }
     }
 
     @Test
-    fun `owner happy path writes INSTALL_MODE express and INSTALLED_AT epoch via batch upsert`() {
-        // The sentinel writes flow through InstallSentinel.writeIfFresh,
-        // which now uses upsertAll for transactional cohesion (one commit
-        // instead of two).
-        val rowsSlot = slot<List<Pair<String, String>>>()
-        every { configService.upsertAll("g1", capture(rowsSlot)) } returns emptyList()
-
-        val before = System.currentTimeMillis()
+    fun `owner happy path delegates completion in express mode`() {
         button.handle(ctx, mockk(relaxed = true), 0)
-        val after = System.currentTimeMillis()
 
-        verify(exactly = 1) { configService.upsertAll("g1", any()) }
-        val rows = rowsSlot.captured
-        assertTrue(rows.size == 2)
-        assertTrue(rows[0] == Configurations.INSTALL_MODE.configValue to "express")
-        assertTrue(rows[1].first == Configurations.INSTALLED_AT.configValue)
-        assertTrue(rows[1].second.toLong() in before..after, "INSTALLED_AT epoch should be ~now")
+        verify(exactly = 1) { installCompletionService.complete(guild, "express", any()) }
     }
 
     @Test

--- a/discord-bot/src/test/kotlin/bot/toby/install/button/InstallExpressButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/button/InstallExpressButtonTest.kt
@@ -85,7 +85,7 @@ internal class InstallExpressButtonTest {
     }
 
     @Test
-    fun `owner happy path defers edit then shows done embed with stripped components`() {
+    fun `owner happy path defers edit then shows done embed with launcher components`() {
         button.handle(ctx, mockk(relaxed = true), 0)
 
         verify(exactly = 1) { event.deferEdit() }

--- a/discord-bot/src/test/kotlin/bot/toby/install/button/InstallFinishButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/button/InstallFinishButtonTest.kt
@@ -1,28 +1,24 @@
 package bot.toby.install.button
 
-import database.dto.guild.ConfigDto.Configurations
-import database.service.guild.ConfigService
-import io.mockk.every
+import bot.toby.install.InstallCompletionService
 import io.mockk.mockk
-import io.mockk.slot
 import io.mockk.verify
 import net.dv8tion.jda.api.components.MessageTopLevelComponent
 import net.dv8tion.jda.api.entities.MessageEmbed
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 internal class InstallFinishButtonTest {
 
-    private lateinit var configService: ConfigService
+    private lateinit var installCompletionService: InstallCompletionService
     private lateinit var button: InstallFinishButton
     private lateinit var fx: InstallButtonFixture
 
     @BeforeEach
     fun setUp() {
-        configService = mockk(relaxed = true)
-        button = InstallFinishButton(configService)
+        installCompletionService = mockk(relaxed = true)
+        button = InstallFinishButton(installCompletionService)
         fx = InstallButtonFixture()
     }
 
@@ -32,34 +28,21 @@ internal class InstallFinishButtonTest {
     }
 
     @Test
-    fun `non-owner is rejected with no writes or edits`() {
+    fun `non-owner is rejected with no completion or edits`() {
         fx.asNonOwner()
 
         button.handle(fx.ctx, mockk(relaxed = true), 0)
 
         verify(exactly = 1) { fx.event.reply(any<String>()) }
-        verify(exactly = 0) { configService.upsertAll(any(), any()) }
-        verify(exactly = 0) {
-            configService.upsertConfig(any<String>(), any<String>(), any<String>())
-        }
+        verify(exactly = 0) { installCompletionService.complete(any(), any(), any()) }
         verify(exactly = 0) { fx.hook.editOriginalEmbeds(any<MessageEmbed>()) }
     }
 
     @Test
-    fun `owner happy path writes INSTALL_MODE custom and INSTALLED_AT epoch via batch upsert`() {
-        val rowsSlot = slot<List<Pair<String, String>>>()
-        every { configService.upsertAll("g1", capture(rowsSlot)) } returns emptyList()
-
-        val before = System.currentTimeMillis()
+    fun `owner happy path delegates completion in custom mode`() {
         button.handle(fx.ctx, mockk(relaxed = true), 0)
-        val after = System.currentTimeMillis()
 
-        verify(exactly = 1) { configService.upsertAll("g1", any()) }
-        val rows = rowsSlot.captured
-        assertTrue(rows.size == 2)
-        assertTrue(rows[0] == Configurations.INSTALL_MODE.configValue to "custom")
-        assertTrue(rows[1].first == Configurations.INSTALLED_AT.configValue)
-        assertTrue(rows[1].second.toLong() in before..after, "INSTALLED_AT epoch should be ~now")
+        verify(exactly = 1) { installCompletionService.complete(fx.guild, "custom", any()) }
     }
 
     @Test

--- a/discord-bot/src/test/kotlin/bot/toby/install/button/InstallFinishButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/button/InstallFinishButtonTest.kt
@@ -46,7 +46,7 @@ internal class InstallFinishButtonTest {
     }
 
     @Test
-    fun `owner happy path defers edit then shows finish-done embed with stripped components`() {
+    fun `owner happy path defers edit then shows finish-done embed with launcher components`() {
         button.handle(fx.ctx, mockk(relaxed = true), 0)
 
         verify(exactly = 1) { fx.event.deferEdit() }


### PR DESCRIPTION
Closes the gap between *"setup done"* and *"value felt"* in onboarding. The install wizard already tells new owners to go type `/blackjack`; these four changes make the bot **demonstrate** its value instead, in the first few seconds after install. Each feature is an isolated commit.

### 1. One-click launcher on the post-install message (`Turn the post-install message into a one-click launcher`)
The Express/Custom "done" embeds used to just list slash commands as text the owner had to retype. They now carry a **non-owner launcher row** so the first post-setup action is a single tap:
- **🎁 Claim daily credits** — new `InstallClaimDailyButton` claims the *clicking* user's daily via the same `LoginStreakService.claim` path as `/daily`, rendered through a new shared `DailyEmbeds` so the button and command stay identical.
- **✨ What can I do?** — reuses the existing public help button.

Both are non-owner-gated, so the welcome message doubles as a shared launcher for everyone in the channel. The command list stays in the copy for people who prefer typing.

### 2. Celebratory "Welcome Aboard" achievement on install (`Celebrate install completion…`)
Completing the wizard now unlocks a new milestone achievement for the owner, which fires the existing **DM / channel / web-push** notification pipeline — so the bot's reward machinery demonstrates itself immediately instead of staying invisible until someone happens to earn something. The unlock is idempotent, so re-running `/install` never re-notifies.

### 3. Seeded server jackpot on first install (same commit as #2)
A casino showing a **$0** jackpot on the first game feels dead. The wizard now seeds the pool with a starting pot so the first `/blackjack` already shows a live, growing number. Gated on a *true* first-ever install (`INSTALLED_AT` survives a guild-leave) so a leave/re-invite cycle can't farm the pool.

Both #2 and #3 are routed through a new `InstallCompletionService` and are best-effort — failures are logged and swallowed so they can never break the install UX (matching `InstallWelcomeHandler`'s posture).

### 4. Live social proof on the welcome pitch (`Add live social-proof line…`)
The guild-join / `/install` welcome now renders an honest *"trusted by N+ servers"* line from the bot's live guild count. Floored to the nearest ten (never overstated) and suppressed entirely below a flattering threshold, so fresh/self-hosted deployments show nothing rather than an unconvincing number.

---

**Testing:** full `:database:test` and `:discord-bot:test` suites pass. Added focused unit tests for the social-proof helper, the launcher row, `InstallClaimDailyButton`, and `InstallCompletionService` (first-install vs. re-invite, failure-swallowing, catalog-code drift guard); updated the Express/Finish button tests for the new completion-service delegation and the achievement catalog invariants for the new `milestone` category.

https://claude.ai/code/session_01UCEsvqKnUcgdC74Cj2odPj

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCEsvqKnUcgdC74Cj2odPj)_