### PR TITLE
Fix level-up announcement regression: restore pre-#492 "always attempt the post" behaviour + thread origins

### DIFF
--- a/application/src/test/kotlin/integration/bot/LevelUpAnnouncementIntegrationTest.kt
+++ b/application/src/test/kotlin/integration/bot/LevelUpAnnouncementIntegrationTest.kt
@@ -1,0 +1,205 @@
+package integration.bot
+
+import app.Application
+import bot.configuration.TestAppConfig
+import bot.configuration.TestBotConfig
+import bot.configuration.TestManagerConfig
+import common.configuration.TestCachingConfig
+import database.configuration.TestDatabaseConfig
+import database.dto.user.UserDto
+import database.service.leveling.XpAwardService
+import database.service.user.UserService
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.SelfMember
+import net.dv8tion.jda.api.entities.channel.ChannelType
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel
+import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel
+import net.dv8tion.jda.api.entities.channel.middleman.GuildMessageChannel
+import net.dv8tion.jda.api.requests.restaction.MessageCreateAction
+import net.dv8tion.jda.api.utils.messages.MessageCreateData
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+
+/**
+ * End-to-end guard for the level-up announcement pipeline:
+ *
+ *   XpAwardService.award (real, transactional)
+ *     -> LevelUpEvent published in the Spring context
+ *     -> every @EventListener (achievements, SSE, LevelUpListener) runs
+ *     -> NotificationRouter.sendChannel resolves the route against the
+ *        real ConfigService / UserNotificationPrefService (default
+ *        opt-ins, no config rows) and posts to the origin channel.
+ *
+ * The unit suites mock the router or the listener, so none of them
+ * would catch a wiring-level break (listener not scanned, a sibling
+ * event listener throwing and rolling back the award, pref defaults
+ * gating the channel post off, route resolution failing). This test
+ * boots the full application context with the shared mocked JDA and
+ * asserts the message actually reaches `TextChannel.sendMessage`.
+ */
+@SpringBootTest(
+    classes = [
+        Application::class,
+        TestCachingConfig::class,
+        TestDatabaseConfig::class,
+        TestManagerConfig::class,
+        TestAppConfig::class,
+        TestBotConfig::class,
+    ]
+)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+class LevelUpAnnouncementIntegrationTest {
+
+    @Autowired lateinit var xpAwardService: XpAwardService
+    @Autowired lateinit var userService: UserService
+    @Autowired lateinit var jda: JDA
+
+    // High id space to avoid colliding with other integration tests' seeds.
+    private val discordId = 9_100_001L
+    private val guildId = 9_100_002L
+    private val originChannelId = 9_100_003L
+
+    @AfterEach
+    fun cleanup() {
+        runCatching { userService.deleteUserById(discordId, guildId) }
+        userService.clearCache()
+        // The JDA bean is shared across @SpringBootTest classes in this
+        // module; drop our guild stub so later tests see the relaxed default.
+        clearMocks(jda)
+    }
+
+    @Test
+    fun `awarding XP across a level threshold posts the announcement to the origin channel`() {
+        userService.clearCache()
+        userService.createNewUser(UserDto(discordId, guildId))
+
+        val sentPayload = slot<MessageCreateData>()
+        // Real JDA returns `this` from mentionUsers; a relaxed mock would
+        // hand back a child mock and queue() would land on that instead.
+        val action = mockk<MessageCreateAction>(relaxed = true) {
+            every { mentionUsers(*anyLongVararg()) } returns this@mockk
+        }
+        val channel = mockk<TextChannel>(relaxed = true) {
+            every { sendMessage(capture(sentPayload)) } returns action
+            every { name } returns "general"
+            every { type } returns ChannelType.TEXT
+        }
+        val selfMember = mockk<SelfMember> {
+            every { hasPermission(any<GuildChannel>(), *anyVararg<Permission>()) } returns true
+        }
+        val guild = mockk<Guild>(relaxed = true) {
+            every { idLong } returns guildId
+            every { id } returns guildId.toString()
+            every {
+                hint(GuildMessageChannel::class)
+                getChannelById(GuildMessageChannel::class.java, originChannelId)
+            } returns channel
+            every { this@mockk.selfMember } returns selfMember
+            every { getMemberById(discordId) } returns null
+        }
+        every { jda.getGuildById(guildId) } returns guild
+
+        // Level 0 -> 1 crosses at 100 XP (LevelCurve), well under the
+        // 1000 XP default daily cap so the full amount lands.
+        val granted = xpAwardService.award(
+            discordId = discordId,
+            guildId = guildId,
+            amount = 150L,
+            reason = "integration-test",
+            channelId = originChannelId,
+        )
+        assertEquals(150L, granted, "XP award should not be clamped or dropped")
+
+        verify(exactly = 1) { channel.sendMessage(any<MessageCreateData>()) }
+        val payload = sentPayload.captured
+        assertEquals("<@$discordId>", payload.content) {
+            "level-up post should carry the leveler's mention in content so the ping fires"
+        }
+        val embed = payload.embeds.single()
+        assertTrue(embed.title!!.contains("LVL 1")) {
+            "expected the new level in the embed title, got '${embed.title}'"
+        }
+        // The post must actually be dispatched, not just built.
+        verify(exactly = 1) { action.queue(any(), any()) }
+    }
+
+    @Test
+    fun `level-up earned inside a thread posts back into that thread`() {
+        userService.clearCache()
+        userService.createNewUser(UserDto(discordId, guildId))
+
+        val action = mockk<MessageCreateAction>(relaxed = true) {
+            every { mentionUsers(*anyLongVararg()) } returns this@mockk
+        }
+        val thread = mockk<ThreadChannel>(relaxed = true) {
+            every { type } returns ChannelType.GUILD_PUBLIC_THREAD
+            every { isArchived } returns false
+            every { isLocked } returns false
+            every { sendMessage(any<MessageCreateData>()) } returns action
+        }
+        val selfMember = mockk<SelfMember> {
+            every { hasPermission(any<GuildChannel>(), *anyVararg<Permission>()) } returns true
+        }
+        val guild = mockk<Guild>(relaxed = true) {
+            every { idLong } returns guildId
+            every { id } returns guildId.toString()
+            every {
+                hint(GuildMessageChannel::class)
+                getChannelById(GuildMessageChannel::class.java, originChannelId)
+            } returns thread
+            every { this@mockk.selfMember } returns selfMember
+            every { getMemberById(discordId) } returns null
+        }
+        every { jda.getGuildById(guildId) } returns guild
+
+        xpAwardService.award(
+            discordId = discordId,
+            guildId = guildId,
+            amount = 150L,
+            reason = "integration-test",
+            channelId = originChannelId,
+        )
+
+        verify(exactly = 1) { thread.sendMessage(any<MessageCreateData>()) }
+        verify(exactly = 1) { action.queue(any(), any()) }
+    }
+
+    @Test
+    fun `award below the threshold posts nothing`() {
+        userService.clearCache()
+        userService.createNewUser(UserDto(discordId, guildId))
+
+        val channel = mockk<TextChannel>(relaxed = true)
+        val guild = mockk<Guild>(relaxed = true) {
+            every { idLong } returns guildId
+            every { id } returns guildId.toString()
+            every { getTextChannelById(originChannelId) } returns channel
+        }
+        every { jda.getGuildById(guildId) } returns guild
+
+        xpAwardService.award(
+            discordId = discordId,
+            guildId = guildId,
+            amount = 50L,
+            reason = "integration-test",
+            channelId = originChannelId,
+        )
+
+        verify(exactly = 0) { channel.sendMessage(any<MessageCreateData>()) }
+    }
+}

--- a/application/src/test/kotlin/integration/bot/LevelUpAnnouncementIntegrationTest.kt
+++ b/application/src/test/kotlin/integration/bot/LevelUpAnnouncementIntegrationTest.kt
@@ -180,6 +180,52 @@ class LevelUpAnnouncementIntegrationTest {
     }
 
     @Test
+    fun `level-up still posts when computed permissions claim the only channel is unwritable`() {
+        // Pre-#492 behaviour pin: the original LevelUpListener never
+        // permission-checked at resolution time — it attempted the send
+        // and let a real Discord rejection surface in the queue-failure
+        // callback. A false negative from JDA's permission computation
+        // must degrade to a logged send failure, not a silent drop.
+        userService.clearCache()
+        userService.createNewUser(UserDto(discordId, guildId))
+
+        val action = mockk<MessageCreateAction>(relaxed = true) {
+            every { mentionUsers(*anyLongVararg()) } returns this@mockk
+        }
+        val channel = mockk<TextChannel>(relaxed = true) {
+            every { sendMessage(any<MessageCreateData>()) } returns action
+            every { name } returns "general"
+            every { type } returns ChannelType.TEXT
+        }
+        val selfMember = mockk<SelfMember> {
+            every { hasPermission(any<GuildChannel>(), *anyVararg<Permission>()) } returns false
+        }
+        val guild = mockk<Guild>(relaxed = true) {
+            every { idLong } returns guildId
+            every { id } returns guildId.toString()
+            every {
+                hint(GuildMessageChannel::class)
+                getChannelById(GuildMessageChannel::class.java, originChannelId)
+            } returns channel
+            every { this@mockk.selfMember } returns selfMember
+            every { getMemberById(discordId) } returns null
+            every { systemChannel } returns null
+        }
+        every { jda.getGuildById(guildId) } returns guild
+
+        xpAwardService.award(
+            discordId = discordId,
+            guildId = guildId,
+            amount = 150L,
+            reason = "integration-test",
+            channelId = originChannelId,
+        )
+
+        verify(exactly = 1) { channel.sendMessage(any<MessageCreateData>()) }
+        verify(exactly = 1) { action.queue(any(), any()) }
+    }
+
+    @Test
     fun `award below the threshold posts nothing`() {
         userService.clearCache()
         userService.createNewUser(UserDto(discordId, guildId))

--- a/discord-bot/src/main/kotlin/bot/toby/notify/NotificationRouter.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/notify/NotificationRouter.kt
@@ -135,10 +135,12 @@ class NotificationRouter(
         }
         val channel = resolveChannel(guild, route, originChannelId) ?: run {
             // WARN, not info: a notification the product decided to send is
-            // being dropped. The config-key trail makes "level-ups stopped
-            // posting" diagnosable from deploy logs alone.
+            // being dropped. Only reachable when NO candidate channel even
+            // exists (resolveChannel attempts unwritable ones best-effort).
+            // The config-key trail makes "level-ups stopped posting"
+            // diagnosable from deploy logs alone.
             logger.warn(
-                "No writable channel resolved for route $route in guild ${guild.idLong}; dropping the post. " +
+                "No channel exists for route $route in guild ${guild.idLong}; dropping the post. " +
                     "Checked config keys ${listOfNotNull(route.primaryConfigKey) + route.fallbackConfigKeys}, " +
                     "originChannelId=$originChannelId, " +
                     "systemChannelFallback=${if (route.systemChannelFallback) "allowed" else "disabled for this route"}."
@@ -379,18 +381,38 @@ class NotificationRouter(
         }
     }
 
+    /**
+     * Walk the route's candidate chain and return the first channel that
+     * passes the permission check. If every existing candidate fails the
+     * check, fall back to the FIRST one that exists anyway: before
+     * routing was centralised (#492) no notifier permission-checked at
+     * resolution time — the send was attempted and a real Discord
+     * rejection surfaced in the queue-failure callback. Keeping that
+     * contract means a computed-permission false negative can never
+     * silently swallow a notification; the worst case is a logged send
+     * failure, exactly like the pre-router code.
+     */
     private fun resolveChannel(
         guild: Guild,
         route: ChannelRouteKey,
         originChannelId: Long?,
     ): GuildMessageChannel? {
+        var firstExisting: GuildMessageChannel? = null
+        // Returns the candidate when it's writable; remembers the first
+        // existing candidate either way for the best-effort fallback.
+        fun writable(candidate: GuildMessageChannel?): GuildMessageChannel? {
+            if (candidate == null) return null
+            if (firstExisting == null) firstExisting = candidate
+            return candidate.takeIf { hasSendPerms(guild, it) }
+        }
+
         // 1. primaryConfigKey
         route.primaryConfigKey
-            ?.let { key -> channelFromConfig(guild, key) }
+            ?.let { key -> writable(channelFromConfig(guild, key)) }
             ?.let { return it }
         // 2. fallbackConfigKeys in order
         route.fallbackConfigKeys.forEach { key ->
-            channelFromConfig(guild, key)?.let { return it }
+            writable(channelFromConfig(guild, key))?.let { return it }
         }
         // 3. originChannelId — any message-capable channel: text, voice
         //    (text-in-voice — activity-initiated PvP challenges pass the
@@ -399,17 +421,27 @@ class NotificationRouter(
         //    forum posts (message XP earned inside a thread carries the
         //    thread id; resolving only TextChannel here silently diverted
         //    those level-up posts to the system channel, or dropped them
-        //    when no system channel was writable).
+        //    when no system channel was writable). Archived/locked threads
+        //    are excluded outright — a send there always fails.
         originChannelId?.let { id ->
             val origin = guild.getChannelById(GuildMessageChannel::class.java, id)
                 ?.takeUnless { it is ThreadChannel && (it.isArchived || it.isLocked) }
-            origin?.takeIf { hasSendPerms(guild, it) }?.let { return it }
+            writable(origin)?.let { return it }
         }
         // 4. system channel fallback (per-route opt-in)
         if (route.systemChannelFallback) {
-            guild.systemChannel?.takeIf { hasSendPerms(guild, it) }?.let { return it }
+            writable(guild.systemChannel)?.let { return it }
         }
-        return null
+        // 5. Best-effort: no candidate passed the permission check, but at
+        //    least one exists — attempt the send there rather than dropping
+        //    the notification on the floor.
+        return firstExisting?.also {
+            logger.warn(
+                "No candidate for route $route in guild ${guild.idLong} passes the send/embed permission " +
+                    "check; attempting best-effort post to #${it.name} anyway. If it fails, grant the bot " +
+                    "Send Messages + Embed Links there (or point the route's config at a writable channel)."
+            )
+        }
     }
 
     private fun channelFromConfig(guild: Guild, configKey: String): TextChannel? {
@@ -421,14 +453,6 @@ class NotificationRouter(
                 "Config $configKey for guild ${guild.idLong} points at channel $raw, " +
                     "which no longer exists (or is not a text channel); falling through."
             )
-            return null
-        }
-        if (!hasSendPerms(guild, channel)) {
-            logger.warn(
-                "Config $configKey for guild ${guild.idLong} points at #${channel.name}, but the bot " +
-                    "lacks Send Messages / Embed Links there; falling through."
-            )
-            return null
         }
         return channel
     }

--- a/discord-bot/src/main/kotlin/bot/toby/notify/NotificationRouter.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/notify/NotificationRouter.kt
@@ -13,6 +13,7 @@ import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel
 import net.dv8tion.jda.api.entities.channel.middleman.GuildMessageChannel
 import net.dv8tion.jda.api.utils.messages.MessageCreateData
 import org.springframework.beans.factory.annotation.Autowired
@@ -133,9 +134,15 @@ class NotificationRouter(
             return
         }
         val channel = resolveChannel(guild, route, originChannelId) ?: run {
-            logger.info {
-                "No writable channel resolved for route $route in guild ${guild.idLong}; skipping."
-            }
+            // WARN, not info: a notification the product decided to send is
+            // being dropped. The config-key trail makes "level-ups stopped
+            // posting" diagnosable from deploy logs alone.
+            logger.warn(
+                "No writable channel resolved for route $route in guild ${guild.idLong}; dropping the post. " +
+                    "Checked config keys ${listOfNotNull(route.primaryConfigKey) + route.fallbackConfigKeys}, " +
+                    "originChannelId=$originChannelId, " +
+                    "systemChannelFallback=${if (route.systemChannelFallback) "allowed" else "disabled for this route"}."
+            )
             return
         }
 
@@ -385,13 +392,17 @@ class NotificationRouter(
         route.fallbackConfigKeys.forEach { key ->
             channelFromConfig(guild, key)?.let { return it }
         }
-        // 3. originChannelId — may be a text channel OR a voice channel
-        //    (voice channels have text chat; activity-initiated PvP
-        //    challenges pass the participants' voice channel here so the
-        //    ping lands where the group is actually looking).
+        // 3. originChannelId — any message-capable channel: text, voice
+        //    (text-in-voice — activity-initiated PvP challenges pass the
+        //    participants' voice channel so the ping lands where the group
+        //    is actually looking), announcement channels, and threads /
+        //    forum posts (message XP earned inside a thread carries the
+        //    thread id; resolving only TextChannel here silently diverted
+        //    those level-up posts to the system channel, or dropped them
+        //    when no system channel was writable).
         originChannelId?.let { id ->
-            val origin: GuildMessageChannel? =
-                guild.getTextChannelById(id) ?: guild.getVoiceChannelById(id)
+            val origin = guild.getChannelById(GuildMessageChannel::class.java, id)
+                ?.takeUnless { it is ThreadChannel && (it.isArchived || it.isLocked) }
             origin?.takeIf { hasSendPerms(guild, it) }?.let { return it }
         }
         // 4. system channel fallback (per-route opt-in)
@@ -404,12 +415,31 @@ class NotificationRouter(
     private fun channelFromConfig(guild: Guild, configKey: String): TextChannel? {
         val raw = configService.getConfigByName(configKey, guild.id)?.value?.toLongOrNull()
             ?: return null
-        val channel = guild.getTextChannelById(raw) ?: return null
-        return channel.takeIf { hasSendPerms(guild, it) }
+        val channel = guild.getTextChannelById(raw)
+        if (channel == null) {
+            logger.warn(
+                "Config $configKey for guild ${guild.idLong} points at channel $raw, " +
+                    "which no longer exists (or is not a text channel); falling through."
+            )
+            return null
+        }
+        if (!hasSendPerms(guild, channel)) {
+            logger.warn(
+                "Config $configKey for guild ${guild.idLong} points at #${channel.name}, but the bot " +
+                    "lacks Send Messages / Embed Links there; falling through."
+            )
+            return null
+        }
+        return channel
     }
 
-    private fun hasSendPerms(guild: Guild, channel: GuildMessageChannel): Boolean =
-        guild.selfMember.hasPermission(channel, Permission.MESSAGE_SEND, Permission.MESSAGE_EMBED_LINKS)
+    private fun hasSendPerms(guild: Guild, channel: GuildMessageChannel): Boolean {
+        // Posting inside a thread is governed by MESSAGE_SEND_IN_THREADS
+        // on the parent; MESSAGE_SEND alone reports false there.
+        val sendPerm =
+            if (channel.type.isThread) Permission.MESSAGE_SEND_IN_THREADS else Permission.MESSAGE_SEND
+        return guild.selfMember.hasPermission(channel, sendPerm, Permission.MESSAGE_EMBED_LINKS)
+    }
 }
 
 /**

--- a/discord-bot/src/test/kotlin/bot/toby/notify/NotificationRouterChannelTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/notify/NotificationRouterChannelTest.kt
@@ -259,6 +259,76 @@ class NotificationRouterChannelTest {
         verify(exactly = 0) { systemChannel.sendMessage(any<MessageCreateData>()) }
     }
 
+    // ---- best-effort last resort (pre-#492 behaviour pins) ----
+    //
+    // Before channel routing was centralised, LevelUpListener (and the
+    // other notifiers) never permission-checked at resolution time: the
+    // post was attempted on the first existing channel in the chain and
+    // a real Discord rejection surfaced in the queue-failure callback.
+    // #492's hasSendPerms gate turned "computed perms say no" into a
+    // silent drop — if JDA's view of the permissions is stricter than
+    // what Discord actually enforces (or the only candidate genuinely
+    // lacks perms), notifications that used to deliver (or at least
+    // log a real error) just vanish. These tests pin the old contract:
+    // never drop silently while a target channel exists.
+
+    @Test
+    fun `config channel failing the permission check is still attempted when nothing else exists`() {
+        stub(ConfigDto.Configurations.LEVEL_UP_CHANNEL, "1")
+        every { guild.getTextChannelById(1L) } returns primaryChannel
+        every { bot.hasPermission(primaryChannel, *anyVararg<Permission>()) } returns false
+        every { guild.systemChannel } returns null
+
+        router.sendChannel(guildId, ChannelRouteKey.LEVEL_UP, message = builder)
+
+        verify(exactly = 1) { primaryChannel.sendMessage(payload) }
+    }
+
+    @Test
+    fun `system channel failing the permission check is still attempted as the last resort`() {
+        stub(ConfigDto.Configurations.LEVEL_UP_CHANNEL, null)
+        every { guild.systemChannel } returns systemChannel
+        every { bot.hasPermission(systemChannel, *anyVararg<Permission>()) } returns false
+
+        router.sendChannel(guildId, ChannelRouteKey.LEVEL_UP, message = builder)
+
+        verify(exactly = 1) { systemChannel.sendMessage(payload) }
+    }
+
+    @Test
+    fun `unwritable config channel is routed around when a writable origin exists`() {
+        // The route-around introduced by #492 is kept: best-effort only
+        // kicks in when NO candidate passes the permission check.
+        stub(ConfigDto.Configurations.LEVEL_UP_CHANNEL, "1")
+        every { guild.getTextChannelById(1L) } returns primaryChannel
+        every { bot.hasPermission(primaryChannel, *anyVararg<Permission>()) } returns false
+        every {
+            hint(GuildMessageChannel::class)
+            guild.getChannelById(GuildMessageChannel::class.java, 3L)
+        } returns originChannel
+
+        router.sendChannel(guildId, ChannelRouteKey.LEVEL_UP, originChannelId = 3L, message = builder)
+
+        verify(exactly = 1) { originChannel.sendMessage(payload) }
+        verify(exactly = 0) { primaryChannel.sendMessage(any<MessageCreateData>()) }
+    }
+
+    @Test
+    fun `best-effort prefers the config channel over later existing candidates`() {
+        // When everything fails the perm check, the attempt goes to the
+        // FIRST existing candidate — the admin-configured channel — not
+        // whatever happened to be inspected last.
+        stub(ConfigDto.Configurations.LEVEL_UP_CHANNEL, "1")
+        every { guild.getTextChannelById(1L) } returns primaryChannel
+        every { guild.systemChannel } returns systemChannel
+        every { bot.hasPermission(any<TextChannel>(), *anyVararg<Permission>()) } returns false
+
+        router.sendChannel(guildId, ChannelRouteKey.LEVEL_UP, message = builder)
+
+        verify(exactly = 1) { primaryChannel.sendMessage(payload) }
+        verify(exactly = 0) { systemChannel.sendMessage(any<MessageCreateData>()) }
+    }
+
     @Test
     fun `skips channels the bot cannot post in and continues the chain`() {
         stub(ConfigDto.Configurations.LOTTERY_CHANNEL, "1")

--- a/discord-bot/src/test/kotlin/bot/toby/notify/NotificationRouterChannelTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/notify/NotificationRouterChannelTest.kt
@@ -15,7 +15,11 @@ import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.entities.SelfMember
+import net.dv8tion.jda.api.entities.channel.ChannelType
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel
+import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel
+import net.dv8tion.jda.api.entities.channel.middleman.GuildMessageChannel
 import net.dv8tion.jda.api.requests.restaction.MessageCreateAction
 import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder
 import net.dv8tion.jda.api.utils.messages.MessageCreateData
@@ -79,6 +83,12 @@ class NotificationRouterChannelTest {
         every { fallbackChannel.idLong } returns 2L
         every { originChannel.idLong } returns 3L
         every { systemChannel.idLong } returns 4L
+        // hasSendPerms branches on type.isThread; pin TEXT explicitly so
+        // the relaxed mocks don't feed it an arbitrary enum constant.
+        every { primaryChannel.type } returns ChannelType.TEXT
+        every { fallbackChannel.type } returns ChannelType.TEXT
+        every { originChannel.type } returns ChannelType.TEXT
+        every { systemChannel.type } returns ChannelType.TEXT
         every { primaryChannel.name } returns "primary"
         every { fallbackChannel.name } returns "fallback"
         every { originChannel.name } returns "origin"
@@ -140,7 +150,9 @@ class NotificationRouterChannelTest {
     @Test
     fun `falls through to originChannelId when configs miss`() {
         stub(ConfigDto.Configurations.LEVEL_UP_CHANNEL, null)
-        every { guild.getTextChannelById(3L) } returns originChannel
+        every {
+            hint(GuildMessageChannel::class)
+            guild.getChannelById(GuildMessageChannel::class.java, 3L) } returns originChannel
 
         router.sendChannel(
             guildId, ChannelRouteKey.LEVEL_UP,
@@ -149,6 +161,70 @@ class NotificationRouterChannelTest {
         )
 
         verify(exactly = 1) { originChannel.sendMessage(payload) }
+    }
+
+    @Test
+    fun `voice-channel origin resolves - activity PvP pings land in text-in-voice`() {
+        stub(ConfigDto.Configurations.LEVEL_UP_CHANNEL, null)
+        val voice = mockk<VoiceChannel>(relaxed = true) {
+            every { type } returns ChannelType.VOICE
+            every { sendMessage(any<MessageCreateData>()) } returns createAction
+        }
+        every {
+            hint(GuildMessageChannel::class)
+            guild.getChannelById(GuildMessageChannel::class.java, 5L) } returns voice
+        every { bot.hasPermission(voice, *anyVararg<Permission>()) } returns true
+
+        router.sendChannel(guildId, ChannelRouteKey.LEVEL_UP, originChannelId = 5L, message = builder)
+
+        verify(exactly = 1) { voice.sendMessage(payload) }
+    }
+
+    @Test
+    fun `thread origin resolves and is gated on MESSAGE_SEND_IN_THREADS`() {
+        // Message XP earned inside a thread carries the thread id; the
+        // level-up announcement must land in that thread, not divert to
+        // the system channel (the pre-fix behaviour).
+        stub(ConfigDto.Configurations.LEVEL_UP_CHANNEL, null)
+        val thread = mockk<ThreadChannel>(relaxed = true) {
+            every { type } returns ChannelType.GUILD_PUBLIC_THREAD
+            every { isArchived } returns false
+            every { isLocked } returns false
+            every { sendMessage(any<MessageCreateData>()) } returns createAction
+        }
+        every {
+            hint(GuildMessageChannel::class)
+            guild.getChannelById(GuildMessageChannel::class.java, 6L) } returns thread
+        every { guild.systemChannel } returns systemChannel
+        every { bot.hasPermission(thread, *anyVararg<Permission>()) } returns true
+
+        router.sendChannel(guildId, ChannelRouteKey.LEVEL_UP, originChannelId = 6L, message = builder)
+
+        verify(exactly = 1) { thread.sendMessage(payload) }
+        verify(exactly = 0) { systemChannel.sendMessage(any<MessageCreateData>()) }
+        // Threads gate on MESSAGE_SEND_IN_THREADS, not MESSAGE_SEND.
+        verify(exactly = 1) {
+            bot.hasPermission(thread, Permission.MESSAGE_SEND_IN_THREADS, Permission.MESSAGE_EMBED_LINKS)
+        }
+    }
+
+    @Test
+    fun `archived thread origin falls through to the system channel`() {
+        stub(ConfigDto.Configurations.LEVEL_UP_CHANNEL, null)
+        val thread = mockk<ThreadChannel>(relaxed = true) {
+            every { type } returns ChannelType.GUILD_PUBLIC_THREAD
+            every { isArchived } returns true
+            every { isLocked } returns false
+        }
+        every {
+            hint(GuildMessageChannel::class)
+            guild.getChannelById(GuildMessageChannel::class.java, 6L) } returns thread
+        every { guild.systemChannel } returns systemChannel
+
+        router.sendChannel(guildId, ChannelRouteKey.LEVEL_UP, originChannelId = 6L, message = builder)
+
+        verify(exactly = 0) { thread.sendMessage(any<MessageCreateData>()) }
+        verify(exactly = 1) { systemChannel.sendMessage(payload) }
     }
 
     @Test


### PR DESCRIPTION
## Context

Report: "level up notification posting seems to have broken?" — and it **did work before**, so this PR pins the previously-working behaviour in tests and fixes the router to match.

## Root cause (regression introduced by #492)

Before channel routing was centralised, `LevelUpListener.resolveAnnouncementChannel` did:

```kotlin
configured?.let { id -> guild.getTextChannelById(id)?.let { return it } }
originId?.let { id -> guild.getTextChannelById(id)?.let { return it } }
return guild.systemChannel
```

**No permission check at all** — the send was always attempted on the first existing channel, and a genuine Discord rejection surfaced in the queue-failure callback.

#492's `NotificationRouter` added a `hasSendPerms` gate (`MESSAGE_SEND` + `MESSAGE_EMBED_LINKS`, applied at every step including the system-channel last resort) that turns a computed-permission "no" into a **silent drop** with a single INFO log. Any guild where JDA's permission view is stricter than what Discord actually enforces (channel-override edge cases, the embed-links requirement) stopped getting level-up posts — and every other route through the router (lottery, achievements shoutout, tips, duels) inherited the same failure mode.

## The fix

`resolveChannel` keeps the useful part of the gate and restores the old contract:

- The first candidate that **passes** the permission check still wins — unwritable channels are routed around when a writable one exists (post-#492 improvement, preserved).
- When **no** candidate passes, the post is attempted best-effort on the first channel that *exists* (config → origin → system) with a WARN naming the channel and the fix — instead of being dropped. Worst case is a logged send failure, exactly like the pre-router code.
- "Dropping the post" now only happens when no candidate channel exists at all, and it's a WARN listing the config keys checked.

Also fixed while in here (same "post where the XP was earned" contract):
- Origin resolution now accepts any message-capable channel (`getChannelById(GuildMessageChannel)`) — XP earned in **threads, forum posts, announcement channels** previously never resolved as the origin. Archived/locked threads are excluded (a send there always fails).
- Thread sends are gated on `MESSAGE_SEND_IN_THREADS` (`MESSAGE_SEND` reports false inside threads even when the bot can post).
- A configured announce channel that's been deleted now WARNs instead of falling through silently.

## Behaviour pins (tests written first, verified red against the old router)

- `NotificationRouterChannelTest`: config channel failing the perm check is still attempted when nothing else exists; system channel failing the perm check is still attempted as last resort; best-effort prefers the config channel over later candidates; route-around to a writable origin is preserved; thread/voice/archived-thread origin coverage incl. the `MESSAGE_SEND_IN_THREADS` gate.
- New `LevelUpAnnouncementIntegrationTest` (full Spring context, Testcontainers Postgres, mocked JDA): drives `XpAwardService.award` across a level threshold and asserts the announcement reaches `TextChannel.sendMessage` — including the case where computed permissions return false everywhere (the exact reported symptom) and the thread-origin case. This pins the entire pipeline: event publishing, listener wiring, pref defaults, route resolution.

Full `:discord-bot` and `:application` suites pass.

https://claude.ai/code/session_01DeLNvgGNwUaFJo4wKSWcN5