### PR TITLE
Fix activity "disallowed web page" kill: mount casino in a nested iframe (Activities must be SPAs)

### DIFF
--- a/web/src/main/kotlin/web/activity/ActivityController.kt
+++ b/web/src/main/kotlin/web/activity/ActivityController.kt
@@ -1,5 +1,6 @@
 package web.activity
 
+import jakarta.servlet.http.HttpServletResponse
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Controller
@@ -37,16 +38,38 @@ class ActivityController(
 
     @PostMapping("/activity/api/token")
     @ResponseBody
-    fun token(@RequestBody request: ActivityTokenRequest): ResponseEntity<ActivityTokenResponse> {
+    fun token(
+        @RequestBody request: ActivityTokenRequest,
+        response: HttpServletResponse,
+    ): ResponseEntity<ActivityTokenResponse> {
         val code = request.code?.takeIf { it.isNotBlank() }
             ?: return ResponseEntity.badRequest()
                 .body(ActivityTokenResponse(ok = false, error = "Missing authorization code."))
         val issued = sessions.exchange(code)
             ?: return ResponseEntity.status(502)
                 .body(ActivityTokenResponse(ok = false, error = "Discord sign-in failed — relaunch the activity."))
+        // Belt-and-braces session carrier: the shell threads the token
+        // into navigations as ?activityToken=, but if a proxy hop or
+        // client webview drops query params, this cookie keeps page
+        // GETs (and EventSource) authenticated. SameSite=None because
+        // the page lives in the Discord iframe (a third-party context);
+        // the cookie is scoped to the proxied origin and HttpOnly.
+        // CSRF stays enforced for cookie-carried requests (see
+        // WebSecurityConfig), so SameSite=None doesn't widen mutation
+        // exposure.
+        response.addHeader(
+            "Set-Cookie",
+            "${ActivityTokenAuthFilter.COOKIE_NAME}=${issued.sessionToken}; " +
+                "Path=/; Max-Age=$COOKIE_MAX_AGE_SECONDS; Secure; HttpOnly; SameSite=None"
+        )
         return ResponseEntity.ok(
             ActivityTokenResponse(ok = true, sessionToken = issued.sessionToken, accessToken = issued.accessToken)
         )
+    }
+
+    companion object {
+        /** Matches the session store's 12h cap in [ActivitySessionService]. */
+        private const val COOKIE_MAX_AGE_SECONDS = 12 * 60 * 60
     }
 }
 

--- a/web/src/main/kotlin/web/activity/ActivitySessionService.kt
+++ b/web/src/main/kotlin/web/activity/ActivitySessionService.kt
@@ -82,6 +82,10 @@ class ActivitySessionService(
             val sessionToken = mintToken()
             val ttlMs = (expiresInSec * 1000).coerceAtMost(MAX_SESSION_TTL_MS)
             sessions[sessionToken] = Entry(principal, nowMs() + ttlMs)
+            // INFO on purpose: one line per activity launch in the deploy
+            // logs makes "did the handshake reach the server?" answerable
+            // without a debugger in the Discord client.
+            logger.info { "Activity session minted for discord user ${principal.name}" }
             ActivitySessions.Issued(sessionToken, accessToken)
         } catch (e: Exception) {
             logger.error { "Activity token exchange failed: ${e.message}" }

--- a/web/src/main/kotlin/web/activity/ActivityTokenAuthFilter.kt
+++ b/web/src/main/kotlin/web/activity/ActivityTokenAuthFilter.kt
@@ -1,6 +1,7 @@
 package web.activity
 
 import jakarta.servlet.FilterChain
+import jakarta.servlet.http.Cookie
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.security.authentication.AnonymousAuthenticationToken
@@ -11,21 +12,36 @@ import org.springframework.web.filter.OncePerRequestFilter
 
 /**
  * Authenticates requests carrying an activity session token issued by
- * [ActivitySessionService]. Two carriers are accepted:
+ * [ActivitySessionService]. Three carriers are accepted, in order:
  *
- *  - `Authorization: Bearer act_…` — used by fetch() calls from JS
- *    (api.js attaches it whenever an activity token is present).
- *  - `?activityToken=act_…` query param — used for full-page navigations
- *    inside the Activity iframe, where a header can't be attached. The
- *    token is opaque, short-lived, and the URL never leaves the
- *    `*.discordsays.com` sandbox, so the leak surface is the proxy's
- *    request log — acceptable for the ephemeral sessions involved.
+ *  - `Authorization: Bearer act_…` — fetch() calls from JS (api.js
+ *    attaches it whenever an activity token is present).
+ *  - `?activityToken=act_…` query param — full-page navigations inside
+ *    the Activity iframe, where a header can't be attached.
+ *  - `tobyActivitySession` cookie — set by the token exchange as a
+ *    fallback for the same navigations (and EventSource, which can
+ *    carry neither header nor bespoke params safely), in case the
+ *    Discord proxy or a client webview drops query params.
  *
  * On a hit the security context gets a principal with the same attribute
  * shape (`id`, `username`) as the oauth2Login path, so every existing
- * controller, WebGuildAccess guard, and the XP interceptor work unchanged.
- * No-ops when the request is already authenticated (normal browser
- * session) or carries no recognisable token.
+ * controller, WebGuildAccess guard, and the XP interceptor work
+ * unchanged. No-ops when the request is already authenticated (normal
+ * browser session) or carries no recognisable token.
+ *
+ * Failure semantics differ by carrier:
+ *  - An EXPLICIT token (header/query param) that doesn't resolve gets a
+ *    self-contained 401 page telling the player to relaunch — inside
+ *    the activity sandbox a bounce toward the login flow would
+ *    eventually navigate to an external origin and Discord kills the
+ *    iframe, so dead sessions must never reach the redirect machinery.
+ *  - A stale COOKIE alone falls through unauthenticated (and is
+ *    cleared) so it can never wedge normal dashboard browsing.
+ *
+ * CSRF note: only bearer-HEADER requests are CSRF-exempt (see
+ * WebSecurityConfig). The cookie is sent automatically by browsers, so
+ * cookie-carried auth deliberately keeps full CSRF protection — it
+ * only needs to cover GETs anyway.
  *
  * Deliberately NOT a @Component: Spring Boot auto-registers Filter beans
  * with the servlet container, which would run it twice. It's instantiated
@@ -41,19 +57,54 @@ class ActivityTokenAuthFilter(
         filterChain: FilterChain,
     ) {
         val existing = SecurityContextHolder.getContext().authentication
-        if (existing == null || existing is AnonymousAuthenticationToken) {
-            extractToken(request)?.let { token ->
-                sessions.resolve(token)?.let { principal ->
-                    val auth = UsernamePasswordAuthenticationToken(principal, null, principal.authorities)
-                    auth.details = WebAuthenticationDetailsSource().buildDetails(request)
-                    SecurityContextHolder.getContext().authentication = auth
-                }
-            }
+        if (existing != null && existing !is AnonymousAuthenticationToken) {
+            filterChain.doFilter(request, response)
+            return
         }
-        filterChain.doFilter(request, response)
+
+        val explicitToken = explicitToken(request)
+        val cookieToken = cookieToken(request)
+        val token = explicitToken ?: cookieToken
+        if (token == null) {
+            filterChain.doFilter(request, response)
+            return
+        }
+
+        val principal = sessions.resolve(token)
+        if (principal != null) {
+            val auth = UsernamePasswordAuthenticationToken(principal, null, principal.authorities)
+            auth.details = WebAuthenticationDetailsSource().buildDetails(request)
+            SecurityContextHolder.getContext().authentication = auth
+            filterChain.doFilter(request, response)
+            return
+        }
+
+        // Dead cookie with no explicit token: clear it and continue
+        // anonymously so a lingering cookie can't wedge the normal site.
+        if (explicitToken == null) {
+            response.addCookie(Cookie(COOKIE_NAME, "").apply {
+                path = "/"
+                maxAge = 0
+                secure = true
+                isHttpOnly = true
+            })
+            filterChain.doFilter(request, response)
+            return
+        }
+
+        // Explicit-but-dead token: the caller is inside the activity (or
+        // a stale tab). Page navigations get the relaunch page; JS/API
+        // callers get a bare 401 their error handling already understands.
+        if (wantsHtml(request)) {
+            response.status = HttpServletResponse.SC_UNAUTHORIZED
+            response.contentType = "text/html;charset=UTF-8"
+            response.writer.write(EXPIRED_PAGE)
+        } else {
+            response.status = HttpServletResponse.SC_UNAUTHORIZED
+        }
     }
 
-    private fun extractToken(request: HttpServletRequest): String? {
+    private fun explicitToken(request: HttpServletRequest): String? {
         val header = request.getHeader("Authorization")
         if (header != null && header.startsWith(BEARER_PREFIX)) {
             return header.removePrefix(BEARER_PREFIX).trim()
@@ -63,8 +114,35 @@ class ActivityTokenAuthFilter(
             ?.takeIf { it.startsWith(ActivitySessionService.TOKEN_PREFIX) }
     }
 
+    private fun cookieToken(request: HttpServletRequest): String? =
+        request.cookies
+            ?.firstOrNull { it.name == COOKIE_NAME }
+            ?.value
+            ?.takeIf { it.startsWith(ActivitySessionService.TOKEN_PREFIX) }
+
+    private fun wantsHtml(request: HttpServletRequest): Boolean {
+        if (!request.method.equals("GET", ignoreCase = true)) return false
+        return request.getHeader("Accept")?.contains("text/html") == true
+    }
+
     companion object {
         const val QUERY_PARAM = "activityToken"
+        const val COOKIE_NAME = "tobyActivitySession"
         private const val BEARER_PREFIX = "Bearer "
+
+        // Self-contained (no template engine in the filter chain, and no
+        // redirects allowed — see class doc). Styling kept inline so it
+        // renders sanely even if static assets are unreachable.
+        private val EXPIRED_PAGE = """
+            <!DOCTYPE html>
+            <html lang="en">
+            <head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+            <title>Session expired</title></head>
+            <body style="background:#1e1f22;color:#dbdee1;font-family:sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0;text-align:center">
+            <div><h1>🎰 Session expired</h1>
+            <p>Your casino session has ended.<br>Close this activity and launch it again to keep playing.</p></div>
+            </body>
+            </html>
+        """.trimIndent()
     }
 }

--- a/web/src/main/kotlin/web/configuration/ForwardedHeaderConfig.kt
+++ b/web/src/main/kotlin/web/configuration/ForwardedHeaderConfig.kt
@@ -1,0 +1,49 @@
+package web.configuration
+
+import jakarta.servlet.DispatcherType
+import org.springframework.boot.web.servlet.FilterRegistrationBean
+import org.springframework.boot.web.servlet.filter.OrderedFilter
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.filter.ForwardedHeaderFilter
+
+/**
+ * Replaces Spring Boot's auto-registered [ForwardedHeaderFilter]
+ * (`server.forward-headers-strategy=framework`) with one configured for
+ * relative redirects.
+ *
+ * Why: the default filter doesn't just apply X-Forwarded-* to the
+ * request — it also wraps the response and rewrites every
+ * `sendRedirect` Location into an ABSOLUTE URL on the forwarded host
+ * (www.toby-bot.co.uk). Inside the Discord Activity iframe the page is
+ * served via the `*.discordsays.com` proxy, so an absolute redirect to
+ * the real host is a navigation out of the sandbox and Discord kills
+ * the activity ("tried to open a disallowed web page"). This is also
+ * why `server.tomcat.use-relative-redirects=true` alone wasn't enough —
+ * Tomcat emitted a relative Location and the wrapper re-absolutised it.
+ *
+ * With `relativeRedirects=true` the filter leaves redirect Locations
+ * exactly as the application issued them, so context-relative redirects
+ * (`/login`, `/leaderboards`, …) resolve against whichever host served
+ * the page: the proxy domain inside the activity, the canonical host on
+ * the normal dashboard. Request-side forwarded-header processing (the
+ * part OAuth2 redirect-uri building needs behind Heroku's router) is
+ * unchanged.
+ *
+ * Boot backs off automatically: its registration is guarded by
+ * `@ConditionalOnMissingFilterBean(ForwardedHeaderFilter)`. Order and
+ * dispatcher types mirror Boot's own registration.
+ */
+@Configuration
+class ForwardedHeaderConfig {
+
+    @Bean
+    fun forwardedHeaderFilter(): FilterRegistrationBean<ForwardedHeaderFilter> {
+        val filter = ForwardedHeaderFilter()
+        filter.setRelativeRedirects(true)
+        val registration = FilterRegistrationBean(filter)
+        registration.setDispatcherTypes(DispatcherType.REQUEST, DispatcherType.ASYNC, DispatcherType.ERROR)
+        registration.order = OrderedFilter.REQUEST_WRAPPER_FILTER_MAX_ORDER - 1
+        return registration
+    }
+}

--- a/web/src/main/resources/static/js/activity.js
+++ b/web/src/main/resources/static/js/activity.js
@@ -4,12 +4,20 @@
 //
 //   ready → authorize (silent OAuth2 code grant) → POST the code to
 //   /activity/api/token (mints an activity session token, see
-//   ActivitySessionService) → authenticate → navigate into the casino.
+//   ActivitySessionService) → authenticate → mount the casino.
 //
-// The session token rides along as a ?activityToken= query param so the
-// destination page's GET authenticates through ActivityTokenAuthFilter;
-// api.js then stashes it in sessionStorage and attaches it as a bearer
-// header on every fetch (and onto same-origin link navigations).
+// CRITICAL CONSTRAINT: Activities must behave as single-page apps. The
+// SDK holds a persistent postMessage connection to the Discord client
+// through THIS document — any top-level navigation (window.location,
+// location.replace, a plain link) tears it down and the client kills
+// the activity with "tried to open a disallowed web page". The casino
+// is a multi-page Thymeleaf app, so it's mounted in a NESTED same-origin
+// iframe below: navigation inside that frame is invisible to the
+// sandbox, while this shell document (and the SDK connection) stays put.
+//
+// The session token rides into the nested frame as ?activityToken= and
+// as the session cookie; api.js inside the frame attaches it as a bearer
+// header on every fetch and onto same-origin link navigations.
 //
 // The SDK bundle is vendored (static/js/vendor/) rather than CDN-loaded:
 // the Activity CSP only allows the app's own proxy origin, so a
@@ -22,6 +30,18 @@ const statusEl = document.getElementById('activity-status');
 
 function status(message) {
     if (statusEl) statusEl.textContent = message;
+}
+
+function mountCasino(guildId, sessionToken) {
+    const frame = document.createElement('iframe');
+    frame.id = 'activity-game-frame';
+    frame.title = 'TobyBot Casino';
+    frame.src = '/casino/' + encodeURIComponent(guildId) + '/slots'
+        + '?activityToken=' + encodeURIComponent(sessionToken);
+    frame.addEventListener('load', () => {
+        if (main) main.hidden = true;
+    });
+    document.body.appendChild(frame);
 }
 
 async function boot() {
@@ -69,15 +89,12 @@ async function boot() {
         sessionStorage.setItem('tobyActivityToken', body.sessionToken);
     } catch (e) {
         // Storage can be unavailable in a sandboxed iframe — the query
-        // param below still authenticates the first page, and api.js
-        // falls back to reading it from the URL.
+        // param on the nested frame still authenticates it, and api.js
+        // falls back to reading the token from the frame's URL.
     }
 
     status('Entering the casino…');
-    window.location.replace(
-        '/casino/' + encodeURIComponent(sdk.guildId) + '/slots'
-        + '?activityToken=' + encodeURIComponent(body.sessionToken)
-    );
+    mountCasino(sdk.guildId, body.sessionToken);
 }
 
 boot().catch((e) => {

--- a/web/src/main/resources/templates/activity.html
+++ b/web/src/main/resources/templates/activity.html
@@ -3,9 +3,11 @@
 <!--
     Bootstrap shell for the Discord Activity. Discord loads this page in
     the Activity iframe via the discordsays.com proxy; activity.js runs
-    the Embedded App SDK handshake and then navigates into the existing
-    casino pages. Deliberately bare — no navbar/footer, since the user
-    isn't authenticated yet and the iframe is small.
+    the Embedded App SDK handshake and then mounts the casino in a
+    nested same-origin iframe (#activity-game-frame). The shell document
+    must NEVER navigate: the SDK's postMessage connection to the Discord
+    client lives here, and a top-level navigation gets the activity
+    killed as "tried to open a disallowed web page".
 -->
 <head>
     <meta charset="UTF-8">
@@ -14,6 +16,16 @@
     <title>TobyBot Casino</title>
     <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
     <link rel="stylesheet" th:href="@{/css/base.css}">
+    <style>
+        /* The nested casino frame owns the whole viewport once mounted. */
+        #activity-game-frame {
+            position: fixed;
+            inset: 0;
+            width: 100%;
+            height: 100%;
+            border: 0;
+        }
+    </style>
 </head>
 <body>
 <main id="activity-main" class="container" th:attr="data-client-id=${clientId}">

--- a/web/src/test/kotlin/web/activity/ActivityControllerTest.kt
+++ b/web/src/test/kotlin/web/activity/ActivityControllerTest.kt
@@ -6,12 +6,14 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.ui.ConcurrentModel
 
 class ActivityControllerTest {
 
     private val sessions = mockk<ActivitySessions>()
     private val controller = ActivityController(sessions, clientId = "  12345 ")
+    private val servletResponse = MockHttpServletResponse()
 
     @Test
     fun `shell renders the activity template with the trimmed client id`() {
@@ -25,35 +27,43 @@ class ActivityControllerTest {
 
     @Test
     fun `token without a code is a 400`() {
-        val response = controller.token(ActivityTokenRequest(code = "  "))
+        val response = controller.token(ActivityTokenRequest(code = "  "), servletResponse)
 
         assertEquals(400, response.statusCode.value())
         assertEquals(false, response.body!!.ok)
     }
 
     @Test
-    fun `failed exchange is a 502 with no tokens in the body`() {
+    fun `failed exchange is a 502 with no tokens in the body and no cookie`() {
         every { sessions.exchange("bad-code") } returns null
 
-        val response = controller.token(ActivityTokenRequest(code = "bad-code"))
+        val response = controller.token(ActivityTokenRequest(code = "bad-code"), servletResponse)
 
         assertEquals(502, response.statusCode.value())
         assertEquals(false, response.body!!.ok)
         assertNull(response.body!!.sessionToken)
         assertNull(response.body!!.accessToken)
+        assertNull(servletResponse.getHeader("Set-Cookie"))
     }
 
     @Test
-    fun `successful exchange returns both tokens`() {
+    fun `successful exchange returns both tokens and sets the session cookie`() {
         every { sessions.exchange("good-code") } returns
             ActivitySessions.Issued(sessionToken = "act_s3ss10n", accessToken = "discord-tok")
 
-        val response = controller.token(ActivityTokenRequest(code = "good-code"))
+        val response = controller.token(ActivityTokenRequest(code = "good-code"), servletResponse)
 
         assertTrue(response.statusCode.is2xxSuccessful)
         val body = response.body!!
         assertEquals(true, body.ok)
         assertEquals("act_s3ss10n", body.sessionToken)
         assertEquals("discord-tok", body.accessToken)
+
+        val cookie = servletResponse.getHeader("Set-Cookie")!!
+        assertTrue(cookie.startsWith("${ActivityTokenAuthFilter.COOKIE_NAME}=act_s3ss10n;"))
+        // Third-party iframe context: SameSite=None + Secure are load-bearing.
+        assertTrue(cookie.contains("SameSite=None"))
+        assertTrue(cookie.contains("Secure"))
+        assertTrue(cookie.contains("HttpOnly"))
     }
 }

--- a/web/src/test/kotlin/web/activity/ActivityTokenAuthFilterTest.kt
+++ b/web/src/test/kotlin/web/activity/ActivityTokenAuthFilterTest.kt
@@ -3,10 +3,13 @@ package web.activity
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import jakarta.servlet.http.Cookie
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.mock.web.MockFilterChain
@@ -29,12 +32,14 @@ class ActivityTokenAuthFilterTest {
 
     private lateinit var sessions: ActivitySessions
     private lateinit var filter: ActivityTokenAuthFilter
+    private lateinit var chain: MockFilterChain
 
     @BeforeEach
     fun setUp() {
         SecurityContextHolder.clearContext()
         sessions = mockk()
         filter = ActivityTokenAuthFilter(sessions)
+        chain = MockFilterChain()
     }
 
     @AfterEach
@@ -42,8 +47,10 @@ class ActivityTokenAuthFilterTest {
         SecurityContextHolder.clearContext()
     }
 
-    private fun run(request: MockHttpServletRequest) {
-        filter.doFilter(request, MockHttpServletResponse(), MockFilterChain())
+    private fun run(request: MockHttpServletRequest): MockHttpServletResponse {
+        val response = MockHttpServletResponse()
+        filter.doFilter(request, response, chain)
+        return response
     }
 
     @Test
@@ -56,6 +63,7 @@ class ActivityTokenAuthFilterTest {
 
         val auth = SecurityContextHolder.getContext().authentication!!
         assertEquals(123L, (auth.principal as OAuth2User).discordIdOrNull())
+        assertNotNull(chain.request) // request continued down the chain
     }
 
     @Test
@@ -71,14 +79,57 @@ class ActivityTokenAuthFilterTest {
     }
 
     @Test
-    fun `unknown token leaves the request anonymous`() {
-        every { sessions.resolve("act_nope") } returns null
+    fun `session cookie authenticates page navigations when params are lost`() {
+        every { sessions.resolve("act_tok") } returns principal
         val request = MockHttpServletRequest("GET", "/casino/42/slots")
-        request.addHeader("Authorization", "Bearer act_nope")
+        request.setCookies(Cookie(ActivityTokenAuthFilter.COOKIE_NAME, "act_tok"))
 
         run(request)
 
+        val auth = SecurityContextHolder.getContext().authentication!!
+        assertEquals(123L, (auth.principal as OAuth2User).discordIdOrNull())
+    }
+
+    @Test
+    fun `an explicit dead token on a page GET renders the relaunch page instead of redirecting`() {
+        every { sessions.resolve("act_dead") } returns null
+        val request = MockHttpServletRequest("GET", "/casino/42/slots")
+        request.setParameter(ActivityTokenAuthFilter.QUERY_PARAM, "act_dead")
+        request.addHeader("Accept", "text/html,application/xhtml+xml")
+
+        val response = run(request)
+
+        assertEquals(401, response.status)
+        assertTrue(response.contentAsString.contains("Session expired"))
+        assertNull(chain.request) // never reached the redirect machinery
+    }
+
+    @Test
+    fun `an explicit dead token on a JSON call is a bare 401`() {
+        every { sessions.resolve("act_dead") } returns null
+        val request = MockHttpServletRequest("POST", "/casino/42/slots/spin")
+        request.addHeader("Authorization", "Bearer act_dead")
+        request.addHeader("Accept", "application/json")
+
+        val response = run(request)
+
+        assertEquals(401, response.status)
+        assertEquals("", response.contentAsString)
+        assertNull(chain.request)
+    }
+
+    @Test
+    fun `a stale cookie alone is cleared and the request continues anonymously`() {
+        every { sessions.resolve("act_stale") } returns null
+        val request = MockHttpServletRequest("GET", "/leaderboards")
+        request.setCookies(Cookie(ActivityTokenAuthFilter.COOKIE_NAME, "act_stale"))
+
+        val response = run(request)
+
         assertNull(SecurityContextHolder.getContext().authentication)
+        assertNotNull(chain.request) // normal browsing unaffected
+        val cleared = response.cookies.first { it.name == ActivityTokenAuthFilter.COOKIE_NAME }
+        assertEquals(0, cleared.maxAge)
     }
 
     @Test


### PR DESCRIPTION
## What

Fixes the "this activity is closed because it tried to open a disallowed web page" kill, diagnosed in three rounds against the live deployment and Discord's actual proxy. Two real causes; both fixed here, plus hardening found along the way.

## Root cause (commit 2): Activities must be single-page apps

The Embedded App SDK holds a persistent postMessage connection to the Discord client through the shell document. The shell's `window.location.replace()` into `/casino/{guildId}/slots` was **itself the disallowed navigation** — any top-level document navigation tears the SDK connection down and the client kills the activity. This matched the observed symptom exactly: the kill fired during the automated handshake with no user interaction.

**Fix:** the shell never navigates. It mounts the casino in a **nested same-origin iframe** (`#activity-game-frame`, full viewport). Multi-page navigation inside the nested frame — game pages, rewritten links, EventSource — is invisible to the sandbox. This is the documented pattern for multi-page apps inside Activities ("nest them within a top-level SPA container").

Probing `https://<client-id>.discordsays.com` directly also established (contrary to earlier theories): query params **survive** the proxy, and the proxy **flattens server-side redirects internally** (an unauthenticated page request returns the login page inline rather than bouncing the iframe) — so server redirects were never the kill trigger.

## Also fixed (commit 1): redirect absolutisation + session robustness

1. **`ForwardedHeaderConfig`** replaces Boot's auto-registered `ForwardedHeaderFilter` with `relativeRedirects=true` — the default re-absolutises every `sendRedirect` Location onto the forwarded host, which made `server.tomcat.use-relative-redirects` (#699) ineffective. Request-side forwarded-header processing (OAuth2 `redirect_uri` building behind Heroku's router) is unchanged.
2. **Session cookie fallback:** the token exchange also sets the session token as a `SameSite=None; Secure; HttpOnly` cookie, accepted by `ActivityTokenAuthFilter` as a third carrier (header → query param → cookie). Cookie-carried requests keep full CSRF protection; only bearer-header requests are exempt.
3. **No silent failures:** an explicit dead token renders a self-contained "Session expired — relaunch" page (bare 401 for JSON) instead of reaching the login redirect; a stale cookie alone is cleared and browsing continues anonymously.
4. **Observability:** minting an activity session logs one INFO line, so launches are visible in deploy logs.

## Testing

- `:web:test` and Jest (760 tests) green; filter tests cover all three token carriers, the expired/bare-401 split, stale-cookie cleanup, and the untouched-session guard; controller tests assert Set-Cookie attributes.
- Verified against production: `frame_id` reaches the app through the proxy and renders the shell; bogus explicit tokens 401; the proxy flattens redirects.
- Final end-to-end confirmation needs a deploy + relaunch on a real client.

https://claude.ai/code/session_01N43jxGduK9mdcPiyYCyqBK