### PR TITLE
Security audit pass 2: actuator lockdown, supply-chain pin, non-root container

### DIFF
--- a/.github/workflows/publish-wiki.yml
+++ b/.github/workflows/publish-wiki.yml
@@ -39,4 +39,6 @@ jobs:
           git diff-index --quiet HEAD || git commit -m "Update Commands.md in wiki"
 
       - name: Publish to Wiki
-        uses: Andrew-Chen-Wang/github-wiki-action@v4
+        # Pinned to the commit the v4 tag pointed at — a moving tag on a
+        # third-party action with contents:write is a supply-chain risk.
+        uses: Andrew-Chen-Wang/github-wiki-action@50650fccf3a10f741995523cf9708c53cec8912a # v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ COPY --chown=root:root . .
 RUN chmod +x gradlew && ./gradlew :application:bootJar --no-daemon
 
 FROM eclipse-temurin:21-jre
-RUN mkdir /app
+RUN mkdir /app && useradd --system --no-create-home tobybot
 COPY --from=build /home/gradle/src/application/build/libs/*.jar /app/toby-bot.jar
+USER tobybot
 EXPOSE 8080
 ENTRYPOINT ["java", "-Xms128m", "-Xmx224m", "-XX:+UseSerialGC", "-XX:MaxMetaspaceSize=192m", "-XX:ReservedCodeCacheSize=48m", "-XX:MaxDirectMemorySize=48m", "-Dio.netty.maxDirectMemory=0", "-Dio.netty.allocator.numDirectArenas=2", "-Dio.netty.allocator.numHeapArenas=2", "-Xss256k", "-XX:+ExitOnOutOfMemoryError", "-jar", "/app/toby-bot.jar"]

--- a/application/src/main/resources/application.properties
+++ b/application/src/main/resources/application.properties
@@ -4,6 +4,14 @@ spring.jpa.open-in-view=false
 server.port=8080
 server.servlet.context-path=/
 server.forward-headers-strategy=framework
+
+# Actuator: pin web exposure to the health probe only. This is Spring
+# Boot's default today, but stating it explicitly means a stray
+# MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE env var (or a future Boot
+# default change) can't silently publish /actuator/env or /actuator/heapdump.
+# WebSecurityConfig deliberately leaves only /actuator/health
+# unauthenticated for platform health checks.
+management.endpoints.web.exposure.include=health
 spring.cache.type=caffeine
 spring.profiles.active=prod
 spring.datasource.driver-class-name=org.postgresql.Driver

--- a/web/src/main/kotlin/web/configuration/WebSecurityConfig.kt
+++ b/web/src/main/kotlin/web/configuration/WebSecurityConfig.kt
@@ -17,7 +17,11 @@ class WebSecurityConfig {
                 auth.requestMatchers(
                     "/", "/terms", "/privacy", "/changelog",
                     "/brother", "/config", "/music", "/user",
-                    "/commands", "/commands/**", "/actuator/**",
+                    "/commands", "/commands/**",
+                    // Health probe only — the rest of /actuator/* (env,
+                    // heapdump, …) must never be anonymously reachable even
+                    // if someone widens the management exposure config.
+                    "/actuator/health",
                     "/v3/api-docs/**", "/swagger-ui/**", "/login", "/error",
                     "/images/**", "/js/**", "/css/**",
                     "/dnd", "/dnd/**",

--- a/web/src/main/resources/static/js/baccarat.js
+++ b/web/src/main/resources/static/js/baccarat.js
@@ -171,7 +171,10 @@ function sideName(raw) {
     if (raw === 'PLAYER') return 'Player';
     if (raw === 'BANKER') return 'Banker';
     if (raw === 'TIE') return 'Tie';
-    return String(raw || '');
+    // The result is concatenated into innerHTML by the win/lose line
+    // builders, so an unexpected value must come out HTML-inert — keep
+    // only characters that can't open a tag or attribute.
+    return String(raw || '').replace(/[^A-Za-z0-9 _-]/g, '');
 }
 
 function winLineHtml(body, sideLabel, winnerLabel) {

--- a/web/src/test/js/baccarat.test.js
+++ b/web/src/test/js/baccarat.test.js
@@ -328,3 +328,59 @@ describe('renderBaccaratResult', () => {
         }
     });
 });
+
+describe('sideName HTML hardening', () => {
+    // sideName's fallback flows into innerHTML via the push/lose line
+    // builders. Whitelisted values map to friendly names; anything else
+    // must come out HTML-inert.
+    test('an unexpected side value cannot inject markup into the result line', () => {
+        document.body.innerHTML = '<div id="r"></div>';
+        const resultEl = document.getElementById('r');
+        renderBaccaratResult({
+            resultEl,
+            bankerCardsEl: null,
+            playerCardsEl: null,
+            bankerTotalEl: null,
+            playerTotalEl: null,
+            tableEl: null,
+            stagger: false,
+            body: {
+                push: true,
+                side: '<img src=x onerror="window.pwned=true">',
+                winner: 'PLAYER',
+                playerCards: [],
+                bankerCards: [],
+                playerTotal: 0,
+                bankerTotal: 0,
+                payout: 50,
+            },
+        });
+        expect(resultEl.querySelector('img')).toBeNull();
+        expect(resultEl.innerHTML).not.toContain('<img');
+    });
+
+    test('whitelisted sides still render their friendly names on a push', () => {
+        document.body.innerHTML = '<div id="r"></div>';
+        const resultEl = document.getElementById('r');
+        renderBaccaratResult({
+            resultEl,
+            bankerCardsEl: null,
+            playerCardsEl: null,
+            bankerTotalEl: null,
+            playerTotalEl: null,
+            tableEl: null,
+            stagger: false,
+            body: {
+                push: true,
+                side: 'BANKER',
+                winner: 'TIE',
+                playerCards: [],
+                bankerCards: [],
+                playerTotal: 0,
+                bankerTotal: 0,
+                payout: 50,
+            },
+        });
+        expect(resultEl.textContent).toContain('Banker');
+    });
+});

--- a/web/src/test/kotlin/web/configuration/WebSecurityConfigActuatorLockdownTest.kt
+++ b/web/src/test/kotlin/web/configuration/WebSecurityConfigActuatorLockdownTest.kt
@@ -1,0 +1,65 @@
+package web.configuration
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * Pins the actuator lockdown from the security audit. Two layers, both
+ * asserted here:
+ *
+ *  1. [WebSecurityConfig] grants anonymous access to `/actuator/health`
+ *     ONLY — never the actuator wildcard matcher. With the wildcard, one
+ *     stray `management.endpoints.web.exposure.include=*` (a common
+ *     debugging move, settable via env var) would publish
+ *     `/actuator/env` and `/actuator/heapdump` to the internet.
+ *  2. `application.properties` pins the management web exposure to
+ *     `health` explicitly rather than relying on Spring Boot's default.
+ *
+ * Source-text assertions match the existing pattern in
+ * [WebSecurityConfigOAuthRedirectTest] — cheap, fast, and they catch the
+ * exact one-line regressions that would reopen the hole.
+ */
+internal class WebSecurityConfigActuatorLockdownTest {
+
+    private val securityConfig: String by lazy {
+        File("src/main/kotlin/web/configuration/WebSecurityConfig.kt")
+            .takeIf { it.exists() }
+            ?.readText()
+            ?: error("WebSecurityConfig.kt not found relative to web module root")
+    }
+
+    private val applicationProperties: String by lazy {
+        File("../application/src/main/resources/application.properties")
+            .takeIf { it.exists() }
+            ?.readText()
+            ?: error("application.properties not found relative to web module root")
+    }
+
+    @Test
+    fun `anonymous actuator access is limited to the health probe`() {
+        assertTrue(
+            securityConfig.contains("\"/actuator/health\""),
+            "WebSecurityConfig.kt must keep /actuator/health anonymously reachable for platform health checks."
+        )
+    }
+
+    @Test
+    fun `the actuator wildcard is never anonymously reachable`() {
+        assertFalse(
+            securityConfig.contains("\"/actuator/**\""),
+            "WebSecurityConfig.kt must not permitAll the /actuator/** wildcard — combined with a widened " +
+                "management exposure config that would publish /actuator/env and /actuator/heapdump publicly."
+        )
+    }
+
+    @Test
+    fun `management web exposure is pinned to health`() {
+        assertTrue(
+            applicationProperties.contains("management.endpoints.web.exposure.include=health"),
+            "application.properties must pin management.endpoints.web.exposure.include=health so an env var " +
+                "or Boot default change can't silently widen the actuator surface."
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Second security-audit pass over the codebase, following up #695. Three parallel deep-dives this round: browser-side code (DOM XSS, service worker, postMessage), server-side authorization (CSRF-exempt APIs, IDOR, SSE, admin), and economy integrity + infrastructure (wager race conditions, GitHub Actions, Docker, actuator).

### Findings fixed

- **Actuator lockdown (the significant one).** `WebSecurityConfig` permitted `/actuator/**` anonymously. Spring Boot's default only web-exposes `health` today, but one stray `MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE=*` (a common debugging move) would have published `/actuator/env` and `/actuator/heapdump` to the internet. Now only `/actuator/health` is anonymous, and `application.properties` pins `management.endpoints.web.exposure.include=health` explicitly — two independent layers.
- **Supply-chain pin.** `publish-wiki.yml` ran the third-party `Andrew-Chen-Wang/github-wiki-action` from the moving `v4` tag with `contents: write`; it's now pinned to the commit SHA that tag resolves to.
- **Non-root container.** The runtime Docker image now runs as a dedicated system user instead of root.
- **Defense-in-depth in `baccarat.js`.** `sideName()`'s fallback echoed the raw value into the `innerHTML` result-line builders; unexpected values are now stripped to an HTML-inert charset.

### Audited clean (no changes needed)

- **Frontend:** all 71 `innerHTML` usages, Thymeleaf templates (no `th:utext`), no `eval`/`postMessage` issues; user data consistently goes through `textContent`/`escapeHtml`. The `intro.url` → `th:href` path is already constrained to http(s) by #695's validation plus the view-model's scheme filter.
- **Authorization:** every CSRF-exempt mutating endpoint (`/api/engagement/**`, `/magic/api/**`, `/api/push/**`) verified to operate only on the authenticated user's own rows; no IDOR found across controllers; SSE streams gate on guild membership; `/admin/**` checks bot-owner on every handler.
- **Economy:** stake bounds validated server-side, balances mutated under row locks with ascending-id deadlock ordering, payouts/multipliers never client-supplied, all coin math in `Long`.
- **Workflows:** untrusted PR title/body interpolated only via `env:` (no script injection), no `pull_request_target` use.

### Tests

- `WebSecurityConfigActuatorLockdownTest` pins both actuator layers (source-text assertion style, matching `WebSecurityConfigOAuthRedirectTest`).
- `baccarat.test.js` gains two regression tests proving an unexpected `side` value can't inject markup while whitelisted values still render.

Full `web` module suite and all 754 JS tests pass locally; the Docker-dependent `application` integration tests run in CI.

https://claude.ai/code/session_015UeoXGbWropZRSBVjJo7As

---
_Generated by [Claude Code](https://claude.ai/code/session_015UeoXGbWropZRSBVjJo7As)_