### PR TITLE
Fix web /meme 403s by using Reddit OAuth like the bot (#403)

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/fetch/RedditTokenProvider.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/fetch/RedditTokenProvider.kt
@@ -35,10 +35,16 @@ import java.util.Base64
 @Component
 class RedditTokenProvider @Autowired constructor(
     private val client: HttpClient,
-    @param:Value($$"${reddit.client-id:}") private val clientId: String = "",
-    @param:Value($$"${reddit.client-secret:}") private val clientSecret: String = "",
+    @param:Value($$"${reddit.client-id:}") clientId: String = "",
+    @param:Value($$"${reddit.client-secret:}") clientSecret: String = "",
     private val nowMs: () -> Long = { System.currentTimeMillis() },
 ) {
+    // Trim defensively: env vars pasted into a host's config (e.g. Heroku)
+    // often carry a trailing newline/space, which would corrupt the Basic
+    // auth header and earn a 401 from Reddit's token endpoint.
+    private val clientId: String = clientId.trim()
+    private val clientSecret: String = clientSecret.trim()
+
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
     private val mutex = Mutex()
 

--- a/web/src/main/kotlin/web/service/RedditTokenProvider.kt
+++ b/web/src/main/kotlin/web/service/RedditTokenProvider.kt
@@ -1,0 +1,106 @@
+package web.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import common.logging.DiscordLogger
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+import java.util.Base64
+
+/**
+ * App-only (client-credentials) OAuth bearer-token source for Reddit's API,
+ * used by the web `/utils/api/meme` tool.
+ *
+ * Reddit dropped unauthenticated `.json` access, so the meme fetcher needs a
+ * token. The Discord `/meme` command was migrated to OAuth in issue #107, but
+ * the web tool was left on the now-blocked anonymous endpoint — Reddit answers
+ * those with a 403, which [UtilsWebService] surfaced to the browser as a 400
+ * (issue #403). This provider closes that gap using the *same*
+ * `REDDIT_CLIENT_ID` / `REDDIT_CLIENT_SECRET` env vars (mapped to
+ * `reddit.client-id` / `reddit.client-secret`) the bot already consumes.
+ *
+ * When unset, [isConfigured] is false and [bearerToken] returns null, so the
+ * fetcher degrades to the legacy anonymous endpoint exactly as before.
+ *
+ * Tokens are cached and refreshed shortly before expiry; the refresh is guarded
+ * by a monitor so a burst of meme calls triggers a single fetch.
+ */
+interface RedditTokenSource {
+    /** True once both client id and secret are present. */
+    val isConfigured: Boolean
+
+    /** A valid app-only bearer token, or null when unconfigured / the token request failed. */
+    fun bearerToken(): String?
+}
+
+@Component
+class RedditTokenProvider(
+    @param:Value($$"${reddit.client-id:}") private val clientId: String = "",
+    @param:Value($$"${reddit.client-secret:}") private val clientSecret: String = "",
+    private val http: HttpClient = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build(),
+    private val nowMs: () -> Long = { System.currentTimeMillis() },
+) : RedditTokenSource {
+
+    private val jackson = ObjectMapper()
+    private val lock = Any()
+
+    @Volatile private var cachedToken: String? = null
+    @Volatile private var expiresAtMs: Long = 0L
+
+    override val isConfigured: Boolean get() = clientId.isNotBlank() && clientSecret.isNotBlank()
+
+    override fun bearerToken(): String? {
+        if (!isConfigured) return null
+        synchronized(lock) {
+            cachedToken?.let { if (nowMs() < expiresAtMs - REFRESH_SKEW_MS) return it }
+            return try {
+                fetchToken()
+            } catch (e: Exception) {
+                logger.error { "Failed to obtain Reddit app token: ${e.message}" }
+                null
+            }
+        }
+    }
+
+    private fun fetchToken(): String {
+        val basic = Base64.getEncoder().encodeToString("$clientId:$clientSecret".toByteArray())
+        val request = HttpRequest.newBuilder(URI.create(TOKEN_URL))
+            .header("Authorization", "Basic $basic")
+            .header("User-Agent", USER_AGENT)
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .timeout(Duration.ofSeconds(10))
+            .POST(HttpRequest.BodyPublishers.ofString("grant_type=client_credentials"))
+            .build()
+        val response = http.send(request, HttpResponse.BodyHandlers.ofString())
+        val token = parseAccessToken(response.body())
+            ?: error("no access_token in Reddit token response (status ${response.statusCode()})")
+        cachedToken = token
+        expiresAtMs = nowMs() + parseExpiresInSec(response.body()) * 1000
+        logger.info { "Obtained Reddit app token" }
+        return token
+    }
+
+    private fun parseAccessToken(body: String): String? = runCatching {
+        jackson.readTree(body).path("access_token").takeIf { it.isTextual }?.asText()
+    }.getOrNull()
+
+    private fun parseExpiresInSec(body: String): Long = runCatching {
+        jackson.readTree(body).path("expires_in").asLong(DEFAULT_EXPIRY_SEC)
+    }.getOrDefault(DEFAULT_EXPIRY_SEC)
+
+    companion object {
+        private val logger: DiscordLogger = DiscordLogger.createLogger(RedditTokenProvider::class.java)
+
+        const val TOKEN_URL = "https://www.reddit.com/api/v1/access_token"
+
+        /** Reddit requires a unique, descriptive User-Agent or it aggressively rate-limits. */
+        const val USER_AGENT = "web:co.uk.toby-bot:1.0 (by /u/toby-bot)"
+
+        private const val REFRESH_SKEW_MS = 60_000L
+        private const val DEFAULT_EXPIRY_SEC = 3600L
+    }
+}

--- a/web/src/main/kotlin/web/service/RedditTokenProvider.kt
+++ b/web/src/main/kotlin/web/service/RedditTokenProvider.kt
@@ -43,11 +43,17 @@ interface RedditTokenSource {
 // both and fails to load the context (issue #403 follow-up).
 @Component("webRedditTokenProvider")
 class RedditTokenProvider(
-    @param:Value($$"${reddit.client-id:}") private val clientId: String = "",
-    @param:Value($$"${reddit.client-secret:}") private val clientSecret: String = "",
+    @param:Value($$"${reddit.client-id:}") clientId: String = "",
+    @param:Value($$"${reddit.client-secret:}") clientSecret: String = "",
     private val http: HttpClient = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build(),
     private val nowMs: () -> Long = { System.currentTimeMillis() },
 ) : RedditTokenSource {
+
+    // Trim defensively: env vars pasted into a host's config (e.g. Heroku)
+    // often carry a trailing newline/space, which would corrupt the Basic
+    // auth header and earn a 401 from Reddit's token endpoint.
+    private val clientId: String = clientId.trim()
+    private val clientSecret: String = clientSecret.trim()
 
     private val jackson = ObjectMapper()
     private val lock = Any()

--- a/web/src/main/kotlin/web/service/RedditTokenProvider.kt
+++ b/web/src/main/kotlin/web/service/RedditTokenProvider.kt
@@ -37,7 +37,11 @@ interface RedditTokenSource {
     fun bearerToken(): String?
 }
 
-@Component
+// Explicit bean name: the discord-bot module also has a `RedditTokenProvider`
+// @Component, and the full application context scans both `bot.toby.*` and
+// `web.*`. Without a distinct name Spring derives `redditTokenProvider` for
+// both and fails to load the context (issue #403 follow-up).
+@Component("webRedditTokenProvider")
 class RedditTokenProvider(
     @param:Value($$"${reddit.client-id:}") private val clientId: String = "",
     @param:Value($$"${reddit.client-secret:}") private val clientSecret: String = "",

--- a/web/src/main/kotlin/web/service/UtilsWebService.kt
+++ b/web/src/main/kotlin/web/service/UtilsWebService.kt
@@ -11,7 +11,9 @@ import java.time.Duration
 import kotlin.random.Random
 
 @Service
-class UtilsWebService {
+class UtilsWebService(
+    private val tokenSource: RedditTokenSource = RedditTokenProvider(),
+) {
     private val http: HttpClient = HttpClient.newBuilder()
         .connectTimeout(Duration.ofSeconds(5))
         .build()
@@ -30,12 +32,24 @@ class UtilsWebService {
         }
         val tp = validTimePeriod(timePeriod)
         val capped = limit.coerceIn(1, 100)
-        val url = "https://old.reddit.com/r/$sub/top/.json?limit=$capped&t=$tp"
+
+        // Reddit blocks the anonymous `.json` endpoint with a 403, so prefer the
+        // app-only OAuth endpoint when credentials are configured (issue #403).
+        val token = tokenSource.bearerToken()
+        val url = when {
+            token != null -> "https://oauth.reddit.com/r/$sub/top.json?limit=$capped&t=$tp&raw_json=1"
+            tokenSource.isConfigured ->
+                // Credentials are set but the token fetch failed (already logged) —
+                // don't fall back to the blocked anonymous endpoint, surface a retry.
+                return UtilsResult.error("Could not reach Reddit right now. Please try again later.")
+            else -> "https://old.reddit.com/r/$sub/top/.json?limit=$capped&t=$tp"
+        }
 
         return try {
             val response = http.send(
                 HttpRequest.newBuilder(URI.create(url))
-                    .header("User-Agent", "tobybot-web/1.0")
+                    .header("User-Agent", RedditTokenProvider.USER_AGENT)
+                    .apply { token?.let { header("Authorization", "bearer $it") } }
                     .timeout(Duration.ofSeconds(10))
                     .GET()
                     .build(),

--- a/web/src/test/kotlin/web/service/RedditTokenProviderTest.kt
+++ b/web/src/test/kotlin/web/service/RedditTokenProviderTest.kt
@@ -1,0 +1,91 @@
+package web.service
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.net.http.HttpClient
+import java.net.http.HttpResponse
+
+class RedditTokenProviderTest {
+
+    private fun response(status: Int, body: String): HttpResponse<String> =
+        mockk<HttpResponse<String>>().also {
+            every { it.statusCode() } returns status
+            every { it.body() } returns body
+        }
+
+    @Test
+    fun `unconfigured provider reports not configured and never touches the network`() {
+        val http = mockk<HttpClient>()
+        val provider = RedditTokenProvider(clientId = "", clientSecret = "  ", http = http)
+
+        assertFalse(provider.isConfigured)
+        assertNull(provider.bearerToken())
+        verify(exactly = 0) { http.send(any(), any<HttpResponse.BodyHandler<String>>()) }
+    }
+
+    @Test
+    fun `configured provider fetches and returns the access token`() {
+        val http = mockk<HttpClient>()
+        every { http.send(any(), any<HttpResponse.BodyHandler<String>>()) } returns
+            response(200, """{"access_token":"tok123","token_type":"bearer","expires_in":3600}""")
+        val provider = RedditTokenProvider(clientId = "id", clientSecret = "secret", http = http)
+
+        assertTrue(provider.isConfigured)
+        assertEquals("tok123", provider.bearerToken())
+    }
+
+    @Test
+    fun `token is cached and only fetched once within its lifetime`() {
+        val http = mockk<HttpClient>()
+        every { http.send(any(), any<HttpResponse.BodyHandler<String>>()) } returns
+            response(200, """{"access_token":"tok123","expires_in":3600}""")
+        var now = 0L
+        val provider = RedditTokenProvider(clientId = "id", clientSecret = "secret", http = http, nowMs = { now })
+
+        assertEquals("tok123", provider.bearerToken())
+        now = 1_000L
+        assertEquals("tok123", provider.bearerToken())
+        verify(exactly = 1) { http.send(any(), any<HttpResponse.BodyHandler<String>>()) }
+    }
+
+    @Test
+    fun `token is refreshed once it nears expiry`() {
+        val http = mockk<HttpClient>()
+        every { http.send(any(), any<HttpResponse.BodyHandler<String>>()) } returnsMany listOf(
+            response(200, """{"access_token":"first","expires_in":3600}"""),
+            response(200, """{"access_token":"second","expires_in":3600}"""),
+        )
+        var now = 0L
+        val provider = RedditTokenProvider(clientId = "id", clientSecret = "secret", http = http, nowMs = { now })
+
+        assertEquals("first", provider.bearerToken())
+        now = 3_600_000L // past (expiry - refresh skew)
+        assertEquals("second", provider.bearerToken())
+        verify(exactly = 2) { http.send(any(), any<HttpResponse.BodyHandler<String>>()) }
+    }
+
+    @Test
+    fun `a token response without an access_token yields null`() {
+        val http = mockk<HttpClient>()
+        every { http.send(any(), any<HttpResponse.BodyHandler<String>>()) } returns
+            response(401, """{"error":"invalid_grant"}""")
+        val provider = RedditTokenProvider(clientId = "id", clientSecret = "secret", http = http)
+
+        assertNull(provider.bearerToken())
+    }
+
+    @Test
+    fun `a transport failure yields null rather than propagating`() {
+        val http = mockk<HttpClient>()
+        every { http.send(any(), any<HttpResponse.BodyHandler<String>>()) } throws java.io.IOException("reddit down")
+        val provider = RedditTokenProvider(clientId = "id", clientSecret = "secret", http = http)
+
+        assertNull(provider.bearerToken())
+    }
+}

--- a/web/src/test/kotlin/web/service/UtilsWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/UtilsWebServiceTest.kt
@@ -80,6 +80,19 @@ class UtilsWebServiceTest {
     }
 
     @Test
+    fun `configured creds with no available token surface a retry error without hitting Reddit`() {
+        // Credentials are set but the token fetch failed: we must NOT fall back
+        // to the anonymous endpoint Reddit now 403s — surface a transient error
+        // (issue #403). No network is touched because the fake returns no token.
+        val service = UtilsWebService(FakeTokenSource(isConfigured = true, token = null))
+
+        val result = service.randomMeme("memes", "day", 10)
+
+        assertNull(result.value)
+        assertEquals("Could not reach Reddit right now. Please try again later.", result.error)
+    }
+
+    @Test
     fun `UtilsResult ok and error helpers produce mutually-exclusive shapes`() {
         val ok = UtilsResult.ok("hi")
         assertEquals("hi", ok.value)
@@ -88,5 +101,12 @@ class UtilsWebServiceTest {
         val err = UtilsResult.error<String>("nope")
         assertNull(err.value)
         assertEquals("nope", err.error)
+    }
+
+    private class FakeTokenSource(
+        override val isConfigured: Boolean,
+        private val token: String?,
+    ) : RedditTokenSource {
+        override fun bearerToken(): String? = token
     }
 }


### PR DESCRIPTION
## Problem

Adding `REDDIT_CLIENT_ID` / `REDDIT_CLIENT_SECRET` to the environment had **no effect on the website's meme tool**, which kept returning errors (the Heroku logs show `GET /utils/api/meme … status=400`).

Root cause: the Discord `/meme` command was migrated to Reddit's app-only OAuth in **#107** (`RedditTokenProvider` + `RedditMemeFetcher`, in the `discord-bot` module). But the **web** tool's backend — `web.service.UtilsWebService` — was never touched. It still hits the anonymous endpoint:

```
https://old.reddit.com/r/<sub>/top/.json
```

Reddit now answers anonymous `.json` requests with a **403**, and `UtilsWebService` wraps any non-200 as a 400 to the browser. The OAuth env vars are only read by the `discord-bot` module, so the website never saw them.

## Fix

- New `web.service.RedditTokenProvider` (+ `RedditTokenSource` interface): mints and caches an app-only bearer token from the **same** `reddit.client-id` / `reddit.client-secret` properties the bot already uses (`REDDIT_CLIENT_ID` / `REDDIT_CLIENT_SECRET`). Token is cached and refreshed shortly before expiry, guarded by a monitor so a burst of requests triggers one fetch.
- `UtilsWebService.randomMeme` now routes through `https://oauth.reddit.com/r/<sub>/top.json?…&raw_json=1` with `Authorization: bearer <token>` when configured.

Degradation behaviour mirrors the bot:
- **Creds unset** → falls back to the legacy anonymous endpoint exactly as before (no behaviour change for dev/CI).
- **Creds set but token fetch fails** → surfaces a transient `"Could not reach Reddit right now. Please try again later."` instead of hammering the blocked endpoint.

No new env vars or config required — the existing `reddit.client-id` / `reddit.client-secret` (already declared in `application.properties` for #107) now drive both the bot and the web tool.

## Tests

- `RedditTokenProviderTest` (6) — unconfigured short-circuit (no network), token fetch/parse, caching within lifetime, refresh near expiry, missing `access_token` → null, transport failure → null.
- `UtilsWebServiceTest` (+1) — configured-but-no-token surfaces the retry error without hitting Reddit.

All 13 tests in these two classes pass (`:web:test`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01KyYWb2tru4kn1uDyqeT8f6)_