### PR TITLE
Web: add member search to the leaderboard standings

### DIFF
--- a/web/src/main/resources/static/css/leaderboard.css
+++ b/web/src/main/resources/static/css/leaderboard.css
@@ -983,3 +983,30 @@ details.lb-collapse[open] .lb-collapse-caret { transform: rotate(90deg); }
         font-size: 0.78rem;
     }
 }
+
+/* -- Member search (Members tab) -- */
+.lb-search {
+    margin-bottom: var(--space-3);
+}
+.lb-search-label {
+    display: block;
+    margin-bottom: var(--space-1);
+    font-size: 0.85rem;
+}
+.lb-search-input {
+    width: 100%;
+    max-width: 360px;
+    padding: var(--space-2) var(--space-3);
+    background: var(--bg-input);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    color: var(--text);
+    font-size: 0.95rem;
+}
+.lb-search-input:focus {
+    outline: none;
+    border-color: var(--accent);
+}
+.lb-search-empty {
+    margin-top: var(--space-2);
+}

--- a/web/src/main/resources/static/js/leaderboard.js
+++ b/web/src/main/resources/static/js/leaderboard.js
@@ -1,3 +1,18 @@
+// Show only the standings rows whose member name contains `query`
+// (case-insensitive, trimmed). Returns the number of visible rows.
+// Pure DOM helper, exported for unit tests.
+function filterStandingsRows(rows, query) {
+    const q = (query || '').trim().toLowerCase();
+    let visible = 0;
+    rows.forEach(function (tr) {
+        const name = tr.getAttribute('data-name') || '';
+        const match = q === '' || name.indexOf(q) !== -1;
+        tr.hidden = !match;
+        if (match) visible += 1;
+    });
+    return visible;
+}
+
 (function () {
     'use strict';
 
@@ -199,4 +214,26 @@
             });
         });
     }
+
+    // ---- Member search (Members tab) ----
+    // The full ranked standings are all in the DOM, so filtering client-side
+    // searches every member — not just the visible top rows. Degrades fine
+    // with JS off (no input shown does nothing; the table is still complete).
+    const searchInput = document.getElementById('lb-member-search');
+    const standingsBody = document.getElementById('lb-standings-body');
+    if (searchInput && standingsBody) {
+        const emptyEl = document.querySelector('.lb-search-empty');
+        const termEl = document.querySelector('.lb-search-term');
+        searchInput.addEventListener('input', () => {
+            const query = searchInput.value;
+            const rows = Array.from(standingsBody.querySelectorAll('tr'));
+            const visible = filterStandingsRows(rows, query);
+            if (termEl) termEl.textContent = query.trim();
+            if (emptyEl) emptyEl.hidden = visible !== 0 || query.trim() === '';
+        });
+    }
 })();
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { filterStandingsRows };
+}

--- a/web/src/main/resources/templates/leaderboard.html
+++ b/web/src/main/resources/templates/leaderboard.html
@@ -205,6 +205,15 @@
             </span>
         </summary>
         <div class="lb-collapse-body">
+            <div class="lb-search">
+                <label class="lb-search-label" for="lb-member-search">Find a member</label>
+                <input type="search" id="lb-member-search" class="lb-search-input"
+                       placeholder="Search members…" autocomplete="off"
+                       aria-controls="lb-standings-body">
+                <p class="lb-search-empty muted" hidden>
+                    No members match “<span class="lb-search-term"></span>”.
+                </p>
+            </div>
             <div class="mod-table-wrap">
                 <table class="mod-table lb-standings-table">
                     <thead>
@@ -226,11 +235,12 @@
                         <th>🎤 Voice this month</th>
                     </tr>
                     </thead>
-                    <tbody>
+                    <tbody id="lb-standings-body">
                     <tr th:each="row : ${view.standings}"
                         th:attr="data-credits-month=${row.creditsEarnedThisMonth},
                                  data-credits-total=${row.socialCredit},
-                                 data-xp=${row.xp}">
+                                 data-xp=${row.xp},
+                                 data-name=${#strings.toLowerCase(row.name)}">
                         <td data-label="#">
                             <span class="lb-rank"
                                   th:classappend="${row.rank == 1 ? 'lb-rank-1' : (row.rank == 2 ? 'lb-rank-2' : (row.rank == 3 ? 'lb-rank-3' : ''))}"

--- a/web/src/test/js/leaderboard-search.test.js
+++ b/web/src/test/js/leaderboard-search.test.js
@@ -1,0 +1,44 @@
+const { filterStandingsRows } = require('../../main/resources/static/js/leaderboard');
+
+// Builds standings rows with a data-name attribute (as the template emits,
+// lower-cased) and returns the row elements.
+function rows(...names) {
+    document.body.innerHTML =
+        '<table><tbody id="lb-standings-body">' +
+        names.map((n) => `<tr data-name="${n.toLowerCase()}"><td>${n}</td></tr>`).join('') +
+        '</tbody></table>';
+    return Array.from(document.querySelectorAll('#lb-standings-body tr'));
+}
+
+describe('filterStandingsRows', () => {
+    test('shows only rows whose name contains the query (case-insensitive)', () => {
+        const r = rows('Alice', 'Bob', 'Albert');
+        const visible = filterStandingsRows(r, 'AL');
+        expect(visible).toBe(2);
+        expect(r[0].hidden).toBe(false); // Alice
+        expect(r[1].hidden).toBe(true); // Bob
+        expect(r[2].hidden).toBe(false); // Albert
+    });
+
+    test('empty and whitespace-only queries show every row', () => {
+        const r = rows('Alice', 'Bob');
+        expect(filterStandingsRows(r, '')).toBe(2);
+        expect(r.every((tr) => tr.hidden === false)).toBe(true);
+
+        expect(filterStandingsRows(r, '   ')).toBe(2);
+        expect(r.every((tr) => tr.hidden === false)).toBe(true);
+    });
+
+    test('no matches hides everything and returns 0', () => {
+        const r = rows('Alice', 'Bob');
+        expect(filterStandingsRows(r, 'zzz')).toBe(0);
+        expect(r.every((tr) => tr.hidden === true)).toBe(true);
+    });
+
+    test('matches substrings anywhere in the name', () => {
+        const r = rows('xXEpicGamerXx', 'plainname');
+        expect(filterStandingsRows(r, 'epicgamer')).toBe(1);
+        expect(r[0].hidden).toBe(false);
+        expect(r[1].hidden).toBe(true);
+    });
+});


### PR DESCRIPTION
Third of the four follow-up directions — **web dashboard wins**.

### Leaderboard member search
Large guilds couldn't find a specific member: the standings table is a visual top-N, but it actually renders **every** ranked member into the DOM — so anyone outside the top rows was only reachable by scrolling a long table. This adds a search box to the "All members" section that filters the standings client-side by name (case-insensitive substring). Because all rows are already present, it searches the **whole guild**, not just the visible top.

- Rows now carry a lowercased `data-name`; the filter is an **exported pure helper** (`filterStandingsRows`) wired into the existing `leaderboard.js`, with a "no members match …" empty state.
- Degrades gracefully with JS off (the table stays complete).
- CSS reuses the existing theme tokens (`--bg-input`, `--border`, `--accent`, spacing/radius vars).

### A note on the other two "quick wins" from the survey
While implementing I found both were mirages, so I deliberately left them out rather than ship something that doesn't work:
- **Dark-mode toggle** — the site is **dark-only by design** (`<meta name="color-scheme" content="dark">` is hardcoded in both head fragments and the CSS has no light theme). A real toggle means building an entire light theme (L, not S).
- **OpenGraph profile previews** — profile pages (and the card PNG) are **auth-gated** (OAuth2 + guild membership), so an unauthenticated Discord/Twitter crawler just hits the login redirect. OG tags there wouldn't produce previews without a new **public** profile route, which is a privacy-sensitive feature, not a quick win.

---

**Testing:** added `leaderboard-search.test.js`; the full Jest suite passes (**752 tests, 51 suites**) and `npm run lint:css` (stylelint) is clean — both are CI gates in `gradle.yml`. No Kotlin changed.

https://claude.ai/code/session_01UCEsvqKnUcgdC74Cj2odPj

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCEsvqKnUcgdC74Cj2odPj)_