### PR TITLE
Make the post-install launcher playable, persistent, and linked to the web app

### DIFF
--- a/application/src/test/kotlin/integration/bot/ButtonManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/ButtonManagerTest.kt
@@ -11,6 +11,7 @@ import bot.toby.install.button.InstallExpressButton
 import bot.toby.install.button.InstallFeaturesButton
 import bot.toby.install.button.InstallFinishButton
 import bot.toby.install.button.InstallHelpButton
+import bot.toby.install.button.InstallQuickFlipButton
 import bot.toby.install.button.InstallSkipButton
 import bot.toby.install.button.InstallToggleButton
 import bot.toby.lavaplayer.GuildMusicManager
@@ -129,6 +130,7 @@ class ButtonManagerTest {
             InstallToggleButton::class.java,
             InstallHelpButton::class.java,
             InstallClaimDailyButton::class.java,
+            InstallQuickFlipButton::class.java,
         )
 
         assertTrue(availableButtons.containsAll(buttonManager.buttons.map { it.javaClass }.toList()))

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/game/casino/coinflip/CoinflipCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/game/casino/coinflip/CoinflipCommand.kt
@@ -4,16 +4,12 @@ import core.command.CommandContext
 import database.dto.user.UserDto
 import common.casino.coinflip.Coinflip
 import database.service.casino.coinflip.CoinflipService
-import database.service.casino.coinflip.CoinflipService.FlipOutcome
-import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.interactions.commands.build.OptionData
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 import bot.toby.command.commands.game.pvp.GameCommand
-import bot.toby.command.commands.game.WagerCommandColors
 import bot.toby.command.commands.game.WagerCommandEmbeds
-import bot.toby.command.commands.game.WagerCommandFailure
 
 /**
  * `/coinflip side:<HEADS|TAILS> stake:<int>` — fair 50/50 double-or-
@@ -36,7 +32,7 @@ class CoinflipCommand @Autowired constructor(
         private const val OPT_STAKE = "stake"
         private const val SIDE_HEADS = "HEADS"
         private const val SIDE_TAILS = "TAILS"
-        private const val TITLE = "🪙 Coinflip"
+        private val TITLE = CoinflipEmbeds.TITLE
     }
 
     override val optionData: List<OptionData> = listOf(
@@ -59,39 +55,12 @@ class CoinflipCommand @Autowired constructor(
         )?.asLong ?: return
 
         val outcome = coinflipService.flip(requestingUserDto.discordId, guild.idLong, stake, side)
-        WagerCommandEmbeds.reply(event, embedFor(outcome), deleteDelay)
+        WagerCommandEmbeds.reply(event, CoinflipEmbeds.outcome(outcome), deleteDelay)
     }
 
     private fun parseSide(raw: String?): Coinflip.Side? = when (raw) {
         SIDE_HEADS -> Coinflip.Side.HEADS
         SIDE_TAILS -> Coinflip.Side.TAILS
         else -> null
-    }
-
-    private fun embedFor(outcome: FlipOutcome) = when (outcome) {
-        is FlipOutcome.Win -> EmbedBuilder()
-            .setTitle("🪙 ${outcome.landed.display}!")
-            .setDescription("You called **${outcome.predicted.display}** and won **+${outcome.net} credits**.")
-            .addField("New balance", "${outcome.newBalance} credits", true)
-            .setColor(WagerCommandColors.WIN)
-            .build()
-
-        is FlipOutcome.Lose -> EmbedBuilder()
-            .setTitle("🪙 ${outcome.landed.display}!")
-            .setDescription("You called **${outcome.predicted.display}**. Lost **${outcome.stake} credits**.")
-            .addField("New balance", "${outcome.newBalance} credits", true)
-            .setColor(WagerCommandColors.LOSE)
-            .build()
-
-        is FlipOutcome.InsufficientCredits -> WagerCommandEmbeds.failureEmbed(
-            TITLE, WagerCommandFailure.InsufficientCredits(outcome.stake, outcome.have)
-        )
-        is FlipOutcome.InsufficientCoinsForTopUp -> WagerCommandEmbeds.failureEmbed(
-            TITLE, WagerCommandFailure.InsufficientCoinsForTopUp(outcome.needed, outcome.have)
-        )
-        is FlipOutcome.InvalidStake -> WagerCommandEmbeds.failureEmbed(
-            TITLE, WagerCommandFailure.InvalidStake(outcome.min, outcome.max)
-        )
-        FlipOutcome.UnknownUser -> WagerCommandEmbeds.failureEmbed(TITLE, WagerCommandFailure.UnknownUser)
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/game/casino/coinflip/CoinflipEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/game/casino/coinflip/CoinflipEmbeds.kt
@@ -1,0 +1,46 @@
+package bot.toby.command.commands.game.casino.coinflip
+
+import bot.toby.command.commands.game.WagerCommandColors
+import bot.toby.command.commands.game.WagerCommandEmbeds
+import bot.toby.command.commands.game.WagerCommandFailure
+import database.service.casino.coinflip.CoinflipService.FlipOutcome
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.entities.MessageEmbed
+
+/**
+ * Shared renderer for a [FlipOutcome], used by both [CoinflipCommand] and
+ * the install wizard's one-click "Flip a coin" launcher
+ * ([bot.toby.install.button.InstallQuickFlipButton]) so the slash command
+ * and the button can't drift on copy or colours.
+ */
+object CoinflipEmbeds {
+
+    const val TITLE: String = "🪙 Coinflip"
+
+    fun outcome(outcome: FlipOutcome): MessageEmbed = when (outcome) {
+        is FlipOutcome.Win -> EmbedBuilder()
+            .setTitle("🪙 ${outcome.landed.display}!")
+            .setDescription("You called **${outcome.predicted.display}** and won **+${outcome.net} credits**.")
+            .addField("New balance", "${outcome.newBalance} credits", true)
+            .setColor(WagerCommandColors.WIN)
+            .build()
+
+        is FlipOutcome.Lose -> EmbedBuilder()
+            .setTitle("🪙 ${outcome.landed.display}!")
+            .setDescription("You called **${outcome.predicted.display}**. Lost **${outcome.stake} credits**.")
+            .addField("New balance", "${outcome.newBalance} credits", true)
+            .setColor(WagerCommandColors.LOSE)
+            .build()
+
+        is FlipOutcome.InsufficientCredits -> WagerCommandEmbeds.failureEmbed(
+            TITLE, WagerCommandFailure.InsufficientCredits(outcome.stake, outcome.have)
+        )
+        is FlipOutcome.InsufficientCoinsForTopUp -> WagerCommandEmbeds.failureEmbed(
+            TITLE, WagerCommandFailure.InsufficientCoinsForTopUp(outcome.needed, outcome.have)
+        )
+        is FlipOutcome.InvalidStake -> WagerCommandEmbeds.failureEmbed(
+            TITLE, WagerCommandFailure.InvalidStake(outcome.min, outcome.max)
+        )
+        FlipOutcome.UnknownUser -> WagerCommandEmbeds.failureEmbed(TITLE, WagerCommandFailure.UnknownUser)
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/install/InstallWizard.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/InstallWizard.kt
@@ -258,12 +258,25 @@ object InstallWizard {
      * slash command: play a real coinflip, claim daily credits, or open the
      * full feature tour. Every button is non-owner-gated — the message
      * doubles as a shared launcher for everyone in the channel.
+     *
+     * When [webBaseUrl] is configured (and [guildId] known) a deep-link
+     * button to the web dashboard's guild profile is appended — the same
+     * `"$webBaseUrl/profile/$guildId"` page the achievement web-push points
+     * at, so the owner can see the "Welcome Aboard" badge they just earned.
+     * The link is omitted when the base URL is unset (self-hosters without a
+     * public dashboard), exactly as the push deep links degrade.
      */
-    fun launcherRow(): ActionRow = ActionRow.of(
-        Button.primary(BTN_QUICK_FLIP, "🪙 Flip a coin"),
-        Button.success(BTN_CLAIM_DAILY, "🎁 Claim daily credits"),
-        Button.secondary(BTN_HELP, "✨ What can I do?"),
-    )
+    fun launcherRow(guildId: String? = null, webBaseUrl: String? = null): ActionRow {
+        val buttons = mutableListOf(
+            Button.primary(BTN_QUICK_FLIP, "🪙 Flip a coin"),
+            Button.success(BTN_CLAIM_DAILY, "🎁 Claim daily credits"),
+            Button.secondary(BTN_HELP, "✨ What can I do?"),
+        )
+        if (!webBaseUrl.isNullOrBlank() && !guildId.isNullOrBlank()) {
+            buttons += Button.link("$webBaseUrl/profile/$guildId", "🌐 View your profile")
+        }
+        return ActionRow.of(buttons)
+    }
 
     fun backButtonRow(): ActionRow = ActionRow.of(
         Button.secondary(BTN_BACK, "← Back"),

--- a/discord-bot/src/main/kotlin/bot/toby/install/InstallWizard.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/InstallWizard.kt
@@ -52,6 +52,14 @@ object InstallWizard {
      * [bot.toby.install.button.InstallClaimDailyButton].
      */
     const val BTN_CLAIM_DAILY = "install_claim_daily"
+
+    /**
+     * Public (non-owner) launcher on the post-install "done" message —
+     * anyone can tap it to play one real coinflip at the minimum stake, so
+     * the casino is demonstrated (not just described) in a single click.
+     * Handled by [bot.toby.install.button.InstallQuickFlipButton].
+     */
+    const val BTN_QUICK_FLIP = "install_quick_flip"
     const val BTN_FINISH = "install_finish"
     const val BTN_BACK = "install_category_back"
     const val BTN_FEATURES = "install_features"
@@ -247,11 +255,12 @@ object InstallWizard {
     /**
      * One-click launcher row left on the post-install "done" message so the
      * owner's (or any member's) very first action is a tap, not a typed
-     * slash command: claim daily credits, or open the full feature tour.
-     * Both buttons are non-owner-gated — the welcome message doubles as a
-     * shared launcher for everyone in the channel.
+     * slash command: play a real coinflip, claim daily credits, or open the
+     * full feature tour. Every button is non-owner-gated — the message
+     * doubles as a shared launcher for everyone in the channel.
      */
     fun launcherRow(): ActionRow = ActionRow.of(
+        Button.primary(BTN_QUICK_FLIP, "🪙 Flip a coin"),
         Button.success(BTN_CLAIM_DAILY, "🎁 Claim daily credits"),
         Button.secondary(BTN_HELP, "✨ What can I do?"),
     )

--- a/discord-bot/src/main/kotlin/bot/toby/install/button/InstallExpressButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/button/InstallExpressButton.kt
@@ -5,6 +5,7 @@ import bot.toby.install.InstallCompletionService
 import bot.toby.install.InstallWizard
 import core.button.ButtonContext
 import database.dto.user.UserDto
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 
 /**
@@ -20,6 +21,7 @@ import org.springframework.stereotype.Component
 @Component
 class InstallExpressButton(
     private val installCompletionService: InstallCompletionService,
+    @param:Value($$"${app.base-url:}") private val webBaseUrl: String = "",
 ) : OwnerOnlyInstallButton() {
 
     override val name: String = InstallWizard.BTN_EXPRESS
@@ -31,7 +33,7 @@ class InstallExpressButton(
         event.deferEdit().queue()
         installCompletionService.complete(ctx.guild, mode = "express", channelId = event.channel.idLong)
         event.hook.editOriginalEmbeds(InstallWizard.expressDoneEmbed())
-            .setComponents(InstallWizard.launcherRow())
+            .setComponents(InstallWizard.launcherRow(ctx.guild.id, webBaseUrl))
             .queue()
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/install/button/InstallExpressButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/button/InstallExpressButton.kt
@@ -35,5 +35,6 @@ class InstallExpressButton(
         event.hook.editOriginalEmbeds(InstallWizard.expressDoneEmbed())
             .setComponents(InstallWizard.launcherRow(ctx.guild.id, webBaseUrl))
             .queue()
+        pinAsControlPanel(event.message)
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/install/button/InstallFinishButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/button/InstallFinishButton.kt
@@ -33,5 +33,6 @@ class InstallFinishButton(
         event.hook.editOriginalEmbeds(InstallWizard.finishDoneEmbed())
             .setComponents(InstallWizard.launcherRow(ctx.guild.id, webBaseUrl))
             .queue()
+        pinAsControlPanel(event.message)
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/install/button/InstallFinishButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/button/InstallFinishButton.kt
@@ -5,6 +5,7 @@ import bot.toby.install.InstallCompletionService
 import bot.toby.install.InstallWizard
 import core.button.ButtonContext
 import database.dto.user.UserDto
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 
 /**
@@ -18,6 +19,7 @@ import org.springframework.stereotype.Component
 @Component
 class InstallFinishButton(
     private val installCompletionService: InstallCompletionService,
+    @param:Value($$"${app.base-url:}") private val webBaseUrl: String = "",
 ) : OwnerOnlyInstallButton() {
 
     override val name: String = InstallWizard.BTN_FINISH
@@ -29,7 +31,7 @@ class InstallFinishButton(
         event.deferEdit().queue()
         installCompletionService.complete(ctx.guild, mode = "custom", channelId = event.channel.idLong)
         event.hook.editOriginalEmbeds(InstallWizard.finishDoneEmbed())
-            .setComponents(InstallWizard.launcherRow())
+            .setComponents(InstallWizard.launcherRow(ctx.guild.id, webBaseUrl))
             .queue()
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/install/button/InstallQuickFlipButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/button/InstallQuickFlipButton.kt
@@ -1,0 +1,45 @@
+package bot.toby.install.button
+
+import bot.toby.command.commands.game.casino.coinflip.CoinflipEmbeds
+import bot.toby.install.InstallWizard
+import common.casino.coinflip.Coinflip
+import core.button.Button
+import core.button.ButtonContext
+import database.dto.user.UserDto
+import database.service.casino.coinflip.CoinflipService
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+/**
+ * "🪙 Flip a coin" — the non-owner launcher button left on the post-install
+ * "done" message. Anyone can tap it to play one real coinflip (calling
+ * heads) at the minimum stake, so a brand-new server *sees the casino work*
+ * in a single click instead of being told to go type `/coinflip`.
+ *
+ * Plays through [CoinflipService.flip] (the same path as
+ * [bot.toby.command.commands.game.casino.coinflip.CoinflipCommand]) and
+ * renders via the shared [CoinflipEmbeds], so the button and command can't
+ * drift. Uses the default ephemeral [Button.defersReply] ack — each clicker
+ * stakes their own credits and gets their own private result. If they're
+ * out of credits or below the per-guild stake floor, the shared embed says
+ * so (and the sibling "Claim daily" button is right next to it).
+ */
+@Component
+class InstallQuickFlipButton @Autowired constructor(
+    private val coinflipService: CoinflipService,
+) : Button {
+
+    override val name: String = InstallWizard.BTN_QUICK_FLIP
+    override val description: String =
+        "Play one quick coinflip straight from the welcome message — usable by anyone, not just the owner."
+
+    override fun handle(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val outcome = coinflipService.flip(
+            discordId = requestingUserDto.discordId,
+            guildId = ctx.guild.idLong,
+            stake = Coinflip.MIN_STAKE,
+            predicted = Coinflip.Side.HEADS,
+        )
+        ctx.event.hook.sendMessageEmbeds(CoinflipEmbeds.outcome(outcome)).queue()
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/install/button/OwnerOnlyInstallButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/button/OwnerOnlyInstallButton.kt
@@ -4,6 +4,7 @@ import bot.toby.install.InstallAuth
 import core.button.Button
 import core.button.ButtonContext
 import database.dto.user.UserDto
+import net.dv8tion.jda.api.entities.Message
 
 /**
  * Shared base for every install-wizard button. Centralizes:
@@ -39,4 +40,21 @@ abstract class OwnerOnlyInstallButton : Button {
         requestingUserDto: UserDto,
         deleteDelay: Int,
     )
+
+    /**
+     * Best-effort pin of the post-install "done" [message] so it lingers as
+     * a persistent control panel — the launcher buttons stay one tap away
+     * instead of scrolling out of sight. Purely cosmetic: pinning needs
+     * Manage Messages and can hit the 50-pin cap, so any failure (sync
+     * permission precheck or async REST error) is logged at warn and
+     * swallowed rather than disrupting the install flow.
+     */
+    protected fun pinAsControlPanel(message: Message) {
+        runCatching {
+            message.pin().queue(
+                { logger.info { "Pinned install control panel ${message.id}" } },
+                { err -> logger.warn { "Could not pin install control panel ${message.id}: ${err.message}" } },
+            )
+        }.onFailure { logger.warn { "Could not pin install control panel ${message.id}: ${it.message}" } }
+    }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/install/InstallWizardTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/InstallWizardTest.kt
@@ -46,6 +46,23 @@ internal class InstallWizardTest {
     }
 
     @Test
+    fun `launcherRow appends a profile deep-link button when a base url is configured`() {
+        val buttons = InstallWizard.launcherRow("g123", "https://toby-bot.co.uk")
+            .components.filterIsInstance<Button>()
+        assertEquals(4, buttons.size)
+        // Link buttons carry a url (and no componentId), pointing at the same
+        // /profile/{guildId} page the achievement web-push deep-links to.
+        assertEquals("https://toby-bot.co.uk/profile/g123", buttons[3].url)
+    }
+
+    @Test
+    fun `launcherRow omits the deep-link when the base url is unset`() {
+        assertEquals(3, InstallWizard.launcherRow("g123", "").components.filterIsInstance<Button>().size)
+        assertEquals(3, InstallWizard.launcherRow("g123", null).components.filterIsInstance<Button>().size)
+        assertEquals(3, InstallWizard.launcherRow(null, "https://x").components.filterIsInstance<Button>().size)
+    }
+
+    @Test
     fun `backButtonRow contains the back button only`() {
         val buttons = InstallWizard.backButtonRow().components.filterIsInstance<Button>()
         assertEquals(1, buttons.size)

--- a/discord-bot/src/test/kotlin/bot/toby/install/InstallWizardTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/InstallWizardTest.kt
@@ -36,12 +36,13 @@ internal class InstallWizardTest {
     }
 
     @Test
-    fun `launcherRow has the non-owner claim-daily and help buttons`() {
+    fun `launcherRow has the non-owner quick-flip, claim-daily and help buttons`() {
         val buttons = InstallWizard.launcherRow().components.filterIsInstance<Button>()
-        assertEquals(2, buttons.size)
-        assertEquals(InstallWizard.BTN_CLAIM_DAILY, buttons[0].customId)
-        assertEquals(ButtonStyle.SUCCESS, buttons[0].style)
-        assertEquals(InstallWizard.BTN_HELP, buttons[1].customId)
+        assertEquals(3, buttons.size)
+        assertEquals(InstallWizard.BTN_QUICK_FLIP, buttons[0].customId)
+        assertEquals(InstallWizard.BTN_CLAIM_DAILY, buttons[1].customId)
+        assertEquals(ButtonStyle.SUCCESS, buttons[1].style)
+        assertEquals(InstallWizard.BTN_HELP, buttons[2].customId)
     }
 
     @Test

--- a/discord-bot/src/test/kotlin/bot/toby/install/button/InstallFinishButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/button/InstallFinishButtonTest.kt
@@ -56,4 +56,20 @@ internal class InstallFinishButtonTest {
         }
         verify(exactly = 1) { fx.editAction.queue() }
     }
+
+    @Test
+    fun `owner happy path pins the done message as a control panel`() {
+        button.handle(fx.ctx, mockk(relaxed = true), 0)
+
+        verify(exactly = 1) { fx.message.pin() }
+    }
+
+    @Test
+    fun `non-owner does not pin`() {
+        fx.asNonOwner()
+
+        button.handle(fx.ctx, mockk(relaxed = true), 0)
+
+        verify(exactly = 0) { fx.message.pin() }
+    }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/install/button/InstallQuickFlipButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/button/InstallQuickFlipButtonTest.kt
@@ -1,0 +1,63 @@
+package bot.toby.install.button
+
+import bot.toby.install.InstallWizard
+import common.casino.coinflip.Coinflip
+import database.dto.user.UserDto
+import database.service.casino.coinflip.CoinflipService
+import database.service.casino.coinflip.CoinflipService.FlipOutcome
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.entities.MessageEmbed
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class InstallQuickFlipButtonTest {
+
+    private lateinit var coinflipService: CoinflipService
+    private lateinit var button: InstallQuickFlipButton
+    private lateinit var fx: InstallButtonFixture
+
+    @BeforeEach
+    fun setUp() {
+        coinflipService = mockk(relaxed = true)
+        button = InstallQuickFlipButton(coinflipService)
+        fx = InstallButtonFixture()
+    }
+
+    @Test
+    fun `name matches the launcher quick-flip id`() {
+        assertEquals(InstallWizard.BTN_QUICK_FLIP, button.name)
+    }
+
+    @Test
+    fun `defersReply is true so each clicker gets an ephemeral result`() {
+        assertEquals(true, button.defersReply)
+    }
+
+    @Test
+    fun `flips the minimum stake on heads for the clicking user, with no owner gate`() {
+        // A non-owner must still be able to play their own flip.
+        fx.asNonOwner()
+        val requestingUser = mockk<UserDto> { every { discordId } returns 42L }
+        every {
+            coinflipService.flip(42L, any(), Coinflip.MIN_STAKE, Coinflip.Side.HEADS, any(), any(), any(), any())
+        } returns FlipOutcome.Win(
+            stake = Coinflip.MIN_STAKE,
+            payout = Coinflip.MIN_STAKE * 2,
+            net = Coinflip.MIN_STAKE,
+            landed = Coinflip.Side.HEADS,
+            predicted = Coinflip.Side.HEADS,
+            newBalance = 110L,
+        )
+
+        button.handle(fx.ctx, requestingUser, 0)
+
+        verify(exactly = 1) {
+            coinflipService.flip(42L, any(), Coinflip.MIN_STAKE, Coinflip.Side.HEADS, any(), any(), any(), any())
+        }
+        verify(exactly = 1) { fx.hook.sendMessageEmbeds(any<MessageEmbed>(), *anyVararg<MessageEmbed>()) }
+        verify(exactly = 0) { fx.event.reply(any<String>()) }
+    }
+}


### PR DESCRIPTION
Follow-up to #680. That PR turned the post-install "done" message into a one-click launcher (claim daily + help). This extends that launcher into a genuine, durable control panel. Three isolated commits:

### 1. A one-click coinflip on the launcher (`Add a one-click coinflip…`)
Adds a **🪙 Flip a coin** button so a new member plays a *real* casino game in a single tap instead of being told to type `/coinflip`. The new `InstallQuickFlipButton` plays one coinflip (calling heads) at the minimum stake via the same `CoinflipService.flip` path as the slash command, rendered through a newly-extracted shared `CoinflipEmbeds` so the two surfaces can't drift. Non-owner-gated + ephemeral like the other launcher buttons; insufficient-funds / out-of-range outcomes render the shared failure embed (with *Claim daily* right beside it).

### 2. A web-dashboard deep-link on the launcher (`Add a web-dashboard deep-link…`)
When `app.base-url` is configured, appends a **🌐 View your profile** link button pointing at `$webBaseUrl/profile/$guildId` — the same dashboard page the achievement web-push deep-links to — so right after setup the owner can jump to the web UI and see the "Welcome Aboard" badge they just earned. Omitted entirely when the base URL is unset, exactly as the push deep links already degrade.

### 3. Pin the launcher as a persistent control panel (`Pin the post-install message…`)
Best-effort pins the done message after setup so the launcher row stays one tap away instead of scrolling off — onboarding becomes a durable surface, not a one-shot moment. Pinning needs Manage Messages and can hit the 50-pin cap, so failures are logged and swallowed via a shared `OwnerOnlyInstallButton` helper.

The launcher row now reads: **🪙 Flip a coin · 🎁 Claim daily credits · ✨ What can I do? · 🌐 View your profile** (the last only when a dashboard URL is configured).

---

**Testing:** `:database:test` and `:discord-bot:test` pass locally. Added unit tests for `InstallQuickFlipButton`, the launcher row's flip + deep-link variants, and the pin behaviour; registered the new button in the `ButtonManagerTest` integration list (that module's Spring/Testcontainers integration tests need Docker, which isn't available in this sandbox, so I verified that list change by inspection — it was the one real failure CI caught last time and I've kept it in lockstep).

https://claude.ai/code/session_01UCEsvqKnUcgdC74Cj2odPj

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCEsvqKnUcgdC74Cj2odPj)_