### PR TITLE
Multi-card Scryfall search for the Magic card tools (Discord + web)

### DIFF
--- a/application/src/test/kotlin/integration/bot/ButtonManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/ButtonManagerTest.kt
@@ -51,6 +51,7 @@ import bot.toby.button.buttons.misc.ExcuseListPageButton
 import bot.toby.button.buttons.casino.highlow.HighlowButton
 import bot.toby.button.buttons.lottery.LotteryBuyButton
 import bot.toby.button.buttons.misc.MemeButton
+import bot.toby.button.buttons.mtg.CardSearchPageButton
 import bot.toby.button.buttons.music.PausePlayButton
 import bot.toby.button.buttons.casino.poker.PokerActionButton
 import bot.toby.button.buttons.misc.RandomButton
@@ -108,6 +109,7 @@ class ButtonManagerTest {
             DuelButton::class.java,
             EightBallButton::class.java,
             ExcuseListPageButton::class.java,
+            CardSearchPageButton::class.java,
             HighlowButton::class.java,
             LotteryBuyButton::class.java,
             MemeButton::class.java,

--- a/common/src/main/kotlin/common/mtg/MtgCommandRef.kt
+++ b/common/src/main/kotlin/common/mtg/MtgCommandRef.kt
@@ -37,6 +37,7 @@ object MtgCommandRef {
 
     object Card {
         const val LOOKUP = "lookup"
+        const val SEARCH = "search"
         const val RULINGS = "rulings"
         const val COMBOS = "combos"
     }
@@ -60,6 +61,7 @@ object MtgCommandRef {
     const val CUBE_PREVIEW = "/$CUBE ${Cube.PREVIEW}"
     const val CUBE_GENERATE = "/$CUBE ${Cube.GENERATE}"
     const val CARD_LOOKUP = "/$CARD ${Card.LOOKUP}"
+    const val CARD_SEARCH = "/$CARD ${Card.SEARCH}"
     const val CARD_RULINGS = "/$CARD ${Card.RULINGS}"
     const val CARD_COMBOS = "/$CARD ${Card.COMBOS}"
     const val DECK_LEGALITY = "/$DECK ${Deck.LEGALITY}"

--- a/common/src/main/kotlin/common/mtg/MtgSearchQuery.kt
+++ b/common/src/main/kotlin/common/mtg/MtgSearchQuery.kt
@@ -1,0 +1,30 @@
+package common.mtg
+
+/**
+ * Builds a Scryfall search query from the structured card-search inputs shared
+ * by the Discord `/mtgcard search` command and the web Magic toolkit's card
+ * search. Keeping it here means the two surfaces interpret a name + type the
+ * same way and can't drift (the same reason [MtgCommandRef] is shared).
+ *
+ * The mapping mirrors what a user would type on scryfall.com:
+ *  - the name fragment becomes a quoted phrase (`"iron man"`), so Scryfall
+ *    reads it as a name-includes-this-phrase match rather than loose words;
+ *  - each whitespace-separated type becomes its own `t:` term, ANDed together
+ *    (`legendary creature` → `t:legendary t:creature`);
+ *  - a raw query is appended verbatim, so power users can AND in anything
+ *    Scryfall understands (`c:r mv<=2`).
+ *
+ * Blank parts drop out; all-blank yields an empty string, which callers treat
+ * as "nothing to search".
+ */
+object MtgSearchQuery {
+
+    fun build(name: String?, type: String?, raw: String?): String = buildList {
+        name?.takeIf { it.isNotBlank() }?.let { add("\"${it.trim().replace("\"", "")}\"") }
+        type?.takeIf { it.isNotBlank() }
+            ?.split(Regex("\\s+"))
+            ?.filter { it.isNotBlank() }
+            ?.forEach { add("t:$it") }
+        raw?.takeIf { it.isNotBlank() }?.let { add(it.trim()) }
+    }.joinToString(" ")
+}

--- a/common/src/test/kotlin/common/mtg/MtgSearchQueryTest.kt
+++ b/common/src/test/kotlin/common/mtg/MtgSearchQueryTest.kt
@@ -1,0 +1,33 @@
+package common.mtg
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class MtgSearchQueryTest {
+
+    @Test
+    fun `quotes the name as a phrase and ANDs each type`() {
+        assertEquals(
+            "\"iron man\" t:legendary t:creature c:r",
+            MtgSearchQuery.build("iron man", "legendary creature", "c:r"),
+        )
+    }
+
+    @Test
+    fun `each part is optional`() {
+        assertEquals("\"iron man\"", MtgSearchQuery.build("iron man", null, null))
+        assertEquals("t:dragon", MtgSearchQuery.build(null, "dragon", null))
+        assertEquals("mv<=2", MtgSearchQuery.build(" ", "", "mv<=2"))
+    }
+
+    @Test
+    fun `all-blank yields an empty query`() {
+        assertEquals("", MtgSearchQuery.build(null, null, null))
+        assertEquals("", MtgSearchQuery.build("  ", "\t", ""))
+    }
+
+    @Test
+    fun `strips embedded quotes from the name so the phrase stays well-formed`() {
+        assertEquals("\"iron man\"", MtgSearchQuery.build("iron \"man\"", null, null))
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/mtg/CardSearchPageButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/mtg/CardSearchPageButton.kt
@@ -1,0 +1,73 @@
+package bot.toby.button.buttons.mtg
+
+import bot.toby.command.commands.mtg.CardCommand
+import bot.toby.command.commands.mtg.CubeEmbeds
+import bot.toby.command.commands.mtg.ScryfallCubeFetcher
+import core.button.Button
+import core.button.ButtonContext
+import database.dto.user.UserDto
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import net.dv8tion.jda.api.components.MessageTopLevelComponent
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+/**
+ * Flips a `/mtgcard search` result browser to the next/previous card. Like the
+ * excuse paginator, the page is stateless: the button id carries the Scryfall
+ * query and the target index, so the click just re-runs the search and
+ * re-renders the chosen card — no server-side session to keep alive past the
+ * interaction's lifetime.
+ */
+@Component
+class CardSearchPageButton @Autowired constructor(
+    private val fetcher: ScryfallCubeFetcher,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : Button {
+
+    override val name: String = CardCommand.SEARCH_BUTTON
+    override val description: String = "Browse the cards matching a /mtgcard search."
+
+    // We edit the source message in place, so ack with deferEdit (no "thinking…"
+    // spinner, no dangling deferred reply).
+    override val defersEdit: Boolean = true
+
+    override fun handle(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        // Read the raw id, NOT the manager's lowercased routing copy — the
+        // base64 query is case-sensitive.
+        val componentId = event.componentId
+        if (componentId == "${CardCommand.SEARCH_BUTTON}:noop") return // the disabled page indicator
+        val parsed = CardCommand.decodeSearchButton(componentId) ?: return
+
+        CoroutineScope(dispatcher).launch {
+            runCatching {
+                when (val res = fetcher.fetch(parsed.query, CardCommand.SEARCH_MAX)) {
+                    is ScryfallCubeFetcher.Result.Failure ->
+                        event.hook.editOriginal("🔎 Couldn't refresh that search: ${res.message}")
+                            .setComponents(emptyList<MessageTopLevelComponent>()).queue({}, {})
+                    is ScryfallCubeFetcher.Result.Success -> {
+                        val cards = res.cards
+                        if (cards.isEmpty()) {
+                            event.hook.editOriginal("🔎 That search no longer matches any cards.")
+                                .setComponents(emptyList<MessageTopLevelComponent>()).queue({}, {})
+                            return@launch
+                        }
+                        val i = parsed.index.coerceIn(0, cards.lastIndex)
+                        val embed = CubeEmbeds.searchResultEmbed(cards[i], i, cards.size, res.capped)
+                        val content =
+                            "🔎 Found **${cards.size}${if (res.capped) "+" else ""}** cards matching `${parsed.query}`."
+                        val row = CardCommand.searchRow(parsed.query, i, cards.size)
+                        event.hook.editOriginal(content).setEmbeds(embed)
+                            .setComponents(listOfNotNull(row))
+                            .queue({}, {})
+                    }
+                }
+            }.onFailure { e ->
+                logger.error("Card search pagination failed for '${parsed.query}': $e")
+            }
+        }
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CardCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CardCommand.kt
@@ -1,20 +1,25 @@
 package bot.toby.command.commands.mtg
 
 import bot.toby.helpers.stringOption
+import common.mtg.CubeCard
 import common.mtg.MtgCommandRef
 import common.mtg.MtgNames
 import core.command.CommandContext
 import database.dto.user.UserDto
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import net.dv8tion.jda.api.components.actionrow.ActionRow
+import net.dv8tion.jda.api.components.buttons.Button
 import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.interactions.commands.build.OptionData
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
+import java.util.Base64
 
 /**
- * `/mtgcard` — single-card lookups: image + facts (`lookup`), official rulings
+ * `/mtgcard` — card lookups and search: a multi-card Scryfall search browser
+ * (`search`), single-card image + facts (`lookup`), official rulings
  * (`rulings`), and the combos a card appears in (`combos`, via Commander
  * Spellbook). Card-centric, not cube-specific.
  */
@@ -25,16 +30,68 @@ class CardCommand @Autowired constructor(
 ) : AbstractMtgCommand(dispatcher) {
 
     override val name: String = MtgCommandRef.CARD
-    override val description: String = "Look up a Magic card — its details, official rulings, or combos."
+    override val description: String = "Search Magic cards, or look up a card's details, rulings, or combos."
 
     override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
         logger.setGuildAndMemberContext(ctx.guild, ctx.member)
         when (ctx.event.subcommandName) {
+            SUB_SEARCH -> launchHandling(ctx) { handleSearch(ctx, deleteDelay) }
             SUB_LOOKUP -> launchHandling(ctx) { handleLookup(ctx, deleteDelay) }
             SUB_RULINGS -> launchHandling(ctx) { handleRulings(ctx, deleteDelay) }
             SUB_COMBOS -> launchHandling(ctx) { handleCombos(ctx, deleteDelay) }
-            else -> replyError(ctx, "Pick a subcommand: lookup, rulings or combos.", deleteDelay)
+            else -> replyError(ctx, "Pick a subcommand: search, lookup, rulings or combos.", deleteDelay)
         }
+    }
+
+    /**
+     * Searches Scryfall for every card matching a name fragment, a card type,
+     * and/or a raw Scryfall query, then sends a one-card-at-a-time browser
+     * (Prev / Next) — the Discord-native take on Scryfall's image grid of
+     * results.
+     */
+    private suspend fun handleSearch(ctx: CommandContext, deleteDelay: Int) {
+        val query = buildSearchQuery(
+            name = ctx.event.stringOption(OPT_NAME)?.trim(),
+            type = ctx.event.stringOption(OPT_TYPE)?.trim(),
+            raw = ctx.event.stringOption(OPT_QUERY)?.trim(),
+        )
+        if (query.isBlank()) {
+            replyError(ctx, "Give me something to search: a `name`, a `type`, or a Scryfall `query`.", deleteDelay)
+            return
+        }
+        when (val res = fetcher.fetch(query, SEARCH_MAX)) {
+            is ScryfallCubeFetcher.Result.Failure -> replyError(ctx, res.message, deleteDelay)
+            is ScryfallCubeFetcher.Result.Success -> sendSearchPage(ctx, query, res.cards, res.capped, 0, deleteDelay)
+        }
+    }
+
+    /**
+     * Sends the page at [index] of a search's [cards]. A lone result is a
+     * plain self-deleting card panel; a multi-card result becomes a persistent
+     * browser whose Prev/Next buttons re-run the [query] (stateless, like the
+     * excuse paginator) and re-render the chosen card.
+     */
+    private fun sendSearchPage(
+        ctx: CommandContext,
+        query: String,
+        cards: List<CubeCard>,
+        capped: Boolean,
+        index: Int,
+        deleteDelay: Int,
+    ) {
+        if (cards.size == 1) {
+            reply(ctx, CubeEmbeds.cardEmbed(cards.first()), deleteDelay)
+            return
+        }
+        val i = index.coerceIn(0, cards.lastIndex)
+        val embed = CubeEmbeds.searchResultEmbed(cards[i], i, cards.size, capped)
+        val content = "🔎 Found **${cards.size}${if (capped) "+" else ""}** cards matching `$query`."
+        val row = searchRow(query, i, cards.size)
+        if (row == null) {
+            reply(ctx, embed, deleteDelay)
+            return
+        }
+        ctx.event.hook.sendMessage(content).addEmbeds(embed).addComponents(row).queue()
     }
 
     /** Looks up a single card by name on Scryfall and shows its image + facts. */
@@ -84,6 +141,12 @@ class CardCommand @Autowired constructor(
     }
 
     override val subCommands: List<SubcommandData> = listOf(
+        SubcommandData(SUB_SEARCH, "Search Magic cards by name, type and/or Scryfall query — browse the matches.")
+            .addOptions(
+                OptionData(OptionType.STRING, OPT_NAME, "Cards whose name includes this (e.g. iron man).", false),
+                OptionData(OptionType.STRING, OPT_TYPE, "Card type(s) to require (e.g. creature, legendary artifact).", false),
+                OptionData(OptionType.STRING, OPT_QUERY, "Raw Scryfall query, ANDed with the above (e.g. c:r mv<=2).", false),
+            ),
         SubcommandData(SUB_LOOKUP, "Look up a single Magic card by name.")
             .addOptions(OptionData(OptionType.STRING, OPT_NAME, "The card's name (e.g. Lightning Bolt).", true)),
         SubcommandData(SUB_RULINGS, "Look up a Magic card's official rulings by name.")
@@ -93,10 +156,73 @@ class CardCommand @Autowired constructor(
     )
 
     companion object {
+        const val SUB_SEARCH = MtgCommandRef.Card.SEARCH
         const val SUB_LOOKUP = MtgCommandRef.Card.LOOKUP
         const val SUB_RULINGS = MtgCommandRef.Card.RULINGS
         const val SUB_COMBOS = MtgCommandRef.Card.COMBOS
 
         const val OPT_NAME = "name"
+        const val OPT_TYPE = "type"
+        const val OPT_QUERY = "query"
+
+        /**
+         * Cards fetched per search: one Scryfall page, so a click re-runs a
+         * single HTTP request. The footer flags `+` when more exist than this.
+         */
+        const val SEARCH_MAX = 175
+
+        /** Button-id prefix the dispatcher routes search pagination clicks on. */
+        const val SEARCH_BUTTON = "mtgcard-search"
+
+        /**
+         * Builds the Scryfall query from the structured search options. Shared
+         * with the web card search via [common.mtg.MtgSearchQuery] so the two
+         * surfaces read a name + type identically.
+         */
+        fun buildSearchQuery(name: String?, type: String?, raw: String?): String =
+            common.mtg.MtgSearchQuery.build(name, type, raw)
+
+        /**
+         * The Prev / page-indicator / Next action row for a search browser, or
+         * null when pagination can't be offered — a single page, or a query so
+         * long its encoded button id would blow Discord's 100-char component-id
+         * cap (in which case the caller shows a static first page).
+         */
+        fun searchRow(query: String, index: Int, total: Int): ActionRow? {
+            if (total <= 1) return null
+            val prevId = encodeSearchButton(query, index - 1)
+            val nextId = encodeSearchButton(query, index + 1)
+            if (prevId.length > COMPONENT_ID_LIMIT || nextId.length > COMPONENT_ID_LIMIT) return null
+            return ActionRow.of(
+                Button.primary(prevId, "⬅️ Prev").withDisabled(index <= 0),
+                Button.secondary("$SEARCH_BUTTON:noop", "${index + 1} / $total").withDisabled(true),
+                Button.primary(nextId, "Next ➡️").withDisabled(index >= total - 1),
+            )
+        }
+
+        private const val COMPONENT_ID_LIMIT = 100
+
+        /**
+         * Encodes a search-pagination button id as `mtgcard-search:<index>:<b64>`,
+         * the query base64'd (url-safe, no padding) so its spaces, quotes and
+         * `:`s survive Discord's component id. Decode with [decodeSearchButton].
+         */
+        fun encodeSearchButton(query: String, index: Int): String {
+            val q = Base64.getUrlEncoder().withoutPadding().encodeToString(query.toByteArray(Charsets.UTF_8))
+            return "$SEARCH_BUTTON:$index:$q"
+        }
+
+        /** Parses an [encodeSearchButton] id, or null when it isn't one we recognise. */
+        fun decodeSearchButton(componentId: String): DecodedSearchButton? {
+            val parts = componentId.split(":", limit = 3)
+            if (parts.size < 3 || parts[0] != SEARCH_BUTTON) return null
+            val index = parts[1].toIntOrNull() ?: return null
+            val query = runCatching {
+                String(Base64.getUrlDecoder().decode(parts[2]), Charsets.UTF_8)
+            }.getOrNull()?.takeIf { it.isNotBlank() } ?: return null
+            return DecodedSearchButton(query, index)
+        }
     }
+
+    data class DecodedSearchButton(val query: String, val index: Int)
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/mtg/CubeEmbeds.kt
@@ -205,6 +205,24 @@ internal object CubeEmbeds {
     }
 
     /**
+     * One page of a `/mtgcard search` result browser: the same single-card
+     * panel as [cardEmbed] plus a footer placing the card within the match set
+     * (`Card 3 of 7` — or `7+` when Scryfall had more than we fetched), so a
+     * multi-card search reads like flipping through Scryfall's grid one card at
+     * a time.
+     */
+    fun searchResultEmbed(card: CubeCard, index: Int, total: Int, capped: Boolean): MessageEmbed =
+        embed(color = OK_COLOR) {
+            setAuthor(AUTHOR)
+            setTitle(card.name)
+            card.imageUrl?.let { setImage(it) }
+            val facts = cardFactLines(card, includeManaValue = true).joinToString("\n")
+            val oracle = card.oracleText?.let { "\n\n${oracleBlock(it)}" }.orEmpty()
+            setDescription(facts + oracle)
+            setFooter("Card ${index + 1} of ${total}${if (capped) "+" else ""}")
+        }
+
+    /**
      * The fact lines on a card panel — type, (optionally) mana value, rarity,
      * colour identity, price and legal formats — in display order, present
      * fields only. Shared by [cardEmbed] (the `/mtgcard` lookup) and the inline

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/mtg/CardSearchPageButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/mtg/CardSearchPageButtonTest.kt
@@ -1,0 +1,78 @@
+package bot.toby.button.buttons.mtg
+
+import bot.toby.button.ButtonTest
+import bot.toby.button.ButtonTest.Companion.event
+import bot.toby.button.DefaultButtonContext
+import bot.toby.command.commands.mtg.CardCommand
+import bot.toby.command.commands.mtg.ScryfallCubeFetcher
+import common.mtg.CubeCard
+import common.mtg.MtgColor
+import database.dto.user.UserDto
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class CardSearchPageButtonTest : ButtonTest {
+
+    private lateinit var fetcher: ScryfallCubeFetcher
+    private lateinit var button: CardSearchPageButton
+
+    @BeforeEach
+    override fun setup() {
+        super.setup()
+        fetcher = mockk()
+        // Unconfined so the button's launched coroutine runs synchronously.
+        button = CardSearchPageButton(fetcher, Dispatchers.Unconfined)
+    }
+
+    @AfterEach
+    override fun tearDown() = super.tearDown()
+
+    private fun run() = button.handle(DefaultButtonContext(event), UserDto(1L, 1L), 0)
+
+    @Test
+    fun `re-runs the encoded query and renders the requested page`() {
+        every { event.componentId } returns CardCommand.encodeSearchButton("\"iron man\" t:creature", 1)
+        coEvery { fetcher.fetch("\"iron man\" t:creature", CardCommand.SEARCH_MAX) } returns
+            ScryfallCubeFetcher.Result.Success(
+                listOf(
+                    CubeCard("Iron Man, Armored Avenger", setOf(MtgColor.WHITE), typeLine = "Legendary Artifact Creature"),
+                    CubeCard("Iron Man, Bleeding Edge", setOf(MtgColor.BLUE), typeLine = "Legendary Artifact Creature"),
+                ),
+            )
+
+        run()
+
+        coVerify { fetcher.fetch("\"iron man\" t:creature", CardCommand.SEARCH_MAX) }
+    }
+
+    @Test
+    fun `ignores the disabled page-indicator button`() {
+        every { event.componentId } returns "${CardCommand.SEARCH_BUTTON}:noop"
+
+        run()
+
+        coVerify(exactly = 0) { fetcher.fetch(any(), any()) }
+    }
+
+    @Test
+    fun `ignores an unparseable component id`() {
+        every { event.componentId } returns "${CardCommand.SEARCH_BUTTON}:notanumber:xxx"
+
+        run()
+
+        coVerify(exactly = 0) { fetcher.fetch(any(), any()) }
+    }
+
+    @Test
+    fun `edits the source message rather than replying`() {
+        // Regression guard: the paginator must ack via deferEdit (defersEdit),
+        // otherwise the async re-render would fire on an unacknowledged button.
+        assert(button.defersEdit) { "CardSearchPageButton must defer as an edit" }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CardCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/mtg/CardCommandTest.kt
@@ -113,11 +113,87 @@ class CardCommandTest : CommandTest {
     }
 
     @Test
-    fun `exposes lookup, rulings and combos subcommands`() {
+    fun `search with one result replies with a single card panel`() {
+        val slot = slot<MessageEmbed>()
+        every { event.hook.sendMessageEmbeds(capture(slot), *anyVararg()) } returns webhookMessageCreateAction
+        every { event.subcommandName } returns CardCommand.SUB_SEARCH
+        every { event.getOption(CardCommand.OPT_NAME) } returns strOpt("iron man")
+        every { event.getOption(CardCommand.OPT_TYPE) } returns null
+        every { event.getOption(CardCommand.OPT_QUERY) } returns null
+        coEvery { fetcher.fetch("\"iron man\"", CardCommand.SEARCH_MAX) } returns ScryfallCubeFetcher.Result.Success(
+            listOf(CubeCard("Iron Man, Tony Stark", setOf(MtgColor.RED), typeLine = "Legendary Artifact Creature")),
+        )
+
+        run()
+
+        assertEquals("Iron Man, Tony Stark", slot.captured.title)
+    }
+
+    @Test
+    fun `search with multiple results sends a paginated browser`() {
+        val content = slot<String>()
+        every { event.hook.sendMessage(capture(content)) } returns webhookMessageCreateAction
+        every { event.subcommandName } returns CardCommand.SUB_SEARCH
+        every { event.getOption(CardCommand.OPT_NAME) } returns strOpt("iron man")
+        every { event.getOption(CardCommand.OPT_TYPE) } returns strOpt("creature")
+        every { event.getOption(CardCommand.OPT_QUERY) } returns null
+        coEvery { fetcher.fetch("\"iron man\" t:creature", CardCommand.SEARCH_MAX) } returns
+            ScryfallCubeFetcher.Result.Success(
+                listOf(
+                    CubeCard("Iron Man, Armored Avenger", setOf(MtgColor.WHITE), typeLine = "Legendary Artifact Creature"),
+                    CubeCard("Iron Man, Bleeding Edge", setOf(MtgColor.BLUE), typeLine = "Legendary Artifact Creature"),
+                ),
+            )
+
+        run()
+
+        assertTrue(content.captured.contains("Found **2**"))
+        assertTrue(content.captured.contains("iron man"))
+    }
+
+    @Test
+    fun `search needs at least one filter`() {
+        val slot = slot<MessageEmbed>()
+        every { event.hook.sendMessageEmbeds(capture(slot), *anyVararg()) } returns webhookMessageCreateAction
+        every { event.subcommandName } returns CardCommand.SUB_SEARCH
+        every { event.getOption(CardCommand.OPT_NAME) } returns null
+        every { event.getOption(CardCommand.OPT_TYPE) } returns null
+        every { event.getOption(CardCommand.OPT_QUERY) } returns null
+
+        run()
+
+        assertTrue(slot.captured.description!!.contains("search"))
+    }
+
+    @Test
+    fun `buildSearchQuery composes name, type and raw query`() {
+        assertEquals(
+            "\"iron man\" t:legendary t:creature c:r",
+            CardCommand.buildSearchQuery("iron man", "legendary creature", "c:r"),
+        )
+        assertEquals("t:dragon", CardCommand.buildSearchQuery(null, "dragon", null))
+        assertEquals("", CardCommand.buildSearchQuery(" ", null, ""))
+    }
+
+    @Test
+    fun `search button id round-trips query and index through base64`() {
+        val id = CardCommand.encodeSearchButton("\"iron man\" t:creature", 3)
+        assertTrue(id.startsWith("${CardCommand.SEARCH_BUTTON}:3:"))
+        val decoded = CardCommand.decodeSearchButton(id)
+        assertEquals("\"iron man\" t:creature", decoded?.query)
+        assertEquals(3, decoded?.index)
+        // A foreign id isn't mistaken for ours.
+        assertEquals(null, CardCommand.decodeSearchButton("excuse-page:approved:1:2:"))
+    }
+
+    @Test
+    fun `exposes search, lookup, rulings and combos subcommands`() {
         assertEquals("mtgcard", command.name)
-        assertEquals(setOf("lookup", "rulings", "combos"), command.subCommands.map { it.name }.toSet())
-        command.subCommands.forEach { sub ->
+        assertEquals(setOf("search", "lookup", "rulings", "combos"), command.subCommands.map { it.name }.toSet())
+        // The single-card subcommands require a name; search's filters are all optional.
+        command.subCommands.filter { it.name != "search" }.forEach { sub ->
             assertTrue(sub.options.first { it.name == "name" }.isRequired)
         }
+        assertTrue(command.subCommands.first { it.name == "search" }.options.none { it.isRequired })
     }
 }

--- a/web/src/main/kotlin/web/controller/CubeController.kt
+++ b/web/src/main/kotlin/web/controller/CubeController.kt
@@ -150,6 +150,27 @@ class CubeController(
     ): ResponseEntity<CubeGenerateResponse> =
         generateResponse(cubeWebService.generateList(request.list, request.packs, request.packSize, request.balanced))
 
+    @GetMapping("/api/search", produces = ["application/json"])
+    @ResponseBody
+    fun search(
+        @RequestParam("name", required = false) name: String?,
+        @RequestParam("type", required = false) type: String?,
+        @RequestParam("query", required = false) query: String?,
+    ): ResponseEntity<CubeSearchResponse> {
+        val built = common.mtg.MtgSearchQuery.build(name, type, query)
+        if (built.isBlank()) {
+            return ResponseEntity.badRequest()
+                .body(CubeSearchResponse(false, "Enter a name, a type, or a Scryfall query to search.", null, 0, false, emptyList()))
+        }
+        return when (val result = cubeWebService.search(built)) {
+            is CubeResult.Success -> ResponseEntity.ok(
+                CubeSearchResponse(true, null, result.value.query, result.value.total, result.value.capped, result.value.cards)
+            )
+            is CubeResult.Failure ->
+                ResponseEntity.badRequest().body(CubeSearchResponse(false, result.error, built, 0, false, emptyList()))
+        }
+    }
+
     @GetMapping("/api/card", produces = ["application/json"])
     @ResponseBody
     fun card(@RequestParam("name") name: String): ResponseEntity<CubeCardResponse> =
@@ -414,6 +435,15 @@ data class ShareCubeResponse(val token: String, val url: String, val name: Strin
 data class CubeListPreviewRequest(val list: String = "", val packSize: Int = 15)
 
 data class CubeCardResponse(val ok: Boolean, val error: String?, val card: CardLookupView?)
+
+data class CubeSearchResponse(
+    val ok: Boolean,
+    val error: String?,
+    val query: String?,
+    val total: Int,
+    val capped: Boolean,
+    val cards: List<CardView>,
+)
 
 data class CubeRulingsResponse(
     val ok: Boolean,

--- a/web/src/main/kotlin/web/service/CubeWebService.kt
+++ b/web/src/main/kotlin/web/service/CubeWebService.kt
@@ -264,6 +264,28 @@ class CubeWebService {
         )
     }
 
+    /**
+     * Runs a Scryfall card search and returns the matches as card views with
+     * images — the web twin of `/mtgcard search`, rendered as a Scryfall-style
+     * grid. [capped] is true when the search hit the [MAX_CARDS] ceiling, so
+     * the page can say there were more.
+     */
+    fun search(query: String): CubeResult<SearchData> {
+        val trimmed = query.trim()
+        if (trimmed.isEmpty()) return CubeResult.error("Enter a name, a type, or a Scryfall query to search.")
+        return when (val pool = fetchPool(trimmed)) {
+            is CubeResult.Failure -> CubeResult.error(pool.error)
+            is CubeResult.Success -> CubeResult.ok(
+                SearchData(
+                    query = trimmed,
+                    total = pool.value.size,
+                    capped = pool.value.size >= MAX_CARDS,
+                    cards = pool.value.map { it.toView() },
+                )
+            )
+        }
+    }
+
     /** As-fan distribution of a Scryfall query's cards, no pack generation. */
     fun preview(query: String, packSize: Int): CubeResult<PreviewData> {
         if (packSize <= 0) return CubeResult.error("Pack size must be at least 1.")
@@ -681,6 +703,14 @@ data class CardView(
     val count: Int = 1,
     /** Scryfall USD market price (raw string, e.g. "1.50"), or null when unpriced. */
     val priceUsd: String? = null,
+)
+
+/** The matches of a card search: the echoed query, total found, and the cards. */
+data class SearchData(
+    val query: String,
+    val total: Int,
+    val capped: Boolean,
+    val cards: List<CardView>,
 )
 
 /** A colour/land bucket plus the actual cards it contains. */

--- a/web/src/main/resources/static/css/magic.css
+++ b/web/src/main/resources/static/css/magic.css
@@ -528,6 +528,18 @@
     box-shadow: 0 0 0 2px var(--mtg-gold-soft);
 }
 
+/* Search filters share one row, each growing to fill the width. */
+.cube-search-form label {
+    flex: 1 1 180px;
+}
+
+/* Separates the Scryfall-style search grid from the single-card lookup. */
+.cube-divider {
+    border: none;
+    border-top: 1px solid var(--border);
+    margin: var(--space-5) 0 var(--space-4);
+}
+
 .cube-checkbox {
     flex-direction: row;
     align-items: center;

--- a/web/src/main/resources/static/js/magic.js
+++ b/web/src/main/resources/static/js/magic.js
@@ -441,6 +441,27 @@
         return '/magic/api/card?name=' + encodeURIComponent(name);
     }
 
+    /**
+     * GET URL for a card search, carrying only the filled-in filters
+     * (name / type / advanced Scryfall query) as query params. Pure.
+     */
+    function searchUrl(filters) {
+        const params = new URLSearchParams();
+        if (filters.name) params.set('name', filters.name);
+        if (filters.type) params.set('type', filters.type);
+        if (filters.query) params.set('query', filters.query);
+        return '/magic/api/search?' + params.toString();
+    }
+
+    /**
+     * A Scryfall-style headline for a search result: "7 cards match" (or
+     * "750+ cards match" when the search hit the fetch ceiling). Pure.
+     */
+    function searchSentence(total, capped) {
+        const n = total + (capped ? '+' : '');
+        return n + ' card' + (total === 1 ? '' : 's') + ' match';
+    }
+
     /** GET URL for a card's official rulings. */
     function rulingsUrl(name) {
         return '/magic/api/rulings?name=' + encodeURIComponent(name);
@@ -836,6 +857,15 @@
             });
             block.appendChild(grid);
             container.appendChild(block);
+        });
+        return container;
+    }
+
+    /** A flat grid of search-result cards, each a thumbnail tile (like the preview). */
+    function renderSearchResults(container, cards) {
+        container.replaceChildren();
+        cards.forEach(function (card) {
+            container.appendChild(cardTile(card));
         });
         return container;
     }
@@ -1415,6 +1445,38 @@
             else if (e.key === 'Escape') { close(); }
         });
         field.addEventListener('blur', function () { setTimeout(close, 150); });
+    }
+
+    function wireSearch(doc) {
+        const form = q(doc, '[data-form="search"]');
+        if (!form) return;
+        const status = statusFor(doc, 'search');
+        const result = q(doc, '[data-result="search"]');
+        form.addEventListener('submit', function (e) {
+            e.preventDefault();
+            const data = new FormData(form);
+            const filters = {
+                name: (data.get('name') || '').trim(),
+                type: (data.get('type') || '').trim(),
+                query: (data.get('query') || '').trim(),
+            };
+            if (!filters.name && !filters.type && !filters.query) {
+                setStatus(status, 'Enter a name, a type, or a Scryfall query to search.');
+                return;
+            }
+            setStatus(status, 'Searching…');
+            hide(result);
+            withBusy(form, true);
+            getJson(searchUrl(filters))
+                .then(function (json) {
+                    if (!json.ok) { setStatus(status, json.error || 'No cards matched that search.'); return; }
+                    setStatus(status, searchSentence(json.total, json.capped));
+                    renderSearchResults(result, json.cards || []);
+                    show(result);
+                })
+                .catch(function () { setStatus(status, 'Something went wrong. Try again.'); })
+                .then(function () { withBusy(form, false); });
+        });
     }
 
     function wireCardLookup(doc) {
@@ -2096,6 +2158,7 @@
         wireExamples(doc);
         wireAsFan(doc);
         wireCompare(doc);
+        wireSearch(doc);
         wireCardLookup(doc);
         wireLegality(doc);
         wireReference(doc);
@@ -2147,6 +2210,9 @@
         watchLine: watchLine,
         renderWatches: renderWatches,
         cardUrl: cardUrl,
+        searchUrl: searchUrl,
+        searchSentence: searchSentence,
+        renderSearchResults: renderSearchResults,
         rulingsUrl: rulingsUrl,
         combosUrl: combosUrl,
         renderCombos: renderCombos,

--- a/web/src/main/resources/templates/magic.html
+++ b/web/src/main/resources/templates/magic.html
@@ -352,11 +352,35 @@
             <div class="cube-diff" data-result="compare" hidden></div>
         </section>
 
-        <!-- Card lookup -->
+        <!-- Card search + lookup -->
         <section id="panel-card" class="cube-panel" role="tabpanel" aria-labelledby="tab-card"
                  data-panel="card">
             <p class="cube-panel-intro">
-                Look up any Magic card by name and see its image and details — the website twin of
+                Search Magic cards by name and type and see every match as a grid of images, the
+                way Scryfall does — or look one card up below for its full details, rulings and combos.
+            </p>
+            <form class="cube-form cube-search-form" data-form="search" autocomplete="off">
+                <label id="card-search-name-label">Name includes
+                    <input type="text" name="name" placeholder="e.g. iron man"
+                           autocomplete="off" aria-labelledby="card-search-name-label">
+                </label>
+                <label id="card-search-type-label">Card type
+                    <input type="text" name="type" placeholder="e.g. creature"
+                           autocomplete="off" aria-labelledby="card-search-type-label">
+                </label>
+                <label id="card-search-query-label">Advanced (Scryfall syntax)
+                    <input type="text" name="query" placeholder="e.g. c:r mv&lt;=2"
+                           autocomplete="off" aria-labelledby="card-search-query-label">
+                </label>
+                <button type="submit" class="btn cube-submit">Search</button>
+            </form>
+            <p class="cube-status" data-status="search" aria-live="polite"></p>
+            <div class="cube-card-grid" data-result="search" hidden></div>
+
+            <hr class="cube-divider">
+
+            <p class="cube-panel-intro">
+                Look up a single card by name for its image and details — the website twin of
                 the <code th:text="${mtgCmd.cardLookup}">/mtgcard lookup</code> Discord command.
             </p>
             <form class="cube-form" data-form="card" autocomplete="off">

--- a/web/src/test/js/magic.test.js
+++ b/web/src/test/js/magic.test.js
@@ -108,6 +108,38 @@ describe('URL builders', () => {
         expect(Cube.generateUrl({ query: 'set:vow', packs: 8, packSize: 15, balanced: false }))
             .toBe('/magic/api/generate?query=set%3Avow&packs=8&packSize=15&balanced=false');
     });
+
+    test('searchUrl carries only the filled-in filters', () => {
+        expect(Cube.searchUrl({ name: 'iron man', type: 'creature', query: '' }))
+            .toBe('/magic/api/search?name=iron+man&type=creature');
+        expect(Cube.searchUrl({ name: '', type: '', query: 'c:r mv<=2' }))
+            .toBe('/magic/api/search?query=c%3Ar+mv%3C%3D2');
+    });
+});
+
+describe('searchSentence', () => {
+    test('reads as a Scryfall-style match count', () => {
+        expect(Cube.searchSentence(7, false)).toBe('7 cards match');
+        expect(Cube.searchSentence(1, false)).toBe('1 card match');
+        expect(Cube.searchSentence(750, true)).toBe('750+ cards match');
+    });
+});
+
+describe('renderSearchResults (the Scryfall-style grid)', () => {
+    test('renders one thumbnail tile per matching card, linking to Scryfall', () => {
+        const container = document.createElement('div');
+        Cube.renderSearchResults(container, [
+            { name: 'Iron Man, Tony Stark', imageUrl: 'https://img/im.jpg', imageUrlLarge: 'https://img/im-lg.jpg', typeLine: 'Legendary Artifact Creature', manaValue: 5 },
+            { name: 'Iron Man, Bleeding Edge', imageUrl: null, imageUrlLarge: null, typeLine: 'Legendary Artifact Creature', manaValue: 4 },
+        ]);
+        const tiles = container.querySelectorAll('.cube-card');
+        expect(tiles).toHaveLength(2);
+        expect(tiles[0].getAttribute('href')).toBe(Cube.scryfallCardUrl('Iron Man, Tony Stark'));
+        expect(tiles[0].querySelector('img.cube-card-img').getAttribute('src')).toBe('https://img/im.jpg');
+        // No image → placeholder, no <img>.
+        expect(tiles[1].querySelector('img')).toBeNull();
+        expect(tiles[1].querySelector('.cube-card-img-empty')).not.toBeNull();
+    });
 });
 
 describe('renderGroups (preview shows the actual cards as thumbnails)', () => {

--- a/web/src/test/kotlin/web/controller/CubeControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/CubeControllerTest.kt
@@ -166,6 +166,34 @@ class CubeControllerTest {
     }
 
     @Test
+    fun `search builds a Scryfall query from name and type and returns the matches`() {
+        every { service.search("\"iron man\" t:creature") } returns CubeResult.ok(
+            web.service.SearchData(
+                query = "\"iron man\" t:creature",
+                total = 2,
+                capped = false,
+                cards = listOf(
+                    CardView("Iron Man, Armored Avenger", "s.jpg", "n.jpg", "Legendary Artifact Creature", 5.0),
+                    CardView("Iron Man, Bleeding Edge", "s2.jpg", "n2.jpg", "Legendary Artifact Creature", 4.0),
+                ),
+            )
+        )
+        val response = controller.search(name = "iron man", type = "creature", query = null)
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertTrue(response.body!!.ok)
+        assertEquals(2, response.body!!.total)
+        assertEquals("Iron Man, Armored Avenger", response.body!!.cards.first().name)
+    }
+
+    @Test
+    fun `search returns 400 when no filters are given`() {
+        val response = controller.search(name = null, type = null, query = "  ")
+        assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+        assertFalse(response.body!!.ok)
+        verify(exactly = 0) { service.search(any()) }
+    }
+
+    @Test
     fun `rulings returns 200 with the looked-up rulings`() {
         every { service.rulings("Doubling Season") } returns CubeResult.ok(
             RulingsView(


### PR DESCRIPTION
## What & why

The card search only resolved a **single** card by name. This brings it in line with the Scryfall search in the attached screenshot — filter by **name fragment + card type** and see **every** match — on both surfaces.

### Discord — `/mtgcard search`
A new subcommand taking any of:
- `name` — name-includes fragment (e.g. `iron man`)
- `type` — card type(s), ANDed (e.g. `legendary creature`)
- `query` — raw Scryfall syntax, ANDed in (e.g. `c:r mv<=2`)

Results are browsable one card at a time with **⬅️ Prev / Next ➡️** buttons. Like the excuse paginator, pagination is stateless — the button id carries the query + index, so a click just re-runs the search and re-renders. A single match is shown as a plain card panel (no buttons).

### Web — the `card` tab
Gains a Scryfall-style search form (Name includes / Card type / Advanced) that renders **every match as a grid of card-image tiles**, reusing the existing cube-preview tiles (lazy-loaded images, hover-zoom, flip). Backed by a new `GET /magic/api/search` endpoint. The single-card lookup stays below for full details / rulings / combos.

### Shared
The name+type → Scryfall-query mapping lives in a new `common.mtg.MtgSearchQuery`, so the Discord command and the web page can't drift on how a search is interpreted (same pattern as `MtgCommandRef`).

## Tests
- `MtgSearchQueryTest` (common) — query composition, optional parts, quote-stripping.
- `CardCommandTest` — search with one / many results, missing-filter error, query build, button-id round-trip.
- `CardSearchPageButtonTest` — re-runs the encoded query, ignores the noop/unparseable ids, defers as an edit.
- `CubeControllerTest` — `/api/search` happy path + blank-filter 400.
- `magic.test.js` — `searchUrl`, `searchSentence`, `renderSearchResults` grid.

All affected Kotlin and JS suites pass; CSS lints clean.

https://claude.ai/code/session_015r56NEE2o7CYMpGPUb3xNK

---
_Generated by [Claude Code](https://claude.ai/code/session_015r56NEE2o7CYMpGPUb3xNK)_