### PR TITLE
Activity follow-up: poker tables + PvP challenge pings in the voice channel

### DIFF
--- a/common/src/main/kotlin/common/notification/NotificationChannelKind.kt
+++ b/common/src/main/kotlin/common/notification/NotificationChannelKind.kt
@@ -30,6 +30,11 @@ enum class NotificationChannelKind(
         description = "Someone challenges you to a duel from the web dashboard.",
         perSurfaceDefaults = mapOf(Surface.CHANNEL to true, Surface.PUSH to false),
     ),
+    PVP_CHALLENGE(
+        displayName = "PvP challenges",
+        description = "Someone challenges you to rock-paper-scissors, tic-tac-toe, or Connect 4 from the web dashboard or the casino activity.",
+        perSurfaceDefaults = mapOf(Surface.CHANNEL to true, Surface.PUSH to false),
+    ),
     TIP_RECEIVED(
         displayName = "Tips received",
         description = "Another user tips you social credit from the web dashboard.",

--- a/discord-bot/src/main/kotlin/bot/toby/notify/NotificationRouter.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/notify/NotificationRouter.kt
@@ -13,6 +13,7 @@ import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import net.dv8tion.jda.api.entities.channel.middleman.GuildMessageChannel
 import net.dv8tion.jda.api.utils.messages.MessageCreateData
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Lazy
@@ -375,7 +376,7 @@ class NotificationRouter(
         guild: Guild,
         route: ChannelRouteKey,
         originChannelId: Long?,
-    ): TextChannel? {
+    ): GuildMessageChannel? {
         // 1. primaryConfigKey
         route.primaryConfigKey
             ?.let { key -> channelFromConfig(guild, key) }
@@ -384,9 +385,14 @@ class NotificationRouter(
         route.fallbackConfigKeys.forEach { key ->
             channelFromConfig(guild, key)?.let { return it }
         }
-        // 3. originChannelId
+        // 3. originChannelId — may be a text channel OR a voice channel
+        //    (voice channels have text chat; activity-initiated PvP
+        //    challenges pass the participants' voice channel here so the
+        //    ping lands where the group is actually looking).
         originChannelId?.let { id ->
-            guild.getTextChannelById(id)?.takeIf { hasSendPerms(guild, it) }?.let { return it }
+            val origin: GuildMessageChannel? =
+                guild.getTextChannelById(id) ?: guild.getVoiceChannelById(id)
+            origin?.takeIf { hasSendPerms(guild, it) }?.let { return it }
         }
         // 4. system channel fallback (per-route opt-in)
         if (route.systemChannelFallback) {
@@ -402,7 +408,7 @@ class NotificationRouter(
         return channel.takeIf { hasSendPerms(guild, it) }
     }
 
-    private fun hasSendPerms(guild: Guild, channel: TextChannel): Boolean =
+    private fun hasSendPerms(guild: Guild, channel: GuildMessageChannel): Boolean =
         guild.selfMember.hasPermission(channel, Permission.MESSAGE_SEND, Permission.MESSAGE_EMBED_LINKS)
 }
 

--- a/discord-bot/src/main/kotlin/bot/toby/notify/VoiceChannelLocator.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/notify/VoiceChannelLocator.kt
@@ -1,0 +1,23 @@
+package bot.toby.notify
+
+import net.dv8tion.jda.api.JDA
+
+/**
+ * Finds the voice channel a PvP notification should land in: the first
+ * of [discordIds] (checked in order) currently connected to voice in
+ * [guildId], or null when none are.
+ *
+ * Used as the `originChannelId` hint for web/activity-initiated
+ * challenge notifications — when the participants are sitting in a
+ * voice channel (the Discord Activity case), the ping belongs in that
+ * channel's text chat, not the system channel. Voice-state cache is
+ * always warm here: the bot ships the music player, so it runs with
+ * voice states cached.
+ */
+fun JDA.currentVoiceChannelId(guildId: Long, vararg discordIds: Long): Long? {
+    val guild = getGuildById(guildId) ?: return null
+    for (id in discordIds) {
+        guild.getMemberById(id)?.voiceState?.channel?.idLong?.let { return it }
+    }
+    return null
+}

--- a/discord-bot/src/main/kotlin/bot/toby/notify/WebDuelOfferNotifier.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/notify/WebDuelOfferNotifier.kt
@@ -7,6 +7,7 @@ import common.notification.NotificationChannelKind
 import common.notification.PushPayload
 import database.configuration.RegistryScheduler
 import database.duel.PendingDuelRegistry
+import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.components.MessageTopLevelComponent
 import net.dv8tion.jda.api.components.actionrow.ActionRow
 import net.dv8tion.jda.api.components.buttons.Button
@@ -43,6 +44,7 @@ import java.util.concurrent.TimeUnit
 class WebDuelOfferNotifier(
     private val notificationRouter: NotificationRouter,
     private val pendingDuelRegistry: PendingDuelRegistry,
+    private val jda: JDA,
     private val scheduler: ScheduledExecutorService = RegistryScheduler.instance,
     @Value("\${app.base-url:}") private val webBaseUrl: String = "",
 ) {
@@ -65,6 +67,16 @@ class WebDuelOfferNotifier(
         ) {
             channel(
                 route = ChannelRouteKey.SYSTEM,
+                // Prefer the participants' current voice channel: when the
+                // duel comes from the casino activity the whole audience is
+                // sitting there, and the Accept/Decline buttons work from
+                // any channel. Falls back to the system channel when
+                // neither party is in voice.
+                originChannelId = jda.currentVoiceChannelId(
+                    event.guildId,
+                    event.opponentDiscordId,
+                    event.initiatorDiscordId,
+                ),
                 onSent = { sent -> scheduleTimeoutCleanup(event, sent) },
                 // Router suppresses the opponent's user-ping when they've
                 // opted out of (DUEL_OFFER, CHANNEL). Buttons still render

--- a/discord-bot/src/main/kotlin/bot/toby/notify/WebPvpChallengeNotifier.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/notify/WebPvpChallengeNotifier.kt
@@ -1,0 +1,75 @@
+package bot.toby.notify
+
+import common.notification.ChannelRouteKey
+import common.notification.NotificationChannelKind
+import common.notification.PushPayload
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+import web.event.WebPvpChallengeEvent
+
+/**
+ * Posts a Discord channel notification when an RPS / tic-tac-toe /
+ * connect-4 challenge is created from the web UI or the casino
+ * activity. Counterpart to [WebDuelOfferNotifier], with one deliberate
+ * difference: duels carry Discord-side Accept/Decline buttons (the
+ * resolution is a single coin flip), while these games are played out
+ * on the web/activity board — so the message is a ping plus a pointer
+ * back into the casino, not an interactive offer.
+ *
+ * Channel choice: the SYSTEM route with the participants' current
+ * voice channel as the origin hint. When the challenge comes from the
+ * activity, everyone involved is sitting in a voice channel — its text
+ * chat is where the ping is actually seen. Opponent's channel wins
+ * over the initiator's (the ping is for them); with neither in voice
+ * the router falls back to the guild's system channel as before.
+ */
+@Component
+class WebPvpChallengeNotifier(
+    private val notificationRouter: NotificationRouter,
+    private val jda: JDA,
+    @Value("\${app.base-url:}") private val webBaseUrl: String = "",
+) {
+
+    @EventListener
+    fun on(event: WebPvpChallengeEvent) {
+        notificationRouter.dispatch(
+            kind = NotificationChannelKind.PVP_CHALLENGE,
+            discordId = event.opponentDiscordId,
+            guildId = event.guildId,
+        ) {
+            channel(
+                route = ChannelRouteKey.SYSTEM,
+                originChannelId = jda.currentVoiceChannelId(
+                    event.guildId,
+                    event.opponentDiscordId,
+                    event.initiatorDiscordId,
+                ),
+                // Router suppresses the opponent's ping when they've opted
+                // out of (PVP_CHALLENGE, CHANNEL); the message still posts.
+                mentions = ChannelMentions(
+                    kind = NotificationChannelKind.PVP_CHALLENGE,
+                    userIds = listOf(event.opponentDiscordId),
+                ),
+            ) {
+                MessageCreateBuilder()
+                    .setContent(
+                        "⚔️ <@${event.opponentDiscordId}> — <@${event.initiatorDiscordId}> challenged you to " +
+                            "${event.gameLabel} for ${event.stake} credits! " +
+                            "Open the TobyBot casino (web or the Discord activity) to respond before it expires."
+                    )
+                    .build()
+            }
+            push {
+                PushPayload(
+                    title = "⚔️ ${event.gameLabel} challenge (${event.stake} credits)",
+                    body = "<@${event.initiatorDiscordId}> challenged you. Respond before it expires.",
+                    deepLink = webBaseUrl.takeIf { it.isNotBlank() }
+                        ?.let { "$it/pvp/${event.guildId}" },
+                )
+            }
+        }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/notify/WebDuelOfferNotifierTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/notify/WebDuelOfferNotifierTest.kt
@@ -35,6 +35,7 @@ class WebDuelOfferNotifierTest {
     private lateinit var router: NotificationRouter
     private lateinit var pendingDuelRegistry: PendingDuelRegistry
     private lateinit var scheduler: ScheduledExecutorService
+    private lateinit var notifierJda: JDA
     private lateinit var notifier: WebDuelOfferNotifier
 
     private val guildId = 42L
@@ -81,7 +82,13 @@ class WebDuelOfferNotifierTest {
             capturedDelays.add(secondArg<Long>())
             mockk(relaxed = true)
         }
-        notifier = WebDuelOfferNotifier(router, pendingDuelRegistry, scheduler)
+        // Separate from the router's relaxed JDA: the notifier's voice
+        // lookup must default to "nobody in voice" (null guild) so the
+        // SYSTEM-route assertions below see originChannelId = null.
+        notifierJda = mockk {
+            every { getGuildById(any<Long>()) } returns null
+        }
+        notifier = WebDuelOfferNotifier(router, pendingDuelRegistry, notifierJda, scheduler)
     }
 
     @Test
@@ -112,6 +119,36 @@ class WebDuelOfferNotifierTest {
         }
         assertEquals(NotificationChannelKind.DUEL_OFFER, mentions.captured.kind)
         assertEquals(listOf(opponentId), mentions.captured.userIds)
+    }
+
+    @Test
+    fun `offer lands in the opponent's voice channel when they're connected`() {
+        val voiceChannel = mockk<net.dv8tion.jda.api.entities.channel.unions.AudioChannelUnion> {
+            every { idLong } returns 777L
+        }
+        val voiceState = mockk<net.dv8tion.jda.api.entities.GuildVoiceState> {
+            every { channel } returns voiceChannel
+        }
+        val member = mockk<net.dv8tion.jda.api.entities.Member> {
+            every { getVoiceState() } returns voiceState
+        }
+        val guild = mockk<net.dv8tion.jda.api.entities.Guild> {
+            every { getMemberById(opponentId) } returns member
+        }
+        every { notifierJda.getGuildById(guildId) } returns guild
+
+        notifier.on(event())
+
+        verify(exactly = 1) {
+            router.sendChannel(
+                guildId = guildId,
+                route = ChannelRouteKey.SYSTEM,
+                originChannelId = 777L,
+                message = any(),
+                onSent = any(),
+                mentions = any(),
+            )
+        }
     }
 
     @Test

--- a/discord-bot/src/test/kotlin/bot/toby/notify/WebPvpChallengeNotifierTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/notify/WebPvpChallengeNotifierTest.kt
@@ -1,0 +1,179 @@
+package bot.toby.notify
+
+import common.notification.ChannelRouteKey
+import common.notification.NotificationChannelKind
+import common.notification.PushAdapter
+import common.notification.PushPayload
+import database.service.guild.ConfigService
+import database.service.user.UserNotificationPrefService
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
+import io.mockk.spyk
+import io.mockk.verify
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.utils.messages.MessageCreateData
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import web.event.WebPvpChallengeEvent
+
+class WebPvpChallengeNotifierTest {
+
+    private lateinit var router: NotificationRouter
+    private lateinit var notifierJda: JDA
+    private lateinit var notifier: WebPvpChallengeNotifier
+
+    private val guildId = 42L
+    private val initiatorId = 100L
+    private val opponentId = 200L
+    private val stake = 25L
+
+    private fun event(game: String = "rock-paper-scissors") = WebPvpChallengeEvent(
+        guildId = guildId,
+        gameLabel = game,
+        initiatorDiscordId = initiatorId,
+        opponentDiscordId = opponentId,
+        stake = stake,
+    )
+
+    @BeforeEach
+    fun setup() {
+        val routerJda = mockk<JDA>(relaxed = true)
+        val prefService = mockk<UserNotificationPrefService>(relaxed = true) {
+            every { isOptedIn(any(), any(), any(), any()) } returns true
+        }
+        router = spyk(NotificationRouter(routerJda, prefService, mockk<ConfigService>(relaxed = true), mockk<PushAdapter>(relaxed = true)))
+        every { router.sendDm(any(), any(), any(), any()) } just runs
+        every { router.sendPush(any(), any(), any(), any()) } just runs
+        every { router.sendChannel(any(), any(), any(), any(), any(), any()) } just runs
+        notifierJda = mockk {
+            every { getGuildById(any<Long>()) } returns null
+        }
+        notifier = WebPvpChallengeNotifier(router, notifierJda, webBaseUrl = "https://example.test")
+    }
+
+    @Test
+    fun `challenge routes to SYSTEM with the opponent mentioned`() {
+        val mentions = slot<ChannelMentions>()
+        every {
+            router.sendChannel(
+                guildId = any(), route = any(), originChannelId = any(),
+                message = any(), onSent = any(), mentions = capture(mentions),
+            )
+        } just runs
+
+        notifier.on(event())
+
+        verify(exactly = 1) {
+            router.sendChannel(
+                guildId = guildId,
+                route = ChannelRouteKey.SYSTEM,
+                originChannelId = null,
+                message = any(),
+                onSent = any(),
+                mentions = any(),
+            )
+        }
+        assertEquals(NotificationChannelKind.PVP_CHALLENGE, mentions.captured.kind)
+        assertEquals(listOf(opponentId), mentions.captured.userIds)
+    }
+
+    @Test
+    fun `challenge lands in the opponent's voice channel when they're connected`() {
+        val voiceChannel = mockk<net.dv8tion.jda.api.entities.channel.unions.AudioChannelUnion> {
+            every { idLong } returns 777L
+        }
+        val voiceState = mockk<net.dv8tion.jda.api.entities.GuildVoiceState> {
+            every { channel } returns voiceChannel
+        }
+        val member = mockk<net.dv8tion.jda.api.entities.Member> {
+            every { getVoiceState() } returns voiceState
+        }
+        val guild = mockk<net.dv8tion.jda.api.entities.Guild> {
+            every { getMemberById(opponentId) } returns member
+        }
+        every { notifierJda.getGuildById(guildId) } returns guild
+
+        notifier.on(event())
+
+        verify(exactly = 1) {
+            router.sendChannel(
+                guildId = guildId,
+                route = ChannelRouteKey.SYSTEM,
+                originChannelId = 777L,
+                message = any(),
+                onSent = any(),
+                mentions = any(),
+            )
+        }
+    }
+
+    @Test
+    fun `falls back to the initiator's voice channel when the opponent isn't in voice`() {
+        val voiceChannel = mockk<net.dv8tion.jda.api.entities.channel.unions.AudioChannelUnion> {
+            every { idLong } returns 888L
+        }
+        val voiceState = mockk<net.dv8tion.jda.api.entities.GuildVoiceState> {
+            every { channel } returns voiceChannel
+        }
+        val initiatorMember = mockk<net.dv8tion.jda.api.entities.Member> {
+            every { getVoiceState() } returns voiceState
+        }
+        val guild = mockk<net.dv8tion.jda.api.entities.Guild> {
+            every { getMemberById(opponentId) } returns null
+            every { getMemberById(initiatorId) } returns initiatorMember
+        }
+        every { notifierJda.getGuildById(guildId) } returns guild
+
+        notifier.on(event())
+
+        verify(exactly = 1) {
+            router.sendChannel(
+                guildId = guildId,
+                route = ChannelRouteKey.SYSTEM,
+                originChannelId = 888L,
+                message = any(),
+                onSent = any(),
+                mentions = any(),
+            )
+        }
+    }
+
+    @Test
+    fun `message content names the game and stake and pings both parties`() {
+        val builder = slot<() -> MessageCreateData>()
+        every {
+            router.sendChannel(
+                guildId = any(), route = any(), originChannelId = any(),
+                message = capture(builder), onSent = any(), mentions = any(),
+            )
+        } just runs
+
+        notifier.on(event(game = "connect 4"))
+
+        val content = builder.captured.invoke().content
+        assertTrue(content.contains("<@$opponentId>"))
+        assertTrue(content.contains("<@$initiatorId>"))
+        assertTrue(content.contains("connect 4"))
+        assertTrue(content.contains("$stake"))
+    }
+
+    @Test
+    fun `push payload deep-links to the guild's pvp page`() {
+        val builder = slot<() -> PushPayload>()
+        every { router.sendPush(any(), any(), any(), capture(builder)) } just runs
+
+        notifier.on(event())
+
+        verify(exactly = 1) {
+            router.sendPush(opponentId, guildId, NotificationChannelKind.PVP_CHALLENGE, any())
+        }
+        val payload = builder.captured.invoke()
+        assertEquals("https://example.test/pvp/$guildId", payload.deepLink)
+        assertTrue(payload.title.contains("rock-paper-scissors"))
+    }
+}

--- a/web/src/main/kotlin/web/controller/PvpController.kt
+++ b/web/src/main/kotlin/web/controller/PvpController.kt
@@ -29,6 +29,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.casino.StakeBounds
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
 import web.event.WebDuelOfferedEvent
+import web.event.WebPvpChallengeEvent
 import web.service.EconomyWebService
 import web.service.PvpSseService
 import web.service.PvpWebService
@@ -1102,6 +1103,18 @@ class PvpController(
         pvpSseService.fanOutToUser(
             guildId, opponentDiscordId, sseEventName,
             ssePayload(session),
+        )
+        // Discord-side ping (channel post via NotificationRouter) so an
+        // opponent who isn't looking at the web/activity sees the offer —
+        // the SSE fan-out above only reaches already-open pages.
+        eventPublisher.publishEvent(
+            WebPvpChallengeEvent(
+                guildId = guildId,
+                gameLabel = gameLabel,
+                initiatorDiscordId = discordId,
+                opponentDiscordId = opponentDiscordId,
+                stake = request.stake,
+            )
         )
         ResponseEntity.ok(PvpActionResponse(ok = true, sessionId = session.id, stake = request.stake))
     }

--- a/web/src/main/kotlin/web/event/WebPvpChallengeEvent.kt
+++ b/web/src/main/kotlin/web/event/WebPvpChallengeEvent.kt
@@ -1,0 +1,23 @@
+package web.event
+
+/**
+ * Published when a PvP challenge (rock-paper-scissors, tic-tac-toe,
+ * connect 4) is created from the web UI or the Discord Activity.
+ * Mirrors [WebDuelOfferedEvent]'s role for the duel flow: web-initiated
+ * challenges have no slash-command channel context, so the discord-bot
+ * module listens for this and posts a channel notification (preferring
+ * the participants' current voice channel — that's where an
+ * activity-launched challenge's audience is looking).
+ *
+ * Unlike duels, these games have no Discord-side accept button — the
+ * notification is a pointer back into the casino (web or activity)
+ * where the offer can be accepted.
+ */
+data class WebPvpChallengeEvent(
+    val guildId: Long,
+    /** Human-readable game name, e.g. "rock-paper-scissors". */
+    val gameLabel: String,
+    val initiatorDiscordId: Long,
+    val opponentDiscordId: Long,
+    val stake: Long,
+)

--- a/web/src/main/resources/static/js/poker-table.js
+++ b/web/src/main/resources/static/js/poker-table.js
@@ -234,7 +234,11 @@
     }
 
     function refresh() {
-        fetch('/poker/' + guildId + '/' + tableId + '/state', { credentials: 'same-origin' })
+        // Inside the Discord Activity there's no session cookie — the
+        // bearer header from TobyApi.authHeaders carries auth instead.
+        // On the normal dashboard it's a no-op.
+        var headers = (window.TobyApi && window.TobyApi.authHeaders) ? window.TobyApi.authHeaders({}) : {};
+        fetch('/poker/' + guildId + '/' + tableId + '/state', { credentials: 'same-origin', headers: headers })
             .then(function (r) {
                 if (r.status === 404) {
                     statusEl.textContent = 'Table closed.';

--- a/web/src/main/resources/templates/activity-casino.html
+++ b/web/src/main/resources/templates/activity-casino.html
@@ -55,6 +55,9 @@
         <a class="activity-game-tile featured" th:href="@{/pvp/{g}(g=${guildId})}">
             <span class="tile-emoji">⚔️</span>PvP Arena<small>duel · RPS · TTT · connect 4</small>
         </a>
+        <a class="activity-game-tile featured" th:href="@{/poker/{g}(g=${guildId})}">
+            <span class="tile-emoji">🂡</span>Poker<small>play together</small>
+        </a>
         <a class="activity-game-tile" th:href="@{/casino/{g}/slots(g=${guildId})}">
             <span class="tile-emoji">🎰</span>Slots
         </a>


### PR DESCRIPTION
## What

Two activity follow-ups in one PR:

### 1. Poker tables in the activity

- The picker gains a **Poker** tile (featured, "play together") opening the existing multi-table lobby at `/poker/{guildId}` inside the activity frame.
- Poker's only raw fetch — the table-state poll in `poker-table.js` — now attaches the activity bearer header via `TobyApi.authHeaders` (all mutations already rode `postJson`). The lobby's reload-based auto-refresh is safe in the nested iframe (it reloads only the inner frame, token preserved in its URL).

### 2. PvP challenge pings land in the voice channel

When someone is challenged from the web or the activity, they now get a Discord ping where they'll actually see it:

- **Router:** the `originChannelId` resolution hint can now resolve **voice channels** (text-in-voice chat) in addition to text channels — `resolveChannel` widened from `TextChannel` to `GuildMessageChannel`. Config-key routing and the system-channel fallback are unchanged.
- **Duels** (which already posted interactive Accept/Decline offers to the SYSTEM route via `WebDuelOfferNotifier`) now pass the participants' current voice channel as the origin hint — opponent's channel first, then initiator's, system channel as before. Buttons work from any channel.
- **RPS / tic-tac-toe / Connect 4** previously had *no* Discord-side notification (SSE only reaches already-open pages). A new `WebPvpChallengeEvent` fires from `PvpController`'s shared challenge helper, and `WebPvpChallengeNotifier` posts a ping + pointer back into the casino. These games are played on the web/activity board, so the message is informational rather than interactive.
- New `NotificationChannelKind.PVP_CHALLENGE` (channel on, push off by default — same surface defaults as duel offers), so users can opt out via the existing preferences UI and the stats/prefs surfaces pick it up automatically (`entries.size`-driven).

The voice-state lookup is a small `JDA.currentVoiceChannelId(guildId, vararg ids)` extension; voice-state cache is always warm since the bot ships the music player.

## Testing

- `:common:test`, `:discord-bot:test`, `:web:test` all green; Jest 766/766.
- New `WebPvpChallengeNotifierTest`: SYSTEM routing + opponent mention, voice-channel preference (opponent first, initiator fallback), message content (game/stake/mentions), push deep link.
- `WebDuelOfferNotifierTest` updated for the new constructor and gains a voice-channel routing case.
- End-to-end: in a voice channel, challenge someone from the activity → the ping should appear in that voice channel's text chat; with nobody in voice, behaviour falls back to the system channel exactly as before.

https://claude.ai/code/session_01N43jxGduK9mdcPiyYCyqBK

---
_Generated by [Claude Code](https://claude.ai/code/session_01N43jxGduK9mdcPiyYCyqBK)_