### PR TITLE
Settle multi blackjack hands per seat vs the dealer, not from a peer pool

### DIFF
--- a/common/src/main/kotlin/common/casino/blackjack/BlackjackTable.kt
+++ b/common/src/main/kotlin/common/casino/blackjack/BlackjackTable.kt
@@ -72,7 +72,7 @@ class BlackjackTable(
         val dealerHitsSoft17: Boolean = false,
         /** Natural-blackjack multiplier on the player's stake. 2.5 = 3:2 (default), 2.2 = 6:5. */
         val blackjackPayoutMultiplier: Double = 2.5,
-        /** Fraction of the multi losers' pool routed to the jackpot pool. */
+        /** Fraction of each losing multi hand-slot's stake routed to the jackpot pool. */
         val rakeFraction: Double = 0.05,
     )
 

--- a/database/src/main/kotlin/database/service/casino/blackjack/BlackjackService.kt
+++ b/database/src/main/kotlin/database/service/casino/blackjack/BlackjackService.kt
@@ -1360,18 +1360,19 @@ class BlackjackService @Autowired constructor(
     }
 
     /**
-     * Dealer plays out (skipped if every seat busted), then we evaluate
-     * every seat against the dealer and split the pot:
+     * Dealer plays out (skipped if every seat busted), then each hand-
+     * slot is settled INDEPENDENTLY vs the dealer. Other players at the
+     * table winning or losing has no effect on what this seat takes
+     * home — beating the dealer is sufficient, the same way the solo
+     * flow already works. Per-slot:
      *
-     *   - Pushed antes are refunded to the push players.
-     *   - Each winner gets their own ante back from the pot.
-     *   - Natural-blackjack winners get an extra 1.5× ante "premium" off
-     *     the top, capped at the losers' contribution; if the losers'
-     *     pool can't cover the full premium it scales down proportionally.
-     *   - Whatever remains of the losers' pool after the BJ premium is
-     *     split equally among ALL winners (BJ + regular). 5% rake on the
-     *     to-be-split chunk goes to the jackpot pool.
-     *   - If no seat won, the entire losers' pool goes to the jackpot.
+     *   - Push → ante refunded (1× stake).
+     *   - Win → 2× stake credited from the house (1:1).
+     *   - Natural blackjack → stake × [TableRules.blackjackPayoutMultiplier]
+     *     credited (3:2 by default).
+     *   - Loss / bust → stake is forfeit; a configurable fraction
+     *     ([TableRules.rakeFraction], default 5%) of each losing slot's
+     *     stake is routed to the per-guild jackpot pool.
      *
      * After payouts, seats are reset to a fresh per-hand state but
      * KEPT — players re-ante on the next [startMultiHand] without
@@ -1383,8 +1384,8 @@ class BlackjackService @Autowired constructor(
         val deck = t.deck ?: error("missing deck on resolve")
         // Flatten to a single (seat, hand-slot, hand-index) list — each
         // split branch is its own wager and is settled independently
-        // (loss tribute / jackpot roll / pot share all happen at the
-        // hand-slot level rather than the seat level).
+        // (per-slot payout / loss tribute happen at the hand-slot level
+        // rather than the seat level).
         data class Entry(
             val seat: BlackjackTable.Seat,
             val slot: BlackjackTable.HandSlot,
@@ -1410,63 +1411,44 @@ class BlackjackService @Autowired constructor(
             entry.slot.status = terminalStatusFor(result, entry.slot.status)
         }
 
-        val totalPot = entries.sumOf { it.slot.stake }
-        val pushEntries = entries.filter { perSlotResult[it] == Blackjack.Result.PUSH }
-        val winnerEntries = entries.filter {
-            val r = perSlotResult[it]
-            r == Blackjack.Result.PLAYER_WIN || r == Blackjack.Result.PLAYER_BLACKJACK
-        }
-        val bjEntries = winnerEntries.filter { perSlotResult[it] == Blackjack.Result.PLAYER_BLACKJACK }
         // One BlackjackNaturalEvent per natural-on-the-deal seat. Same
         // guarantees as the solo path: `evaluate` only returns
         // PLAYER_BLACKJACK on a two-card hand with fromSplit=false.
-        bjEntries.forEach { entry ->
-            eventPublisher?.publishEvent(
-                BlackjackNaturalEvent(discordId = entry.seat.discordId, guildId = t.guildId)
-            )
-        }
-        val regularEntries = winnerEntries.filter { perSlotResult[it] == Blackjack.Result.PLAYER_WIN }
-        val pushTotal = pushEntries.sumOf { it.slot.stake }
-        val winnerStakeTotal = winnerEntries.sumOf { it.slot.stake }
-        val losersPool = (totalPot - pushTotal - winnerStakeTotal).coerceAtLeast(0L)
+        perSlotResult.entries
+            .filter { it.value == Blackjack.Result.PLAYER_BLACKJACK }
+            .forEach { (entry, _) ->
+                eventPublisher?.publishEvent(
+                    BlackjackNaturalEvent(discordId = entry.seat.discordId, guildId = t.guildId)
+                )
+            }
 
-        // Per-slot payouts → aggregated per-discordId at the end. Pushed
-        // slots get their own stake refunded; winners get their own
-        // stake refunded plus a share of the losers' pool.
+        val totalPot = entries.sumOf { it.slot.stake }
+        val payoutMult = t.rules.blackjackPayoutMultiplier
+
+        // Per-slot payouts vs the dealer — same shape as solo. House
+        // pays winners; no peer-pool redistribution between seats.
         val payoutBySlot = HashMap<Entry, Long>()
-        for (e in pushEntries) payoutBySlot[e] = e.slot.stake
-        for (e in winnerEntries) payoutBySlot[e] = e.slot.stake
+        for (entry in entries) {
+            val result = perSlotResult[entry] ?: Blackjack.Result.PUSH
+            val multiplier = blackjack.multiplier(result, payoutMult)
+            val payout = (entry.slot.stake * multiplier).toLong()
+            if (payout > 0L) payoutBySlot[entry] = payout
+        }
 
-        val bjPremiumFraction = (t.rules.blackjackPayoutMultiplier - 1.0).coerceAtLeast(0.0)
+        // Loss tribute: a fraction of each losing slot's stake routed
+        // to the per-guild jackpot pool. Uses the table's snapshot rate
+        // ([BLACKJACK_RAKE_PCT]) so admins can tune the blackjack-specific
+        // cut independently of the global loss tribute rate.
         var rake = 0L
-        if (winnerEntries.isEmpty()) {
-            rake = losersPool
-        } else if (losersPool > 0L) {
-            val baseRake = (losersPool * t.rules.rakeFraction).toLong()
-            val payable = losersPool - baseRake
-            val regularEntitled = regularEntries.sumOf { it.slot.stake }
-            val bjEntitled = bjEntries.sumOf { (it.slot.stake * bjPremiumFraction).toLong() }
-            val totalEntitled = regularEntitled + bjEntitled
-
-            if (totalEntitled > 0L && payable >= totalEntitled) {
-                for (e in regularEntries) payoutBySlot.merge(e, e.slot.stake) { a, b -> a + b }
-                for (e in bjEntries) {
-                    payoutBySlot.merge(e, (e.slot.stake * bjPremiumFraction).toLong()) { a, b -> a + b }
+        val rakeRate = t.rules.rakeFraction
+        if (rakeRate > 0.0) {
+            for (entry in entries) {
+                val result = perSlotResult[entry] ?: continue
+                if (result == Blackjack.Result.DEALER_WIN || result == Blackjack.Result.PLAYER_BUST) {
+                    if (entry.slot.stake > 0L) {
+                        rake += kotlin.math.floor(entry.slot.stake * rakeRate).toLong()
+                    }
                 }
-                rake = baseRake + (payable - totalEntitled)
-            } else if (totalEntitled > 0L) {
-                for (e in regularEntries) {
-                    val share = (e.slot.stake * payable) / totalEntitled
-                    payoutBySlot.merge(e, share) { a, b -> a + b }
-                }
-                for (e in bjEntries) {
-                    val owed = (e.slot.stake * bjPremiumFraction).toLong()
-                    val share = (owed * payable) / totalEntitled
-                    payoutBySlot.merge(e, share) { a, b -> a + b }
-                }
-                rake = baseRake
-            } else {
-                rake = losersPool
             }
         }
         if (rake > 0L) jackpotService.addToPool(guildId, rake)

--- a/database/src/test/kotlin/database/service/BlackjackServiceTest.kt
+++ b/database/src/test/kotlin/database/service/BlackjackServiceTest.kt
@@ -499,10 +499,10 @@ class BlackjackServiceTest {
     }
 
     @Test
-    fun `multi hand with all winners refunds stakes only - no losers means no bonus`() {
-        // Two-seat table where both players win against the dealer. With
-        // no losers contributing to the pot, each winner just gets their
-        // stake back; nothing rakes to the jackpot.
+    fun `multi hand pays each winner 2x stake from the house with no rake`() {
+        // Two-seat table where both players beat the dealer. Each winner
+        // is paid 1:1 by the house (2× stake) — no peer pool, so neither
+        // player needs the other to lose. No losers → no rake.
         val host = userWithBalance(1_000L)
         val joiner = userWithBalance(1_000L, id = otherDiscordId)
         every { userService.getUserByIdForUpdate(discordId, guildId) } returns host
@@ -520,28 +520,22 @@ class BlackjackServiceTest {
         val resolved = service.applyMultiAction(otherDiscordId, guildId, create.tableId, Blackjack.Action.STAND)
             as BlackjackService.MultiActionOutcome.HandResolved
 
-        // Both at the table win → losers' pool is 0 → each winner just
-        // gets their 100 stake refunded. No rake (no pool to skim).
-        assertEquals(1_000L, host.socialCredit)
-        assertEquals(1_000L, joiner.socialCredit)
+        // Each winner gets 200 from house (stake + 1× winnings).
+        // 900 ante-debited + 200 payout = 1100.
+        assertEquals(1_100L, host.socialCredit)
+        assertEquals(1_100L, joiner.socialCredit)
         assertEquals(0L, resolved.result.rake)
         verify(exactly = 0) { jackpotService.addToPool(guildId, any()) }
     }
 
     @Test
-    fun `multi hand pays winner from loser's stake with 5pct rake`() {
+    fun `multi hand pays winner independently of other seats and tributes 5pct of each loss`() {
         val host = userWithBalance(1_000L)
         val joiner = userWithBalance(1_000L, id = otherDiscordId)
         every { userService.getUserByIdForUpdate(discordId, guildId) } returns host
         every { userService.getUserByIdForUpdate(otherDiscordId, guildId) } returns joiner
-        // Host wins, joiner busts.
-        every { blackjack.evaluate(any(), any()) } answers {
-            // Order isn't deterministic per call — pin off who's playing.
-            // We rely on the order winners are listed via seat order.
-            Blackjack.Result.PLAYER_WIN
-        }
-        // Stub per-seat by capturing the player hand reference.
-        // Simpler: just stub differently via answers cycle.
+        // Host wins, joiner loses — verify host is paid the full 1:1
+        // amount from the house regardless of what joiner does.
         var n = 0
         every { blackjack.evaluate(any(), any()) } answers {
             n++
@@ -556,21 +550,16 @@ class BlackjackServiceTest {
         val resolved = service.applyMultiAction(otherDiscordId, guildId, create.tableId, Blackjack.Action.STAND)
             as BlackjackService.MultiActionOutcome.HandResolved
 
-        // Pot=200, losersPool=100, baseRake=5, payable=95, host entitled to 100.
-        // 95 < 100 → scaled: host gets 95. Plus stake refund 100 → +95 net.
-        // Host: 900 + 100 (refund) + 95 (share) = 1095. Joiner: 900 (lost stake).
-        assertEquals(1_095L, host.socialCredit)
+        // Host: 900 + 200 (2× stake) = 1100. Joiner: 900 (lost ante).
+        // Rake = 5% of joiner's lost 100 = 5 to jackpot.
+        assertEquals(1_100L, host.socialCredit)
         assertEquals(900L, joiner.socialCredit)
         assertEquals(5L, resolved.result.rake)
         verify { jackpotService.addToPool(guildId, 5L) }
     }
 
     @Test
-    fun `multi hand BJ winner takes 1_5x premium plus stake refund from losers pool`() {
-        // 3-seat table so the losers' pool (200) can cover the host's
-        // BJ premium (150) with surplus to spare. Everyone stands so the
-        // resolution path is deterministic regardless of which cards the
-        // real Deck dealt — outcomes are pinned by the evaluate stub.
+    fun `multi hand pays BJ winner 2_5x stake regardless of other seats`() {
         val host = userWithBalance(1_000L)
         val a = userWithBalance(1_000L, id = otherDiscordId)
         val b = userWithBalance(1_000L, id = 102L)
@@ -593,19 +582,17 @@ class BlackjackServiceTest {
         val resolved = service.applyMultiAction(102L, guildId, create.tableId, Blackjack.Action.STAND)
             as BlackjackService.MultiActionOutcome.HandResolved
 
-        // Pot=300, losersPool=200, baseRake=10, payable=190.
-        // BJ entitled = 100*1.5 = 150. Total entitled 150 ≤ 190 → full
-        // bonus. Surplus 40 → jackpot. Total rake = 10 + 40 = 50.
-        // Host payout: 100 (refund) + 150 (premium) = 250 → 900+250 = 1150.
+        // Host BJ → 250 (2.5× stake) paid by house. Losers each lose 100.
+        // Rake = 5% × 2 losses × 100 = 10 to jackpot.
         assertEquals(1_150L, host.socialCredit)
         assertEquals(900L, a.socialCredit)
         assertEquals(900L, b.socialCredit)
-        assertEquals(50L, resolved.result.rake)
-        verify { jackpotService.addToPool(guildId, 50L) }
+        assertEquals(10L, resolved.result.rake)
+        verify { jackpotService.addToPool(guildId, 10L) }
     }
 
     @Test
-    fun `multi hand routes entire pot to jackpot when all seats bust`() {
+    fun `multi hand tributes 5pct of each lost stake to the jackpot when all seats bust`() {
         val host = userWithBalance(1_000L)
         val joiner = userWithBalance(1_000L, id = otherDiscordId)
         every { userService.getUserByIdForUpdate(discordId, guildId) } returns host
@@ -625,8 +612,10 @@ class BlackjackServiceTest {
         val outcome = service.applyMultiAction(otherDiscordId, guildId, create.tableId, Blackjack.Action.HIT)
         val resolved = assertInstanceOf(BlackjackService.MultiActionOutcome.HandResolved::class.java, outcome)
 
-        // Both bust: no winners, no pushes — entire 200 to jackpot.
-        verify { jackpotService.addToPool(guildId, 200L) }
+        // Both bust: each contributes 5% of their 100 ante → 10 to jackpot.
+        // The remainder of each lost ante stays with the house (player's
+        // wallet already debited at the start of the hand).
+        verify { jackpotService.addToPool(guildId, 10L) }
         assertEquals(900L, host.socialCredit, "host loses ante")
         assertEquals(900L, joiner.socialCredit, "joiner loses ante")
         assertEquals(0, resolved.result.payouts.values.sum())
@@ -704,7 +693,7 @@ class BlackjackServiceTest {
         val create = service.createMultiTable(discordId, guildId, ante = 100L)
             as BlackjackService.MultiCreateOutcome.Ok
         service.joinMultiTable(otherDiscordId, guildId, create.tableId)
-        // First hand: starts and resolves with both winning (no-loser refund path).
+        // First hand: both beat the dealer → each paid 2× stake from the house.
         service.startMultiHand(discordId, guildId, create.tableId)
         service.applyMultiAction(discordId, guildId, create.tableId, Blackjack.Action.STAND)
         service.applyMultiAction(otherDiscordId, guildId, create.tableId, Blackjack.Action.STAND)
@@ -715,13 +704,13 @@ class BlackjackServiceTest {
         assertEquals(2, tableAfter!!.seats.size)
         assertEquals(0L, tableAfter.seats[0].stake, "stake reset between hands")
         assertEquals(0L, tableAfter.seats[1].stake)
-        assertEquals(1_000L, host.socialCredit)
-        assertEquals(1_000L, joiner.socialCredit)
+        assertEquals(1_100L, host.socialCredit)
+        assertEquals(1_100L, joiner.socialCredit)
 
-        // Second hand: re-debit each seat's ante.
+        // Second hand: re-debit each seat's ante from their post-payout balance.
         service.startMultiHand(discordId, guildId, create.tableId) as BlackjackService.MultiStartOutcome.Ok
-        assertEquals(900L, host.socialCredit, "ante re-debited")
-        assertEquals(900L, joiner.socialCredit)
+        assertEquals(1_000L, host.socialCredit, "ante re-debited")
+        assertEquals(1_000L, joiner.socialCredit)
     }
 
     @Test

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/game/casino/blackjack/BlackjackEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/game/casino/blackjack/BlackjackEmbeds.kt
@@ -218,7 +218,7 @@ internal object BlackjackEmbeds {
                     "Host (<@${table.hostDiscordId}>) starts the hand with `/blackjack start table:${table.id}`.",
                 false
             )
-            .setFooter("Best non-bust beats the dealer. Pot splits among winners; ${(Blackjack.MULTI_RAKE * 100).toInt()}% rake to the jackpot pool.")
+            .setFooter("Beat the dealer to win — each seat plays independently. ${(Blackjack.MULTI_RAKE * 100).toInt()}% of each loss feeds the jackpot pool.")
             .setColor(TABLE_COLOR)
             .build()
     }

--- a/web/src/main/resources/templates/blackjack-lobby.html
+++ b/web/src/main/resources/templates/blackjack-lobby.html
@@ -12,8 +12,9 @@
         <a class="back-link" th:href="@{/blackjack/guilds(pick=true)}">&larr; All servers</a>
         <h1 th:text="'🂡 Blackjack • ' + ${guildName}">🂡 Blackjack</h1>
         <p class="muted">
-            Players vs. shared dealer. Each seat antes the same amount per hand.
-            Up to <span th:text="${maxSeats}">5</span> seats. 5% rake on each pot
+            Players vs. shared dealer. Each seat plays independently and is paid by the house —
+            you only need to beat the dealer, not the other players. Each seat antes the same
+            amount per hand. Up to <span th:text="${maxSeats}">5</span> seats. 5% of each loss
             feeds the per-server jackpot. Natural blackjack pays 3:2.
         </p>
     </div>
@@ -65,7 +66,7 @@
             <li>Pick a table to join, or create your own with the form above and an ante you choose.</li>
             <li>Beat the dealer's hand without going over <strong>21</strong>. Natural blackjack pays <strong>3:2</strong>; any other win pays <strong>1:1</strong>; pushes refund.</li>
             <li>The dealer stands on all 17. <strong>Double</strong>, <strong>split</strong>, and re-split (up to 4 hands) are available on every seat.</li>
-            <li>Each multiplayer hand takes a <strong>5% rake</strong> from losers' chips into the per-guild jackpot pool — somebody at the table eventually scoops it.</li>
+            <li>Each losing hand sends a <strong>5% tribute</strong> from its lost chips to the per-guild jackpot pool.</li>
         </ul>
     </section>
 </main>

--- a/web/src/main/resources/templates/blackjack-table.html
+++ b/web/src/main/resources/templates/blackjack-table.html
@@ -67,7 +67,7 @@
             <li>A two-card 21 (a "natural blackjack") pays <strong>3:2</strong>. Any other win pays <strong>1:1</strong>. Pushes refund the ante.</li>
             <li><strong>Double down</strong> on your first two cards: doubles your stake, you draw exactly one more card.</li>
             <li><strong>Split</strong> a matching pair (e.g. 8-8) into two hands — each plays its own ante. Up to 4 split hands; split aces auto-stand on one card.</li>
-            <li>Each hand pays a <strong>5% rake</strong> on losers' chips into the per-guild jackpot pool.</li>
+            <li>Each losing hand sends a <strong>5% tribute</strong> from its lost chips to the per-guild jackpot pool.</li>
         </ul>
     </section>
 </main>


### PR DESCRIPTION
## Summary

The multi-table resolver pooled every losing seat's stake, then split the remainder among winners after a flat rake — so two players who both beat the dealer would just trade refunds with no winnings, and a single winner's payout scaled with how many others happened to lose. Players were effectively competing with each other, not the dealer.

Now each hand-slot is settled independently against the dealer, matching how the solo flow already pays out:

- Win → 1:1 (2× stake) paid by the house
- Natural blackjack → 3:2 (or the configured multiplier) paid by the house
- Push → ante refunded
- Loss / bust → stake forfeit; a configurable fraction (`BLACKJACK_RAKE_PCT`, default 5%) of each losing slot's stake is routed to the per-guild jackpot pool

## What changed

- `BlackjackService.resolveMultiHand` rewritten to per-slot payout using `blackjack.multiplier(result, payoutMult)` — same shape as `settleSolo`. No more `losersPool` / `bjPremium` / proportional scaling.
- `TableRules.rakeFraction` semantic shift: from "fraction of the losers' pool" to "fraction of each losing slot's stake". The `BLACKJACK_RAKE_PCT` admin knob still works.
- Embed footer + lobby/table HTML copy updated to describe the new behaviour.
- Multi-resolution tests rewritten to assert independent per-seat payouts (`2× stake` on a regular win, `2.5× stake` on a natural, 5% of each loss to jackpot).

## Test plan

- [x] `./gradlew :database:test --tests "database.service.BlackjackServiceTest"` passes
- [x] `./gradlew :web:test --tests "*Blackjack*" :discord-bot:test --tests "*Blackjack*" :common:test --tests "*Blackjack*"` passes
- [ ] Manual: create a multi table with 2 seats, both win → verify each gets paid 2× stake from the house
- [ ] Manual: 1 winner + 1 loser → winner gets full 2× stake regardless of loser's stake; 5% of loser's stake hits the jackpot
- [ ] Manual: all bust → 5% of each lost stake hits the jackpot; no payouts

https://claude.ai/code/session_01JZwsxNkFmzAqTnPPZCmUio

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZwsxNkFmzAqTnPPZCmUio)_