### PR TITLE
Fix cube pack tiles stretching on desktop until whole row collapses

### DIFF
--- a/web/src/main/resources/static/css/magic.css
+++ b/web/src/main/resources/static/css/magic.css
@@ -1063,6 +1063,7 @@ details[open] > .cube-section-summary .cube-collapse-chevron {
 .cube-packs {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    align-items: start;
     gap: var(--space-3);
     margin-top: var(--space-3);
 }


### PR DESCRIPTION
## Summary
- Each generated cube pack is a `<details>` element inside a CSS grid (`.cube-packs`). The grid relied on the default `align-items: stretch`, so every tile in a row was sized to the tallest open sibling.
- As a result, collapsing one pack appeared to do nothing on the desktop view until every pack in that row was also closed.
- Setting `align-items: start` lets each tile size to its own content, so collapsing an individual pack now shrinks just that tile.

## Test plan
- [ ] Generate packs on the cube page, expand one pack in a row, collapse it, and verify the tile shrinks immediately even while its row-neighbours stay open.
- [ ] Expand/collapse a mix of packs across multiple rows and confirm row heights still feel even when all packs in a row are open.

---
_Generated by [Claude Code](https://claude.ai/code/session_019AGvAhzvH9UFwY5KvZH2ib)_