### PR TITLE
Test coverage: add the two missing command-handler tests (/daily, /casinoholdem)

### DIFF
--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/game/casino/casinoholdem/CasinoHoldemCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/game/casino/casinoholdem/CasinoHoldemCommandTest.kt
@@ -1,0 +1,102 @@
+package bot.toby.command.commands.game.casino.casinoholdem
+
+import bot.toby.command.CommandTest
+import bot.toby.command.CommandTest.Companion.event
+import bot.toby.command.CommandTest.Companion.requestingUserDto
+import bot.toby.command.DefaultCommandContext
+import database.poker.CasinoHoldemTableRegistry
+import database.service.casino.casinoholdem.CasinoHoldemService
+import database.service.casino.casinoholdem.CasinoHoldemService.DealOutcome
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.interactions.commands.OptionMapping
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class CasinoHoldemCommandTest : CommandTest {
+
+    private lateinit var service: CasinoHoldemService
+    private lateinit var tableRegistry: CasinoHoldemTableRegistry
+    private lateinit var command: CasinoHoldemCommand
+
+    @BeforeEach
+    fun setUp() {
+        setUpCommonMocks()
+        service = mockk(relaxed = true)
+        tableRegistry = mockk(relaxed = true)
+        command = CasinoHoldemCommand(service, tableRegistry)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        tearDownCommonMocks()
+        clearAllMocks()
+    }
+
+    private fun intOpt(v: Long): OptionMapping = mockk(relaxed = true) { every { asLong } returns v }
+
+    @Test
+    fun `outside a guild it does not deal`() {
+        every { event.guild } returns null
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 5)
+
+        verify(exactly = 0) { service.dealSolo(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `missing stake does not deal`() {
+        every { event.getOption("stake") } returns null
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 5)
+
+        verify(exactly = 0) { service.dealSolo(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `delegates to the service with the parsed stake and auto-topup defaulting to false`() {
+        every { event.getOption("stake") } returns intOpt(100L)
+        every { event.getOption("auto_topup") } returns null
+        every { service.dealSolo(1L, 1L, 100L, false) } returns DealOutcome.InvalidStake(10L, 500L)
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 5)
+
+        verify(exactly = 1) { service.dealSolo(1L, 1L, 100L, false) }
+    }
+
+    @Test
+    fun `failure outcomes reply with an embed`() {
+        every { event.getOption("stake") } returns intOpt(100L)
+        val failures = listOf(
+            DealOutcome.InvalidStake(10L, 500L),
+            DealOutcome.InsufficientCredits(stake = 100L, have = 5L),
+            DealOutcome.InsufficientCoinsForTopUp(needed = 50L, have = 5L),
+            DealOutcome.UnknownUser,
+        )
+
+        failures.forEach { outcome ->
+            every { service.dealSolo(any(), any(), any(), any()) } returns outcome
+            command.handle(DefaultCommandContext(event), requestingUserDto, 5)
+        }
+
+        verify(atLeast = failures.size) {
+            event.hook.sendMessageEmbeds(any<MessageEmbed>(), *anyVararg<MessageEmbed>())
+        }
+    }
+
+    @Test
+    fun `a dealt hand whose table has vanished replies with an error`() {
+        every { event.getOption("stake") } returns intOpt(100L)
+        every { service.dealSolo(any(), any(), any(), any()) } returns
+            DealOutcome.Dealt(tableId = 7L, snapshot = mockk(relaxed = true), newBalance = 0L)
+        every { tableRegistry.get(7L) } returns null
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 5)
+
+        verify { event.hook.sendMessageEmbeds(any<MessageEmbed>(), *anyVararg<MessageEmbed>()) }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/misc/DailyCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/misc/DailyCommandTest.kt
@@ -1,0 +1,72 @@
+package bot.toby.command.commands.misc
+
+import bot.toby.command.CommandTest
+import bot.toby.command.CommandTest.Companion.event
+import bot.toby.command.CommandTest.Companion.requestingUserDto
+import bot.toby.command.DefaultCommandContext
+import database.service.social.LoginStreakService
+import database.service.social.LoginStreakService.ClaimResult
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.entities.MessageEmbed
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class DailyCommandTest : CommandTest {
+
+    private lateinit var loginStreakService: LoginStreakService
+    private lateinit var command: DailyCommand
+
+    @BeforeEach
+    fun setUp() {
+        setUpCommonMocks()
+        loginStreakService = mockk(relaxed = true)
+        command = DailyCommand(loginStreakService)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        tearDownCommonMocks()
+        clearAllMocks()
+    }
+
+    @Test
+    fun `claims the daily for the invoking user and replies`() {
+        every { loginStreakService.claim(1L, 1L, any(), any()) } returns
+            ClaimResult.Granted(
+                currentStreak = 1,
+                longestStreak = 1,
+                xpGranted = 25L,
+                creditsGranted = 50L,
+                isNewBest = true,
+            )
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 5)
+
+        verify(exactly = 1) { loginStreakService.claim(1L, 1L, any(), any()) }
+        verify { event.hook.sendMessageEmbeds(any<MessageEmbed>(), *anyVararg<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `already-claimed result still replies without claiming again`() {
+        every { loginStreakService.claim(any(), any(), any(), any()) } returns
+            ClaimResult.AlreadyClaimed(currentStreak = 3, longestStreak = 5)
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 5)
+
+        verify(exactly = 1) { loginStreakService.claim(any(), any(), any(), any()) }
+        verify { event.hook.sendMessageEmbeds(any<MessageEmbed>(), *anyVararg<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `outside a guild it does not claim`() {
+        every { event.guild } returns null
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 5)
+
+        verify(exactly = 0) { loginStreakService.claim(any(), any(), any(), any()) }
+    }
+}


### PR DESCRIPTION
Last of the four follow-up directions — **test coverage**.

### Honest finding first
The survey that motivated this direction claimed the moderation commands (and dnd/economy) had "zero tests." **That's wrong** — a real audit shows they're already fully covered (every moderation command except the marker interface has a `*CommandTest`, dnd/economy/casino likewise). The codebase is genuinely well-tested. So rather than duplicate existing tests, I did an empirical gap analysis (every command/handler/service class vs. any test referencing it) and found the actual untested **command handlers** were just two:

- **`DailyCommand`** — 0 referencing tests
- **`CasinoHoldemCommand`** — 0 referencing tests

(Everything else flagged was a marker interface, an `*Embeds` helper already exercised via its command's test, or — like `NotificationRouter`, referenced by 14 test files — already well covered.)

### What this adds
Handler tests mirroring the existing `CommandTest` harness:
- **`DailyCommandTest`** — delegates to `LoginStreakService.claim` for the invoking user and replies on both `Granted` and `AlreadyClaimed`; doesn't claim outside a guild. (Also locks in the `DailyEmbeds` extraction from the earlier launcher work.)
- **`CasinoHoldemCommandTest`** — guards on missing guild/stake, delegates `dealSolo` with the parsed stake + auto-topup default, renders every failure outcome (`InvalidStake` / `InsufficientCredits` / `InsufficientCoinsForTopUp` / `UnknownUser`), and errors cleanly when a dealt table has vanished.

Test-only; **no production changes**.

---

**Testing:** full `:discord-bot:test` passes.

**Remaining (optional, low-yield):** the only other genuinely-untested classes with logic are two shared helpers (`WagerCommandHelper`, `PvpChallengeCeremony`); happy to add those if you want, but coverage is already strong.

https://claude.ai/code/session_01UCEsvqKnUcgdC74Cj2odPj

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCEsvqKnUcgdC74Cj2odPj)_