### PR TITLE
Promote solo blackjack tables to multiplayer when a second player joins

### DIFF
--- a/common/src/main/kotlin/common/casino/blackjack/Blackjack.kt
+++ b/common/src/main/kotlin/common/casino/blackjack/Blackjack.kt
@@ -143,7 +143,16 @@ class Blackjack(private val random: Random = Random.Default) {
 
         const val MULTI_MIN_ANTE: Long = 10L
         const val MULTI_MAX_ANTE: Long = 500L
-        const val MULTI_MIN_SEATS: Int = 2
+        /**
+         * Minimum seated players for a multi table to deal a hand. A
+         * single-seat multi table is the natural post-promotion state of
+         * a solo table (and the residual state of a multi table whose
+         * other players have all left), so dealing has to work with
+         * just one seat — the host hits Start exactly as in the 2+ seat
+         * case. Previously was 2 (couldn't deal solo from a multi
+         * table); now 1 (solo is just a 1-seat multi).
+         */
+        const val MULTI_MIN_SEATS: Int = 1
         const val MULTI_MAX_SEATS: Int = 5
 
         /** Fraction of a multiplayer pot routed to the jackpot pool. */

--- a/common/src/main/kotlin/common/casino/blackjack/BlackjackTable.kt
+++ b/common/src/main/kotlin/common/casino/blackjack/BlackjackTable.kt
@@ -19,9 +19,23 @@ import common.casino.blackjack.Blackjack
 class BlackjackTable(
     val id: Long,
     val guildId: Long,
-    val mode: Mode,
-    /** Null for SOLO tables (the seated player is implicitly the host). */
-    val hostDiscordId: Long?,
+    /**
+     * SOLO when a single seat created the table via `/blackjack solo`
+     * (or the web solo deal). Flips to MULTI in-place when a second
+     * player joins — see [database.service.casino.blackjack.BlackjackService.joinMultiTable]
+     * for the promotion path. Once promoted, never demoted back.
+     */
+    var mode: Mode,
+    /**
+     * SOLO tables set this to the seated player's id at creation time
+     * (the player is implicitly the host) — used by the lobby
+     * projection to render a meaningful "host" name even before the
+     * SOLO table has been promoted to MULTI. On SOLO → MULTI promotion
+     * the value is left in place (or backfilled from the seated player
+     * if it was somehow null) so the existing `startMultiHand` /
+     * host-only controls keep working unchanged.
+     */
+    var hostDiscordId: Long?,
     /**
      * Per-hand wager. SOLO tables can in principle re-deal at a
      * different stake, but v1 makes a fresh table per `/blackjack solo`
@@ -30,7 +44,13 @@ class BlackjackTable(
      * same per hand.
      */
     val ante: Long,
-    val maxSeats: Int,
+    /**
+     * SOLO tables ship with `maxSeats = 1` to reflect the single-player
+     * shape. Promoted to the regular multi cap on SOLO → MULTI
+     * conversion so a joiner can actually fit (and the table can grow
+     * to the full multi capacity afterwards).
+     */
+    var maxSeats: Int,
     var phase: Phase = Phase.LOBBY,
     val seats: MutableList<Seat> = mutableListOf(),
     val dealer: MutableList<Card> = mutableListOf(),

--- a/database/src/main/kotlin/database/service/casino/blackjack/BlackjackService.kt
+++ b/database/src/main/kotlin/database/service/casino/blackjack/BlackjackService.kt
@@ -260,13 +260,15 @@ class BlackjackService @Autowired constructor(
         stake: Long,
         autoTopUp: Boolean = false
     ): SoloDealOutcome {
-        // Reject a redeal while the caller still has an in-flight solo
-        // table on this guild — without this guard, hitting the web Deal
-        // form mid-hand would debit the stake again, orphan the previous
-        // table in the registry, and leave the wallet wonky.
+        // Reject a redeal while the caller is already seated at any
+        // in-flight table — solo OR multi (a solo table that's been
+        // promoted by a joiner is now MULTI and the caller belongs at
+        // /blackjack/{guildId}/{tableId}, not on a fresh solo escrow).
+        // Without this guard, hitting the web Deal form mid-hand would
+        // debit the stake again, orphan the previous table, and leave
+        // the wallet wonky.
         tableRegistry.listForGuild(guildId).firstOrNull { t ->
-            t.mode == BlackjackTable.Mode.SOLO &&
-                t.phase != BlackjackTable.Phase.RESOLVED &&
+            t.phase != BlackjackTable.Phase.RESOLVED &&
                 t.seats.any { it.discordId == discordId }
         }?.let { return SoloDealOutcome.HandInProgress(it.id) }
 
@@ -895,6 +897,17 @@ class BlackjackService @Autowired constructor(
         )
     }
 
+    /**
+     * Seat a player at an existing table.
+     *
+     * Accepts both MULTI tables (between hands, exactly as before) and
+     * SOLO tables (after the solo hand has resolved). Joining a SOLO
+     * table promotes it in place: the original solo seat becomes the
+     * host, mode flips to MULTI, and the table transitions from
+     * RESOLVED to LOBBY so the host can start the next (now multi)
+     * hand. Mid-hand joins on either mode are rejected with
+     * `HandInProgress`.
+     */
     @Transactional
     fun joinMultiTable(
         discordId: Long,
@@ -904,13 +917,25 @@ class BlackjackService @Autowired constructor(
     ): MultiJoinOutcome {
         val table = tableRegistry.get(tableId) ?: return MultiJoinOutcome.TableNotFound
         if (table.guildId != guildId) return MultiJoinOutcome.TableNotFound
-        if (table.mode != BlackjackTable.Mode.MULTI) return MultiJoinOutcome.TableNotFound
 
         val pre = synchronized(table) {
+            val isJoinablePhase = when (table.mode) {
+                // Multi tables only accept joins in their explicit LOBBY
+                // phase (between hands). The pendingLeave / multi seat
+                // book-keeping assumes this.
+                BlackjackTable.Mode.MULTI -> table.phase == BlackjackTable.Phase.LOBBY
+                // Solo tables don't ever sit in LOBBY — they go straight
+                // from creation into PLAYER_TURNS and end in RESOLVED. A
+                // joiner can only walk in after the solo hand resolved.
+                BlackjackTable.Mode.SOLO -> table.phase == BlackjackTable.Phase.RESOLVED
+            }
+            // The TableFull check intentionally runs in the inner monitor
+            // block below (not here) so a SOLO table's pre-promotion cap
+            // of `maxSeats=1` doesn't reject a join before the promotion
+            // step gets a chance to bump the cap.
             when {
-                table.phase != BlackjackTable.Phase.LOBBY -> JoinPreflight.HandInProgress
+                !isJoinablePhase -> JoinPreflight.HandInProgress
                 table.seats.any { it.discordId == discordId } -> JoinPreflight.AlreadySeated
-                table.seats.size >= table.maxSeats -> JoinPreflight.TableFull
                 else -> JoinPreflight.Ok
             }
         }
@@ -922,6 +947,15 @@ class BlackjackService @Autowired constructor(
         }
 
         val ante = table.ante
+        // Solo tables ship with maxSeats=1. On the first join we need
+        // to bump that to the guild's configured multi cap so the
+        // joiner (and any subsequent joiners) actually fit. Read the
+        // params once here, outside the table monitor, matching the
+        // ordering the rest of the service uses.
+        val promotedMaxSeats: Int? = if (table.mode == BlackjackTable.Mode.SOLO) {
+            readMultiTableParams(guildId).maxSeats
+        } else null
+
         val user = userService.getUserByIdForUpdate(discordId, guildId)
             ?: return MultiJoinOutcome.UnknownUser
         val balance = user.socialCredit ?: 0L
@@ -947,8 +981,33 @@ class BlackjackService @Autowired constructor(
         }
 
         val seatIndex = synchronized(table) {
-            if (table.phase != BlackjackTable.Phase.LOBBY) return@synchronized -3
+            // Re-validate join eligibility under the monitor — phase /
+            // seat count may have changed since the preflight read.
+            val stillJoinable = when (table.mode) {
+                BlackjackTable.Mode.MULTI -> table.phase == BlackjackTable.Phase.LOBBY
+                BlackjackTable.Mode.SOLO -> table.phase == BlackjackTable.Phase.RESOLVED
+            }
+            if (!stillJoinable) return@synchronized -3
             if (table.seats.any { it.discordId == discordId }) return@synchronized -1
+
+            // Promote SOLO → MULTI in place BEFORE the seat-count gate
+            // so the post-promotion cap (read from the guild's multi
+            // params) is what's enforced. Without this order the
+            // promotion would never fire because the solo table's
+            // maxSeats=1 cap rejects the joiner first. The original
+            // solo seat becomes the host so the existing host-only
+            // `startMultiHand` gate, lobby UI, and shot-clock wiring
+            // all work without mode-specific branches downstream.
+            if (table.mode == BlackjackTable.Mode.SOLO) {
+                val originalSeat = table.seats.firstOrNull()
+                if (originalSeat != null && table.hostDiscordId == null) {
+                    table.hostDiscordId = originalSeat.discordId
+                }
+                table.mode = BlackjackTable.Mode.MULTI
+                table.phase = BlackjackTable.Phase.LOBBY
+                table.lastResult = null
+                if (promotedMaxSeats != null) table.maxSeats = promotedMaxSeats
+            }
             if (table.seats.size >= table.maxSeats) return@synchronized -2
             table.seats.add(
                 BlackjackTable.Seat(

--- a/database/src/test/kotlin/database/service/BlackjackServiceTest.kt
+++ b/database/src/test/kotlin/database/service/BlackjackServiceTest.kt
@@ -479,13 +479,75 @@ class BlackjackServiceTest {
     }
 
     @Test
-    fun `startMultiHand requires at least the minimum seat count`() {
+    fun `joining a resolved SOLO table promotes it to MULTI with the original player as host`() {
+        // The solo flow creates a Mode.SOLO single-seat table that
+        // resolves the hand and then sits in Phase.RESOLVED. A second
+        // player asking to join now finds it via listMultiTables and
+        // promotes it in place: mode → MULTI, phase → LOBBY, host →
+        // original solo player. From here the standard multi flow
+        // applies (host hits Start to deal the next hand).
+        val player = userWithBalance(1_000L)
+        val joiner = userWithBalance(1_000L, id = otherDiscordId)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns player
+        every { userService.getUserByIdForUpdate(otherDiscordId, guildId) } returns joiner
+        every { userService.getUserById(discordId, guildId) } returns player
+        // Deal & resolve a solo hand: 20 vs 18 → player wins.
+        every { blackjack.dealStartingHands(any()) } returns Blackjack.StartingDeal(
+            mutableListOf(c(Rank.KING), c(Rank.QUEEN)),
+            mutableListOf(c(Rank.NINE), c(Rank.NINE, Suit.HEARTS))
+        )
+        every { blackjack.evaluate(any(), any()) } returns Blackjack.Result.PLAYER_WIN
+        val deal = service.dealSolo(discordId, guildId, stake = 100L)
+            as BlackjackService.SoloDealOutcome.Dealt
+        service.applySoloAction(discordId, guildId, deal.tableId, Blackjack.Action.STAND)
+        val resolved = registry.get(deal.tableId)!!
+        assertEquals(BlackjackTable.Mode.SOLO, resolved.mode)
+        assertEquals(BlackjackTable.Phase.RESOLVED, resolved.phase)
+
+        val join = service.joinMultiTable(otherDiscordId, guildId, deal.tableId)
+        val ok = assertInstanceOf(BlackjackService.MultiJoinOutcome.Ok::class.java, join)
+        assertEquals(1, ok.seatIndex, "joiner seated after the original solo player")
+
+        val promoted = registry.get(deal.tableId)!!
+        assertEquals(BlackjackTable.Mode.MULTI, promoted.mode, "table promoted to MULTI")
+        assertEquals(BlackjackTable.Phase.LOBBY, promoted.phase, "phase reset to LOBBY for the next deal")
+        assertEquals(discordId, promoted.hostDiscordId, "original solo player becomes the host")
+        assertEquals(2, promoted.seats.size)
+        assertEquals(otherDiscordId, promoted.seats[1].discordId)
+    }
+
+    @Test
+    fun `joining a SOLO table mid-hand returns HandInProgress`() {
+        val player = userWithBalance(1_000L)
+        val joiner = userWithBalance(1_000L, id = otherDiscordId)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns player
+        every { userService.getUserByIdForUpdate(otherDiscordId, guildId) } returns joiner
+        // Deal a solo hand and leave it in PLAYER_TURNS — non-blackjack
+        // starting cards so the table stays mid-hand instead of resolving.
+        every { blackjack.dealStartingHands(any()) } returns Blackjack.StartingDeal(
+            mutableListOf(c(Rank.FIVE), c(Rank.SEVEN)),
+            mutableListOf(c(Rank.NINE), c(Rank.NINE, Suit.HEARTS))
+        )
+        val deal = service.dealSolo(discordId, guildId, stake = 100L)
+            as BlackjackService.SoloDealOutcome.Dealt
+
+        val outcome = service.joinMultiTable(otherDiscordId, guildId, deal.tableId)
+        assertEquals(BlackjackService.MultiJoinOutcome.HandInProgress, outcome)
+        assertEquals(BlackjackTable.Mode.SOLO, registry.get(deal.tableId)!!.mode, "still SOLO; not promoted")
+    }
+
+    @Test
+    fun `startMultiHand deals with the host alone now that MIN_SEATS is 1`() {
+        // Used to require ≥ 2 seats; the SOLO-promotion refactor lowered
+        // MULTI_MIN_SEATS to 1 so a residual one-seat table (or a freshly
+        // created multi table waiting for joiners) can still deal hands
+        // exactly like the solo flow.
         val host = userWithBalance(1_000L)
         every { userService.getUserByIdForUpdate(discordId, guildId) } returns host
         val create = service.createMultiTable(discordId, guildId, ante = 100L)
             as BlackjackService.MultiCreateOutcome.Ok
         val outcome = service.startMultiHand(discordId, guildId, create.tableId)
-        assertEquals(BlackjackService.MultiStartOutcome.NotEnoughPlayers, outcome)
+        assertInstanceOf(BlackjackService.MultiStartOutcome.Ok::class.java, outcome)
     }
 
     @Test
@@ -830,14 +892,17 @@ class BlackjackServiceTest {
         service.applyMultiAction(otherDiscordId, guildId, create.tableId, Blackjack.Action.HIT)
 
         // Try a second hand — `poor` has 50 credits, can't cover the 100 ante.
-        // Single seat can pay → falls below MIN_SEATS → NotEnoughPlayers,
-        // unfunded seat dropped from table.
+        // Host (the only solvent seat) is dropped to a one-seat table and
+        // the hand still deals: MULTI_MIN_SEATS=1 since the SOLO-promotion
+        // refactor, so a single solvent seat is enough to keep the table
+        // running solo-style. The unfunded seat is evicted exactly as
+        // before so it doesn't permanently block re-starts.
         val outcome = service.startMultiHand(discordId, guildId, create.tableId)
-        assertEquals(BlackjackService.MultiStartOutcome.NotEnoughPlayers, outcome)
+        assertInstanceOf(BlackjackService.MultiStartOutcome.Ok::class.java, outcome)
         val live = registry.get(create.tableId)!!
         assertEquals(1, live.seats.size)
         assertEquals(discordId, live.seats[0].discordId, "host kept; poor dropped")
-        assertEquals(900L, host.socialCredit, "host not debited when start aborted")
+        assertEquals(800L, host.socialCredit, "host re-debited for the solo continuation")
     }
 
     // -------------------------------------------------------------------------

--- a/web/src/main/kotlin/web/controller/BlackjackController.kt
+++ b/web/src/main/kotlin/web/controller/BlackjackController.kt
@@ -437,9 +437,14 @@ class BlackjackController(
     }
 
     private fun findActiveSoloTable(guildId: Long, discordId: Long): Long? {
+        // Mode-agnostic lookup: returns the latest table the caller is
+        // seated at, whether it's still SOLO or has been promoted to
+        // MULTI by a joiner. The solo page's state poll uses this to
+        // notice promotion (state.mode != "SOLO") and redirect to the
+        // multi-table view; without dropping the mode filter, /solo/state
+        // would 404 the moment someone else joins.
         val mine = tableRegistry.listForGuild(guildId).filter { table ->
-            table.mode == BlackjackTable.Mode.SOLO &&
-                table.seats.any { it.discordId == discordId }
+            table.seats.any { it.discordId == discordId }
         }
         // Prefer a still-in-flight hand. After a hand resolves, the table now
         // sticks around (so /state can render the result + disable buttons)

--- a/web/src/main/kotlin/web/service/BlackjackWebService.kt
+++ b/web/src/main/kotlin/web/service/BlackjackWebService.kt
@@ -132,19 +132,25 @@ class BlackjackWebService(
     )
 
     fun listMultiTables(guildId: Long): List<TableSummaryView> {
+        // Lists every blackjack table on the guild, MULTI and SOLO
+        // alike. A SOLO table appears as a 1-seat table that a second
+        // player can join (joinMultiTable accepts SOLO tables in
+        // RESOLVED phase and promotes them in place). For SOLO tables
+        // the displayed "host" is the lone seated player — SOLO tables
+        // don't track a hostDiscordId until promotion.
         val tables = tableRegistry.listForGuild(guildId)
-            .filter { it.mode == BlackjackTable.Mode.MULTI }
-        // Batch-resolve every host's display name once so the lobby doesn't
-        // hit JDA per row.
-        val hostIds = tables.mapNotNull { it.hostDiscordId }.toSet()
-        val hosts = memberLookup.resolveAll(guildId, hostIds)
+        val displayHostIds = tables.mapNotNull { table ->
+            table.hostDiscordId ?: table.seats.firstOrNull()?.discordId
+        }.toSet()
+        val hosts = memberLookup.resolveAll(guildId, displayHostIds)
         return tables.map { table ->
-            val host = table.hostDiscordId?.let { hosts[it] }
+            val displayHostId = table.hostDiscordId ?: table.seats.firstOrNull()?.discordId
+            val host = displayHostId?.let { hosts[it] }
             TableSummaryView(
                 tableId = table.id,
-                hostDiscordId = table.hostDiscordId?.toString(),
+                hostDiscordId = displayHostId?.toString(),
                 hostName = host?.name
-                    ?: table.hostDiscordId?.let { memberLookup.fallbackName(it) }
+                    ?: displayHostId?.let { memberLookup.fallbackName(it) }
                     ?: "—",
                 mode = table.mode.name,
                 seats = table.seats.size,

--- a/web/src/main/resources/static/js/blackjack-solo.js
+++ b/web/src/main/resources/static/js/blackjack-solo.js
@@ -478,7 +478,20 @@
                 if (!r.ok) throw new Error("state HTTP " + r.status);
                 return r.json();
             })
-            .then(function (state) { renderState(state); })
+            .then(function (state) {
+                // Promotion redirect: if a second player joined this
+                // solo table, the server has flipped its mode to MULTI
+                // in place. The multi-table page is the right surface
+                // for ≥2 seats (host start button, per-actor controls),
+                // so move the original solo player there. One-shot —
+                // stop the poll first so we don't race the navigation.
+                if (state && state.mode && state.mode !== "SOLO") {
+                    stopPoll();
+                    window.location.href = "/blackjack/" + guildId + "/" + state.tableId;
+                    return;
+                }
+                renderState(state);
+            })
             .catch(function (e) { console.warn("state poll failed", e); });
     }
 

--- a/web/src/main/resources/static/js/blackjack-table.js
+++ b/web/src/main/resources/static/js/blackjack-table.js
@@ -174,7 +174,15 @@
         }
 
         var seated = state.mySeatIndex != null;
-        joinCard.hidden = seated || state.phase !== "LOBBY";
+        // A table accepts joiners between hands: explicit LOBBY phase
+        // for MULTI tables, RESOLVED phase for SOLO tables (which never
+        // sit in LOBBY — they go straight from creation to PLAYER_TURNS
+        // and end in RESOLVED, then promote on join). Mirror the
+        // service-side preflight in BlackjackService.joinMultiTable.
+        var joinablePhase = state.mode === "SOLO"
+            ? state.phase === "RESOLVED"
+            : state.phase === "LOBBY";
+        joinCard.hidden = seated || !joinablePhase;
 
         var iAmHost = state.hostDiscordId != null && state.hostDiscordId === myId;
         startBtn.hidden = !(iAmHost && state.phase === "LOBBY");

--- a/web/src/main/resources/templates/blackjack-lobby.html
+++ b/web/src/main/resources/templates/blackjack-lobby.html
@@ -18,7 +18,9 @@
             feeds the per-server jackpot. Natural blackjack pays 3:2.
         </p>
         <p class="muted">
-            Prefer to play alone?
+            Open tables include both multiplayer tables waiting for joiners and
+            solo hands that have just resolved — joining either kind seats you for
+            the next deal. Prefer to play alone?
             <a th:href="@{/blackjack/{id}/solo(id=${guildId})}">Open a solo hand &rsaquo;</a>
         </p>
     </div>

--- a/web/src/test/kotlin/web/service/BlackjackWebServiceMoreTest.kt
+++ b/web/src/test/kotlin/web/service/BlackjackWebServiceMoreTest.kt
@@ -379,15 +379,26 @@ class BlackjackWebServiceMoreTest {
     }
 
     @Test
-    fun `listMultiTables filters out SOLO tables`() {
-        // Create a SOLO table — should not appear in the lobby list
-        registry.create(
+    fun `listMultiTables includes SOLO tables so they are discoverable as joinable`() {
+        // SOLO tables now show up in the lobby list — a second player
+        // can find them and join, which promotes the table to MULTI in
+        // place. Pre-refactor, the lobby filtered Mode.MULTI only.
+        val table = registry.create(
             guildId = guildId,
             mode = BlackjackTable.Mode.SOLO,
             hostDiscordId = player1,
             ante = 50L, maxSeats = 1,
         )
-        assertTrue(service.listMultiTables(guildId).isEmpty())
+        table.seats.add(BlackjackTable.Seat(discordId = player1, ante = 50L, stake = 50L))
+        every { memberLookup.resolveAll(guildId, setOf(player1)) } returns mapOf(
+            player1 to MemberLookupHelper.MemberDisplay(name = "Alice", avatarUrl = "alice.png"),
+        )
+
+        val rows = service.listMultiTables(guildId)
+        assertEquals(1, rows.size)
+        assertEquals("SOLO", rows[0].mode)
+        assertEquals(1, rows[0].seats)
+        assertEquals("Alice", rows[0].hostName, "uses the lone seated player as the display host")
     }
 
     @Test
@@ -419,13 +430,35 @@ class BlackjackWebServiceMoreTest {
     }
 
     @Test
-    fun `listMultiTables hostName is dash when host is null`() {
-        // A MULTI table with null hostDiscordId
+    fun `listMultiTables hostName falls back to the seated player when host is null`() {
+        // SOLO tables (and the rare MULTI table with a null host) now
+        // fall back to the lone seated player's name so the lobby has
+        // something meaningful to render — pre-refactor, a null host
+        // rendered as a literal dash even though a player was seated.
         val table = registry.create(
             guildId = guildId, mode = BlackjackTable.Mode.MULTI,
             hostDiscordId = null, ante = 100L, maxSeats = 6,
         )
         table.seats.add(BlackjackTable.Seat(discordId = player1, ante = 100L, stake = 100L))
+        every { memberLookup.resolveAll(guildId, setOf(player1)) } returns mapOf(
+            player1 to MemberLookupHelper.MemberDisplay(name = "Alice", avatarUrl = "alice.png"),
+        )
+
+        val rows = service.listMultiTables(guildId)
+        assertEquals(1, rows.size)
+        assertEquals("Alice", rows[0].hostName)
+        assertEquals(player1.toString(), rows[0].hostDiscordId)
+    }
+
+    @Test
+    fun `listMultiTables hostName is dash when no seats and no host`() {
+        // The fallback only fires when *somebody* is seated. An empty
+        // multi table (e.g. after every seat was evicted but before the
+        // table itself was dropped) still renders the literal dash.
+        registry.create(
+            guildId = guildId, mode = BlackjackTable.Mode.MULTI,
+            hostDiscordId = null, ante = 100L, maxSeats = 6,
+        )
 
         val rows = service.listMultiTables(guildId)
         assertEquals(1, rows.size)


### PR DESCRIPTION
## Summary

Removes the up-front "solo vs multi" decision in web blackjack. A solo table is now just a 1-seat multi table that hasn't been joined yet: when a second player joins, the table flips mode in place (`SOLO → MULTI`, `RESOLVED → LOBBY`, original solo player becomes the host) and proceeds through the standard multi flow. The reverse direction works without coordination too — a multi table that drops to one seat keeps running, because `MULTI_MIN_SEATS` is now 1.

## What changed

**Backend**
- `BlackjackTable.mode`, `hostDiscordId`, and `maxSeats` are now `var` so promotion can flip them in place.
- `Blackjack.MULTI_MIN_SEATS = 1` (was 2). A one-seat table can deal.
- `BlackjackService.joinMultiTable` accepts SOLO tables in `RESOLVED` phase and promotes them: mode → MULTI, phase → LOBBY, host backfilled to the original solo player, `maxSeats` bumped to the guild's multi cap so the joiner fits. Mid-hand joins are still rejected as `HandInProgress`. The pre-join `TableFull` check moved inside the monitor so the cap is evaluated after the bump.
- `BlackjackService.dealSolo`'s in-flight detection is mode-agnostic — a user whose solo table was promoted between deals doesn't get a second escrow.

**Frontend**
- `BlackjackWebService.listMultiTables` returns every table on the guild (was MULTI-only). Display host falls back to the lone seated player when `hostDiscordId` is null.
- `BlackjackController.findActiveSoloTable` drops the mode filter so `/solo/state` still serves the promoted table for one poll before the client redirects.
- `blackjack-solo.js` watches for `state.mode !== "SOLO"` and redirects to `/blackjack/{guildId}/{tableId}` so the original solo player ends up on the multi-table surface (host start button, per-actor controls) as soon as the join completes.
- `blackjack-table.js` accepts joins in RESOLVED phase for SOLO tables (mirrors the service-side preflight).
- Lobby copy explains that solo hands appear in the list and are joinable.

## Test plan

- [x] `./gradlew :database:test :web:test --tests "*Blackjack*"` passes
- [x] `npx jest src/test/js/` passes (752 tests)
- [ ] Manual: deal a solo hand, finish it, have a second user open the lobby, click the now-listed solo table, click Join — verify the host page redirects to the multi table and shows the Start button
- [ ] Manual: in an active multi table, have everyone but one player leave; the remaining player can still click Start to deal solo-style

https://claude.ai/code/session_01JZwsxNkFmzAqTnPPZCmUio

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZwsxNkFmzAqTnPPZCmUio)_