### PR TITLE
Wire Scryfall autocomplete on every /magic card-input field

### DIFF
--- a/web/src/main/resources/static/css/magic.css
+++ b/web/src/main/resources/static/css/magic.css
@@ -300,7 +300,18 @@
     line-height: 1.5;
 }
 
-.cube-list-wrap textarea:focus {
+/* Single-line card-name inputs inside .cube-list-wrap should fill the
+   wrapper so the suggestion dropdown (absolute, full-width) aligns. The
+   wrapper sits inside a grid-item <label>, so giving the input a sensible
+   minimum width keeps the field readable in narrow layouts. */
+.cube-list-wrap input[type="text"] {
+    width: 100%;
+    box-sizing: border-box;
+    min-width: 240px;
+}
+
+.cube-list-wrap textarea:focus,
+.cube-list-wrap input[type="text"]:focus {
     outline: none;
     border-color: var(--mtg-gold);
     box-shadow: 0 0 0 2px var(--mtg-gold-soft);

--- a/web/src/main/resources/static/js/magic.js
+++ b/web/src/main/resources/static/js/magic.js
@@ -1329,14 +1329,26 @@
     }
 
     /**
-     * As the user types a card name in the list box, suggests real card names
-     * from Scryfall's autocomplete API and completes the current line on pick
-     * (keeping any leading quantity). Arrow keys + Enter/Escape, plus mouse.
+     * Wires every card-input on the page to Scryfall's autocomplete API.
+     * Each input/textarea sits inside a [.cube-list-wrap] with a sibling
+     * [data-card-suggest] listbox; this finds those pairs and wires them.
      */
     function wireCardAutocomplete(doc) {
-        const textarea = doc.querySelector('textarea[name="list"]');
-        const box = doc.querySelector('[data-card-suggest]');
-        if (!textarea || !box) return;
+        doc.querySelectorAll('[data-card-suggest]').forEach(function (box) {
+            const wrap = box.closest('.cube-list-wrap');
+            const field = wrap && wrap.querySelector('textarea, input[type="text"]');
+            if (field) wireCardAutocompletePair(field, box);
+        });
+    }
+
+    /**
+     * As the user types a card name in [field], suggests real card names from
+     * Scryfall's autocomplete API and completes the current line on pick
+     * (keeping any leading quantity for decklist textareas). Works for both
+     * `<textarea>` decklists and single-line `<input>` card-name fields.
+     * Arrow keys + Enter/Escape, plus mouse.
+     */
+    function wireCardAutocompletePair(field, box) {
         let timer = null;
         let controller = null;
         let items = [];
@@ -1354,11 +1366,13 @@
         }
 
         function pick(name) {
-            const applied = applyCardChoice(textarea.value, textarea.selectionStart, name);
-            textarea.value = applied.value;
-            textarea.selectionStart = textarea.selectionEnd = applied.caret;
+            const applied = applyCardChoice(field.value, field.selectionStart || 0, name);
+            field.value = applied.value;
+            try { field.selectionStart = field.selectionEnd = applied.caret; } catch (e) { /* some input types reject setSelectionRange */ }
             close();
-            textarea.focus();
+            field.focus();
+            // Let listeners (card-count badge, etc.) react to the completion.
+            field.dispatchEvent(new Event('input', { bubbles: true }));
         }
 
         function render(names) {
@@ -1378,7 +1392,7 @@
         }
 
         function suggest() {
-            const info = currentLineInfo(textarea.value, textarea.selectionStart);
+            const info = currentLineInfo(field.value, field.selectionStart || 0);
             const partial = splitQuantityPrefix(info.text).name.trim();
             if (partial.length < 2) { close(); return; }
             if (controller) controller.abort();
@@ -1389,18 +1403,18 @@
                 .catch(function () { /* aborted or offline — leave the box as it is */ });
         }
 
-        textarea.addEventListener('input', function () {
+        field.addEventListener('input', function () {
             if (timer) clearTimeout(timer);
             timer = setTimeout(suggest, 160);
         });
-        textarea.addEventListener('keydown', function (e) {
+        field.addEventListener('keydown', function (e) {
             if (box.hidden) return;
             if (e.key === 'ArrowDown') { e.preventDefault(); setActive(Math.min(active + 1, items.length - 1)); }
             else if (e.key === 'ArrowUp') { e.preventDefault(); setActive(Math.max(active - 1, 0)); }
             else if (e.key === 'Enter' && active >= 0) { e.preventDefault(); pick(items[active]); }
             else if (e.key === 'Escape') { close(); }
         });
-        textarea.addEventListener('blur', function () { setTimeout(close, 150); });
+        field.addEventListener('blur', function () { setTimeout(close, 150); });
     }
 
     function wireCardLookup(doc) {

--- a/web/src/main/resources/templates/magic.html
+++ b/web/src/main/resources/templates/magic.html
@@ -328,13 +328,23 @@
                 name (counts included), no Scryfall lookup needed.
             </p>
             <form class="cube-form cube-compare-form" data-form="compare" autocomplete="off">
-                <label class="cube-compare-col">List A (before)
-                    <textarea name="listA" rows="8" spellcheck="false"
-                              placeholder="One card per line:&#10;1 Lightning Bolt&#10;10 Forest"></textarea>
+                <label class="cube-compare-col" id="compare-a-label">List A (before)
+                    <div class="cube-list-wrap">
+                        <textarea name="listA" rows="8" spellcheck="false"
+                                  aria-labelledby="compare-a-label"
+                                  aria-autocomplete="list" aria-controls="compare-a-suggest"
+                                  placeholder="One card per line:&#10;1 Lightning Bolt&#10;10 Forest"></textarea>
+                        <ul class="cube-card-suggest" id="compare-a-suggest" data-card-suggest role="listbox" hidden></ul>
+                    </div>
                 </label>
-                <label class="cube-compare-col">List B (after)
-                    <textarea name="listB" rows="8" spellcheck="false"
-                              placeholder="The new version of the list"></textarea>
+                <label class="cube-compare-col" id="compare-b-label">List B (after)
+                    <div class="cube-list-wrap">
+                        <textarea name="listB" rows="8" spellcheck="false"
+                                  aria-labelledby="compare-b-label"
+                                  aria-autocomplete="list" aria-controls="compare-b-suggest"
+                                  placeholder="The new version of the list"></textarea>
+                        <ul class="cube-card-suggest" id="compare-b-suggest" data-card-suggest role="listbox" hidden></ul>
+                    </div>
                 </label>
                 <button type="submit" class="btn cube-submit">Compare</button>
             </form>
@@ -350,8 +360,14 @@
                 the <code th:text="${mtgCmd.cardLookup}">/mtgcard lookup</code> Discord command.
             </p>
             <form class="cube-form" data-form="card" autocomplete="off">
-                <label>Card name
-                    <input type="text" name="name" placeholder="e.g. Lightning Bolt" autocomplete="off" required>
+                <label id="card-lookup-label">Card name
+                    <div class="cube-list-wrap">
+                        <input type="text" name="name" placeholder="e.g. Lightning Bolt"
+                               autocomplete="off"
+                               aria-labelledby="card-lookup-label"
+                               aria-autocomplete="list" aria-controls="card-lookup-suggest" required>
+                        <ul class="cube-card-suggest" id="card-lookup-suggest" data-card-suggest role="listbox" hidden></ul>
+                    </div>
                 </label>
                 <button type="submit" class="btn cube-submit">Look up</button>
             </form>
@@ -367,9 +383,14 @@
                 not-in-format card is flagged. The website twin of <code th:text="${mtgCmd.deckLegality}">/mtgdeck legality</code>.
             </p>
             <form class="cube-form" data-form="legality" autocomplete="off">
-                <label>Decklist
-                    <textarea name="list" rows="10" spellcheck="false"
-                              placeholder="One card per line:&#10;4 Ragavan, Nimble Pilferer&#10;4 Lightning Bolt&#10;20 Mountain"></textarea>
+                <label id="legality-list-label">Decklist
+                    <div class="cube-list-wrap">
+                        <textarea name="list" rows="10" spellcheck="false"
+                                  aria-labelledby="legality-list-label"
+                                  aria-autocomplete="list" aria-controls="legality-card-suggest"
+                                  placeholder="One card per line:&#10;4 Ragavan, Nimble Pilferer&#10;4 Lightning Bolt&#10;20 Mountain"></textarea>
+                        <ul class="cube-card-suggest" id="legality-card-suggest" data-card-suggest role="listbox" hidden></ul>
+                    </div>
                 </label>
                 <label>Format
                     <select name="format">
@@ -423,8 +444,14 @@
             </p>
             <div th:if="${loggedIn}" data-watch-block>
                 <form class="cube-form cube-watch-form" data-form="watch" autocomplete="off">
-                    <label>Card
-                        <input type="text" name="name" placeholder="e.g. Ragavan, Nimble Pilferer" autocomplete="off" required>
+                    <label id="watch-card-label">Card
+                        <div class="cube-list-wrap">
+                            <input type="text" name="name" placeholder="e.g. Ragavan, Nimble Pilferer"
+                                   autocomplete="off"
+                                   aria-labelledby="watch-card-label"
+                                   aria-autocomplete="list" aria-controls="watch-card-suggest" required>
+                            <ul class="cube-card-suggest" id="watch-card-suggest" data-card-suggest role="listbox" hidden></ul>
+                        </div>
                     </label>
                     <label>Alert when price is
                         <select name="direction">


### PR DESCRIPTION
## Summary
- The cube-list textarea was the only field with Scryfall autocomplete. The legality decklist, card lookup, price-watch, and Compare textareas all had nothing — typing a partial name there gave no help even though the backend resolved full names fine.
- `wireCardAutocomplete` now iterates every `[data-card-suggest]` listbox on the page and wires its sibling `textarea`/`input`, so all five fields get the same arrow-key + mouse-pick suggestions. The helper handles single-line `<input>` too (`applyCardChoice` already worked on a one-line value), so the lookup and price-watch fields complete with the same logic.
- CSS gives the wrapper a sensible `min-width` when it sits inside a flex form label so the input doesn't collapse to default browser width.

## Note on the reported legality bug
I couldn't reproduce the "can't find the card" message for `4 Lightning Bolt` + Modern. I ran `CubeWebService.checkLegality("4 Lightning Bolt", "modern")` against live Scryfall and got `legal=true total=4 notFound=[] banned=[] notLegal=[]` — same for the placeholder example (`4 Ragavan, Nimble Pilferer / 4 Lightning Bolt / 20 Mountain`). The wiring (`magic.js:wireLegality` → `/magic/api/legality` → `CubeWebService.checkLegality`) all looks intact, and CSRF/permit-all are configured correctly for `/magic/api/**`. To diagnose further I'd need the exact status-line text you see and the browser DevTools Network tab response for the `/magic/api/legality` POST.

## Test plan
- [x] `./gradlew :web:test` passes
- [x] `npm test` (Jest) passes — 752 tests
- [ ] Manual: on `/magic`, type a partial name in each tab's card input — Card lookup, Legality decklist, Price watch, Compare List A/B — and confirm suggestions appear and Enter/click completes the name (with leading quantity preserved for decklist textareas)
- [ ] Manual: re-test the legality form with the same input to capture the actual symptom for the second half of the task

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9fadHEZjpN35AGkWmfXE6)_