### PR TITLE
Keep the Discord Activity inside the proxy sandbox (fix "disallowed web page" kill)

### DIFF
--- a/application/src/main/resources/application.properties
+++ b/application/src/main/resources/application.properties
@@ -4,6 +4,14 @@ spring.jpa.open-in-view=false
 server.port=8080
 server.servlet.context-path=/
 server.forward-headers-strategy=framework
+# Keep Location headers relative on sendRedirect (Tomcat default is an
+# absolute URL on the canonical host). Inside the Discord Activity
+# iframe the page lives on <client-id>.discordsays.com; an absolute
+# redirect to www.toby-bot.co.uk is a navigation out of the sandbox and
+# Discord kills the activity ("tried to open a disallowed web page").
+# Relative Locations resolve against whichever host served the page, so
+# the same redirect works on both the dashboard and the activity.
+server.tomcat.use-relative-redirects=true
 
 # Actuator: pin web exposure to the health probe only. This is Spring
 # Boot's default today, but stating it explicitly means a stray

--- a/application/src/test/kotlin/web/controller/HomeControllerTest.kt
+++ b/application/src/test/kotlin/web/controller/HomeControllerTest.kt
@@ -103,17 +103,18 @@ class HomeControllerTest {
     }
 
     @Test
-    fun `a discord activity launch on the root is forwarded to the shell with its params intact`() {
+    fun `a discord activity launch on the root renders the shell in place`() {
         // Discord always loads the proxy root "/" with the SDK params in
-        // the query string; the Embedded App SDK needs every one of them
-        // (frame_id, instance_id, platform, ...) present on the shell URL.
-        every { request.queryString } returns "instance_id=i-1&frame_id=abc&platform=mobile"
-
+        // the query string. The shell must render IN PLACE (no redirect):
+        // a redirect's absolute Location points at the real host, which
+        // the Discord sandbox treats as opening a disallowed web page —
+        // and an in-place render keeps frame_id et al in location.search
+        // where the Embedded App SDK reads them.
         val view = home(frameId = "abc")
 
-        assertEquals("redirect:/activity?instance_id=i-1&frame_id=abc&platform=mobile", view)
-        // The redirect branch must not touch the model or the stats
-        // service — it renders nothing.
+        assertEquals("activity", view)
+        verify { model.addAttribute("clientId", clientId) }
+        // The activity branch must not run the homepage population.
         verify(exactly = 0) { homeStatsService.get() }
     }
 

--- a/web/src/main/kotlin/web/controller/HomeController.kt
+++ b/web/src/main/kotlin/web/controller/HomeController.kt
@@ -27,11 +27,16 @@ class HomeController(
     ): String {
         // Discord Activity launches always load the proxy root "/" — there
         // is no entry-path setting in the Developer Portal. The launch is
-        // recognisable by the SDK params Discord appends (frame_id et al);
-        // forward those to the activity bootstrap shell INTACT, since the
-        // Embedded App SDK reads frame_id/instance_id from location.search.
+        // recognisable by the SDK params Discord appends (frame_id et al).
+        // Render the activity shell DIRECTLY rather than redirecting to
+        // /activity: the servlet container turns a redirect into an
+        // absolute Location on the real host, which the Discord sandbox
+        // treats as opening a disallowed web page and kills the activity.
+        // An in-place render keeps the iframe URL on *.discordsays.com and
+        // leaves the SDK params intact in location.search.
         if (frameId != null) {
-            return "redirect:/activity?${request.queryString}"
+            model.addAttribute("clientId", discordClientId.trim())
+            return "activity"
         }
         model.addAttribute("inviteUrl", DiscordInvite.urlFor(discordClientId))
         model.addAttribute("username", user?.getAttribute<String>("username"))


### PR DESCRIPTION
## What

Second live-test round on the phone: the SDK handshake now completes (consent → sign-in) and then Discord kills the activity with **"tried to open a disallowed web page"**. That message means the iframe navigated off the `*.discordsays.com` sandbox origin. Two causes, both fixed:

### 1. Tomcat rewrites every redirect to an absolute URL
Spring Boot's embedded Tomcat defaults `use-relative-redirects` to `false`, so every `sendRedirect` — the `/` → `/activity` hop from #698, login bounces, `WebGuildAccess` guard-failure flashes — emits `Location: https://www.toby-bot.co.uk/...`. Followed from inside the proxy, that's a navigation out of the sandbox → activity killed. `server.tomcat.use-relative-redirects=true` keeps Locations relative, so they resolve against whichever host served the page: the proxy domain inside the activity, the real host on the normal dashboard. Failure paths inside the activity now degrade to showing a page in the iframe instead of killing it.

### 2. The `/` → `/activity` redirect is gone entirely
When the SDK launch params (`frame_id`) are present on the root URL, `HomeController` now renders the activity shell **in place** instead of redirecting. This removes the launch path's only redirect and keeps `frame_id`/`instance_id` in `location.search`, where the Embedded App SDK reads them. `/activity` remains for direct access.

## Testing

- `:web:test` green; `application` `HomeControllerTest` updated for the in-place render (asserts the `activity` view + `clientId` model attribute, homepage population untouched).
- Needs a deploy + relaunch to confirm end-to-end on the phone.

https://claude.ai/code/session_01N43jxGduK9mdcPiyYCyqBK

---
_Generated by [Claude Code](https://claude.ai/code/session_01N43jxGduK9mdcPiyYCyqBK)_