### PR TITLE
Security audit: fix open redirect and harden web-layer input handling

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1058,9 +1058,9 @@
       }
     },
     "node_modules/@jest/environment-jsdom-abstract/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1859,9 +1859,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3627,9 +3627,9 @@
       }
     },
     "node_modules/jest-environment-jsdom/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4617,9 +4617,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5722,9 +5722,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/web/src/main/kotlin/web/controller/GlobalExceptionHandler.kt
+++ b/web/src/main/kotlin/web/controller/GlobalExceptionHandler.kt
@@ -5,6 +5,8 @@ import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.multipart.MaxUploadSizeExceededException
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.util.DefaultGuildCookie
+import java.net.URI
 
 @ControllerAdvice
 class GlobalExceptionHandler {
@@ -15,7 +17,26 @@ class GlobalExceptionHandler {
         ra: RedirectAttributes
     ): String {
         ra.addFlashAttribute("error", "File too large. Maximum size is 550KB.")
-        val referer = request.getHeader("Referer") ?: "/intro/guilds"
-        return "redirect:$referer"
+        return "redirect:${safeRefererTarget(request.getHeader("Referer"))}"
+    }
+
+    companion object {
+        private const val FALLBACK = "/intro/guilds"
+
+        /**
+         * The Referer header is attacker-controllable, so it must never feed
+         * a redirect verbatim (open redirect → phishing). Keep only the path
+         * and query of the referring page and pass the path through the same
+         * in-app whitelist the cookie redirects use; anything that doesn't
+         * survive as a clean single-slash relative path falls back to the
+         * intro picker.
+         */
+        internal fun safeRefererTarget(referer: String?): String {
+            val uri = referer?.let { runCatching { URI(it) }.getOrNull() }
+            val path = DefaultGuildCookie.sanitizeRedirect(uri?.rawPath, fallback = FALLBACK)
+            if (path == FALLBACK) return FALLBACK
+            val query = uri?.rawQuery
+            return if (query.isNullOrBlank()) path else "$path?$query"
+        }
     }
 }

--- a/web/src/main/kotlin/web/profile/ProfileCardRenderer.kt
+++ b/web/src/main/kotlin/web/profile/ProfileCardRenderer.kt
@@ -265,6 +265,11 @@ class ProfileCardRenderer {
     }
 
     private fun loadAvatar(url: String): BufferedImage? {
+        // Avatar URLs come from Discord's CDN today, but this renderer
+        // fetches whatever it's handed — refuse anything that isn't plain
+        // https so a future caller can't be talked into reading file:/
+        // internal-network resources into a public PNG.
+        if (!isFetchableAvatarUrl(url)) return null
         avatarCache.getIfPresent(url)?.let { return it }
         val fetched = runCatching {
             val conn = URI(url).toURL().openConnection() as HttpURLConnection
@@ -331,6 +336,10 @@ class ProfileCardRenderer {
     companion object {
         const val WIDTH = 900
         const val HEIGHT = 400
+
+        /** See [loadAvatar] — plain https URLs only, everything else is dropped. */
+        internal fun isFetchableAvatarUrl(url: String): Boolean =
+            runCatching { URI(url).scheme?.lowercase() == "https" }.getOrDefault(false)
 
         private const val AVATAR_X = 40
         private const val AVATAR_Y = 40

--- a/web/src/main/kotlin/web/service/IntroWebService.kt
+++ b/web/src/main/kotlin/web/service/IntroWebService.kt
@@ -30,6 +30,10 @@ class IntroWebService(
         const val MAX_CLIP_DURATION_MS = MAX_INTRO_DURATION_SECONDS * 1000
         private val objectMapper = ObjectMapper()
         private val logger = DiscordLogger(IntroWebService::class.java)
+        // Real ids are 11 chars of this alphabet; the upper bound leaves
+        // headroom should YouTube ever lengthen them.
+        private val VIDEO_ID_PATTERN = Regex("[A-Za-z0-9_-]{1,20}")
+        private val API_KEY_PARAM = Regex("([?&]key=)[^&]+")
     }
 
     // Caches the Discord-side guild list per access token so rapid navigation
@@ -292,7 +296,7 @@ class IntroWebService(
         }
 
         val fileBytes = file.bytes
-        val fileName = file.originalFilename ?: "intro.mp3"
+        val fileName = sanitizeUploadFileName(file.originalFilename) ?: "intro.mp3"
         val selectedDto = replaceIndex?.let { idx -> existingIntros.find { it.index == idx } }
 
         if (selectedDto != null) {
@@ -499,8 +503,11 @@ class IntroWebService(
         val request = Request.Builder().url(apiUrl).build()
         return youtubeApiClient.newCall(request).execute().use { response ->
             if (!response.isSuccessful) {
+                // Redact the key= query param — this log line ends up in
+                // Discord via DiscordLogger, which must never see the API key.
                 logger.warn {
-                    "YouTube Data API returned HTTP ${response.code} (${response.message}) for $apiUrl"
+                    "YouTube Data API returned HTTP ${response.code} (${response.message}) " +
+                        "for ${apiUrl.replace(API_KEY_PARAM, "$1<redacted>")}"
                 }
                 null
             } else {
@@ -524,7 +531,11 @@ class IntroWebService(
         // Exclude `/` from the capture so a trailing slash (e.g. `…/shorts/ID/`)
         // doesn't get baked into the videoId and break the iframe embed URL.
         val regex = Regex("(?<=v=|/videos/|embed/|youtu\\.be/|/v/|/e/|watch\\?v=|&v=|^youtu\\.be/|/shorts/)([^#&?/\\n]+)")
-        return regex.find(url)?.value
+        // The id is interpolated into thumbnail/embed URLs, the template
+        // layer and the Data API query string, so reject anything outside
+        // the YouTube id alphabet rather than passing exotic characters
+        // (quotes, parens, spaces…) into those contexts.
+        return regex.find(url)?.value?.takeIf { VIDEO_ID_PATTERN.matches(it) }
     }
 
     /**
@@ -541,12 +552,31 @@ class IntroWebService(
 
     private fun isValidUrl(url: String): Boolean {
         return try {
-            URI(url).toURL()
-            true
+            // http(s) only — URI/URL alone would also accept file:, ftp:,
+            // jar: etc., and the saved URL is later fetched by the music
+            // player, so any other scheme is a local-resource read primitive.
+            val uri = URI(url)
+            uri.scheme?.lowercase() in setOf("http", "https") && !uri.host.isNullOrBlank()
         } catch (e: Exception) {
             false
         }
     }
+
+    /**
+     * Browsers send the client-side file name verbatim and some include a
+     * full path. Strip directory components, control characters and
+     * leading/trailing whitespace before the name is persisted or echoed
+     * back, so a crafted name can't smuggle traversal sequences into a
+     * later export or a URL shape into the blob-heal logic in
+     * [getUserIntros] (which trusts URL-shaped fileNames on blobless rows).
+     */
+    internal fun sanitizeUploadFileName(raw: String?): String? =
+        raw?.substringAfterLast('/')
+            ?.substringAfterLast('\\')
+            ?.filter { it.code >= 0x20 }
+            ?.trim()
+            ?.take(255)
+            ?.takeIf { it.isNotEmpty() }
 
     /** Parses ISO-8601 durations like "PT1M3S" or "PT15S" into seconds. Returns null if unparseable. */
     private fun parseIsoDurationSeconds(iso: String?): Int? {

--- a/web/src/test/kotlin/web/controller/GlobalExceptionHandlerTest.kt
+++ b/web/src/test/kotlin/web/controller/GlobalExceptionHandlerTest.kt
@@ -1,0 +1,75 @@
+package web.controller
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import jakarta.servlet.http.HttpServletRequest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+
+/**
+ * Pins the open-redirect fix on the max-upload-size handler: the Referer
+ * header is attacker-controllable, so only its in-app path (+ query) may
+ * feed the redirect — absolute external targets are reduced to their path,
+ * and protocol-relative / opaque / unparseable values fall back to the
+ * intro picker.
+ */
+internal class GlobalExceptionHandlerTest {
+
+    private val handler = GlobalExceptionHandler()
+
+    private fun handle(referer: String?): String {
+        val request = mockk<HttpServletRequest> {
+            every { getHeader("Referer") } returns referer
+        }
+        val ra = mockk<RedirectAttributes>(relaxed = true)
+        return handler.handleMaxUploadSize(request, ra)
+    }
+
+    @Test
+    fun `redirects back to the referring in-app path`() {
+        assertEquals("redirect:/intro/manage", handle("https://bot.example/intro/manage"))
+    }
+
+    @Test
+    fun `keeps the referring page's query string`() {
+        assertEquals(
+            "redirect:/intro/manage?guildId=42",
+            handle("https://bot.example/intro/manage?guildId=42")
+        )
+    }
+
+    @Test
+    fun `falls back when the referer is missing`() {
+        assertEquals("redirect:/intro/guilds", handle(null))
+    }
+
+    @Test
+    fun `does not follow an external host with no path`() {
+        assertEquals("redirect:/intro/guilds", handle("https://evil.example"))
+    }
+
+    @Test
+    fun `does not follow a protocol-relative referer`() {
+        assertEquals("redirect:/intro/guilds", handle("//evil.example"))
+    }
+
+    @Test
+    fun `does not follow an opaque scheme referer`() {
+        assertEquals("redirect:/intro/guilds", handle("javascript:alert(1)"))
+    }
+
+    @Test
+    fun `does not follow an unparseable referer`() {
+        assertEquals("redirect:/intro/guilds", handle("ht!tp://%%%"))
+    }
+
+    @Test
+    fun `flashes the size error message`() {
+        val request = mockk<HttpServletRequest> { every { getHeader("Referer") } returns null }
+        val ra = mockk<RedirectAttributes>(relaxed = true)
+        handler.handleMaxUploadSize(request, ra)
+        verify { ra.addFlashAttribute("error", "File too large. Maximum size is 550KB.") }
+    }
+}

--- a/web/src/test/kotlin/web/profile/ProfileCardRendererTest.kt
+++ b/web/src/test/kotlin/web/profile/ProfileCardRendererTest.kt
@@ -1,6 +1,7 @@
 package web.profile
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -105,6 +106,20 @@ class ProfileCardRendererTest {
     @Test
     fun `renders with a large multi-digit streak without overflowing`() {
         val png = renderer.renderPng(sample(streakDays = 365, streakActive = true))
+        assertPngShape(png, 900, 400)
+    }
+
+    @Test
+    fun `avatar fetches are restricted to https urls`() {
+        assertTrue(ProfileCardRenderer.isFetchableAvatarUrl("https://cdn.discordapp.com/avatars/1/a.png"))
+        assertFalse(ProfileCardRenderer.isFetchableAvatarUrl("http://cdn.discordapp.com/avatars/1/a.png"))
+        assertFalse(ProfileCardRenderer.isFetchableAvatarUrl("file:///etc/passwd"))
+        assertFalse(ProfileCardRenderer.isFetchableAvatarUrl("not a url"))
+    }
+
+    @Test
+    fun `renders a grey-disc card without fetching when the avatar URL is not https`() {
+        val png = renderer.renderPng(sample(avatarUrl = "file:///etc/passwd"))
         assertPngShape(png, 900, 400)
     }
 

--- a/web/src/test/kotlin/web/service/IntroWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/IntroWebServiceTest.kt
@@ -412,4 +412,52 @@ class IntroWebServiceTest {
         assertNull(preview.title)
         assertEquals("https://img.youtube.com/vi/abc123/mqdefault.jpg", preview.thumbnailUrl)
     }
+
+    // --- security hardening ----------------------------------------------
+
+    @Test
+    fun `setIntroByUrl rejects non-http schemes`() {
+        // file:/ftp:/javascript: would otherwise be persisted and later fetched
+        // by the music player — a local-resource read primitive.
+        assertEquals("Invalid URL provided.", service.setIntroByUrl(discordId, guildId, "file:///etc/passwd", 50, null, null, null))
+        assertEquals("Invalid URL provided.", service.setIntroByUrl(discordId, guildId, "ftp://internal.host/clip.mp3", 50, null, null, null))
+        assertEquals("Invalid URL provided.", service.setIntroByUrl(discordId, guildId, "javascript:alert(1)", 50, null, null, null))
+    }
+
+    @Test
+    fun `setIntroByUrl rejects an http url without a host`() {
+        assertEquals("Invalid URL provided.", service.setIntroByUrl(discordId, guildId, "https://", 50, null, null, null))
+    }
+
+    @Test
+    fun `fetchYouTubePreview rejects ids outside the YouTube id alphabet`() {
+        // Quotes, parens and spaces would otherwise flow into the thumbnail
+        // CSS url(...) and the Data API query string.
+        assertNull(service.fetchYouTubePreview("https://www.youtube.com/watch?v=abc')injected"))
+        assertNull(service.fetchYouTubePreview("https://www.youtube.com/watch?v=abc def"))
+    }
+
+    @Test
+    fun `sanitizeUploadFileName strips directory components and control characters`() {
+        assertEquals("clip.mp3", service.sanitizeUploadFileName("../../../etc/clip.mp3"))
+        assertEquals("clip.mp3", service.sanitizeUploadFileName("C:\\Users\\victim\\clip.mp3"))
+        assertEquals("clip.mp3", service.sanitizeUploadFileName("cl ip.mp3"))
+        assertNull(service.sanitizeUploadFileName(null))
+        assertNull(service.sanitizeUploadFileName("   "))
+    }
+
+    @Test
+    fun `sanitizeUploadFileName collapses a url-shaped name so it cannot feed the blob-heal path`() {
+        assertEquals("evil.mp3", service.sanitizeUploadFileName("https://evil.example/evil.mp3"))
+    }
+
+    @Test
+    fun `setIntroByFile persists the sanitized file name`() {
+        every { userService.getUserById(discordId, guildId) } returns user()
+        val saved = slot<MusicDto>()
+        every { musicFileService.createNewMusicFile(capture(saved)) } returns mockk()
+        val result = service.setIntroByFile(discordId, guildId, mp3("..\\..\\traversal.mp3", byteArrayOf(1)), 60, null, null, null)
+        assertNull(result)
+        assertEquals("traversal.mp3", saved.captured.fileName)
+    }
 }


### PR DESCRIPTION
## Summary

A security audit of the codebase (web layer, Discord bot, database, config). The database/bot layer came back clean — parameterized queries throughout, no command injection or path traversal, secrets via env vars, permission checks on privileged commands, and dependency CVEs already pinned in `build.gradle`. The web layer had one real vulnerability and a few hardening gaps, all fixed here.

## Fixes

### Open redirect via `Referer` header (the real one)
`GlobalExceptionHandler.handleMaxUploadSize` redirected to the raw `Referer` header, which is attacker-controllable — a crafted upload request could bounce a victim to an external phishing site. The handler now reduces the Referer to its in-app path + query through the existing `DefaultGuildCookie.sanitizeRedirect` whitelist, falling back to `/intro/guilds` for absolute external, protocol-relative, opaque-scheme, or unparseable values.

### Hardening (defense in depth)
- **`IntroWebService.isValidUrl`** accepted any scheme `URI/URL` could parse (`file:`, `ftp:`, `jar:`…). Saved intro URLs are later fetched by the music player, so this was a potential local-resource read primitive. Now restricted to `http(s)` with a non-blank host.
- **Upload filenames** were persisted verbatim from `MultipartFile.originalFilename`. Directory components and control characters are now stripped, which also prevents a URL-shaped filename from feeding the blob-heal logic in `getUserIntros` (which trusts URL-shaped filenames on blobless rows).
- **YouTube video IDs** extracted from user URLs are now validated against the YouTube ID alphabet (`[A-Za-z0-9_-]`) before being interpolated into thumbnail URLs (rendered inside a `th:style` `url(...)` context), embed URLs, and the Data API query string.
- **`YOUTUBE_API_KEY` redacted** from the Data API failure log line, which flows to Discord via `DiscordLogger`.
- **`ProfileCardRenderer.loadAvatar`** now refuses non-`https` URLs, so the renderer can never be handed a `file:`/internal URL to embed into a public PNG (avatar URLs come from Discord's CDN today; this guards future callers).

## Tests

- New `GlobalExceptionHandlerTest` pinning the redirect whitelist (8 cases: in-app path, query preservation, missing/external/protocol-relative/opaque/unparseable referers, flash message).
- `IntroWebServiceTest`: scheme rejection, host-less URL rejection, video-ID alphabet rejection, filename sanitization (traversal, Windows paths, control chars, URL-shaped names), and persistence of the sanitized name.
- `ProfileCardRendererTest`: https-only avatar guard plus an end-to-end render with a `file:` avatar URL.

Full `:web` test suite passes; full `build koverVerify` run in progress at time of PR creation (will follow up if anything regresses).

https://claude.ai/code/session_015UeoXGbWropZRSBVjJo7As

---
_Generated by [Claude Code](https://claude.ai/code/session_015UeoXGbWropZRSBVjJo7As)_