### PR TITLE
Activity landing: surface the guild's full games list

### DIFF
--- a/web/src/main/kotlin/web/activity/ActivityController.kt
+++ b/web/src/main/kotlin/web/activity/ActivityController.kt
@@ -26,11 +26,16 @@ import web.util.WebGuildAccess
  * authenticate — then mounts the casino in a nested iframe pointed at
  * GET /activity/casino/{guildId} (see activity.js).
  *
- * GET /activity/casino/{guildId} is the activity's landing surface: a
- * slim game picker for the launch guild. Authenticated like every other
+ * GET /activity/casino/{guildId} is the activity's landing surface: the
+ * full games list for the launch guild — the same catalogue the web UI's
+ * guild cards show, just chrome-free. Authenticated like every other
  * per-guild page (here via the activity token filter) — friends in the
  * same voice channel each land on their own picker and can meet at the
- * same blackjack table.
+ * same blackjack table. Deliberately NOT the /casino/guilds page itself:
+ * the cross-guild pickers need an OAuth2AuthorizedClient (to enumerate
+ * mutual guilds via Discord's API), which activity sessions don't
+ * register — fresh activity-only users would bounce into the external
+ * OAuth redirect and the sandbox would kill the iframe.
  *
  * POST /activity/api/token is the code-for-session exchange. Anonymous by
  * design (the caller can't be authenticated yet) and CSRF-exempt: it sets
@@ -59,9 +64,10 @@ class ActivityController(
         ra: RedirectAttributes,
     ): String = WebGuildAccess.requireMemberForPage(
         user, guildId, economyWebService, ra, lobbyPath = "/leaderboards"
-    ) {
+    ) { discordId ->
         model.addAttribute("guildId", guildId.toString())
         model.addAttribute("guildName", jda.getGuildById(guildId)?.name ?: "your server")
+        model.addAttribute("credits", economyWebService.getCredits(discordId, guildId))
         "activity-casino"
     }
 

--- a/web/src/main/kotlin/web/controller/CasinoController.kt
+++ b/web/src/main/kotlin/web/controller/CasinoController.kt
@@ -70,7 +70,8 @@ class CasinoController(
     }
 
     companion object {
-        // Mirrors the game buttons rendered in casino-guilds.html. Lottery
+        // Mirrors the game buttons rendered in casino-guilds.html (and the
+        // activity landing, activity-casino.html). Lottery
         // is a casino-routed entry on the same picker even though it has
         // its own navbar item; baccarat / casino-hold'em sit under "Table
         // games" but route through /casino/{id}/...

--- a/web/src/main/kotlin/web/service/EconomyWebService.kt
+++ b/web/src/main/kotlin/web/service/EconomyWebService.kt
@@ -64,6 +64,15 @@ class EconomyWebService(
         }.sortedBy { it.name.lowercase() }
     }
 
+    /**
+     * Wallet balance for a single (user, guild) pair — the per-guild
+     * credits the guild cards show, without the mutual-guild enumeration
+     * of [getGuildsWhereUserCanView] (which needs an OAuth access token
+     * that activity sessions don't carry).
+     */
+    fun getCredits(discordId: Long, guildId: Long): Long =
+        userService.getUserById(discordId, guildId)?.socialCredit ?: 0L
+
     fun getEconomyView(guildId: Long, discordId: Long): EconomyView? {
         val guild = jda.getGuildById(guildId) ?: return null
         val market = tradeService.loadOrCreateMarket(guildId)

--- a/web/src/main/resources/templates/activity-casino.html
+++ b/web/src/main/resources/templates/activity-casino.html
@@ -1,12 +1,16 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="en">
 <!--
-    Activity landing page: the slim game picker mounted in the nested
-    iframe by activity.js after the SDK handshake. Deliberately chrome-
+    Activity landing page: the guild's full games list, mounted in the
+    nested iframe by activity.js after the SDK handshake. Mirrors the
+    per-guild game catalogue on casino-guilds.html (keep the two in sync
+    with CasinoController.CASINO_GAME_SLUGS), but deliberately chrome-
     free (no navbar/footer): inside the Activity sandbox the dashboard
-    chrome wastes space and its external links (Ko-fi, invite) would be
-    blocked anyway. Links navigate the NESTED frame only, so the SDK
-    connection in the shell document is untouched.
+    chrome wastes space, its external links (Ko-fi, invite) would be
+    blocked anyway, and its cross-guild picker links need an OAuth2
+    authorized client that activity sessions don't have. Links navigate
+    the NESTED frame only, so the SDK connection in the shell document
+    is untouched.
 
     api.js is loaded so the ?activityToken= the shell appended gets
     stashed in sessionStorage and re-appended to every game link on
@@ -20,11 +24,18 @@
     <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
     <link rel="stylesheet" th:href="@{/css/base.css}">
     <style>
+        .activity-group-title {
+            margin: 1.5rem 0 0;
+            font-size: 0.95rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            opacity: 0.7;
+        }
         .activity-game-grid {
             display: grid;
             grid-template-columns: repeat(auto-fill, minmax(9.5rem, 1fr));
             gap: 0.75rem;
-            margin-top: 1rem;
+            margin-top: 0.75rem;
         }
         .activity-game-tile {
             display: flex;
@@ -45,10 +56,12 @@
 <body>
 <main class="container">
     <h1>🎰 Casino • <span th:text="${guildName}">Server</span></h1>
-    <p class="muted">Pick a game — everyone plays with their own credits.
-        Join the same blackjack table to play together.</p>
+    <p class="muted">Your wallet: <strong th:text="${credits} + ' credits'">0 credits</strong>.
+        Pick a game — everyone plays with their own credits.
+        Join the same table to play together.</p>
 
-    <nav class="activity-game-grid" aria-label="Games">
+    <h2 class="activity-group-title">Play together</h2>
+    <nav class="activity-game-grid" aria-label="Multiplayer games">
         <a class="activity-game-tile featured" th:href="@{/blackjack/{g}(g=${guildId})}">
             <span class="tile-emoji">🃏</span>Blackjack<small>play together</small>
         </a>
@@ -58,20 +71,56 @@
         <a class="activity-game-tile featured" th:href="@{/poker/{g}(g=${guildId})}">
             <span class="tile-emoji">🂡</span>Poker<small>play together</small>
         </a>
-        <a class="activity-game-tile" th:href="@{/casino/{g}/slots(g=${guildId})}">
-            <span class="tile-emoji">🎰</span>Slots
+    </nav>
+
+    <h2 class="activity-group-title">Quick play</h2>
+    <nav class="activity-game-grid" aria-label="Quick play games">
+        <a class="activity-game-tile" th:href="@{/casino/{g}/coinflip(g=${guildId})}">
+            <span class="tile-emoji">🪙</span>Coinflip
         </a>
         <a class="activity-game-tile" th:href="@{/casino/{g}/dice(g=${guildId})}">
             <span class="tile-emoji">🎲</span>Dice
         </a>
-        <a class="activity-game-tile" th:href="@{/casino/{g}/coinflip(g=${guildId})}">
-            <span class="tile-emoji">🪙</span>Coinflip
+        <a class="activity-game-tile" th:href="@{/casino/{g}/highlow(g=${guildId})}">
+            <span class="tile-emoji">🔼</span>High-Low
+        </a>
+        <a class="activity-game-tile" th:href="@{/casino/{g}/keno(g=${guildId})}">
+            <span class="tile-emoji">🎯</span>Keno
         </a>
         <a class="activity-game-tile" th:href="@{/casino/{g}/roulette(g=${guildId})}">
             <span class="tile-emoji">🎡</span>Roulette
         </a>
-        <a class="activity-game-tile" th:href="@{/casino/{g}/highlow(g=${guildId})}">
-            <span class="tile-emoji">🔼</span>High-Low
+        <a class="activity-game-tile" th:href="@{/casino/{g}/scratch(g=${guildId})}">
+            <span class="tile-emoji">🎟️</span>Scratch
+        </a>
+        <a class="activity-game-tile" th:href="@{/casino/{g}/slots(g=${guildId})}">
+            <span class="tile-emoji">🎰</span>Slots
+        </a>
+        <a class="activity-game-tile" th:href="@{/casino/{g}/plinko(g=${guildId})}">
+            <span class="tile-emoji">🟢</span>Plinko
+        </a>
+        <a class="activity-game-tile" th:href="@{/casino/{g}/horse-racing(g=${guildId})}">
+            <span class="tile-emoji">🐎</span>Horse Racing
+        </a>
+        <a class="activity-game-tile" th:href="@{/casino/{g}/wheel(g=${guildId})}">
+            <span class="tile-emoji">🎡</span>Wheel
+        </a>
+    </nav>
+
+    <h2 class="activity-group-title">Table games</h2>
+    <nav class="activity-game-grid" aria-label="Table games">
+        <a class="activity-game-tile" th:href="@{/casino/{g}/baccarat(g=${guildId})}">
+            <span class="tile-emoji">🎴</span>Baccarat
+        </a>
+        <a class="activity-game-tile" th:href="@{/casino/{g}/casinoholdem(g=${guildId})}">
+            <span class="tile-emoji">♠️</span>Casino Hold'em
+        </a>
+    </nav>
+
+    <h2 class="activity-group-title">Daily draw</h2>
+    <nav class="activity-game-grid" aria-label="Daily draw">
+        <a class="activity-game-tile" th:href="@{/casino/{g}/lottery(g=${guildId})}">
+            <span class="tile-emoji">🎟️</span>Lottery
         </a>
     </nav>
 </main>

--- a/web/src/test/kotlin/web/activity/ActivityControllerTest.kt
+++ b/web/src/test/kotlin/web/activity/ActivityControllerTest.kt
@@ -38,8 +38,9 @@ class ActivityControllerTest {
     }
 
     @Test
-    fun `casino picker renders for guild members with guild context`() {
+    fun `casino picker renders for guild members with guild context and wallet`() {
         every { economyWebService.isMember(100L, 42L) } returns true
+        every { economyWebService.getCredits(100L, 42L) } returns 1234L
         every { jda.getGuildById(42L) } returns mockk<Guild> { every { name } returns "Test Guild" }
         val model = ConcurrentModel()
 
@@ -48,6 +49,7 @@ class ActivityControllerTest {
         assertEquals("activity-casino", view)
         assertEquals("42", model.getAttribute("guildId"))
         assertEquals("Test Guild", model.getAttribute("guildName"))
+        assertEquals(1234L, model.getAttribute("credits"))
     }
 
     @Test


### PR DESCRIPTION
## Why

The activity picker showed a curated 8-game subset; reaching the other games meant clicking "← All servers" into the cross-guild pickers (`/casino/guilds`). That detour only works when the user happens to have a server-side `OAuth2AuthorizedClient` from a past website login (the picker pages inject `@RegisteredOAuth2AuthorizedClient` to enumerate mutual guilds) — a fresh activity-only session has no authorized client registered, so it bounces into the external OAuth redirect and the Discord sandbox kills the iframe.

There was never a blocker on the *guild-scoped* games list itself: every per-guild game route already authenticates fine through the activity token filter.

## What

- `/activity/casino/{guildId}` now renders the full per-guild game catalogue — the same games as the casino-guilds card, grouped the same way (Play together / Quick play / Table games / Daily draw) — instead of the 8-game subset. Still chrome-free for the sandbox.
- Adds the "Your wallet: N credits" line, via a new `EconomyWebService.getCredits(discordId, guildId)` that skips the mutual-guild enumeration the OAuth-dependent pickers use.
- Controller KDoc now records *why* the landing isn't the literal `/casino/guilds` page; `CASINO_GAME_SLUGS` comment points at both templates to keep them in sync.

## Testing

- `./gradlew :web:test` — full web module suite green, including the updated `ActivityControllerTest` asserting the credits model attribute.

https://claude.ai/code/session_01QQcvBfo4iXgKVfibA5yvis

---
_Generated by [Claude Code](https://claude.ai/code/session_01QQcvBfo4iXgKVfibA5yvis)_