### PR TITLE
Fix broken OAuth login: run ForwardedHeaderFilter before the security chain

### DIFF
--- a/application/src/test/kotlin/integration/web/OAuthLoginRedirectForwardedHeaderIT.kt
+++ b/application/src/test/kotlin/integration/web/OAuthLoginRedirectForwardedHeaderIT.kt
@@ -1,0 +1,91 @@
+package integration.web
+
+import app.Application
+import bot.configuration.TestAppConfig
+import bot.configuration.TestBotConfig
+import bot.configuration.TestManagerConfig
+import common.configuration.TestCachingConfig
+import database.configuration.TestDatabaseConfig
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.web.util.UriComponentsBuilder
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+
+/**
+ * End-to-end regression test for the "Log in with Discord" button
+ * (`/oauth2/authorization/discord`).
+ *
+ * The button is a plain link; clicking it makes Spring Security's
+ * OAuth2 authorization-request filter redirect to Discord with a
+ * `redirect_uri` query param expanded from the `{baseUrl}` template in
+ * application.properties. `{baseUrl}` is derived from the *current
+ * request's* scheme/host, so behind Heroku's router it is only correct
+ * once the `X-Forwarded-*` headers have been applied by the
+ * ForwardedHeaderFilter.
+ *
+ * The Discord Activity work (#700) registered a custom ForwardedHeaderFilter
+ * at an order that ran AFTER the Spring Security chain, so the headers
+ * weren't applied when the redirect_uri was built — Discord then rejected
+ * the redirect (internal dyno host ≠ registered URI) and the login button
+ * broke. This drives the real filter stack and asserts the redirect_uri
+ * reflects the forwarded host.
+ *
+ * Boots the same context as [PageRenderSmokeIT]; the discord client
+ * registration is fully configured (provider URIs from application.properties,
+ * client id/secret from application-test.properties).
+ */
+@SpringBootTest(
+    classes = [
+        Application::class,
+        TestCachingConfig::class,
+        TestDatabaseConfig::class,
+        TestManagerConfig::class,
+        TestAppConfig::class,
+        TestBotConfig::class,
+    ]
+)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class OAuthLoginRedirectForwardedHeaderIT {
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `login button builds the redirect_uri from the X-Forwarded host`() {
+        val location = mockMvc.perform(
+            get("/oauth2/authorization/discord")
+                .header("X-Forwarded-Proto", "https")
+                .header("X-Forwarded-Host", "www.toby-bot.co.uk")
+        ).andReturn().response.getHeader("Location")
+            ?: error("expected a redirect Location to Discord's authorize endpoint")
+
+        assertTrue(
+            location.startsWith("https://discord.com/api/oauth2/authorize"),
+            "the login button must redirect to Discord's authorize endpoint, got: $location"
+        )
+
+        val redirectUri = UriComponentsBuilder.fromUriString(location)
+            .build(true)
+            .queryParams
+            .getFirst("redirect_uri")
+            ?.let { URLDecoder.decode(it, StandardCharsets.UTF_8) }
+            ?: error("authorize redirect had no redirect_uri param: $location")
+
+        assertEquals(
+            "https://www.toby-bot.co.uk/login/oauth2/code/discord",
+            redirectUri,
+            "redirect_uri must be built from the X-Forwarded-* host so it matches Discord's registered " +
+                "callback. If the ForwardedHeaderFilter runs after Spring Security it regresses to the " +
+                "internal host and Discord rejects the login."
+        )
+    }
+}

--- a/web/src/main/kotlin/web/configuration/ForwardedHeaderConfig.kt
+++ b/web/src/main/kotlin/web/configuration/ForwardedHeaderConfig.kt
@@ -2,9 +2,9 @@ package web.configuration
 
 import jakarta.servlet.DispatcherType
 import org.springframework.boot.web.servlet.FilterRegistrationBean
-import org.springframework.boot.web.servlet.filter.OrderedFilter
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.Ordered
 import org.springframework.web.filter.ForwardedHeaderFilter
 
 /**
@@ -32,7 +32,17 @@ import org.springframework.web.filter.ForwardedHeaderFilter
  *
  * Boot backs off automatically: its registration is guarded by
  * `@ConditionalOnMissingFilterBean(ForwardedHeaderFilter)`. Order and
- * dispatcher types mirror Boot's own registration.
+ * dispatcher types mirror Boot's own registration: `HIGHEST_PRECEDENCE`,
+ * so the forwarded-header rewrite runs BEFORE the Spring Security filter
+ * chain (registered at `DEFAULT_FILTER_ORDER`, i.e. -100). That ordering
+ * is load-bearing: Spring Security builds the OAuth2 `redirect_uri` (and
+ * saved-request URLs) from the request's scheme/host, so the
+ * X-Forwarded-* headers must already be applied when the chain runs.
+ * Registering this filter any later than the security chain (the earlier
+ * `REQUEST_WRAPPER_FILTER_MAX_ORDER - 1` = -1 did exactly that) leaves
+ * the request looking like the internal Heroku host during OAuth, so the
+ * redirect_uri sent to Discord no longer matches the registered one and
+ * login breaks.
  */
 @Configuration
 class ForwardedHeaderConfig {
@@ -43,7 +53,7 @@ class ForwardedHeaderConfig {
         filter.setRelativeRedirects(true)
         val registration = FilterRegistrationBean(filter)
         registration.setDispatcherTypes(DispatcherType.REQUEST, DispatcherType.ASYNC, DispatcherType.ERROR)
-        registration.order = OrderedFilter.REQUEST_WRAPPER_FILTER_MAX_ORDER - 1
+        registration.order = Ordered.HIGHEST_PRECEDENCE
         return registration
     }
 }

--- a/web/src/test/kotlin/web/configuration/ForwardedHeaderConfigBehaviourTest.kt
+++ b/web/src/test/kotlin/web/configuration/ForwardedHeaderConfigBehaviourTest.kt
@@ -1,0 +1,48 @@
+package web.configuration
+
+import jakarta.servlet.http.HttpServletRequest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.mock.web.MockFilterChain
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+
+/**
+ * Proves the request-side half of [ForwardedHeaderConfig]: even with
+ * `relativeRedirects=true` (which only changes how response Location
+ * headers are written), the filter still rewrites the *request*'s
+ * scheme/host/port from the `X-Forwarded-*` headers.
+ *
+ * That rewrite is what Spring Security reads when it builds the OAuth2
+ * `redirect_uri` for the "Log in with Discord" button. Behind Heroku's
+ * router the inbound request hits the dyno as `http://<internal>:8080`;
+ * only after this filter runs does it look like
+ * `https://www.toby-bot.co.uk`. If that ever stops happening the
+ * redirect_uri sent to Discord reverts to the internal host and login
+ * breaks — so this pins the behaviour directly, independent of filter
+ * ordering (covered by [ForwardedHeaderConfigOrderTest]).
+ */
+internal class ForwardedHeaderConfigBehaviourTest {
+
+    private val filter = ForwardedHeaderConfig().forwardedHeaderFilter().filter
+
+    @Test
+    fun `rewrites the request scheme, host and port from X-Forwarded headers`() {
+        val request = MockHttpServletRequest("GET", "/oauth2/authorization/discord").apply {
+            scheme = "http"
+            serverName = "10.0.0.5"
+            serverPort = 8080
+            addHeader("X-Forwarded-Proto", "https")
+            addHeader("X-Forwarded-Host", "www.toby-bot.co.uk")
+            addHeader("X-Forwarded-Port", "443")
+        }
+        val chain = MockFilterChain()
+
+        filter.doFilter(request, MockHttpServletResponse(), chain)
+
+        val forwarded = chain.request as HttpServletRequest
+        assertEquals("https", forwarded.scheme, "scheme must come from X-Forwarded-Proto")
+        assertEquals("www.toby-bot.co.uk", forwarded.serverName, "host must come from X-Forwarded-Host")
+        assertEquals(443, forwarded.serverPort, "port must come from X-Forwarded-Port")
+    }
+}

--- a/web/src/test/kotlin/web/configuration/ForwardedHeaderConfigOrderTest.kt
+++ b/web/src/test/kotlin/web/configuration/ForwardedHeaderConfigOrderTest.kt
@@ -1,0 +1,49 @@
+package web.configuration
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.security.SecurityProperties
+import org.springframework.core.Ordered
+
+/**
+ * Regression guard for OAuth login behind Heroku's router.
+ *
+ * [ForwardedHeaderConfig] replaces Boot's auto-registered
+ * [org.springframework.web.filter.ForwardedHeaderFilter] so it can keep
+ * redirect Locations relative (for the Discord Activity sandbox). The
+ * registration MUST run before the Spring Security filter chain, because
+ * Spring Security builds the OAuth2 `redirect_uri` (and saved-request
+ * URLs) from the request's scheme/host — the X-Forwarded-* rewrite has to
+ * land first or the redirect_uri reflects the internal dyno host and
+ * Discord rejects it.
+ *
+ * The original commit registered the filter at
+ * `REQUEST_WRAPPER_FILTER_MAX_ORDER - 1` (= -1), which is AFTER the
+ * security chain ([SecurityProperties.DEFAULT_FILTER_ORDER] = -100), and
+ * that broke login. This pins the order to Boot's own value
+ * (`HIGHEST_PRECEDENCE`) and asserts it stays ahead of the security chain.
+ */
+internal class ForwardedHeaderConfigOrderTest {
+
+    private val registration = ForwardedHeaderConfig().forwardedHeaderFilter()
+
+    @Test
+    fun `forwarded-header filter is registered at HIGHEST_PRECEDENCE like Boot`() {
+        assertEquals(
+            Ordered.HIGHEST_PRECEDENCE,
+            registration.order,
+            "ForwardedHeaderFilter must mirror Boot's HIGHEST_PRECEDENCE registration."
+        )
+    }
+
+    @Test
+    fun `forwarded-header filter runs before the Spring Security filter chain`() {
+        assertTrue(
+            registration.order < SecurityProperties.DEFAULT_FILTER_ORDER,
+            "ForwardedHeaderFilter (order ${registration.order}) must run before the Spring Security " +
+                "chain (order ${SecurityProperties.DEFAULT_FILTER_ORDER}); otherwise the X-Forwarded-* " +
+                "headers aren't applied when Spring Security builds the OAuth2 redirect_uri and login breaks."
+        )
+    }
+}


### PR DESCRIPTION
## Problem

Discord OAuth login is broken on the deployed dashboard.

## Root cause

The Discord Activity work in #700 added a custom `ForwardedHeaderConfig` that replaces Boot's auto-registered `ForwardedHeaderFilter` with one set to `relativeRedirects=true` (needed so redirects stay relative inside the `*.discordsays.com` sandbox).

The problem is the **order** it was registered at:

- Custom filter: `REQUEST_WRAPPER_FILTER_MAX_ORDER - 1` = **-1**
- Spring Security filter chain: `SecurityProperties.DEFAULT_FILTER_ORDER` = **-100**
- Boot's own forwarded-header filter (the one we replaced): `Ordered.HIGHEST_PRECEDENCE`

Lower order = higher precedence = runs first. At order `-1` the custom filter runs **after** the Spring Security chain (`-100`). So behind Heroku's router the `X-Forwarded-*` headers were no longer applied to the request when Spring Security built the OAuth2 `redirect_uri` (and saved-request URLs). The `redirect_uri` reflected the internal dyno host instead of `https://www.toby-bot.co.uk`, Discord saw a mismatch against the registered redirect URI, and login failed.

The code comment already *claimed* the registration mirrored Boot's order — it didn't.

## Fix

Register the filter at `Ordered.HIGHEST_PRECEDENCE`, matching Boot's auto-registration, so the forwarded-header rewrite runs before the security chain again. The request-side processing OAuth needs is restored; relative redirects for the Activity sandbox are unaffected (that's a response-side setting).

## Test

Adds `ForwardedHeaderConfigOrderTest`, a bean-level test asserting the filter is registered at `HIGHEST_PRECEDENCE` and stays strictly ahead of `SecurityProperties.DEFAULT_FILTER_ORDER`. Full `:web:test` suite passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_015KhuCqLSGGQZNrer2dAUZy)_