### PR TITLE
Player-side onboarding: first-game achievement, empty-state recovery, invite loop

### DIFF
--- a/common/src/main/kotlin/common/events/casino/CasinoGamePlayedEvent.kt
+++ b/common/src/main/kotlin/common/events/casino/CasinoGamePlayedEvent.kt
@@ -1,0 +1,15 @@
+package common.events.casino
+
+/**
+ * Fact emitted by `CasinoEdgeService` on every play of a luck game
+ * (coinflip, dice, slots, plinko, wheel-of-fortune) — win or lose — since
+ * those all route their RNG outcome through the shared bot-edge pass.
+ * Subscribers (achievements) unlock the one-shot `casino_first_game`
+ * milestone on a player's first such play, celebrating new members the
+ * moment they actually try the casino (the install launcher funnels them
+ * straight into a coinflip).
+ */
+data class CasinoGamePlayedEvent(
+    val discordId: Long,
+    val guildId: Long,
+)

--- a/database/src/main/kotlin/database/achievement/AchievementCatalog.kt
+++ b/database/src/main/kotlin/database/achievement/AchievementCatalog.kt
@@ -54,6 +54,17 @@ object AchievementCatalog {
             xpReward = 100,
             creditReward = 500,
         ),
+        // First casino play (win or lose) — fired by AchievementEventHandler
+        // on CasinoGamePlayedEvent from the shared luck-game edge pass.
+        AchievementSpec(
+            code = "casino_first_game",
+            name = "First Bet",
+            description = "Play your first casino luck game (coinflip, dice, slots, plinko or wheel).",
+            category = "casino",
+            icon = "🎰",
+            xpReward = 50,
+            creditReward = 50,
+        ),
         // Streak achievements — fired by AchievementEventHandler on StreakClaimedEvent.
         AchievementSpec(
             code = "streak_first",

--- a/database/src/main/kotlin/database/service/casino/CasinoEdgeService.kt
+++ b/database/src/main/kotlin/database/service/casino/CasinoEdgeService.kt
@@ -1,5 +1,6 @@
 package database.service.casino
 
+import common.events.casino.CasinoGamePlayedEvent
 import common.events.moderation.AntiAutoclickEvent
 import database.dto.guild.ConfigDto
 import org.springframework.context.ApplicationEventPublisher
@@ -67,6 +68,9 @@ class CasinoEdgeService(
         val streak = botSuspicionService.recordAndScore(
             discordId, guildId, gameKey, clickX, clickY, mouseMoved
         )
+        // Fired once per play (win or lose) for every luck game that routes
+        // through here — drives the one-shot `casino_first_game` achievement.
+        eventPublisher.publishEvent(CasinoGamePlayedEvent(discordId, guildId))
         val maxEdgePct = configService.cfgLong(
             edgeMaxConfig, guildId, default = DEFAULT_EDGE_MAX_PCT, min = 0L
         ).coerceAtMost(HARD_EDGE_MAX_PCT)

--- a/database/src/test/kotlin/database/achievement/AchievementCatalogTest.kt
+++ b/database/src/test/kotlin/database/achievement/AchievementCatalogTest.kt
@@ -132,6 +132,7 @@ class AchievementCatalogTest {
             "baccarat_first_win",
             "casino_holdem_first_win",
             "highlow_first_streak",
+            "casino_first_game",
             // Unlocked directly by InstallCompletionService when the owner
             // finishes the install wizard — wired, just not via the
             // AchievementEventHandler event path.

--- a/database/src/test/kotlin/database/service/CasinoEdgeServiceTest.kt
+++ b/database/src/test/kotlin/database/service/CasinoEdgeServiceTest.kt
@@ -1,5 +1,6 @@
 package database.service
 
+import common.events.casino.CasinoGamePlayedEvent
 import common.events.moderation.AntiAutoclickEvent
 import database.dto.guild.ConfigDto
 import io.mockk.every
@@ -280,5 +281,20 @@ class CasinoEdgeServiceTest {
                 AntiAutoclickEvent.BiasFired(guildId, discordId, gameKey, streak = 50, edgePct = 10.0)
             )
         }
+    }
+
+    @Test
+    fun `publishes CasinoGamePlayedEvent on every play, win or lose`() {
+        // No suspicion, fair outcome stands — but the play still counts,
+        // driving the one-shot casino_first_game achievement.
+        stubStreak(0)
+        service = CasinoEdgeService(botSuspicionService, configService, eventPublisher, mockk(relaxed = true))
+
+        service.applyBotEdge(
+            discordId, guildId, gameKey, 100, 200, false, edgeMaxConfig,
+            fairOutcome = "fair", asLoss = { "loss" },
+        )
+
+        verify(exactly = 1) { eventPublisher.publishEvent(CasinoGamePlayedEvent(discordId, guildId)) }
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/handler/AchievementEventHandler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/handler/AchievementEventHandler.kt
@@ -6,6 +6,7 @@ import common.events.user.AchievementUnlockedEvent
 import common.events.casino.baccarat.BaccaratWonEvent
 import common.events.casino.blackjack.BlackjackNaturalEvent
 import common.events.casino.casinoholdem.CasinoHoldemWonEvent
+import common.events.casino.CasinoGamePlayedEvent
 import common.events.casino.coinflip.CoinflipWonEvent
 import common.events.casino.dice.DiceWonEvent
 import common.events.pvp.duel.DuelResolvedEvent
@@ -285,6 +286,11 @@ class AchievementEventHandler(
     @EventListener
     fun onCoinflipWon(event: CoinflipWonEvent) {
         achievementService.unlock(event.discordId, event.guildId, "coinflip_first_win")
+    }
+
+    @EventListener
+    fun onCasinoGamePlayed(event: CasinoGamePlayedEvent) {
+        achievementService.unlock(event.discordId, event.guildId, "casino_first_game")
     }
 
     @EventListener

--- a/discord-bot/src/main/kotlin/bot/toby/install/InstallWizard.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/InstallWizard.kt
@@ -260,33 +260,46 @@ object InstallWizard {
         Button.success(BTN_FINISH, "Finish"),
     )
 
+    /** Bot invite URL for [clientId] (the bot's application/user id). Mirrors `web.util.DiscordInvite`. */
+    fun inviteUrl(clientId: String): String =
+        "https://discord.com/api/oauth2/authorize?client_id=$clientId" +
+            "&permissions=8&scope=bot%20applications.commands"
+
     /**
-     * One-click launcher row left on the post-install "done" message so the
-     * owner's (or any member's) very first action is a tap, not a typed
-     * slash command: play a real coinflip, claim daily credits, or open the
-     * full feature tour. Every button is non-owner-gated — the message
-     * doubles as a shared launcher for everyone in the channel.
+     * The post-install "done" message's launcher, returned as one or two
+     * action rows so the very first action is a tap, not a typed command.
      *
-     * The owner-only **View setup** button is always present (non-owners get
-     * an ephemeral reject on click). When [webBaseUrl] is configured (and
-     * [guildId] known) a deep-link button to the web dashboard's guild
-     * profile is also appended — the same `"$webBaseUrl/profile/$guildId"`
-     * page the achievement web-push points at, so the owner can see the
-     * "Welcome Aboard" badge they just earned. The link is omitted when the
-     * base URL is unset (self-hosters without a public dashboard), exactly
-     * as the push deep links degrade.
+     * Row 1 (always) — the action buttons: play a real coinflip, claim daily
+     * credits, the feature tour, and the owner-only **View setup** summary.
+     * All non-owner-gated except View setup, so the message doubles as a
+     * shared launcher for everyone in the channel.
+     *
+     * Row 2 (link buttons, only when present) — a web-dashboard profile
+     * deep-link when [webBaseUrl] + [guildId] are known (the same
+     * `"$webBaseUrl/profile/$guildId"` page the achievement web-push points
+     * at), and an "add me to another server" invite when [inviteUrl] is
+     * supplied. Links live on their own row because Discord caps an action
+     * row at five buttons and row 1 already holds four.
      */
-    fun launcherRow(guildId: String? = null, webBaseUrl: String? = null): ActionRow {
-        val buttons = mutableListOf(
+    fun launcherRows(
+        guildId: String? = null,
+        webBaseUrl: String? = null,
+        inviteUrl: String? = null,
+    ): List<ActionRow> {
+        val actions = ActionRow.of(
             Button.primary(BTN_QUICK_FLIP, "🪙 Flip a coin"),
             Button.success(BTN_CLAIM_DAILY, "🎁 Claim daily credits"),
             Button.secondary(BTN_HELP, "✨ What can I do?"),
             Button.secondary(BTN_VIEW_SETUP, "⚙️ View setup"),
         )
+        val links = mutableListOf<Button>()
         if (!webBaseUrl.isNullOrBlank() && !guildId.isNullOrBlank()) {
-            buttons += Button.link("$webBaseUrl/profile/$guildId", "🌐 View your profile")
+            links += Button.link("$webBaseUrl/profile/$guildId", "🌐 View your profile")
         }
-        return ActionRow.of(buttons)
+        if (!inviteUrl.isNullOrBlank()) {
+            links += Button.link(inviteUrl, "➕ Add me to another server")
+        }
+        return listOfNotNull(actions, links.takeIf { it.isNotEmpty() }?.let { ActionRow.of(it) })
     }
 
     fun backButtonRow(): ActionRow = ActionRow.of(

--- a/discord-bot/src/main/kotlin/bot/toby/install/button/InstallExpressButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/button/InstallExpressButton.kt
@@ -33,7 +33,13 @@ class InstallExpressButton(
         event.deferEdit().queue()
         installCompletionService.complete(ctx.guild, mode = "express", channelId = event.channel.idLong)
         event.hook.editOriginalEmbeds(InstallWizard.expressDoneEmbed())
-            .setComponents(InstallWizard.launcherRow(ctx.guild.id, webBaseUrl))
+            .setComponents(
+                InstallWizard.launcherRows(
+                    guildId = ctx.guild.id,
+                    webBaseUrl = webBaseUrl,
+                    inviteUrl = InstallWizard.inviteUrl(event.jda.selfUser.id),
+                ),
+            )
             .queue()
         pinAsControlPanel(event.message)
     }

--- a/discord-bot/src/main/kotlin/bot/toby/install/button/InstallFinishButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/button/InstallFinishButton.kt
@@ -31,7 +31,13 @@ class InstallFinishButton(
         event.deferEdit().queue()
         installCompletionService.complete(ctx.guild, mode = "custom", channelId = event.channel.idLong)
         event.hook.editOriginalEmbeds(InstallWizard.finishDoneEmbed())
-            .setComponents(InstallWizard.launcherRow(ctx.guild.id, webBaseUrl))
+            .setComponents(
+                InstallWizard.launcherRows(
+                    guildId = ctx.guild.id,
+                    webBaseUrl = webBaseUrl,
+                    inviteUrl = InstallWizard.inviteUrl(event.jda.selfUser.id),
+                ),
+            )
             .queue()
         pinAsControlPanel(event.message)
     }

--- a/discord-bot/src/main/kotlin/bot/toby/install/button/InstallQuickFlipButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/button/InstallQuickFlipButton.kt
@@ -7,6 +7,8 @@ import core.button.Button
 import core.button.ButtonContext
 import database.dto.user.UserDto
 import database.service.casino.coinflip.CoinflipService
+import net.dv8tion.jda.api.components.actionrow.ActionRow
+import net.dv8tion.jda.api.components.buttons.Button as JdaButton
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
@@ -40,6 +42,15 @@ class InstallQuickFlipButton @Autowired constructor(
             stake = Coinflip.MIN_STAKE,
             predicted = Coinflip.Side.HEADS,
         )
-        ctx.event.hook.sendMessageEmbeds(CoinflipEmbeds.outcome(outcome)).queue()
+        val reply = ctx.event.hook.sendMessageEmbeds(CoinflipEmbeds.outcome(outcome))
+        // Close the dead-end: a broke new member gets a one-tap way to top up
+        // right on the "not enough credits" result instead of hunting for
+        // /daily. Routes to the same InstallClaimDailyButton as the launcher.
+        if (outcome is CoinflipService.FlipOutcome.InsufficientCredits) {
+            reply.addComponents(
+                ActionRow.of(JdaButton.success(InstallWizard.BTN_CLAIM_DAILY, "🎁 Claim daily credits")),
+            )
+        }
+        reply.queue()
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/handler/AchievementEventHandlerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/handler/AchievementEventHandlerTest.kt
@@ -7,6 +7,7 @@ import common.events.user.AchievementUnlockedEvent
 import common.events.casino.baccarat.BaccaratWonEvent
 import common.events.casino.blackjack.BlackjackNaturalEvent
 import common.events.casino.casinoholdem.CasinoHoldemWonEvent
+import common.events.casino.CasinoGamePlayedEvent
 import common.events.casino.coinflip.CoinflipWonEvent
 import common.events.casino.dice.DiceWonEvent
 import common.events.pvp.duel.DuelResolvedEvent
@@ -331,6 +332,14 @@ class AchievementEventHandlerTest {
         handler.onCoinflipWon(CoinflipWonEvent(discordId, guildId))
         verify(exactly = 1) {
             achievementService.unlock(discordId, guildId, "coinflip_first_win")
+        }
+    }
+
+    @Test
+    fun `casino play unlocks casino_first_game for the player`() {
+        handler.onCasinoGamePlayed(CasinoGamePlayedEvent(discordId, guildId))
+        verify(exactly = 1) {
+            achievementService.unlock(discordId, guildId, "casino_first_game")
         }
     }
 

--- a/discord-bot/src/test/kotlin/bot/toby/install/InstallWizardTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/InstallWizardTest.kt
@@ -36,31 +36,44 @@ internal class InstallWizardTest {
     }
 
     @Test
-    fun `launcherRow has the quick-flip, claim-daily, help and view-setup buttons`() {
-        val buttons = InstallWizard.launcherRow().components.filterIsInstance<Button>()
-        assertEquals(4, buttons.size)
-        assertEquals(InstallWizard.BTN_QUICK_FLIP, buttons[0].customId)
-        assertEquals(InstallWizard.BTN_CLAIM_DAILY, buttons[1].customId)
-        assertEquals(ButtonStyle.SUCCESS, buttons[1].style)
-        assertEquals(InstallWizard.BTN_HELP, buttons[2].customId)
-        assertEquals(InstallWizard.BTN_VIEW_SETUP, buttons[3].customId)
+    fun `launcherRows row one has the four action buttons`() {
+        val actions = InstallWizard.launcherRows()[0].components.filterIsInstance<Button>()
+        assertEquals(4, actions.size)
+        assertEquals(InstallWizard.BTN_QUICK_FLIP, actions[0].customId)
+        assertEquals(InstallWizard.BTN_CLAIM_DAILY, actions[1].customId)
+        assertEquals(ButtonStyle.SUCCESS, actions[1].style)
+        assertEquals(InstallWizard.BTN_HELP, actions[2].customId)
+        assertEquals(InstallWizard.BTN_VIEW_SETUP, actions[3].customId)
     }
 
     @Test
-    fun `launcherRow appends a profile deep-link button when a base url is configured`() {
-        val buttons = InstallWizard.launcherRow("g123", "https://toby-bot.co.uk")
-            .components.filterIsInstance<Button>()
-        assertEquals(5, buttons.size)
-        // Link buttons carry a url (and no componentId), pointing at the same
-        // /profile/{guildId} page the achievement web-push deep-links to.
-        assertEquals("https://toby-bot.co.uk/profile/g123", buttons[4].url)
+    fun `launcherRows has no link row when nothing links`() {
+        assertEquals(1, InstallWizard.launcherRows().size)
+        assertEquals(1, InstallWizard.launcherRows("g1", "", "").size)
     }
 
     @Test
-    fun `launcherRow omits the deep-link when the base url is unset`() {
-        assertEquals(4, InstallWizard.launcherRow("g123", "").components.filterIsInstance<Button>().size)
-        assertEquals(4, InstallWizard.launcherRow("g123", null).components.filterIsInstance<Button>().size)
-        assertEquals(4, InstallWizard.launcherRow(null, "https://x").components.filterIsInstance<Button>().size)
+    fun `launcherRows adds a link row with profile then invite buttons`() {
+        val rows = InstallWizard.launcherRows("g123", "https://toby-bot.co.uk", "https://discord/invite-x")
+        assertEquals(2, rows.size)
+        val links = rows[1].components.filterIsInstance<Button>()
+        assertEquals(2, links.size)
+        assertEquals("https://toby-bot.co.uk/profile/g123", links[0].url)
+        assertEquals("https://discord/invite-x", links[1].url)
+    }
+
+    @Test
+    fun `launcherRows includes only the invite link when web base url is unset`() {
+        val rows = InstallWizard.launcherRows(guildId = "g1", webBaseUrl = "", inviteUrl = "https://inv")
+        assertEquals(2, rows.size)
+        val links = rows[1].components.filterIsInstance<Button>()
+        assertEquals(1, links.size)
+        assertEquals("https://inv", links[0].url)
+    }
+
+    @Test
+    fun `inviteUrl embeds the client id`() {
+        assertTrue(InstallWizard.inviteUrl("12345").contains("client_id=12345"))
     }
 
     @Test

--- a/discord-bot/src/test/kotlin/bot/toby/install/button/InstallExpressButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/button/InstallExpressButtonTest.kt
@@ -56,7 +56,7 @@ internal class InstallExpressButtonTest {
         @Suppress("UNCHECKED_CAST")
         editAction = mockk<WebhookMessageEditAction<Message>>(relaxed = true)
         every { hook.editOriginalEmbeds(any<MessageEmbed>()) } returns editAction
-        every { editAction.setComponents(*anyVararg<MessageTopLevelComponent>()) } returns editAction
+        every { editAction.setComponents(any<Collection<MessageTopLevelComponent>>()) } returns editAction
         every { editAction.queue() } just Runs
     }
 
@@ -91,7 +91,7 @@ internal class InstallExpressButtonTest {
         verify(exactly = 1) { event.deferEdit() }
         verify(exactly = 1) { hook.editOriginalEmbeds(any<MessageEmbed>()) }
         verify(exactly = 1) {
-            editAction.setComponents(*anyVararg<MessageTopLevelComponent>())
+            editAction.setComponents(any<Collection<MessageTopLevelComponent>>())
         }
         verify(exactly = 1) { editAction.queue() }
     }

--- a/discord-bot/src/test/kotlin/bot/toby/install/button/InstallFinishButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/button/InstallFinishButtonTest.kt
@@ -52,7 +52,7 @@ internal class InstallFinishButtonTest {
         verify(exactly = 1) { fx.event.deferEdit() }
         verify(exactly = 1) { fx.hook.editOriginalEmbeds(any<MessageEmbed>()) }
         verify(exactly = 1) {
-            fx.editAction.setComponents(*anyVararg<MessageTopLevelComponent>())
+            fx.editAction.setComponents(any<Collection<MessageTopLevelComponent>>())
         }
         verify(exactly = 1) { fx.editAction.queue() }
     }

--- a/discord-bot/src/test/kotlin/bot/toby/install/button/InstallQuickFlipButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/button/InstallQuickFlipButtonTest.kt
@@ -8,7 +8,10 @@ import database.service.casino.coinflip.CoinflipService.FlipOutcome
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import net.dv8tion.jda.api.components.MessageTopLevelComponent
+import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -59,5 +62,21 @@ internal class InstallQuickFlipButtonTest {
         }
         verify(exactly = 1) { fx.hook.sendMessageEmbeds(any<MessageEmbed>(), *anyVararg<MessageEmbed>()) }
         verify(exactly = 0) { fx.event.reply(any<String>()) }
+    }
+
+    @Test
+    fun `insufficient credits offers a one-tap claim-daily button`() {
+        val requestingUser = mockk<UserDto> { every { discordId } returns 42L }
+        every {
+            coinflipService.flip(42L, any(), Coinflip.MIN_STAKE, Coinflip.Side.HEADS, any(), any(), any(), any())
+        } returns FlipOutcome.InsufficientCredits(stake = Coinflip.MIN_STAKE, have = 0L)
+
+        val createAction = mockk<WebhookMessageCreateAction<Message>>(relaxed = true)
+        every { fx.hook.sendMessageEmbeds(any<MessageEmbed>(), *anyVararg<MessageEmbed>()) } returns createAction
+        every { createAction.addComponents(*anyVararg<MessageTopLevelComponent>()) } returns createAction
+
+        button.handle(fx.ctx, requestingUser, 0)
+
+        verify(exactly = 1) { createAction.addComponents(*anyVararg<MessageTopLevelComponent>()) }
     }
 }


### PR DESCRIPTION
Follow-up to #680/#681/#682. Those rewarded the **owner** at install; this turns attention to the **players** the owner is trying to keep, and closes the last onboarding dead-ends. Three isolated commits (disjoint files).

### 1. Celebrate a player's first casino game (`Celebrate a player's first casino game…`)
`CasinoEdgeService` — the shared bot-edge pass that every luck game (coinflip, dice, slots, plinko, wheel) runs through exactly once per play — now publishes a `CasinoGamePlayedEvent` on **every play, win or lose**. `AchievementEventHandler` unlocks a new one-shot **"First Bet"** (`casino_first_game`) milestone on it, firing the full DM/channel/web-push pipeline *for the player*. Since the install launcher funnels new members straight into a coinflip, their very first action now pops a reward.

> Scope note: this fires on the five luck games that share the edge pass (which includes the launcher's coinflip) — not table games like blackjack/poker. The achievement copy says so explicitly.

### 2. One-tap recovery on the launcher flip's empty state (`Offer a one-tap Claim daily…`)
When a broke new member taps **🪙 Flip a coin** and gets `InsufficientCredits`, the reply now carries a **🎁 Claim daily credits** button (routing to the existing `InstallClaimDailyButton`) instead of being a dead end.

### 3. An invite loop on the control panel (`Add an 'Add me to another server' invite link…`)
The pinned control panel gains a **➕ Add me to another server** link, turning a happy installer into a distribution channel. Four action buttons + profile + invite links exceed Discord's 5-per-row cap, so `launcherRow` becomes **`launcherRows`** — actions on row one, link buttons (profile when `app.base-url` is set, invite always) on row two. The invite URL is built from the bot's own application id (`jda.selfUser.id`) at runtime, no new config.

---

**Testing:** `:common:test`, `:database:test`, `:discord-bot:test` pass; `:application` test sources compile. Added/updated unit tests for the played-event publish (`CasinoEdgeServiceTest`), the handler unlock (`AchievementEventHandlerTest`), the catalog wiring (`AchievementCatalogTest`), the flip empty-state button (`InstallQuickFlipButtonTest`), and the two-row launcher + invite URL (`InstallWizardTest`, Express/Finish button tests). The `:application` Spring/Testcontainers integration tests need Docker (unavailable in my sandbox) — no new button beans were added this time, so no `ButtonManagerTest` change was needed.

https://claude.ai/code/session_01UCEsvqKnUcgdC74Cj2odPj

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCEsvqKnUcgdC74Cj2odPj)_