### PR TITLE
Expose multiplayer blackjack and ante limits in the web UI

### DIFF
--- a/web/src/main/resources/static/js/moderation/settings.js
+++ b/web/src/main/resources/static/js/moderation/settings.js
@@ -240,13 +240,18 @@
             // is a hook added just for this lookup. Split into MIN / MAX
             // by the data-key suffix so the same cell loop drives both
             // sides.
+            // Blackjack uses `_MIN_ANTE` / `_MAX_ANTE` keys instead of
+            // `_MIN_STAKE` / `_MAX_STAKE` — semantically the same
+            // per-hand bound, just named after the blackjack jargon.
             const stakeCells = Array.from(document.querySelectorAll('.settings-stake-cell[data-key]'));
+            const isMinKey = (key) => key.endsWith('_MIN_STAKE') || key.endsWith('_MIN_ANTE');
+            const isMaxKey = (key) => key.endsWith('_MAX_STAKE') || key.endsWith('_MAX_ANTE');
             const targets = [];
             stakeCells.forEach(cell => {
                 const key = cell.dataset.key || '';
-                if (minVal !== '' && key.endsWith('_MIN_STAKE')) {
+                if (minVal !== '' && isMinKey(key)) {
                     targets.push({ key: key, value: minVal, cell: cell });
-                } else if (maxVal !== '' && key.endsWith('_MAX_STAKE')) {
+                } else if (maxVal !== '' && isMaxKey(key)) {
                     targets.push({ key: key, value: maxVal, cell: cell });
                 }
             });

--- a/web/src/main/resources/templates/blackjack-lobby.html
+++ b/web/src/main/resources/templates/blackjack-lobby.html
@@ -17,6 +17,10 @@
             amount per hand. Up to <span th:text="${maxSeats}">5</span> seats. 5% of each loss
             feeds the per-server jackpot. Natural blackjack pays 3:2.
         </p>
+        <p class="muted">
+            Prefer to play alone?
+            <a th:href="@{/blackjack/{id}/solo(id=${guildId})}">Open a solo hand &rsaquo;</a>
+        </p>
     </div>
 
     <div th:replace="~{fragments/alerts :: error}"></div>

--- a/web/src/main/resources/templates/blackjack-solo.html
+++ b/web/src/main/resources/templates/blackjack-solo.html
@@ -16,6 +16,10 @@
             <span th:text="${maxStake}">500</span> credits per hand.
             Dealer stands on all 17. Natural blackjack pays 3:2.
         </p>
+        <p class="muted">
+            Want to play with friends?
+            <a th:href="@{/blackjack/{id}(id=${guildId})}">Open multiplayer tables &rsaquo;</a>
+        </p>
     </div>
 
     <div th:replace="~{fragments/alerts :: error}"></div>

--- a/web/src/main/resources/templates/casino-guilds.html
+++ b/web/src/main/resources/templates/casino-guilds.html
@@ -55,7 +55,7 @@
                         <a class="btn-secondary"
                            th:href="@{/casino/{id}/baccarat(id=${g.id})}">🎴 Baccarat</a>
                         <a class="btn-secondary"
-                           th:href="@{/blackjack/{id}/solo(id=${g.id})}">🂡 Blackjack</a>
+                           th:href="@{/blackjack/{id}(id=${g.id})}">🂡 Blackjack</a>
                         <a class="btn-secondary"
                            th:href="@{/casino/{id}/casinoholdem(id=${g.id})}">♠️ Casino Hold'em</a>
                         <a class="btn-secondary"

--- a/web/src/main/resources/templates/moderation/settings.html
+++ b/web/src/main/resources/templates/moderation/settings.html
@@ -764,9 +764,10 @@
                     <summary>Game stake limits</summary>
                     <p class="muted config-section-lead">
                         Stake bounds for every simple casino game. Set any maximum to
-                        <code>0</code> to remove the cap. Blackjack ante limits live
-                        in the <strong>Blackjack</strong> section; poker blinds and
-                        buy-ins live in the <strong>Poker</strong> section.
+                        <code>0</code> to remove the cap. Blackjack ante limits are
+                        editable here too (and mirrored in the <strong>Blackjack</strong>
+                        section). Poker blinds and buy-ins live in the
+                        <strong>Poker</strong> section.
                     </p>
 
                     <!--
@@ -1067,6 +1068,29 @@
                                             <label class="sr-only">Wheel of Fortune maximum stake (0 = unlimited; default 500)</label>
                                             <input type="number" min="0"
                                                    th:value="${overview.config['WHEEL_OF_FORTUNE_MAX_STAKE']}"
+                                                   placeholder="500"
+                                                   th:disabled="${!isOwner}">
+                                            <button type="button" class="btn btn-sm save-config" th:disabled="${!isOwner}">Save</button>
+                                        </div>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th scope="row">Blackjack</th>
+                                    <td data-label="Minimum stake">
+                                        <div class="config-row settings-stake-cell" data-key="BLACKJACK_MIN_ANTE">
+                                            <label class="sr-only">Blackjack minimum ante per hand (applies to solo &amp; multi; default 10)</label>
+                                            <input type="number" min="1"
+                                                   th:value="${overview.config['BLACKJACK_MIN_ANTE']}"
+                                                   placeholder="10"
+                                                   th:disabled="${!isOwner}">
+                                            <button type="button" class="btn btn-sm save-config" th:disabled="${!isOwner}">Save</button>
+                                        </div>
+                                    </td>
+                                    <td data-label="Maximum stake">
+                                        <div class="config-row settings-stake-cell" data-key="BLACKJACK_MAX_ANTE">
+                                            <label class="sr-only">Blackjack maximum ante per hand (applies to solo &amp; multi; 0 = unlimited; default 500)</label>
+                                            <input type="number" min="0"
+                                                   th:value="${overview.config['BLACKJACK_MAX_ANTE']}"
                                                    placeholder="500"
                                                    th:disabled="${!isOwner}">
                                             <button type="button" class="btn btn-sm save-config" th:disabled="${!isOwner}">Save</button>

--- a/web/src/test/kotlin/web/template/ModerationTemplateRowsTest.kt
+++ b/web/src/test/kotlin/web/template/ModerationTemplateRowsTest.kt
@@ -168,15 +168,18 @@ class ModerationTemplateRowsTest {
     fun `game stake limits table labels every game row with its name`() {
         // Stake limits live in a table so each game's min + max sit side by
         // side instead of stacked. Admins still scan by game — the row
-        // header replaces the old h4 sub-grouping. Sample three games
-        // (a simple one, a chance game, and Duel) so a flatten regression
-        // or accidentally-dropped row trips a single assertion.
-        // Blackjack and Poker rows live in their dedicated game sections
-        // under "Stakes per hand" / "Blinds & buy-ins" subgroups.
+        // header replaces the old h4 sub-grouping. Sample a few games
+        // (a simple one, a chance game, Duel, and Blackjack) so a flatten
+        // regression or accidentally-dropped row trips a single assertion.
+        // Blackjack is mirrored here AND inside its own dedicated section
+        // so the bulk "apply to all games" handler can target it. Poker
+        // blinds / buy-ins are still single-source inside the Poker
+        // section because they don't map to a single min/max stake.
         val rowHeaders = listOf(
             "<th scope=\"row\">Dice</th>",
             "<th scope=\"row\">Coinflip</th>",
             "<th scope=\"row\">Duel</th>",
+            "<th scope=\"row\">Blackjack</th>",
         )
         for (h in rowHeaders) {
             assertTrue(
@@ -188,9 +191,11 @@ class ModerationTemplateRowsTest {
 
     @Test
     fun `blackjack section consolidates table rules and stake bounds in one place`() {
-        // Pre-pass, BLACKJACK_MIN_ANTE / MAX_ANTE lived in a separate
-        // "Casino stakes & buy-ins" card; tuning blackjack meant scrolling
-        // between two sections. Pin them inside the Blackjack section.
+        // Stakes still live inside the Blackjack section so admins tuning
+        // the table rules don't have to scroll to a separate card to set
+        // bounds. (They're also mirrored into the Game stake limits table
+        // so the "apply to all games" bulk handler can hit them — see
+        // `game stake limits table labels every game row with its name`.)
         val blackjackStart = settingsHtml.indexOf("<summary>Blackjack</summary>")
         assertTrue(blackjackStart >= 0, "Blackjack section not found")
         val sectionEnd = settingsHtml.indexOf("</details>", blackjackStart)
@@ -199,7 +204,7 @@ class ModerationTemplateRowsTest {
         for (key in listOf("BLACKJACK_MIN_ANTE", "BLACKJACK_MAX_ANTE")) {
             assertTrue(
                 sectionHtml.contains("data-key=\"$key\""),
-                "$key should live inside the Blackjack section, not the Game stake limits card"
+                "$key should live inside the Blackjack section so admins can tune it alongside table rules"
             )
         }
     }


### PR DESCRIPTION
## Summary

Two related discoverability fixes for blackjack on the web surface.

### 1. Multiplayer blackjack reachable from the web casino picker

The `/casino/{guildId}` picker linked Blackjack straight to `/blackjack/{id}/solo`, and the solo page had no cross-link to multi — so players going through that path had no way to find the multi lobby (where you create / join a table).

- `casino-guilds.html` Blackjack button now points at `/blackjack/{id}` (the multi lobby), matching how Poker is linked from the same picker.
- Header cross-links added to `blackjack-solo.html` ("Open multiplayer tables") and `blackjack-lobby.html` ("Open a solo hand") so players can flip between modes without backing out to the guild picker.

### 2. Blackjack ante in the global stake-limits table

Ante bounds (`BLACKJACK_MIN_ANTE` / `BLACKJACK_MAX_ANTE`) lived only inside the dedicated Blackjack section, so the "Apply to all games" bulk setter on the stake-limits table skipped them. Admins setting a guild-wide stake had to remember to also touch the Blackjack section separately.

- Add a Blackjack row to the Game stake limits table (mirrors the same `BLACKJACK_*_ANTE` keys — both edit points hit the same config rows).
- Bulk handler in `settings.js` extended to match `_MIN_ANTE` / `_MAX_ANTE` suffixes so blackjack participates in "apply to all".
- Lead text and `ModerationTemplateRowsTest` updated to reflect the new mirroring.

## Test plan

- [x] `./gradlew :web:test --tests "*Blackjack*" --tests "web.template.ModerationTemplateRowsTest" --tests "web.template.CasinoMinigameTemplatesTest" --tests "web.controller.BlackjackControllerTest"` passes
- [ ] Manual: navigate Casino → Blackjack from a guild — lands on the multi lobby with the Create Table form visible
- [ ] Manual: from the solo page, click "Open multiplayer tables" — reaches the lobby
- [ ] Manual: from the lobby, click "Open a solo hand" — reaches solo
- [ ] Manual: in moderation Settings → Game stake limits, type a min and max in the bulk fields and apply — blackjack ante values are updated alongside the other games

https://claude.ai/code/session_01JZwsxNkFmzAqTnPPZCmUio

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZwsxNkFmzAqTnPPZCmUio)_