### PR TITLE
Unify the Magic card tab into one search

### DIFF
--- a/web/src/main/resources/static/css/magic.css
+++ b/web/src/main/resources/static/css/magic.css
@@ -533,13 +533,6 @@
     flex: 1 1 180px;
 }
 
-/* Separates the Scryfall-style search grid from the single-card lookup. */
-.cube-divider {
-    border: none;
-    border-top: 1px solid var(--border);
-    margin: var(--space-5) 0 var(--space-4);
-}
-
 .cube-checkbox {
     flex-direction: row;
     align-items: center;

--- a/web/src/main/resources/static/js/magic.js
+++ b/web/src/main/resources/static/js/magic.js
@@ -554,7 +554,7 @@
         facts.appendChild(link);
 
         // On-demand rulings: a button that fetches /magic/api/rulings for this
-        // card and renders them into the box below (wired in wireCardLookup).
+        // card and renders them into the box below (wired in wireCardDetail).
         const rulingsBtn = document.createElement('button');
         rulingsBtn.type = 'button';
         rulingsBtn.className = 'btn btn-secondary cube-rulings-btn';
@@ -1462,10 +1462,38 @@
         if (!form) return;
         const status = statusFor(doc, 'search');
         const result = q(doc, '[data-result="search"]');
-        // Clicking a result opens its full details in the lookup panel below,
-        // reusing that panel's rulings/combos wiring.
+        // The full-detail panel below the grid (rulings/combos wired separately
+        // in wireCardDetail). It opens on click-through from a multi-result grid,
+        // or automatically when a search narrows to exactly one card.
         const cardResult = q(doc, '[data-result="card"]');
         const cardStatus = statusFor(doc, 'card');
+
+        // Loads a card's full details into the detail panel below the grid.
+        // [scroll] brings it into view (a click-through), but is skipped on an
+        // auto-open so an as-you-type search doesn't yank the page around.
+        function openCardDetail(name, scroll) {
+            if (!name || !cardResult) return;
+            setStatus(cardStatus, 'Loading ' + name + '…');
+            hide(cardResult);
+            getJson(cardUrl(name))
+                .then(function (json) {
+                    if (!json.ok) { setStatus(cardStatus, json.error || 'No card found.'); return; }
+                    setStatus(cardStatus, '');
+                    renderCardLookup(cardResult, json.card);
+                    show(cardResult);
+                    if (scroll && cardResult.scrollIntoView) cardResult.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                })
+                .catch(function () { setStatus(cardStatus, 'Something went wrong. Try again.'); });
+        }
+
+        // Clears the detail panel — used when a search widens back to many (or
+        // zero) results, so a stale single-card detail doesn't linger.
+        function clearCardDetail() {
+            if (!cardResult) return;
+            hide(cardResult);
+            cardResult.replaceChildren();
+            setStatus(cardStatus, '');
+        }
 
         // Delegated so it survives each grid re-render: a left-click on a result
         // tile loads that card's detail panel instead of leaving for Scryfall.
@@ -1477,17 +1505,7 @@
             const name = tile.getAttribute('data-card-name') || tile.getAttribute('title');
             if (!name || !cardResult) return;
             e.preventDefault();
-            setStatus(cardStatus, 'Loading ' + name + '…');
-            hide(cardResult);
-            getJson(cardUrl(name))
-                .then(function (json) {
-                    if (!json.ok) { setStatus(cardStatus, json.error || 'No card found.'); return; }
-                    setStatus(cardStatus, '');
-                    renderCardLookup(cardResult, json.card);
-                    show(cardResult);
-                    if (cardResult.scrollIntoView) cardResult.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                })
-                .catch(function () { setStatus(cardStatus, 'Something went wrong. Try again.'); });
+            openCardDetail(name, true);
         });
 
         let timer = null;
@@ -1509,6 +1527,7 @@
             if (!filters.name && !filters.type && !filters.query) {
                 setStatus(status, 'Enter a name, a type, or a Scryfall query to search.');
                 hide(result);
+                clearCardDetail();
                 return;
             }
             // Supersede any in-flight request so its response is dropped.
@@ -1521,10 +1540,18 @@
                 .then(function (r) { return r.json(); })
                 .then(function (json) {
                     if (token !== seq) return;
-                    if (!json.ok) { setStatus(status, json.error || 'No cards matched that search.'); hide(result); return; }
+                    if (!json.ok) { setStatus(status, json.error || 'No cards matched that search.'); hide(result); clearCardDetail(); return; }
                     setStatus(status, searchSentence(json.total, json.capped));
-                    renderSearchResults(result, json.cards || []);
+                    const cards = json.cards || [];
+                    renderSearchResults(result, cards);
                     show(result);
+                    // Narrowed to a single card? Open its full details inline,
+                    // saving the extra click. A wider result clears any stale one.
+                    if (json.total === 1 && cards.length === 1) {
+                        openCardDetail(cards[0].name, false);
+                    } else {
+                        clearCardDetail();
+                    }
                 })
                 .catch(function (e) {
                     if (e && e.name === 'AbortError') return; // superseded — leave the UI to the newer search
@@ -1553,6 +1580,7 @@
                     seq++; // drop any in-flight response
                     setStatus(status, '');
                     hide(result);
+                    clearCardDetail();
                     return;
                 }
                 if (f.name.length >= AUTO_SEARCH_MIN || f.type.length >= AUTO_SEARCH_MIN || f.query.length >= AUTO_SEARCH_MIN) {
@@ -1565,14 +1593,18 @@
         });
     }
 
-    function wireCardLookup(doc) {
-        const form = q(doc, '[data-form="card"]');
-        if (!form) return;
-        const status = statusFor(doc, 'card');
+    /**
+     * Wires the on-demand "Show rulings" / "Show combos" buttons on the card
+     * detail panel. The panel itself is populated by the card search (a
+     * click-through, or an auto-open when a search narrows to one card); this
+     * just delegates the two reveal buttons, surviving each re-render of the
+     * panel's contents.
+     */
+    function wireCardDetail(doc) {
         const result = q(doc, '[data-result="card"]');
+        if (!result) return;
 
-        // Delegated so it survives each re-render of the lookup result: the
-        // "Show rulings" button fetches that card's rulings on demand.
+        // The "Show rulings" button fetches that card's rulings on demand.
         result.addEventListener('click', function (e) {
             const btn = e.target.closest && e.target.closest('[data-load-rulings]');
             if (!btn) return;
@@ -1608,24 +1640,6 @@
                     btn.hidden = true;
                 })
                 .catch(function () { btn.disabled = false; btn.textContent = 'Show combos'; });
-        });
-
-        form.addEventListener('submit', function (e) {
-            e.preventDefault();
-            const name = (new FormData(form).get('name') || '').trim();
-            if (!name) { setStatus(status, 'Enter a card name.'); return; }
-            setStatus(status, 'Looking up…');
-            hide(result);
-            withBusy(form, true);
-            getJson(cardUrl(name))
-                .then(function (json) {
-                    if (!json.ok) { setStatus(status, json.error || 'No card found.'); return; }
-                    setStatus(status, '');
-                    renderCardLookup(result, json.card);
-                    show(result);
-                })
-                .catch(function () { setStatus(status, 'Something went wrong. Try again.'); })
-                .then(function () { withBusy(form, false); });
         });
     }
 
@@ -2245,7 +2259,7 @@
         wireAsFan(doc);
         wireCompare(doc);
         wireSearch(doc);
-        wireCardLookup(doc);
+        wireCardDetail(doc);
         wireLegality(doc);
         wireReference(doc);
         wireWatch(doc);

--- a/web/src/main/resources/templates/magic.html
+++ b/web/src/main/resources/templates/magic.html
@@ -358,7 +358,9 @@
             <p class="cube-panel-intro">
                 Search Magic cards by name and type and see every match as a grid of images, the
                 way Scryfall does — results update as you type. Click any card for its full
-                details, rulings and combos, or look one up by name below.
+                details, rulings and combos; a search that narrows to a single card opens those
+                details automatically. The website twin of the
+                <code th:text="${mtgCmd.cardLookup}">/mtgcard lookup</code> Discord command.
             </p>
             <form class="cube-form cube-search-form" data-form="search" autocomplete="off">
                 <label id="card-search-name-label">Name includes
@@ -378,24 +380,6 @@
             <p class="cube-status" data-status="search" aria-live="polite"></p>
             <div class="cube-card-grid" data-result="search" hidden></div>
 
-            <hr class="cube-divider">
-
-            <p class="cube-panel-intro">
-                Look up a single card by name for its image and details — the website twin of
-                the <code th:text="${mtgCmd.cardLookup}">/mtgcard lookup</code> Discord command.
-            </p>
-            <form class="cube-form" data-form="card" autocomplete="off">
-                <label id="card-lookup-label">Card name
-                    <div class="cube-list-wrap">
-                        <input type="text" name="name" placeholder="e.g. Lightning Bolt"
-                               autocomplete="off"
-                               aria-labelledby="card-lookup-label"
-                               aria-autocomplete="list" aria-controls="card-lookup-suggest" required>
-                        <ul class="cube-card-suggest" id="card-lookup-suggest" data-card-suggest role="listbox" hidden></ul>
-                    </div>
-                </label>
-                <button type="submit" class="btn cube-submit">Look up</button>
-            </form>
             <p class="cube-status" data-status="card" aria-live="polite"></p>
             <div class="cube-cardlookup-wrap" data-result="card" hidden></div>
         </section>


### PR DESCRIPTION
## Summary

Collapses the Magic toolkit's **Card lookup** tab from two overlapping tools into a single search. The three search boxes (name / type / advanced Scryfall) now do everything the retired single-card lookup form did.

## What changed

- **Dropped the single-card lookup form.** The `data-form="card"` form, its label, autocomplete listbox, the explanatory paragraph, and the `<hr class="cube-divider">` separator are gone from `magic.html`. The unified search intro keeps the `/mtgcard lookup` command reference (sourced from `MtgCommandRef`).
- **Auto-open on a single match.** When a search narrows to exactly one card (`total === 1`), its full detail panel opens inline — no extra click. Scrolling is skipped on auto-open so an as-you-type search doesn't yank the page around.
- **Click-through unchanged.** Left-clicking a tile in a multi-result grid still opens that card's detail panel; modifier/middle clicks still fall through to Scryfall.
- **Stale-detail cleanup.** Widening (or clearing) a search clears any previously auto-opened detail so it doesn't linger.
- **Rulings/combos wiring moved.** The on-demand "Show rulings" / "Show combos" delegation moved off the retired form's handler (`wireCardLookup`) onto the detail container itself (`wireCardDetail`).
- Removed the now-dead `.cube-divider` CSS rule.

## Testing

- `npx jest src/test/js/magic.test.js` → **124 passing**
- `./gradlew :web:test --tests "web.template.MagicTemplateRenderTest"` → **green**
- `stylelint` on `magic.css` → clean

https://claude.ai/code/session_01Jx7ecAub9NmVngokoeuNDx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jx7ecAub9NmVngokoeuNDx)_