### PR TITLE
Activity follow-up: PvP arena (duel, RPS, tic-tac-toe, connect 4)

### DIFF
--- a/web/src/main/resources/static/js/pvp.js
+++ b/web/src/main/resources/static/js/pvp.js
@@ -11,6 +11,22 @@
 (function (root) {
     'use strict';
 
+    // Discord Activity support: state-read GETs attach the activity
+    // bearer header via TobyApi.authHeaders (no-op on the normal
+    // dashboard), and the SSE stream — which can't carry headers —
+    // threads the token as a query param instead. Both carriers are
+    // accepted by ActivityTokenAuthFilter.
+    function activityGetOpts() {
+        const headers = (root && root.TobyApi && root.TobyApi.authHeaders) ? root.TobyApi.authHeaders({}) : {};
+        return { credentials: 'same-origin', headers: headers };
+    }
+
+    function pvpStreamUrl(guildId) {
+        const token = (root && root.TobyApi && root.TobyApi.activityToken) ? root.TobyApi.activityToken() : '';
+        const base = '/pvp/' + guildId + '/stream';
+        return token ? base + '?activityToken=' + encodeURIComponent(token) : base;
+    }
+
     function makeFigure(name, avatarUrl, side, doc) {
         const d = doc || (root && root.document);
         const fig = d.createElement('div');
@@ -240,6 +256,9 @@
         makeFigure: makeFigure,
         formatExpiry: formatExpiry,
         playFromResolution: playFromResolution,
+        // Exported for unit tests — activity-token plumbing for SSE/GETs.
+        pvpStreamUrl: pvpStreamUrl,
+        activityGetOpts: activityGetOpts,
     };
     if (root) root.TobyDuel = api;
     if (typeof module !== 'undefined' && module.exports) {
@@ -398,7 +417,7 @@
     }
 
     function refreshPending() {
-        fetch('/pvp/' + guildId + '/duel/pending', { credentials: 'same-origin' })
+        fetch('/pvp/' + guildId + '/duel/pending', activityGetOpts())
             .then(function (r) { return r.ok ? r.json() : []; })
             .then(renderPending)
             .catch(function () { /* keep last known state */ });
@@ -427,7 +446,7 @@
     }
 
     function refreshOutgoing() {
-        fetch('/pvp/' + guildId + '/duel/outgoing', { credentials: 'same-origin' })
+        fetch('/pvp/' + guildId + '/duel/outgoing', activityGetOpts())
             .then(function (r) {
                 return r.ok ? r.json() : { pending: [], resolutions: [] };
             })
@@ -632,9 +651,9 @@
             if (initialFetched) return;
             initialFetched = true;
             Promise.all([
-                fetch('/pvp/' + guildId + '/rps/pending', { credentials: 'same-origin' }).then(safeJson),
-                fetch('/pvp/' + guildId + '/rps/outgoing', { credentials: 'same-origin' }).then(safeJson),
-                fetch('/pvp/' + guildId + '/rps/active', { credentials: 'same-origin' }).then(safeJson),
+                fetch('/pvp/' + guildId + '/rps/pending', activityGetOpts()).then(safeJson),
+                fetch('/pvp/' + guildId + '/rps/outgoing', activityGetOpts()).then(safeJson),
+                fetch('/pvp/' + guildId + '/rps/active', activityGetOpts()).then(safeJson),
             ]).then(function (results) {
                 renderPendingList(pendingList, results[0] || [], 'incoming');
                 renderPendingList(outgoingList, results[1] || [], 'outgoing');
@@ -658,7 +677,7 @@
         function ensureStream() {
             if (eventSource) return;
             try {
-                eventSource = new EventSource('/pvp/' + guildId + '/stream');
+                eventSource = new EventSource(pvpStreamUrl(guildId));
             } catch (e) {
                 return; // no SSE support — RPS still works via GET initial-fetch on tab show
             }
@@ -674,7 +693,7 @@
         // ── Event handlers ──
         function onOffered(payload) {
             // Refetch pending list (the payload may be partial; safer to GET).
-            fetch('/pvp/' + guildId + '/rps/pending', { credentials: 'same-origin' })
+            fetch('/pvp/' + guildId + '/rps/pending', activityGetOpts())
                 .then(safeJson).then(function (rows) {
                     renderPendingList(pendingList, rows || [], 'incoming');
                 });
@@ -683,7 +702,7 @@
             // Either I or my opponent accepted an offer; an active session exists now.
             // Pull the session view for the right id.
             if (!payload || !payload.sessionId) return;
-            fetch('/pvp/' + guildId + '/rps/' + payload.sessionId, { credentials: 'same-origin' })
+            fetch('/pvp/' + guildId + '/rps/' + payload.sessionId, activityGetOpts())
                 .then(safeJson).then(function (view) { if (view) openActiveSession(view); });
             // Pending and outgoing lists need refreshing too — the offer is no longer pending.
             refreshLists();
@@ -712,9 +731,9 @@
         }
 
         function refreshLists() {
-            fetch('/pvp/' + guildId + '/rps/pending', { credentials: 'same-origin' })
+            fetch('/pvp/' + guildId + '/rps/pending', activityGetOpts())
                 .then(safeJson).then(function (rows) { renderPendingList(pendingList, rows || [], 'incoming'); });
-            fetch('/pvp/' + guildId + '/rps/outgoing', { credentials: 'same-origin' })
+            fetch('/pvp/' + guildId + '/rps/outgoing', activityGetOpts())
                 .then(safeJson).then(function (rows) { renderPendingList(outgoingList, rows || [], 'outgoing'); });
         }
 
@@ -919,9 +938,9 @@
             if (initialFetched) return;
             initialFetched = true;
             Promise.all([
-                fetch('/pvp/' + guildId + '/' + slug + '/pending', { credentials: 'same-origin' }).then(safeJson),
-                fetch('/pvp/' + guildId + '/' + slug + '/outgoing', { credentials: 'same-origin' }).then(safeJson),
-                fetch('/pvp/' + guildId + '/' + slug + '/active', { credentials: 'same-origin' }).then(safeJson),
+                fetch('/pvp/' + guildId + '/' + slug + '/pending', activityGetOpts()).then(safeJson),
+                fetch('/pvp/' + guildId + '/' + slug + '/outgoing', activityGetOpts()).then(safeJson),
+                fetch('/pvp/' + guildId + '/' + slug + '/active', activityGetOpts()).then(safeJson),
             ]).then(function (results) {
                 renderPendingList(pendingList, results[0] || [], 'incoming');
                 renderPendingList(outgoingList, results[1] || [], 'outgoing');
@@ -948,7 +967,7 @@
         function onOffered() { refreshLists(); }
         function onAccepted(payload) {
             if (!payload || !payload.sessionId) return;
-            fetch('/pvp/' + guildId + '/' + slug + '/' + payload.sessionId, { credentials: 'same-origin' })
+            fetch('/pvp/' + guildId + '/' + slug + '/' + payload.sessionId, activityGetOpts())
                 .then(safeJson).then(function (view) { if (view) openActiveSession(view); });
             refreshLists();
         }
@@ -958,7 +977,7 @@
                 openActiveSession(payload.view);
             } else {
                 // Empty view fan-out — refetch the canonical state.
-                fetch('/pvp/' + guildId + '/' + slug + '/' + payload.sessionId, { credentials: 'same-origin' })
+                fetch('/pvp/' + guildId + '/' + slug + '/' + payload.sessionId, activityGetOpts())
                     .then(safeJson).then(function (view) { if (view) openActiveSession(view); });
             }
         }
@@ -977,9 +996,9 @@
         }
 
         function refreshLists() {
-            fetch('/pvp/' + guildId + '/' + slug + '/pending', { credentials: 'same-origin' })
+            fetch('/pvp/' + guildId + '/' + slug + '/pending', activityGetOpts())
                 .then(safeJson).then(function (rows) { renderPendingList(pendingList, rows || [], 'incoming'); });
-            fetch('/pvp/' + guildId + '/' + slug + '/outgoing', { credentials: 'same-origin' })
+            fetch('/pvp/' + guildId + '/' + slug + '/outgoing', activityGetOpts())
                 .then(safeJson).then(function (rows) { renderPendingList(outgoingList, rows || [], 'outgoing'); });
         }
 
@@ -1049,7 +1068,7 @@
                             // refreshes on the next onMoved fan-out (or the immediate /move
                             // response). Refetch for safety.
                             else {
-                                fetch('/pvp/' + guildId + '/' + slug + '/' + view.sessionId, { credentials: 'same-origin' })
+                                fetch('/pvp/' + guildId + '/' + slug + '/' + view.sessionId, activityGetOpts())
                                     .then(safeJson).then(function (v) { if (v) openActiveSession(v); });
                             }
                         });
@@ -1110,7 +1129,7 @@
         const main = document.getElementById('main');
         if (!main || !main.dataset.guildId) return;
         const eventSource = (function () {
-            try { return new EventSource('/pvp/' + main.dataset.guildId + '/stream'); } catch (_) { return null; }
+            try { return new EventSource(pvpStreamUrl(main.dataset.guildId)); } catch (_) { return null; }
         })();
         if (!eventSource) return;
         ['tictactoe.offered','tictactoe.accepted','tictactoe.moved','tictactoe.resolved','tictactoe.removed',

--- a/web/src/main/resources/templates/activity-casino.html
+++ b/web/src/main/resources/templates/activity-casino.html
@@ -52,6 +52,9 @@
         <a class="activity-game-tile featured" th:href="@{/blackjack/{g}(g=${guildId})}">
             <span class="tile-emoji">🃏</span>Blackjack<small>play together</small>
         </a>
+        <a class="activity-game-tile featured" th:href="@{/pvp/{g}(g=${guildId})}">
+            <span class="tile-emoji">⚔️</span>PvP Arena<small>duel · RPS · TTT · connect 4</small>
+        </a>
         <a class="activity-game-tile" th:href="@{/casino/{g}/slots(g=${guildId})}">
             <span class="tile-emoji">🎰</span>Slots
         </a>

--- a/web/src/test/js/pvp-activity-token.test.js
+++ b/web/src/test/js/pvp-activity-token.test.js
@@ -1,0 +1,72 @@
+/**
+ * PvP inside the Discord Activity: the page's state-read GETs and its
+ * SSE stream must carry the activity session token, because the iframe
+ * has no OAuth2 session cookie. GETs take a bearer header via
+ * TobyApi.authHeaders; EventSource can't set headers, so the stream URL
+ * carries ?activityToken= instead (ActivityTokenAuthFilter accepts
+ * both). Outside the activity both must collapse to the pre-existing
+ * behaviour exactly.
+ */
+
+const PVP_PATH = '../../main/resources/static/js/pvp.js';
+
+function loadPvp() {
+    let api;
+    jest.isolateModules(() => {
+        api = require(PVP_PATH);
+    });
+    return api;
+}
+
+function loadTobyApi() {
+    let api;
+    jest.isolateModules(() => {
+        api = require('../../main/resources/static/js/api.js');
+    });
+    return api;
+}
+
+describe('pvp.js activity token plumbing', () => {
+    beforeEach(() => {
+        sessionStorage.clear();
+        document.head.innerHTML = '';
+        document.body.innerHTML = '';
+        window.history.pushState({}, '', '/');
+        delete window.TobyApi;
+    });
+
+    test('stream URL carries the activity token when present', () => {
+        sessionStorage.setItem('tobyActivityToken', 'act_abc');
+        loadTobyApi(); // installs window.TobyApi
+        const pvp = loadPvp();
+
+        expect(pvp.pvpStreamUrl('42')).toBe('/pvp/42/stream?activityToken=act_abc');
+    });
+
+    test('stream URL is unchanged outside the activity', () => {
+        loadTobyApi();
+        const pvp = loadPvp();
+
+        expect(pvp.pvpStreamUrl('42')).toBe('/pvp/42/stream');
+    });
+
+    test('state-read options attach the bearer header inside the activity', () => {
+        sessionStorage.setItem('tobyActivityToken', 'act_abc');
+        loadTobyApi();
+        const pvp = loadPvp();
+
+        const opts = pvp.activityGetOpts();
+
+        expect(opts.credentials).toBe('same-origin');
+        expect(opts.headers['Authorization']).toBe('Bearer act_abc');
+    });
+
+    test('state-read options degrade gracefully without TobyApi', () => {
+        const pvp = loadPvp();
+
+        const opts = pvp.activityGetOpts();
+
+        expect(opts.credentials).toBe('same-origin');
+        expect(opts.headers).toEqual({});
+    });
+});


### PR DESCRIPTION
## What

Follow-up to #701: the **PvP arena** — Duel, Rock-Paper-Scissors, Tic-Tac-Toe, Connect 4 — joins the activity. It gets a second featured tile on the picker ("⚔️ PvP Arena"), landing on the existing `/pvp/{guildId}` page inside the activity's nested iframe. Challenging someone in the same voice channel and playing it out in the activity is exactly what these games were made for.

## Changes

All four games share one page, and its mutations (challenge/accept/move/forfeit) already go through `TobyApi.postJson`, which carries the activity bearer token. The gap was the read paths:

1. **State-read GETs** — the 17 `fetch(..., { credentials: 'same-origin' })` calls (pending/outgoing/active lists, session views) now build options via `activityGetOpts()`, which merges the bearer header through `TobyApi.authHeaders`. No-op on the normal dashboard, works in the iframe even where webviews block third-party cookies.
2. **The PvP SSE stream** — `EventSource` can't set headers, so `pvpStreamUrl()` threads the session token as `?activityToken=` (same pattern as the notifications stream); `ActivityTokenAuthFilter` accepts both carriers. Both `new EventSource` sites use it.
3. Picker template gains the PvP tile.

No server-side changes needed — the PvP endpoints authenticate through the same filter as everything else.

## Testing

- Jest 766/766, including a new suite covering: stream URL with/without token, bearer header merge, and graceful degradation when `TobyApi` is absent.
- The helpers are exported alongside pvp.js's existing UMD test surface.
- End-to-end after deploy: two phones in a voice channel → activity → PvP Arena → challenge each other (SSE should push the offer to the other screen live).

https://claude.ai/code/session_01N43jxGduK9mdcPiyYCyqBK

---
_Generated by [Claude Code](https://claude.ai/code/session_01N43jxGduK9mdcPiyYCyqBK)_