### PR TITLE
Reliability: retry transient music loads, harden intro media download

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/intro/IntroMediaLoader.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/intro/IntroMediaLoader.kt
@@ -1,9 +1,11 @@
 package bot.toby.intro
 
 import bot.toby.helpers.FileUtils
+import common.logging.DiscordLogger
 import net.dv8tion.jda.api.entities.Message.Attachment
 import org.springframework.stereotype.Service
 import java.io.InputStream
+import java.util.concurrent.TimeUnit
 
 /**
  * I/O for intro media: pulls bytes off a Discord attachment proxy and
@@ -14,11 +16,22 @@ import java.io.InputStream
 @Service
 class IntroMediaLoader {
 
+    private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
+
     fun downloadAttachment(attachment: Attachment): InputStream? =
-        runCatching { attachment.proxy.download().get() }
-            .onFailure { it.printStackTrace() }
+        // Bound the blocking download: an unresponsive Discord CDN must not
+        // hang the calling handler forever. Failures are logged (not dumped
+        // to stderr) so production can actually diagnose them.
+        runCatching { attachment.proxy.download().get(DOWNLOAD_TIMEOUT_SECONDS, TimeUnit.SECONDS) }
+            .onFailure { logger.error { "Failed to download intro attachment '${attachment.fileName}': ${it.message}" } }
             .getOrNull()
 
     fun readContents(inputStream: InputStream): ByteArray? =
-        runCatching { FileUtils.readInputStreamToByteArray(inputStream) }.getOrNull()
+        runCatching { FileUtils.readInputStreamToByteArray(inputStream) }
+            .onFailure { logger.error { "Failed to read intro media stream: ${it.message}" } }
+            .getOrNull()
+
+    private companion object {
+        const val DOWNLOAD_TIMEOUT_SECONDS = 30L
+    }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/lavaplayer/PlayerManager.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/lavaplayer/PlayerManager.kt
@@ -30,6 +30,9 @@ import dev.lavalink.youtube.clients.TvHtml5Simply
 import dev.lavalink.youtube.clients.Web
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
 import java.util.function.Function
 
 private const val CIPHER_API_URL = "https://cipher.kikkia.dev/api"
@@ -52,7 +55,14 @@ private const val LAVAPLAYER_ENABLE_TWITCH = "LAVAPLAYER_ENABLE_TWITCH"
 
 private val logger: DiscordLogger = DiscordLogger.createLogger(PlayerManager::class.java)
 
-class PlayerManager(private val audioPlayerManager: AudioPlayerManager) {
+class PlayerManager(
+    private val audioPlayerManager: AudioPlayerManager,
+    // Backs the transient-load retry backoff. Daemon so it never blocks JVM
+    // shutdown; injectable so tests can run retries synchronously.
+    private val retryExecutor: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor { r ->
+        Thread(r, "track-load-retry").apply { isDaemon = true }
+    },
+) {
     private val musicManagers: MutableMap<Long, GuildMusicManager> = HashMap()
     var isCurrentlyStoppable: Boolean = true
     private var previousVolume: Int? = null
@@ -238,6 +248,7 @@ class PlayerManager(private val audioPlayerManager: AudioPlayerManager) {
         volume: Int,
         deleteDelay: Int,
         isIntro: Boolean = false,
+        attempt: Int = 1,
     ): AudioLoadResultHandler {
         return object : AudioLoadResultHandler {
             private val scheduler: TrackScheduler = musicManager.scheduler
@@ -265,8 +276,36 @@ class PlayerManager(private val audioPlayerManager: AudioPlayerManager) {
             }
 
             override fun loadFailed(exception: FriendlyException) {
+                // COMMON = track-specific (e.g. video unavailable): retrying won't help.
+                // SUSPICIOUS / FAULT are usually transient (rate-limit, IP block,
+                // momentary source glitch) and frequently succeed on a second try —
+                // exactly the cases users work around today by re-running /play.
+                val transient = exception.severity == FriendlyException.Severity.SUSPICIOUS ||
+                    exception.severity == FriendlyException.Severity.FAULT
+                if (transient && attempt < MAX_LOAD_ATTEMPTS) {
+                    val delayMs = LOAD_RETRY_BASE_MS * attempt
+                    logger.warn {
+                        "Track load failed for url=$trackUrl severity=${exception.severity}; " +
+                            "retry $attempt/${MAX_LOAD_ATTEMPTS - 1} in ${delayMs}ms"
+                    }
+                    retryExecutor.schedule(
+                        {
+                            audioPlayerManager.loadItemOrdered(
+                                musicManager,
+                                trackUrl,
+                                getResultHandler(
+                                    event, musicManager, trackUrl, startPosition, endPosition,
+                                    volume, deleteDelay, isIntro, attempt + 1,
+                                ),
+                            )
+                        },
+                        delayMs,
+                        TimeUnit.MILLISECONDS,
+                    )
+                    return
+                }
                 logger.error {
-                    "Track load failed for url=$trackUrl severity=${exception.severity}\n" +
+                    "Track load failed for url=$trackUrl severity=${exception.severity} after $attempt attempt(s)\n" +
                             exception.stackTraceToString()
                 }
                 event?.hook?.replyAndDelete("Could not play: ${exception.message}", deleteDelay)
@@ -299,6 +338,12 @@ class PlayerManager(private val audioPlayerManager: AudioPlayerManager) {
     }
 
     companion object {
+        /** Total load attempts before giving up (1 initial + retries). */
+        const val MAX_LOAD_ATTEMPTS = 3
+
+        /** Base backoff between transient-load retries; multiplied by the attempt number. */
+        const val LOAD_RETRY_BASE_MS = 1_000L
+
         val instance: PlayerManager by lazy {
             PlayerManager()
         }

--- a/discord-bot/src/test/kotlin/bot/toby/intro/IntroMediaLoaderTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/intro/IntroMediaLoaderTest.kt
@@ -1,0 +1,44 @@
+package bot.toby.intro
+
+import io.mockk.every
+import io.mockk.mockk
+import net.dv8tion.jda.api.entities.Message.Attachment
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+
+class IntroMediaLoaderTest {
+
+    private val loader = IntroMediaLoader()
+
+    private fun attachmentReturning(future: CompletableFuture<InputStream>): Attachment =
+        mockk(relaxed = true) { every { proxy.download() } returns future }
+
+    @Test
+    fun `downloadAttachment returns the stream on success`() {
+        val stream: InputStream = ByteArrayInputStream(byteArrayOf(1, 2, 3))
+        val future = mockk<CompletableFuture<InputStream>>()
+        every { future.get(any(), any<TimeUnit>()) } returns stream
+
+        assertSame(stream, loader.downloadAttachment(attachmentReturning(future)))
+    }
+
+    @Test
+    fun `downloadAttachment returns null (no throw) when the bounded download fails`() {
+        val future = mockk<CompletableFuture<InputStream>>()
+        every { future.get(any(), any<TimeUnit>()) } throws RuntimeException("cdn timeout")
+
+        assertNull(loader.downloadAttachment(attachmentReturning(future)))
+    }
+
+    @Test
+    fun `readContents reads the stream to bytes`() {
+        val bytes = byteArrayOf(4, 5, 6, 7)
+        assertArrayEquals(bytes, loader.readContents(ByteArrayInputStream(bytes)))
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/lavaplayer/PlayerManagerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/lavaplayer/PlayerManagerTest.kt
@@ -1,0 +1,76 @@
+package bot.toby.lavaplayer
+
+import com.sedmelluq.discord.lavaplayer.player.AudioLoadResultHandler
+import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager
+import com.sedmelluq.discord.lavaplayer.tools.FriendlyException
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.concurrent.ScheduledExecutorService
+
+class PlayerManagerTest {
+
+    private lateinit var apm: AudioPlayerManager
+    private lateinit var guild: Guild
+    private lateinit var event: SlashCommandInteractionEvent
+    private val handlers = mutableListOf<AudioLoadResultHandler>()
+    private lateinit var pm: PlayerManager
+
+    @BeforeEach
+    fun setUp() {
+        apm = mockk(relaxed = true)
+        handlers.clear()
+        val handlerSlot = slot<AudioLoadResultHandler>()
+        every { apm.loadItemOrdered(any<Any>(), any<String>(), capture(handlerSlot)) } answers {
+            handlers.add(handlerSlot.captured)
+            mockk<java.util.concurrent.Future<Void>>(relaxed = true)
+        }
+        // Run scheduled retries synchronously so the test is deterministic.
+        val immediate = mockk<ScheduledExecutorService>()
+        every { immediate.schedule(any<Runnable>(), any<Long>(), any<java.util.concurrent.TimeUnit>()) } answers {
+            firstArg<Runnable>().run()
+            mockk<java.util.concurrent.ScheduledFuture<*>>(relaxed = true)
+        }
+        pm = PlayerManager(apm, immediate)
+        guild = mockk(relaxed = true) { every { idLong } returns 1L }
+        event = mockk(relaxed = true)
+    }
+
+    private fun transientFailure() =
+        FriendlyException("rate limited", FriendlyException.Severity.SUSPICIOUS, RuntimeException("x"))
+
+    @Test
+    fun `transient load failures are retried up to the attempt cap`() {
+        pm.loadAndPlay(guild, event, "url", true, 5, 0L, 50, null)
+        assertEquals(1, handlers.size)
+
+        handlers.last().loadFailed(transientFailure())
+        assertEquals(2, handlers.size, "first transient failure should trigger a retry")
+
+        handlers.last().loadFailed(transientFailure())
+        assertEquals(3, handlers.size, "second transient failure should trigger another retry")
+
+        handlers.last().loadFailed(transientFailure())
+        assertEquals(3, handlers.size, "at the cap no further load is attempted")
+
+        verify(exactly = PlayerManager.MAX_LOAD_ATTEMPTS) { apm.loadItemOrdered(any<Any>(), any<String>(), any<AudioLoadResultHandler>()) }
+    }
+
+    @Test
+    fun `common track-specific failures are not retried`() {
+        pm.loadAndPlay(guild, event, "url", true, 5, 0L, 50, null)
+
+        handlers.last().loadFailed(
+            FriendlyException("video unavailable", FriendlyException.Severity.COMMON, RuntimeException("x")),
+        )
+
+        assertEquals(1, handlers.size)
+        verify(exactly = 1) { apm.loadItemOrdered(any<Any>(), any<String>(), any<AudioLoadResultHandler>()) }
+    }
+}


### PR DESCRIPTION
Second of the four follow-up directions — **reliability hardening**, scoped to playback & media (the riskiest external-fetch surfaces). Two isolated commits.

### 1. Retry transient music track-load failures (`Retry transient music track-load failures…`)
A momentary YouTube IP-block / rate-limit surfaced "Could not play" and users just re-ran `/play`. `PlayerManager` now retries on **transient** `FriendlyException` severities (`SUSPICIOUS` / `FAULT`) up to a small cap (`MAX_LOAD_ATTEMPTS = 3`) with linear backoff, only giving up — and replying — once retries are exhausted. **`COMMON`** (track-specific, e.g. "video unavailable") failures are **not** retried since a retry can't help. The backoff runs on an injected daemon `ScheduledExecutorService`, so it never blocks shutdown and tests drive retries synchronously. The success / `noMatches` paths are untouched.

### 2. Harden intro media download (`Harden intro media download…`)
`IntroMediaLoader.downloadAttachment` blocked on `.get()` with **no timeout** (an unresponsive Discord CDN could hang the handler) and swallowed failures via `printStackTrace()`, losing them in production. Now it bounds the wait with `get(30s)` and logs failures through `DiscordLogger`; `readContents` logs on failure too. Both still return `null` on error, so callers are unaffected.

---

**Testing:** full `:discord-bot:test` passes; `:application` test sources compile. Added `PlayerManagerTest` (transient failures retried to the cap; `COMMON` not retried) and `IntroMediaLoaderTest` (bounded download returns the stream / returns null without throwing on failure; `readContents` reads bytes). No new beans, so no `ButtonManagerTest` change.

**Deferred (happy to follow up):** the rest of the reliability bucket — Scryfall/D&D 429 backoff + caching, and the broader `runCatching{}.getOrNull()` silent-failure audit — I kept out of this PR to keep the core-playback change isolated and reviewable.

https://claude.ai/code/session_01UCEsvqKnUcgdC74Cj2odPj

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCEsvqKnUcgdC74Cj2odPj)_