### PR TITLE
Activity follow-up: game-picker landing with multiplayer blackjack

### DIFF
--- a/web/src/main/kotlin/web/activity/ActivityController.kt
+++ b/web/src/main/kotlin/web/activity/ActivityController.kt
@@ -1,14 +1,21 @@
 package web.activity
 
 import jakarta.servlet.http.HttpServletResponse
+import net.dv8tion.jda.api.JDA
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.ResponseBody
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.service.EconomyWebService
+import web.util.WebGuildAccess
 
 /**
  * Entry point for the Discord Activity surface.
@@ -16,8 +23,14 @@ import org.springframework.web.bind.annotation.ResponseBody
  * GET /activity renders the bootstrap shell that Discord loads in the
  * Activity iframe (via the `*.discordsays.com` proxy). The shell runs the
  * Embedded App SDK handshake — ready → authorize → POST the code here →
- * authenticate — then navigates into the existing casino pages with the
- * issued session token (see activity.js).
+ * authenticate — then mounts the casino in a nested iframe pointed at
+ * GET /activity/casino/{guildId} (see activity.js).
+ *
+ * GET /activity/casino/{guildId} is the activity's landing surface: a
+ * slim game picker for the launch guild. Authenticated like every other
+ * per-guild page (here via the activity token filter) — friends in the
+ * same voice channel each land on their own picker and can meet at the
+ * same blackjack table.
  *
  * POST /activity/api/token is the code-for-session exchange. Anonymous by
  * design (the caller can't be authenticated yet) and CSRF-exempt: it sets
@@ -28,12 +41,28 @@ import org.springframework.web.bind.annotation.ResponseBody
 class ActivityController(
     private val sessions: ActivitySessions,
     @param:Value($$"${spring.security.oauth2.client.registration.discord.client-id:}") private val clientId: String,
+    private val economyWebService: EconomyWebService,
+    private val jda: JDA,
 ) {
 
     @GetMapping("/activity")
     fun shell(model: Model): String {
         model.addAttribute("clientId", clientId.trim())
         return "activity"
+    }
+
+    @GetMapping("/activity/casino/{guildId}")
+    fun casino(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+        model: Model,
+        ra: RedirectAttributes,
+    ): String = WebGuildAccess.requireMemberForPage(
+        user, guildId, economyWebService, ra, lobbyPath = "/leaderboards"
+    ) {
+        model.addAttribute("guildId", guildId.toString())
+        model.addAttribute("guildName", jda.getGuildById(guildId)?.name ?: "your server")
+        "activity-casino"
     }
 
     @PostMapping("/activity/api/token")

--- a/web/src/main/resources/static/js/activity.js
+++ b/web/src/main/resources/static/js/activity.js
@@ -36,7 +36,7 @@ function mountCasino(guildId, sessionToken) {
     const frame = document.createElement('iframe');
     frame.id = 'activity-game-frame';
     frame.title = 'TobyBot Casino';
-    frame.src = '/casino/' + encodeURIComponent(guildId) + '/slots'
+    frame.src = '/activity/casino/' + encodeURIComponent(guildId)
         + '?activityToken=' + encodeURIComponent(sessionToken);
     frame.addEventListener('load', () => {
         if (main) main.hidden = true;

--- a/web/src/main/resources/static/js/api.js
+++ b/web/src/main/resources/static/js/api.js
@@ -41,6 +41,14 @@
         return headers;
     }
 
+    // For pages that issue their own fetch() calls (blackjack's state
+    // polling, the lobby refresh) rather than going through postJson:
+    // merges the activity bearer header into the caller's headers when
+    // running inside the Discord Activity, and is a no-op otherwise.
+    function authHeaders(extra) {
+        return withActivityAuth(extra || {});
+    }
+
     function postJson(url, body) {
         const headers = withActivityAuth({ 'Content-Type': 'application/json', 'Accept': 'application/json' });
         const token = getCsrfToken();
@@ -112,9 +120,9 @@
     }
     rewriteActivityLinks();
 
-    window.TobyApi = { postJson: postJson, del: del, activityToken: activityToken };
+    window.TobyApi = { postJson: postJson, del: del, activityToken: activityToken, authHeaders: authHeaders };
 
     if (typeof module !== 'undefined') {
-        module.exports = { postJson: postJson, del: del, activityToken: activityToken };
+        module.exports = { postJson: postJson, del: del, activityToken: activityToken, authHeaders: authHeaders };
     }
 })();

--- a/web/src/main/resources/static/js/blackjack-lobby.js
+++ b/web/src/main/resources/static/js/blackjack-lobby.js
@@ -10,7 +10,9 @@
     var listEl = document.getElementById("bj-table-list");
 
     function refreshList() {
-        return fetch("/blackjack/" + guildId, { credentials: "same-origin", headers: { "Accept": "text/html" } })
+        var headers = { "Accept": "text/html" };
+        if (window.TobyApi && window.TobyApi.authHeaders) headers = window.TobyApi.authHeaders(headers);
+        return fetch("/blackjack/" + guildId, { credentials: "same-origin", headers: headers })
             // No public list endpoint; the easiest refresh is reload-on-action.
             .catch(function () {});
     }

--- a/web/src/main/resources/static/js/blackjack-solo.js
+++ b/web/src/main/resources/static/js/blackjack-solo.js
@@ -469,7 +469,11 @@
     }
 
     function refreshState() {
-        return fetch("/blackjack/" + guildId + "/solo/state", { credentials: "same-origin" })
+        // Inside the Discord Activity there's no session cookie — the
+        // bearer header from TobyApi.authHeaders carries auth instead.
+        // On the normal dashboard it's a no-op.
+        var headers = (window.TobyApi && window.TobyApi.authHeaders) ? window.TobyApi.authHeaders({}) : {};
+        return fetch("/blackjack/" + guildId + "/solo/state", { credentials: "same-origin", headers: headers })
             .then(function (r) {
                 if (r.status === 404) {
                     stopPoll();

--- a/web/src/main/resources/static/js/blackjack-table.js
+++ b/web/src/main/resources/static/js/blackjack-table.js
@@ -303,7 +303,11 @@
     }
 
     function refreshState() {
-        return fetch("/blackjack/" + guildId + "/" + tableId + "/state", { credentials: "same-origin" })
+        // Inside the Discord Activity there's no session cookie — the
+        // bearer header from TobyApi.authHeaders carries auth instead.
+        // On the normal dashboard it's a no-op.
+        var headers = (window.TobyApi && window.TobyApi.authHeaders) ? window.TobyApi.authHeaders({}) : {};
+        return fetch("/blackjack/" + guildId + "/" + tableId + "/state", { credentials: "same-origin", headers: headers })
             .then(function (r) {
                 if (r.status === 404) {
                     statusEl.textContent = "This table no longer exists.";

--- a/web/src/main/resources/templates/activity-casino.html
+++ b/web/src/main/resources/templates/activity-casino.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<!--
+    Activity landing page: the slim game picker mounted in the nested
+    iframe by activity.js after the SDK handshake. Deliberately chrome-
+    free (no navbar/footer): inside the Activity sandbox the dashboard
+    chrome wastes space and its external links (Ko-fi, invite) would be
+    blocked anyway. Links navigate the NESTED frame only, so the SDK
+    connection in the shell document is untouched.
+
+    api.js is loaded so the ?activityToken= the shell appended gets
+    stashed in sessionStorage and re-appended to every game link on
+    click — each game page then authenticates the same way this one did.
+-->
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="color-scheme" content="dark">
+    <title>TobyBot Casino</title>
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" th:href="@{/css/base.css}">
+    <style>
+        .activity-game-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(9.5rem, 1fr));
+            gap: 0.75rem;
+            margin-top: 1rem;
+        }
+        .activity-game-tile {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 0.25rem;
+            padding: 1rem 0.5rem;
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            border-radius: 0.75rem;
+            text-decoration: none;
+            text-align: center;
+        }
+        .activity-game-tile .tile-emoji { font-size: 2rem; }
+        .activity-game-tile small { opacity: 0.7; }
+        .activity-game-tile.featured { border-color: rgba(87, 242, 135, 0.5); }
+    </style>
+</head>
+<body>
+<main class="container">
+    <h1>🎰 Casino • <span th:text="${guildName}">Server</span></h1>
+    <p class="muted">Pick a game — everyone plays with their own credits.
+        Join the same blackjack table to play together.</p>
+
+    <nav class="activity-game-grid" aria-label="Games">
+        <a class="activity-game-tile featured" th:href="@{/blackjack/{g}(g=${guildId})}">
+            <span class="tile-emoji">🃏</span>Blackjack<small>play together</small>
+        </a>
+        <a class="activity-game-tile" th:href="@{/casino/{g}/slots(g=${guildId})}">
+            <span class="tile-emoji">🎰</span>Slots
+        </a>
+        <a class="activity-game-tile" th:href="@{/casino/{g}/dice(g=${guildId})}">
+            <span class="tile-emoji">🎲</span>Dice
+        </a>
+        <a class="activity-game-tile" th:href="@{/casino/{g}/coinflip(g=${guildId})}">
+            <span class="tile-emoji">🪙</span>Coinflip
+        </a>
+        <a class="activity-game-tile" th:href="@{/casino/{g}/roulette(g=${guildId})}">
+            <span class="tile-emoji">🎡</span>Roulette
+        </a>
+        <a class="activity-game-tile" th:href="@{/casino/{g}/highlow(g=${guildId})}">
+            <span class="tile-emoji">🔼</span>High-Low
+        </a>
+    </nav>
+</main>
+<script th:src="@{/js/api.js}"></script>
+</body>
+</html>

--- a/web/src/test/js/activity-token.test.js
+++ b/web/src/test/js/activity-token.test.js
@@ -97,6 +97,23 @@ describe('api.js activity token plumbing', () => {
         expect(anchor.getAttribute('href')).toBe('https://discord.com/invite/whatever');
     });
 
+    test('authHeaders merges the bearer token into caller-supplied headers', () => {
+        sessionStorage.setItem('tobyActivityToken', 'act_abc');
+        const api = loadApi();
+
+        const headers = api.authHeaders({ 'Accept': 'text/html' });
+
+        expect(headers['Authorization']).toBe('Bearer act_abc');
+        expect(headers['Accept']).toBe('text/html');
+    });
+
+    test('authHeaders is a no-op outside the activity', () => {
+        const api = loadApi();
+
+        expect(api.authHeaders({})).toEqual({});
+        expect(api.authHeaders()).toEqual({});
+    });
+
     test('outside the activity no click listener rewrites anything', () => {
         loadApi();
 

--- a/web/src/test/kotlin/web/activity/ActivityControllerTest.kt
+++ b/web/src/test/kotlin/web/activity/ActivityControllerTest.kt
@@ -2,18 +2,30 @@ package web.activity
 
 import io.mockk.every
 import io.mockk.mockk
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.entities.Guild
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.ui.ConcurrentModel
+import org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap
+import web.service.EconomyWebService
 
 class ActivityControllerTest {
 
     private val sessions = mockk<ActivitySessions>()
-    private val controller = ActivityController(sessions, clientId = "  12345 ")
+    private val economyWebService = mockk<EconomyWebService>()
+    private val jda = mockk<JDA>()
+    private val controller = ActivityController(sessions, clientId = "  12345 ", economyWebService, jda)
     private val servletResponse = MockHttpServletResponse()
+
+    private val user = mockk<OAuth2User> {
+        every { getAttribute<String>("id") } returns "100"
+        every { getAttribute<String>("username") } returns "tester"
+    }
 
     @Test
     fun `shell renders the activity template with the trimmed client id`() {
@@ -23,6 +35,28 @@ class ActivityControllerTest {
 
         assertEquals("activity", view)
         assertEquals("12345", model.getAttribute("clientId"))
+    }
+
+    @Test
+    fun `casino picker renders for guild members with guild context`() {
+        every { economyWebService.isMember(100L, 42L) } returns true
+        every { jda.getGuildById(42L) } returns mockk<Guild> { every { name } returns "Test Guild" }
+        val model = ConcurrentModel()
+
+        val view = controller.casino(42L, user, model, RedirectAttributesModelMap())
+
+        assertEquals("activity-casino", view)
+        assertEquals("42", model.getAttribute("guildId"))
+        assertEquals("Test Guild", model.getAttribute("guildName"))
+    }
+
+    @Test
+    fun `casino picker bounces non-members like every other per-guild page`() {
+        every { economyWebService.isMember(100L, 42L) } returns false
+
+        val view = controller.casino(42L, user, ConcurrentModel(), RedirectAttributesModelMap())
+
+        assertEquals("redirect:/leaderboards", view)
     }
 
     @Test


### PR DESCRIPTION
## What

Follow-up to #700: the activity no longer hardcodes solo slots — it lands on a **game picker** with **multiplayer blackjack** as the headline. Friends in the same voice channel each open the activity, tap Blackjack, and join the same per-guild table (the existing 2-second-polling tables — no new game logic).

## Changes

1. **`GET /activity/casino/{guildId}`** — slim, chrome-free landing page mounted in the activity's nested iframe: Blackjack (featured, "play together"), Slots, Dice, Coinflip, Roulette, High-Low. Authenticated + membership-guarded via `WebGuildAccess` exactly like every per-guild page; the activity token filter supplies the principal. Links navigate only the nested frame, so the SDK connection in the shell stays alive, and `api.js`'s click rewriter keeps the token on every hop.

2. **`TobyApi.authHeaders(extra)`** in `api.js` — merges the activity bearer header into caller-supplied headers (no-op on the normal dashboard). Blackjack's mutations already went through `postJson` (bearer attached), but its three raw `fetch()` call sites — solo state poll, table state poll, lobby refresh — would have relied on the cookie alone inside the iframe. They now carry the bearer too, so blackjack works in the activity even where the webview blocks third-party cookies (iOS).

3. `activity.js` mounts `/activity/casino/{guildId}` instead of the slots page.

## Testing

- Jest 762/762 (new `authHeaders` cases: merge with token, no-op without).
- `:web:test` green — picker tests cover the member render (guild context in the model) and the non-member bounce.
- End-to-end: relaunch after deploy → handshake → picker → blackjack lobby → create/join table from two phones in the same voice channel.

https://claude.ai/code/session_01N43jxGduK9mdcPiyYCyqBK

---
_Generated by [Claude Code](https://claude.ai/code/session_01N43jxGduK9mdcPiyYCyqBK)_