### PR TITLE
Hint at Scryfall's exact-name operator in the Advanced search placeholder

### DIFF
--- a/web/src/main/resources/templates/magic.html
+++ b/web/src/main/resources/templates/magic.html
@@ -370,7 +370,7 @@
                            autocomplete="off" aria-labelledby="card-search-type-label">
                 </label>
                 <label id="card-search-query-label">Advanced (Scryfall syntax)
-                    <input type="text" name="query" placeholder="e.g. c:r mv&lt;=2"
+                    <input type="text" name="query" placeholder="e.g. c:r mv&lt;=2, or !&quot;exact name&quot;"
                            autocomplete="off" aria-labelledby="card-search-query-label">
                 </label>
                 <button type="submit" class="btn cube-submit">Search</button>


### PR DESCRIPTION
Follow-up to #706. The Advanced field passes its text verbatim to Scryfall, so `!"exact name"` is the easy way to do a single-card search from the same three grid-search fields — but the operator is non-obvious. Surface it in the placeholder:

> e.g. c:r mv<=2, or !"exact name"

One-line template change; `MagicTemplateRenderTest` (5 tests) passes.

https://claude.ai/code/session_019cWT9cM51Vzn3sGL8BNGRL

---
_Generated by [Claude Code](https://claude.ai/code/session_019cWT9cM51Vzn3sGL8BNGRL)_