### PR TITLE
Add /install summary + a View setup control-panel button

### DIFF
--- a/application/src/test/kotlin/integration/bot/ButtonManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/ButtonManagerTest.kt
@@ -13,6 +13,7 @@ import bot.toby.install.button.InstallFinishButton
 import bot.toby.install.button.InstallHelpButton
 import bot.toby.install.button.InstallQuickFlipButton
 import bot.toby.install.button.InstallSkipButton
+import bot.toby.install.button.InstallSummaryButton
 import bot.toby.install.button.InstallToggleButton
 import bot.toby.lavaplayer.GuildMusicManager
 import bot.toby.lavaplayer.PlayerManager
@@ -131,6 +132,7 @@ class ButtonManagerTest {
             InstallHelpButton::class.java,
             InstallClaimDailyButton::class.java,
             InstallQuickFlipButton::class.java,
+            InstallSummaryButton::class.java,
         )
 
         assertTrue(availableButtons.containsAll(buttonManager.buttons.map { it.javaClass }.toList()))

--- a/discord-bot/src/main/kotlin/bot/toby/install/InstallCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/InstallCommand.kt
@@ -3,19 +3,41 @@ package bot.toby.install
 import bot.toby.command.commands.moderation.ModerationCommand
 import core.command.CommandContext
 import database.dto.user.UserDto
+import database.service.economy.JackpotService
+import database.service.guild.ConfigService
+import net.dv8tion.jda.api.interactions.commands.build.SubcommandData
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 
 /**
- * `/install` — owner-only. Opens the in-Discord install wizard (welcome
- * embed + Express / Custom / Skip buttons). Always re-runnable; idempotency
- * for the auto-welcome on guild-join is enforced by the
- * [InstallWelcomeHandler] checking the `INSTALL_MODE` sentinel.
+ * `/install` — owner-only, two subcommands:
+ *
+ *  - `/install setup` opens the in-Discord install wizard (welcome embed +
+ *    Express / Custom / Skip buttons). Always re-runnable; idempotency for
+ *    the auto-welcome on guild-join is enforced by [InstallWelcomeHandler].
+ *  - `/install summary` shows the current per-guild configuration snapshot
+ *    plus recommended next steps (see [InstallSummary]).
+ *
+ * Responds directly (the wizard posts publicly; the summary is ephemeral),
+ * so it opts out of the manager's auto-defer with `defersReply = false`,
+ * matching the other direct-reply moderation command (`/setconfig`).
  */
 @Component
-class InstallCommand : ModerationCommand {
+class InstallCommand(
+    private val configService: ConfigService,
+    private val jackpotService: JackpotService,
+    @param:Value($$"${app.base-url:}") private val webBaseUrl: String = "",
+) : ModerationCommand {
 
     override val name = "install"
-    override val description = "Owner-only — open the bot's install / setup wizard."
+    override val description = "Owner-only — set up the bot or review your current setup."
+
+    override val defersReply: Boolean = false
+
+    override val subCommands: List<SubcommandData> = listOf(
+        SubcommandData(SUB_SETUP, "Open the install / setup wizard."),
+        SubcommandData(SUB_SUMMARY, "Show your current setup and recommended next steps."),
+    )
 
     override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
         val event = ctx.event
@@ -24,8 +46,31 @@ class InstallCommand : ModerationCommand {
             event.reply("This command can only be used in a server.").setEphemeral(true).queue()
             return
         }
-        event.replyEmbeds(InstallWizard.welcomeEmbed(guild.name, event.jda.guildCache.size().toInt()))
-            .addComponents(InstallWizard.wizardButtons())
-            .queue()
+
+        when (event.subcommandName) {
+            SUB_SUMMARY -> {
+                val reader = InstallWizard.configReader(configService, guild.id)
+                event.replyEmbeds(
+                    InstallSummary.embed(
+                        guild = guild,
+                        reader = reader,
+                        jackpotPool = jackpotService.getPool(guild.idLong),
+                        winChanceDisplay = jackpotService.winProbabilityDisplay(guild.idLong),
+                        webBaseUrl = webBaseUrl,
+                    ),
+                ).setEphemeral(true).queue()
+            }
+            // SUB_SETUP (and any unexpected/null subcommand) opens the wizard.
+            else -> {
+                event.replyEmbeds(InstallWizard.welcomeEmbed(guild.name, event.jda.guildCache.size().toInt()))
+                    .addComponents(InstallWizard.wizardButtons())
+                    .queue()
+            }
+        }
+    }
+
+    companion object {
+        const val SUB_SETUP = "setup"
+        const val SUB_SUMMARY = "summary"
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/install/InstallSummary.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/InstallSummary.kt
@@ -1,0 +1,118 @@
+package bot.toby.install
+
+import common.casino.coinflip.Coinflip
+import database.dto.guild.ConfigDto.Configurations
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.MessageEmbed
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+
+/**
+ * Builds the owner-facing "how is this server set up?" snapshot rendered by
+ * `/install summary` and the control panel's "View setup" button. Pure: it
+ * takes a [ConfigReader] plus the already-computed economy values (so the
+ * caller owns the service wiring and this stays trivially testable), reads
+ * the high-signal config, resolves channel ids against [Guild], and — the
+ * valuable part — flags recommended-but-unset settings as next steps rather
+ * than dumping the whole 100-key schema.
+ */
+object InstallSummary {
+
+    private val DATE_FMT: DateTimeFormatter =
+        DateTimeFormatter.ofPattern("d MMM yyyy").withZone(ZoneOffset.UTC)
+
+    /** Channel configs surfaced in the summary, in display order. */
+    private val CHANNEL_LINES: List<Pair<String, Configurations>> = listOf(
+        "Leaderboard" to Configurations.LEADERBOARD_CHANNEL,
+        "Level-up announce" to Configurations.LEVEL_UP_CHANNEL,
+        "Achievement announce" to Configurations.ACHIEVEMENT_ANNOUNCE_CHANNEL,
+        "Casino modlog" to Configurations.CASINO_MODLOG_CHANNEL_ID,
+        "Move target" to Configurations.MOVE,
+    )
+
+    fun embed(
+        guild: Guild,
+        reader: ConfigReader,
+        jackpotPool: Long,
+        winChanceDisplay: String,
+        webBaseUrl: String,
+    ): MessageEmbed {
+        val mode = reader(Configurations.INSTALL_MODE)
+        val builder = EmbedBuilder()
+            .setTitle("⚙️ Toby Bot — setup summary for ${guild.name}")
+            .setDescription(headerLine(mode, reader(Configurations.INSTALLED_AT)?.toLongOrNull()))
+
+        val coinMin = reader(Configurations.COINFLIP_MIN_STAKE)?.toLongOrNull() ?: Coinflip.MIN_STAKE
+        val coinMax = reader(Configurations.COINFLIP_MAX_STAKE)?.toLongOrNull() ?: Coinflip.MAX_STAKE
+        builder.addField(
+            "🎲 Casino & economy",
+            "Jackpot pool: **$jackpotPool** 💰\n" +
+                "Jackpot win chance: **$winChanceDisplay%**\n" +
+                "Coinflip stakes: $coinMin–$coinMax credits",
+            false,
+        )
+
+        val features = OptInFeatures.entries.joinToString("\n") { f ->
+            "${if (reader(f.key) == "true") "✅" else "⬜"} ${f.label}"
+        }
+        builder.addField(
+            "✨ Features",
+            "✅ Casino & games · ✅ Music · ✅ Daily streak\n$features",
+            false,
+        )
+
+        val channels = CHANNEL_LINES.joinToString("\n") { (label, key) ->
+            val mention = reader(key)?.toLongOrNull()?.let { guild.getGuildChannelById(it)?.asMention }
+            "$label: ${mention ?: "*not set*"}"
+        }
+        builder.addField("📺 Channels", channels, false)
+
+        builder.addField(
+            "🌐 Web dashboard",
+            if (webBaseUrl.isNotBlank()) "[Open your dashboard]($webBaseUrl/profile/${guild.id})"
+            else "Not configured for this deployment.",
+            false,
+        )
+
+        buildSuggestions(reader).takeIf { it.isNotEmpty() }?.let { tips ->
+            builder.addField("💡 Suggested next steps", tips.joinToString("\n") { "• $it" }, false)
+        }
+
+        builder.setFooter("Owner-only · reflects your current config")
+        return builder.build()
+    }
+
+    private fun headerLine(mode: String?, installedAt: Long?): String {
+        if (mode.isNullOrBlank()) {
+            return "⚠️ Setup isn't finished yet — run `/install setup` to get going."
+        }
+        val date = installedAt?.let { DATE_FMT.format(Instant.ofEpochMilli(it)) } ?: "an earlier date"
+        val modeLabel = mode.replaceFirstChar { it.uppercase() }
+        return "Installed **$modeLabel** · $date · re-run `/install setup` to change anything."
+    }
+
+    private fun buildSuggestions(reader: ConfigReader): List<String> {
+        val out = mutableListOf<String>()
+        val activityOn = reader(Configurations.ACTIVITY_TRACKING) == "true"
+        val lotteryOn = reader(Configurations.LOTTERY_DAILY_ENABLED) == "true"
+
+        if (!activityOn) {
+            out += "Turn on **Activity tracking** for XP & leaderboards — `/install setup` → Optional features."
+        }
+        if (!lotteryOn) {
+            out += "Enable the **Daily lottery** for a server-wide draw — `/install setup` → Optional features."
+        }
+        if (reader(Configurations.LEADERBOARD_CHANNEL)?.toLongOrNull() == null) {
+            out += "Set a **leaderboard channel** so winners get a public shoutout — `/setconfig general`."
+        }
+        if (activityOn && reader(Configurations.LEVEL_UP_CHANNEL)?.toLongOrNull() == null) {
+            out += "Set a **level-up announce channel** — `/setconfig activity`."
+        }
+        if (reader(Configurations.ACHIEVEMENT_ANNOUNCE_CHANNEL)?.toLongOrNull() == null) {
+            out += "Set an **achievement announce channel** for public unlock shoutouts."
+        }
+        return out
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/install/InstallWizard.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/InstallWizard.kt
@@ -60,6 +60,14 @@ object InstallWizard {
      * Handled by [bot.toby.install.button.InstallQuickFlipButton].
      */
     const val BTN_QUICK_FLIP = "install_quick_flip"
+
+    /**
+     * Owner-only launcher button on the post-install "done" message — opens
+     * the ephemeral setup summary (same content as `/install summary`).
+     * Handled by [bot.toby.install.button.InstallSummaryButton]. Non-owners
+     * who click it get the standard owner-only ephemeral reject.
+     */
+    const val BTN_VIEW_SETUP = "install_view_setup"
     const val BTN_FINISH = "install_finish"
     const val BTN_BACK = "install_category_back"
     const val BTN_FEATURES = "install_features"
@@ -259,18 +267,21 @@ object InstallWizard {
      * full feature tour. Every button is non-owner-gated — the message
      * doubles as a shared launcher for everyone in the channel.
      *
-     * When [webBaseUrl] is configured (and [guildId] known) a deep-link
-     * button to the web dashboard's guild profile is appended — the same
-     * `"$webBaseUrl/profile/$guildId"` page the achievement web-push points
-     * at, so the owner can see the "Welcome Aboard" badge they just earned.
-     * The link is omitted when the base URL is unset (self-hosters without a
-     * public dashboard), exactly as the push deep links degrade.
+     * The owner-only **View setup** button is always present (non-owners get
+     * an ephemeral reject on click). When [webBaseUrl] is configured (and
+     * [guildId] known) a deep-link button to the web dashboard's guild
+     * profile is also appended — the same `"$webBaseUrl/profile/$guildId"`
+     * page the achievement web-push points at, so the owner can see the
+     * "Welcome Aboard" badge they just earned. The link is omitted when the
+     * base URL is unset (self-hosters without a public dashboard), exactly
+     * as the push deep links degrade.
      */
     fun launcherRow(guildId: String? = null, webBaseUrl: String? = null): ActionRow {
         val buttons = mutableListOf(
             Button.primary(BTN_QUICK_FLIP, "🪙 Flip a coin"),
             Button.success(BTN_CLAIM_DAILY, "🎁 Claim daily credits"),
             Button.secondary(BTN_HELP, "✨ What can I do?"),
+            Button.secondary(BTN_VIEW_SETUP, "⚙️ View setup"),
         )
         if (!webBaseUrl.isNullOrBlank() && !guildId.isNullOrBlank()) {
             buttons += Button.link("$webBaseUrl/profile/$guildId", "🌐 View your profile")

--- a/discord-bot/src/main/kotlin/bot/toby/install/button/InstallSummaryButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/button/InstallSummaryButton.kt
@@ -1,0 +1,46 @@
+package bot.toby.install.button
+
+import bot.toby.install.InstallSummary
+import bot.toby.install.InstallWizard
+import core.button.ButtonContext
+import database.dto.user.UserDto
+import database.service.economy.JackpotService
+import database.service.guild.ConfigService
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+/**
+ * "⚙️ View setup" — owner-only launcher button on the post-install control
+ * panel. Replies (ephemerally) with the same setup summary as
+ * `/install summary`, so the owner can audit the current config and see
+ * recommended next steps without re-running the whole wizard.
+ *
+ * Extends [OwnerOnlyInstallButton] for the owner gate; unlike its siblings
+ * it doesn't edit the source message — it sends a fresh ephemeral reply
+ * (the control panel stays put). Owner gate plus `defersReply = false`
+ * means the interaction is un-acked here, so a direct `reply` is correct.
+ */
+@Component
+class InstallSummaryButton(
+    private val configService: ConfigService,
+    private val jackpotService: JackpotService,
+    @param:Value($$"${app.base-url:}") private val webBaseUrl: String = "",
+) : OwnerOnlyInstallButton() {
+
+    override val name: String = InstallWizard.BTN_VIEW_SETUP
+    override val description: String = "Owner-only — show the current setup summary."
+
+    override fun handleAsOwner(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val guild = ctx.guild
+        val reader = InstallWizard.configReader(configService, guild.id)
+        ctx.event.replyEmbeds(
+            InstallSummary.embed(
+                guild = guild,
+                reader = reader,
+                jackpotPool = jackpotService.getPool(guild.idLong),
+                winChanceDisplay = jackpotService.winProbabilityDisplay(guild.idLong),
+                webBaseUrl = webBaseUrl,
+            ),
+        ).setEphemeral(true).queue()
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/install/InstallCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/InstallCommandTest.kt
@@ -7,16 +7,18 @@ import bot.toby.command.CommandTest.Companion.member
 import bot.toby.command.CommandTest.Companion.replyCallbackAction
 import bot.toby.command.CommandTest.Companion.requestingUserDto
 import bot.toby.command.DefaultCommandContext
+import database.service.economy.JackpotService
+import database.service.guild.ConfigService
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.just
+import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.slot
 import io.mockk.verify
 import net.dv8tion.jda.api.components.actionrow.ActionRow
 import net.dv8tion.jda.api.components.buttons.Button
 import net.dv8tion.jda.api.entities.MessageEmbed
-import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -25,17 +27,22 @@ import org.junit.jupiter.api.Test
 
 internal class InstallCommandTest : CommandTest {
 
+    private lateinit var configService: ConfigService
+    private lateinit var jackpotService: JackpotService
     private lateinit var command: InstallCommand
 
     @BeforeEach
     fun setUp() {
         setUpCommonMocks()
-        command = InstallCommand()
+        configService = mockk(relaxed = true)
+        jackpotService = mockk(relaxed = true)
+        command = InstallCommand(configService, jackpotService)
         every { event.reply(any<String>()) } returns replyCallbackAction
         every { event.replyEmbeds(any<MessageEmbed>()) } returns replyCallbackAction
         every { replyCallbackAction.addComponents(any<ActionRow>()) } returns replyCallbackAction
         every { guild.name } returns "Test Guild"
         every { member.isOwner } returns true
+        every { event.subcommandName } returns InstallCommand.SUB_SETUP
     }
 
     @AfterEach
@@ -45,13 +52,18 @@ internal class InstallCommandTest : CommandTest {
     }
 
     @Test
-    fun `name is install`() {
+    fun `name is install with setup and summary subcommands`() {
         assertEquals("install", command.name)
-        assertTrue(command.subCommands.isEmpty(), "install has no subcommands")
+        assertEquals(
+            listOf(InstallCommand.SUB_SETUP, InstallCommand.SUB_SUMMARY),
+            command.subCommands.map { it.name },
+        )
+        // Direct-reply command: must opt out of the manager's auto-defer.
+        assertEquals(false, command.defersReply)
     }
 
     @Test
-    fun `non-owner gets ephemeral reject and no welcome posted`() {
+    fun `non-owner gets ephemeral reject and nothing posted`() {
         every { member.isOwner } returns false
 
         command.handle(DefaultCommandContext(event), requestingUserDto, 0)
@@ -75,7 +87,8 @@ internal class InstallCommandTest : CommandTest {
     }
 
     @Test
-    fun `owner happy path posts welcome embed and the three wizard buttons`() {
+    fun `setup subcommand posts the welcome embed and wizard buttons`() {
+        every { event.subcommandName } returns InstallCommand.SUB_SETUP
         val embedSlot = slot<MessageEmbed>()
         val componentsSlot = slot<ActionRow>()
         every { event.replyEmbeds(capture(embedSlot)) } returns replyCallbackAction
@@ -86,14 +99,28 @@ internal class InstallCommandTest : CommandTest {
 
         verify(exactly = 1) { event.replyEmbeds(any<MessageEmbed>()) }
         verify(exactly = 1) { replyCallbackAction.addComponents(any<ActionRow>()) }
-        // Embed mentions the guild name.
         assertTrue(embedSlot.captured.description?.contains("Express") == true)
-        // Action row has the three owner buttons plus the public help button.
         val buttons = componentsSlot.captured.components.filterIsInstance<Button>()
         assertEquals(4, buttons.size)
         assertEquals(InstallWizard.BTN_EXPRESS, buttons[0].customId)
-        assertEquals(InstallWizard.BTN_CUSTOM, buttons[1].customId)
-        assertEquals(InstallWizard.BTN_SKIP, buttons[2].customId)
         assertEquals(InstallWizard.BTN_HELP, buttons[3].customId)
+    }
+
+    @Test
+    fun `summary subcommand replies ephemerally with the setup summary`() {
+        every { event.subcommandName } returns InstallCommand.SUB_SUMMARY
+        every { jackpotService.getPool(1L) } returns 1234L
+        every { jackpotService.winProbabilityDisplay(1L) } returns "1"
+        val embedSlot = slot<MessageEmbed>()
+        every { event.replyEmbeds(capture(embedSlot)) } returns replyCallbackAction
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 0)
+
+        verify(exactly = 1) { jackpotService.getPool(1L) }
+        verify(exactly = 1) { event.replyEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 1) { replyCallbackAction.setEphemeral(true) }
+        // No wizard buttons on the summary.
+        verify(exactly = 0) { replyCallbackAction.addComponents(any<ActionRow>()) }
+        assertTrue(embedSlot.captured.title!!.contains("setup summary"))
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/install/InstallSummaryTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/InstallSummaryTest.kt
@@ -1,0 +1,100 @@
+package bot.toby.install
+
+import database.dto.guild.ConfigDto.Configurations
+import io.mockk.every
+import io.mockk.mockk
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class InstallSummaryTest {
+
+    private fun guild(name: String = "My Guild", id: String = "g1"): Guild = mockk(relaxed = true) {
+        every { this@mockk.name } returns name
+        every { this@mockk.id } returns id
+    }
+
+    private fun fieldValue(embed: net.dv8tion.jda.api.entities.MessageEmbed, nameContains: String): String? =
+        embed.fields.firstOrNull { it.name?.contains(nameContains) == true }?.value
+
+    @Test
+    fun `header reflects the install mode and prompts a re-run`() {
+        val reader: ConfigReader = { key ->
+            when (key) {
+                Configurations.INSTALL_MODE -> "express"
+                Configurations.INSTALLED_AT -> "1700000000000"
+                else -> null
+            }
+        }
+        val embed = InstallSummary.embed(guild(), reader, jackpotPool = 1000, winChanceDisplay = "1", webBaseUrl = "")
+        assertTrue(embed.title!!.contains("My Guild"))
+        assertTrue(embed.description!!.contains("Express"))
+        assertTrue(embed.description!!.contains("/install setup"))
+    }
+
+    @Test
+    fun `not-installed header nudges to run setup`() {
+        val embed = InstallSummary.embed(guild(), { null }, 0, "0", "")
+        assertTrue(embed.description!!.contains("isn't finished", ignoreCase = true))
+        assertTrue(embed.description!!.contains("/install setup"))
+    }
+
+    @Test
+    fun `economy field shows the jackpot pool and win chance`() {
+        val economy = fieldValue(
+            InstallSummary.embed(guild(), { null }, jackpotPool = 2500, winChanceDisplay = "0.5", webBaseUrl = ""),
+            "Casino",
+        )!!
+        assertTrue(economy.contains("2500"))
+        assertTrue(economy.contains("0.5%"))
+    }
+
+    @Test
+    fun `features field marks opt-ins on or off`() {
+        val reader: ConfigReader = { key -> if (key == Configurations.ACTIVITY_TRACKING) "true" else null }
+        val features = fieldValue(InstallSummary.embed(guild(), reader, 0, "0", ""), "Features")!!
+        assertTrue(features.contains("✅ Activity tracking"))
+        assertTrue(features.contains("⬜ Daily lottery"))
+    }
+
+    @Test
+    fun `set channel renders a mention, unset renders not set`() {
+        val channel = mockk<GuildChannel> { every { asMention } returns "<#999>" }
+        val g = guild()
+        every { g.getGuildChannelById(999L) } returns channel
+        val reader: ConfigReader = { key -> if (key == Configurations.LEADERBOARD_CHANNEL) "999" else null }
+
+        val channels = fieldValue(InstallSummary.embed(g, reader, 0, "0", ""), "Channels")!!
+        assertTrue(channels.contains("Leaderboard: <#999>"))
+        assertTrue(channels.contains("Move target: *not set*"))
+    }
+
+    @Test
+    fun `web dashboard link shown only when a base url is set`() {
+        assertTrue(fieldValue(InstallSummary.embed(guild(), { null }, 0, "0", "https://x"), "Web")!!.contains("https://x/profile/g1"))
+        assertTrue(fieldValue(InstallSummary.embed(guild(), { null }, 0, "0", ""), "Web")!!.contains("Not configured"))
+    }
+
+    @Test
+    fun `suggestions flag unset recommendations and disappear when everything relevant is set`() {
+        val tips = fieldValue(InstallSummary.embed(guild(), { null }, 0, "0", ""), "Suggested")!!
+        assertTrue(tips.contains("Activity tracking"))
+        assertTrue(tips.contains("Daily lottery"))
+        assertTrue(tips.contains("leaderboard channel"))
+
+        val allSet: ConfigReader = { key ->
+            when (key) {
+                Configurations.ACTIVITY_TRACKING, Configurations.LOTTERY_DAILY_ENABLED -> "true"
+                Configurations.LEADERBOARD_CHANNEL,
+                Configurations.LEVEL_UP_CHANNEL,
+                Configurations.ACHIEVEMENT_ANNOUNCE_CHANNEL,
+                -> "123"
+                else -> null
+            }
+        }
+        assertNull(fieldValue(InstallSummary.embed(guild(), allSet, 0, "0", ""), "Suggested"))
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/install/InstallWizardTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/InstallWizardTest.kt
@@ -36,30 +36,31 @@ internal class InstallWizardTest {
     }
 
     @Test
-    fun `launcherRow has the non-owner quick-flip, claim-daily and help buttons`() {
+    fun `launcherRow has the quick-flip, claim-daily, help and view-setup buttons`() {
         val buttons = InstallWizard.launcherRow().components.filterIsInstance<Button>()
-        assertEquals(3, buttons.size)
+        assertEquals(4, buttons.size)
         assertEquals(InstallWizard.BTN_QUICK_FLIP, buttons[0].customId)
         assertEquals(InstallWizard.BTN_CLAIM_DAILY, buttons[1].customId)
         assertEquals(ButtonStyle.SUCCESS, buttons[1].style)
         assertEquals(InstallWizard.BTN_HELP, buttons[2].customId)
+        assertEquals(InstallWizard.BTN_VIEW_SETUP, buttons[3].customId)
     }
 
     @Test
     fun `launcherRow appends a profile deep-link button when a base url is configured`() {
         val buttons = InstallWizard.launcherRow("g123", "https://toby-bot.co.uk")
             .components.filterIsInstance<Button>()
-        assertEquals(4, buttons.size)
+        assertEquals(5, buttons.size)
         // Link buttons carry a url (and no componentId), pointing at the same
         // /profile/{guildId} page the achievement web-push deep-links to.
-        assertEquals("https://toby-bot.co.uk/profile/g123", buttons[3].url)
+        assertEquals("https://toby-bot.co.uk/profile/g123", buttons[4].url)
     }
 
     @Test
     fun `launcherRow omits the deep-link when the base url is unset`() {
-        assertEquals(3, InstallWizard.launcherRow("g123", "").components.filterIsInstance<Button>().size)
-        assertEquals(3, InstallWizard.launcherRow("g123", null).components.filterIsInstance<Button>().size)
-        assertEquals(3, InstallWizard.launcherRow(null, "https://x").components.filterIsInstance<Button>().size)
+        assertEquals(4, InstallWizard.launcherRow("g123", "").components.filterIsInstance<Button>().size)
+        assertEquals(4, InstallWizard.launcherRow("g123", null).components.filterIsInstance<Button>().size)
+        assertEquals(4, InstallWizard.launcherRow(null, "https://x").components.filterIsInstance<Button>().size)
     }
 
     @Test

--- a/discord-bot/src/test/kotlin/bot/toby/install/button/InstallSummaryButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/button/InstallSummaryButtonTest.kt
@@ -1,0 +1,61 @@
+package bot.toby.install.button
+
+import bot.toby.install.InstallWizard
+import database.service.economy.JackpotService
+import database.service.guild.ConfigService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class InstallSummaryButtonTest {
+
+    private lateinit var configService: ConfigService
+    private lateinit var jackpotService: JackpotService
+    private lateinit var button: InstallSummaryButton
+    private lateinit var fx: InstallButtonFixture
+
+    @BeforeEach
+    fun setUp() {
+        configService = mockk(relaxed = true)
+        jackpotService = mockk(relaxed = true)
+        button = InstallSummaryButton(configService, jackpotService)
+        fx = InstallButtonFixture()
+    }
+
+    @Test
+    fun `name matches the view-setup id`() {
+        assertEquals(InstallWizard.BTN_VIEW_SETUP, button.name)
+    }
+
+    @Test
+    fun `defersReply is false like the other install buttons`() {
+        assertEquals(false, button.defersReply)
+    }
+
+    @Test
+    fun `non-owner is rejected with no summary reply`() {
+        fx.asNonOwner()
+
+        button.handle(fx.ctx, mockk(relaxed = true), 0)
+
+        verify(exactly = 1) { fx.event.reply(any<String>()) }
+        verify(exactly = 0) { fx.event.replyEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `owner gets an ephemeral setup summary`() {
+        val reply: ReplyCallbackAction = mockk(relaxed = true)
+        every { fx.event.replyEmbeds(any<MessageEmbed>()) } returns reply
+        every { reply.setEphemeral(any()) } returns reply
+
+        button.handle(fx.ctx, mockk(relaxed = true), 0)
+
+        verify(exactly = 1) { fx.event.replyEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 1) { reply.setEphemeral(true) }
+    }
+}


### PR DESCRIPTION
Follow-up to #680/#681. Gives server owners a way to **audit their current setup and see what's still worth turning on** — without re-running the wizard.

### What's new
- **`/install summary`** — an owner-only, ephemeral snapshot of the current per-guild config.
- **⚙️ View setup** — an owner-only button added to the pinned post-install control panel that shows the same summary.

Both render a shared `InstallSummary` embed reporting:
- install mode + date, jackpot pool & win chance, coinflip stake range
- which optional features are **on/off** (reusing the existing `OptInFeatures` enum so it stays in lockstep)
- which announce/modlog channels are **set vs unset** (resolved to mentions)
- a web-dashboard deep-link (when `app.base-url` is configured)
- **💡 Suggested next steps** — the valuable part: it flags recommended-but-unset settings (activity tracking, daily lottery, leaderboard/level-up/achievement channels) so it *guides* rather than just dumping state. The field disappears entirely once everything relevant is configured.

### Notable change
A Discord slash command with subcommands can't also be invoked bare, so **`/install` becomes `/install setup`** (plus the new `/install summary`). `InstallCommand` now responds directly — setup posts publicly, summary is ephemeral — so it sets `defersReply = false`, matching `/setconfig` (the other direct-reply moderation command). `InstallSummary` itself is a pure embed builder (takes a `ConfigReader` + precomputed economy values), so it's trivially unit-tested.

---

**Testing:** `:database:test` and `:discord-bot:test` pass; `:application` test sources compile (registered the new button in `ButtonManagerTest`). Added unit tests for `InstallSummary` (header, economy, feature on/off, channel set/unset, deep-link, suggestion logic), the rewritten `InstallCommandTest` (setup vs summary dispatch, owner gate), `InstallSummaryButtonTest`, and the updated launcher-row assertions. As before, the `:application` Spring/Testcontainers integration tests need Docker (unavailable in my sandbox), so that one list change is verified by compilation + inspection.

https://claude.ai/code/session_01UCEsvqKnUcgdC74Cj2odPj

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCEsvqKnUcgdC74Cj2odPj)_