### PR TITLE
Fix crowded music dashboard by switching to 2-column layout

### DIFF
--- a/web/src/main/resources/static/css/music-player.css
+++ b/web/src/main/resources/static/css/music-player.css
@@ -32,10 +32,26 @@
 }
 
 .music-grid {
+    /* Two columns — now-playing hero on the left, side stack (queue /
+       playlists / voice) on the right. The previous 3-column layout
+       crammed every card under ~1100px wide: Search inputs truncated to
+       "URL or sear", playlist names collapsed to "Pl…", buttons sat on
+       top of each other. Two columns gives every card enough width to
+       breathe at the typical desktop viewport. */
     display: grid;
-    grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr) minmax(0, 1fr);
+    grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
     gap: 1.25rem;
     align-items: start;
+}
+
+.music-side-column {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    /* Same min-width: 0 escape hatch as the cards themselves — grid
+       items default to min-content, which would let a long search title
+       stretch the column past its track. */
+    min-width: 0;
 }
 
 @media (max-width: 768px) {
@@ -49,6 +65,9 @@
            floor lets the column shrink to the container so the inner
            ellipsis/wrap rules can do their job. */
         grid-template-columns: minmax(0, 1fr);
+        gap: 1rem;
+    }
+    .music-side-column {
         gap: 1rem;
     }
 }

--- a/web/src/main/resources/templates/music-player.html
+++ b/web/src/main/resources/templates/music-player.html
@@ -5,7 +5,7 @@
 <a href="#main" class="skip-link">Skip to content</a>
 <div th:replace="~{fragments/navbar :: navbar}"></div>
 
-<main id="main" class="container music-dashboard">
+<main id="main" class="container-wide music-dashboard">
 
     <header class="music-header">
         <div class="music-header-titles">
@@ -59,55 +59,63 @@
             </div>
         </article>
 
-        <!-- Add Track / Queue -->
-        <article class="queue-card" data-reveal aria-labelledby="queue-heading">
-            <h2 id="queue-heading">Up next</h2>
-            <form id="add-track-form" class="add-track-form" autocomplete="off">
-                <input id="add-track-input" type="text" placeholder="URL or search term — Spotify / YouTube / SoundCloud / Bandcamp / Apple Music / Deezer" required>
-                <button class="btn-primary" type="submit">Search</button>
-            </form>
-            <p class="add-track-hint muted">
-                Tip — paste a link to queue it directly, or type plain text to see what would play before adding.
-            </p>
+        <!-- Side stack: queue + playlists + voice. Wrapper so the music-grid
+             can stay a clean 2-column layout (hero now-playing on the left,
+             everything else stacked on the right) instead of cramming three
+             skinny columns side-by-side. -->
+        <div class="music-side-column">
 
-            <section id="search-results-section" class="search-results-section" hidden aria-live="polite">
-                <header class="search-results-header">
-                    <h3 class="search-results-title">Results for <span id="search-results-query"></span></h3>
-                    <button type="button" class="btn-tertiary" id="search-results-close" aria-label="Close results">Clear</button>
-                </header>
-                <ol id="search-results-list" class="search-results-list"></ol>
-                <p id="search-results-empty" class="muted" hidden>No results.</p>
-            </section>
+            <!-- Add Track / Queue -->
+            <article class="queue-card" data-reveal aria-labelledby="queue-heading">
+                <h2 id="queue-heading">Up next</h2>
+                <form id="add-track-form" class="add-track-form" autocomplete="off">
+                    <input id="add-track-input" type="text" placeholder="URL or search term — Spotify / YouTube / SoundCloud / Bandcamp / Apple Music / Deezer" required>
+                    <button class="btn-primary" type="submit">Search</button>
+                </form>
+                <p class="add-track-hint muted">
+                    Tip — paste a link to queue it directly, or type plain text to see what would play before adding.
+                </p>
 
-            <ol id="queue-list" class="queue-list" aria-live="polite"></ol>
-            <p id="queue-empty" class="muted">Queue is empty.</p>
-        </article>
+                <section id="search-results-section" class="search-results-section" hidden aria-live="polite">
+                    <header class="search-results-header">
+                        <h3 class="search-results-title">Results for <span id="search-results-query"></span></h3>
+                        <button type="button" class="btn-tertiary" id="search-results-close" aria-label="Close results">Clear</button>
+                    </header>
+                    <ol id="search-results-list" class="search-results-list"></ol>
+                    <p id="search-results-empty" class="muted" hidden>No results.</p>
+                </section>
 
-        <!-- Playlists -->
-        <article class="playlists-card" data-reveal aria-labelledby="playlists-heading">
-            <h2 id="playlists-heading">Saved playlists</h2>
-            <form id="save-playlist-form" class="save-playlist-form" autocomplete="off">
-                <input id="save-playlist-name" type="text" maxlength="80" placeholder="New playlist name" required>
-                <div class="save-playlist-actions">
-                    <button class="btn-primary" type="submit">＋ New</button>
-                    <button class="btn-secondary" type="button" id="save-queue-btn"
-                            title="Snapshot the current queue into a new playlist">💾 Save queue</button>
-                </div>
-            </form>
-            <p class="add-track-hint muted">Create an empty playlist, then add tracks from search — building a playlist never plays anything.</p>
-            <ul id="playlist-list" class="playlist-list" aria-live="polite"></ul>
-            <p id="playlists-empty" class="muted">No saved playlists yet.</p>
-        </article>
+                <ol id="queue-list" class="queue-list" aria-live="polite"></ol>
+                <p id="queue-empty" class="muted">Queue is empty.</p>
+            </article>
 
-        <!-- Voice channel members -->
-        <article class="voice-card" data-reveal aria-labelledby="voice-heading">
-            <h2 id="voice-heading">🔈 In the voice channel</h2>
-            <p id="voice-channel-name" class="voice-channel-name" hidden></p>
-            <p id="voice-channel-empty" class="voice-channel-empty">
-                Bot isn't in a voice channel. Run <code>/join</code> in Discord first.
-            </p>
-            <ul id="voice-member-list" class="voice-member-list" aria-live="polite"></ul>
-        </article>
+            <!-- Playlists -->
+            <article class="playlists-card" data-reveal aria-labelledby="playlists-heading">
+                <h2 id="playlists-heading">Saved playlists</h2>
+                <form id="save-playlist-form" class="save-playlist-form" autocomplete="off">
+                    <input id="save-playlist-name" type="text" maxlength="80" placeholder="New playlist name" required>
+                    <div class="save-playlist-actions">
+                        <button class="btn-primary" type="submit">＋ New</button>
+                        <button class="btn-secondary" type="button" id="save-queue-btn"
+                                title="Snapshot the current queue into a new playlist">💾 Save queue</button>
+                    </div>
+                </form>
+                <p class="add-track-hint muted">Create an empty playlist, then add tracks from search — building a playlist never plays anything.</p>
+                <ul id="playlist-list" class="playlist-list" aria-live="polite"></ul>
+                <p id="playlists-empty" class="muted">No saved playlists yet.</p>
+            </article>
+
+            <!-- Voice channel members -->
+            <article class="voice-card" data-reveal aria-labelledby="voice-heading">
+                <h2 id="voice-heading">🔈 In the voice channel</h2>
+                <p id="voice-channel-name" class="voice-channel-name" hidden></p>
+                <p id="voice-channel-empty" class="voice-channel-empty">
+                    Bot isn't in a voice channel. Run <code>/join</code> in Discord first.
+                </p>
+                <ul id="voice-member-list" class="voice-member-list" aria-live="polite"></ul>
+            </article>
+
+        </div>
 
     </section>
 


### PR DESCRIPTION
## Summary
The music player dashboard was packing four cards into a 3-column grid that broke down badly at ~980px viewports — the Search input truncated to "URL or sear", playlist names collapsed to "Pl…", and the Save-queue/＋New buttons stacked on top of each other.

This switches the dashboard to a 2-column layout: the now-playing hero on the left, and queue / playlists / voice stacked in a side column on the right. Every card gets enough width to breathe, and the page is promoted to `container-wide` so it can actually use the desktop viewport.

## Changes
- Wrapped queue, playlists, and voice cards in a new `.music-side-column` flex stack.
- Replaced the 3-column `.music-grid` with `1.4fr 1fr` two-column tracks.
- Promoted `<main>` to `container-wide` (1100px) so a hero + side-stack fits comfortably.
- Mobile (≤768px) still collapses to a single column — the side-column inherits the same stack with a tighter gap.

## Test plan
- [x] `npx stylelint src/main/resources/static/css/music-player.css` — no errors
- [x] `npx jest music-player-resync music-preview music-playlist-builder` — 16/16 pass
- [ ] Visually verify desktop layout looks balanced and uncramped
- [ ] Visually verify mobile (single-column) still polished


---
_Generated by [Claude Code](https://claude.ai/code/session_016Lwo2WYeNnYBXDhEH1GaJK)_