### PR TITLE
Fix the nowPlaying stale-message bug (#85) and the broken /meme Reddit auth (#107)

### DIFF
--- a/application/src/main/resources/application.properties
+++ b/application/src/main/resources/application.properties
@@ -17,6 +17,11 @@ spring.datasource.hikari.minimum-idle=1
 spring.datasource.hikari.idle-timeout=60000
 spring.datasource.hikari.max-lifetime=600000
 
+# Reddit app-only OAuth for the /meme command (issue #107). When unset, /meme
+# falls back to the (now Reddit-blocked) unauthenticated endpoint.
+reddit.client-id=${REDDIT_CLIENT_ID:}
+reddit.client-secret=${REDDIT_CLIENT_SECRET:}
+
 # Discord OAuth2
 spring.security.oauth2.client.registration.discord.client-id=${DISCORD_CLIENT_ID}
 spring.security.oauth2.client.registration.discord.client-secret=${DISCORD_CLIENT_SECRET}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/fetch/RedditMemeFetcher.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/fetch/RedditMemeFetcher.kt
@@ -31,6 +31,7 @@ import kotlin.random.Random
 @Component
 class RedditMemeFetcher @Autowired constructor(
     private val client: HttpClient,
+    private val tokenProvider: RedditTokenProvider,
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
 
@@ -44,11 +45,28 @@ class RedditMemeFetcher @Autowired constructor(
 
     /** Fetches a random non-NSFW, non-video post from the top [limit] of [subreddit] over [timePeriod]. */
     suspend fun fetch(subreddit: String?, timePeriod: String, limit: Int): Result = withContext(dispatcher) {
-        val url = String.format(RedditAPIDto.REDDIT_PREFIX, subreddit, limit, timePeriod)
+        val token = tokenProvider.bearerToken()
+        val url: String = when {
+            token != null -> String.format(RedditAPIDto.REDDIT_OAUTH_PREFIX, subreddit, limit, timePeriod)
+            tokenProvider.isConfigured -> {
+                // Credentials are set but the token fetch failed (already logged) — don't
+                // fall back to the unauth endpoint, just surface a transient error.
+                return@withContext Result.Error("Couldn't reach Reddit right now. Please try again later.")
+            }
+            else -> {
+                logger.warn(
+                    "Reddit credentials are not configured (reddit.client-id/secret) — using the " +
+                        "unauthenticated endpoint, which Reddit now blocks. Set them to fix /meme (issue #107)."
+                )
+                String.format(RedditAPIDto.REDDIT_PREFIX, subreddit, limit, timePeriod)
+            }
+        }
         logger.info("Fetching Reddit post from URL: $url")
         try {
             val response = client.get(url) {
                 header(HttpHeaders.Accept, "application/json")
+                header(HttpHeaders.UserAgent, RedditTokenProvider.USER_AGENT)
+                token?.let { header(HttpHeaders.Authorization, "bearer $it") }
                 timeout { requestTimeoutMillis = TIMEOUT_MS }
             }
             if (response.status.value != 200) {

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/fetch/RedditTokenProvider.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/fetch/RedditTokenProvider.kt
@@ -1,0 +1,89 @@
+package bot.toby.command.commands.fetch
+
+import com.google.gson.JsonParser
+import common.logging.DiscordLogger
+import io.ktor.client.HttpClient
+import io.ktor.client.request.forms.FormDataContent
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.Parameters
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.util.Base64
+
+/**
+ * Supplies an application-only (client-credentials) OAuth bearer token for
+ * Reddit's API. Reddit dropped unauthenticated `.json` access, so `/meme`
+ * needs a token to work (issue #107).
+ *
+ * Configure with a Reddit "script"/"web app" client id + secret via the
+ * `REDDIT_CLIENT_ID` / `REDDIT_CLIENT_SECRET` env vars (mapped to
+ * `reddit.client-id` / `reddit.client-secret`). When unset, [isConfigured]
+ * is false and [bearerToken] returns null — the fetcher then degrades to
+ * the legacy unauthenticated endpoint (which Reddit now blocks), so the
+ * command behaves exactly as before until credentials are provided.
+ *
+ * Tokens are cached and refreshed shortly before expiry; the refresh is
+ * guarded by a [Mutex] so a burst of `/meme` calls triggers one fetch.
+ */
+@Component
+class RedditTokenProvider @Autowired constructor(
+    private val client: HttpClient,
+    @param:Value($$"${reddit.client-id:}") private val clientId: String = "",
+    @param:Value($$"${reddit.client-secret:}") private val clientSecret: String = "",
+    private val nowMs: () -> Long = { System.currentTimeMillis() },
+) {
+    private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
+    private val mutex = Mutex()
+
+    @Volatile private var cachedToken: String? = null
+    @Volatile private var expiresAtMs: Long = 0L
+
+    val isConfigured: Boolean get() = clientId.isNotBlank() && clientSecret.isNotBlank()
+
+    /**
+     * A valid app-only bearer token, fetched/refreshed as needed. Returns
+     * null when unconfigured or when the token request fails (logged).
+     */
+    suspend fun bearerToken(): String? {
+        if (!isConfigured) return null
+        return mutex.withLock {
+            cachedToken?.let { if (nowMs() < expiresAtMs - REFRESH_SKEW_MS) return@withLock it }
+            runCatching { fetchToken() }
+                .onFailure { logger.error { "Failed to obtain Reddit app token: ${it.message}" } }
+                .getOrNull()
+        }
+    }
+
+    private suspend fun fetchToken(): String {
+        val basic = Base64.getEncoder().encodeToString("$clientId:$clientSecret".toByteArray())
+        val response = client.post(TOKEN_URL) {
+            header(HttpHeaders.Authorization, "Basic $basic")
+            header(HttpHeaders.UserAgent, USER_AGENT)
+            setBody(FormDataContent(Parameters.build { append("grant_type", "client_credentials") }))
+        }
+        val json = JsonParser.parseString(response.bodyAsText()).asJsonObject
+        val token = json.get("access_token")?.takeIf { !it.isJsonNull }?.asString
+            ?: error("no access_token in Reddit token response (status ${response.status.value})")
+        val expiresInSec = json.get("expires_in")?.takeIf { !it.isJsonNull }?.asLong ?: 3600L
+        cachedToken = token
+        expiresAtMs = nowMs() + expiresInSec * 1000
+        logger.info { "Obtained Reddit app token (expires in ${expiresInSec}s)" }
+        return token
+    }
+
+    companion object {
+        const val TOKEN_URL = "https://www.reddit.com/api/v1/access_token"
+
+        /** Reddit requires a unique, descriptive User-Agent or it aggressively rate-limits. */
+        const val USER_AGENT = "discord:co.uk.toby-bot:1.0 (by /u/toby-bot)"
+
+        private const val REFRESH_SKEW_MS = 60_000L
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/dto/web/RedditAPIDto.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/dto/web/RedditAPIDto.kt
@@ -43,6 +43,10 @@ class RedditAPIDto {
     }
 
     companion object {
+        /** Legacy unauthenticated endpoint — Reddit now rate-limits/blocks this; kept as a fallback when no creds are set. */
         const val REDDIT_PREFIX: String = "https://old.reddit.com/r/%s/top/.json?limit=%d&t=%s"
+
+        /** Authenticated endpoint used with an app-only bearer token (issue #107). */
+        const val REDDIT_OAUTH_PREFIX: String = "https://oauth.reddit.com/r/%s/top.json?limit=%d&t=%s&raw_json=1"
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/MusicPlayerHelper.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/MusicPlayerHelper.kt
@@ -18,6 +18,7 @@ import net.dv8tion.jda.api.components.actionrow.ActionRow
 import net.dv8tion.jda.api.components.buttons.Button
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.interactions.InteractionHook
 import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback
@@ -85,23 +86,44 @@ object MusicPlayerHelper {
 
         if (nowPlayingInfo != null) {
             logger.info("Nowplaying message ${nowPlayingInfo.idLong} will be edited on guild $guildId")
-            // Update existing message
+            // Update the existing message — but the stored reference can be
+            // stale (e.g. the intro's now-playing was deleted on Discord's
+            // side), in which case the edit fails. Don't let that silently
+            // show nothing: fall back to posting a fresh message (#85).
             nowPlayingInfo.editMessageEmbeds(embed)
                 .setComponents(ActionRow.of(pausePlayButton, stopButton))
-                .queue()
-            hook.deleteOriginal().queue()
+                .queue(
+                    { hook.deleteOriginal().queue() },
+                    { error ->
+                        logger.warn {
+                            "Now-playing message ${nowPlayingInfo.idLong} no longer editable on guild " +
+                                "$guildId (${error.message}); posting a fresh one"
+                        }
+                        sendNewNowPlayingMessage(hook, embed, pausePlayButton, stopButton, guildId)
+                    },
+                )
         } else {
-            // Send a new message and store it in the map
-            hook.sendMessageEmbeds(embed)
-                .setComponents(ActionRow.of(pausePlayButton, stopButton))
-                .queue {
-                    logger.info("Nowplaying message ${it.idLong} will be stored on guild $guildId")
-                    nowPlayingManager.setNowPlayingMessage(guildId, it)
-                }
+            sendNewNowPlayingMessage(hook, embed, pausePlayButton, stopButton, guildId)
         }
         nowPlayingManager.scheduleNowPlayingUpdate(
             guildId, track, audioPlayer, 0L, 3L, clipStart, clipEnd, musicManager.scheduler, guild,
         )
+    }
+
+    /** Post a brand-new now-playing message and store it as the guild's current one. */
+    private fun sendNewNowPlayingMessage(
+        hook: InteractionHook,
+        embed: MessageEmbed,
+        pausePlayButton: Button,
+        stopButton: Button,
+        guildId: Long,
+    ) {
+        hook.sendMessageEmbeds(embed)
+            .setComponents(ActionRow.of(pausePlayButton, stopButton))
+            .queue {
+                logger.info("Nowplaying message ${it.idLong} will be stored on guild $guildId")
+                nowPlayingManager.setNowPlayingMessage(guildId, it)
+            }
     }
 
     private fun checkForPlayingTrack(track: AudioTrack?, hook: InteractionHook, deleteDelay: Int): Boolean {

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/fetch/RedditMemeFetcherTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/fetch/RedditMemeFetcherTest.kt
@@ -20,8 +20,12 @@ class RedditMemeFetcherTest {
 
     private val jsonHeaders = headersOf(HttpHeaders.ContentType, "application/json")
 
-    private fun fetcherWith(engine: MockEngine): RedditMemeFetcher =
-        RedditMemeFetcher(HttpClient(engine) { install(HttpTimeout) }, Dispatchers.Unconfined)
+    // Unconfigured token provider → fetcher uses the legacy unauthenticated
+    // endpoint, exercising the existing behaviour these tests assert.
+    private fun fetcherWith(engine: MockEngine): RedditMemeFetcher {
+        val client = HttpClient(engine) { install(HttpTimeout) }
+        return RedditMemeFetcher(client, RedditTokenProvider(client), Dispatchers.Unconfined)
+    }
 
     private fun listing(vararg posts: String): String =
         """{"data":{"children":[${posts.joinToString(",")}]}}"""
@@ -83,6 +87,58 @@ class RedditMemeFetcherTest {
         val result = fetcherWith(MockEngine { respond(listing(post(video = true)), HttpStatusCode.OK, jsonHeaders) }).fetch("memes", "day", 1)
         val error = assertInstanceOf(RedditMemeFetcher.Result.Error::class.java, result)
         assertTrue(error.message.contains("video"))
+    }
+
+    @Test
+    fun `fetch uses the authenticated endpoint with a bearer token when configured`() = runBlocking {
+        val engine = MockEngine { req ->
+            when {
+                req.url.toString().startsWith(RedditTokenProvider.TOKEN_URL) ->
+                    respond(
+                        """{"access_token":"tok123","token_type":"bearer","expires_in":3600}""",
+                        HttpStatusCode.OK, jsonHeaders,
+                    )
+                req.url.host == "oauth.reddit.com" ->
+                    respond(listing(post(title = "Authed")), HttpStatusCode.OK, jsonHeaders)
+                else -> respondError(HttpStatusCode.NotFound)
+            }
+        }
+        val client = HttpClient(engine) { install(HttpTimeout) }
+        val fetcher = RedditMemeFetcher(
+            client,
+            RedditTokenProvider(client, clientId = "id", clientSecret = "secret"),
+            Dispatchers.Unconfined,
+        )
+
+        val result = fetcher.fetch("memes", "day", 5)
+
+        val success = assertInstanceOf(RedditMemeFetcher.Result.Success::class.java, result)
+        assertEquals("Authed", success.title)
+        val listingReq = engine.requestHistory.single { it.url.host == "oauth.reddit.com" }
+        assertEquals("bearer tok123", listingReq.headers[HttpHeaders.Authorization])
+        assertTrue(listingReq.url.toString().contains("/r/memes/"), "url was: ${listingReq.url}")
+    }
+
+    @Test
+    fun `fetch returns an error (no listing call) when configured but the token request fails`() = runBlocking {
+        val engine = MockEngine { req ->
+            if (req.url.toString().startsWith(RedditTokenProvider.TOKEN_URL)) {
+                respondError(HttpStatusCode.Unauthorized)
+            } else {
+                respond(listing(post()), HttpStatusCode.OK, jsonHeaders)
+            }
+        }
+        val client = HttpClient(engine) { install(HttpTimeout) }
+        val fetcher = RedditMemeFetcher(
+            client,
+            RedditTokenProvider(client, clientId = "id", clientSecret = "secret"),
+            Dispatchers.Unconfined,
+        )
+
+        val result = fetcher.fetch("memes", "day", 5)
+
+        assertInstanceOf(RedditMemeFetcher.Result.Error::class.java, result)
+        assertTrue(engine.requestHistory.none { it.url.host == "oauth.reddit.com" })
     }
 
     @Test

--- a/discord-bot/src/test/kotlin/bot/toby/helpers/MusicPlayerHelperTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/helpers/MusicPlayerHelperTest.kt
@@ -179,7 +179,39 @@ class MusicPlayerHelperTest {
             message.editMessageEmbeds(match<MessageEmbed> {
                 it.title == "Title" && it.description?.contains("Author") == true
             })
-            messageEditAction.setComponents(any<ActionRow>()).queue()
+            messageEditAction.setComponents(any<ActionRow>()).queue(any(), any())
+        }
+    }
+
+    @Test
+    fun `test nowPlaying falls back to a new message when editing a stale stored message fails`() {
+        every { audioPlayer.volume } returns 50
+        every { audioPlayer.isPaused } returns false
+
+        // Pre-store a stale message whose edit will fail (deleted on Discord's side).
+        val staleMessage = mockk<Message>(relaxed = true)
+        val failingEdit = mockk<MessageEditAction>(relaxed = true)
+        every { staleMessage.editMessageEmbeds(any<MessageEmbed>()) } returns failingEdit
+        every { failingEdit.setComponents(any<ActionRow>()) } returns failingEdit
+        every { failingEdit.queue(any(), any()) } answers {
+            // JDA's queue(success, failure) takes java.util.function.Consumer, not a Kotlin lambda.
+            secondArg<java.util.function.Consumer<Throwable>>().accept(RuntimeException("10008: Unknown Message"))
+        }
+
+        val freshMessage = mockk<Message>(relaxed = true)
+        val webhookCreateAction = mockk<WebhookMessageCreateAction<Message>>()
+        createWebhookMocking(webhookCreateAction, freshMessage)
+
+        MusicPlayerHelper.nowPlayingManager.clear()
+        MusicPlayerHelper.nowPlayingManager.setNowPlayingMessage(guildId, staleMessage)
+
+        MusicPlayerHelper.nowPlaying(replyCallback, playerManager, 5)
+
+        // The stale edit was attempted, then a fresh message was posted and stored.
+        verify {
+            staleMessage.editMessageEmbeds(any<MessageEmbed>())
+            replyCallback.hook.sendMessageEmbeds(any<MessageEmbed>())
+            webhookCreateAction.queue(any())
         }
     }
 
@@ -296,7 +328,7 @@ class MusicPlayerHelperTest {
             )
         } returns messageEditAction
         every {
-            messageEditAction.setComponents(any<ActionRow>()).queue()
+            messageEditAction.setComponents(any<ActionRow>()).queue(any(), any())
         } just Runs
 
     }


### PR DESCRIPTION
Fixes two long-standing maintainer-filed bugs. Two isolated commits.

### Fixes #85 — `nowPlaying` shows nothing when the stored message is stale
`MusicPlayerHelper.nowPlaying` edited the stored now-playing message with a bare `.queue()` and **no failure path**. When that stored reference was stale (e.g. the message was deleted on Discord's side after an intro played), the edit failed silently and **no embed appeared at all**. Added a failure callback that posts a fresh message instead — extracted as `sendNewNowPlayingMessage`, shared with the existing no-stored-message branch — so a missing message self-heals. Exactly the fix the issue describes ("check the message exists; if not, create a new one").

### Fixes #107 — `/meme` is broken because Reddit requires auth
Reddit dropped unauthenticated `.json` access, so `/meme` silently **401s in production** — tests passed only because they use a `MockEngine`. Added:
- **`RedditTokenProvider`** — fetches and caches an app-only (client-credentials) bearer token from `REDDIT_CLIENT_ID` / `REDDIT_CLIENT_SECRET` (mapped to `reddit.client-id` / `reddit.client-secret`), refreshing before expiry under a mutex.
- **`RedditMemeFetcher`** now calls `oauth.reddit.com` with that token + a descriptive `User-Agent` (which Reddit also requires and the old code omitted).
- **Graceful degradation:** when creds are unset, it falls back to the legacy unauthenticated endpoint and logs a warning — behaviour is unchanged until you supply credentials, at which point `/meme` works again.

> ⚙️ **Action required to actually fix `/meme`:** create a Reddit app (type "script" or "web app") at https://www.reddit.com/prefs/apps and set `REDDIT_CLIENT_ID` + `REDDIT_CLIENT_SECRET` in the deploy env. Without them the command stays broken exactly as it is today.

---

**Testing:** full `:discord-bot:test` passes; `:application` test sources compile. Added tests for the now-playing stale-edit fallback (`MusicPlayerHelperTest`) and the authenticated Reddit path — bearer header + `oauth.reddit.com` host on success, and an error with no listing call when the token request fails (`RedditMemeFetcherTest`). The existing unauthenticated-path tests still pass via an unconfigured token provider. (`:application` Spring/Testcontainers integration tests need Docker, unavailable in my sandbox; no new button/command beans were added.)

https://claude.ai/code/session_01UCEsvqKnUcgdC74Cj2odPj

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCEsvqKnUcgdC74Cj2odPj)_