### PR TITLE
Extend the never-drop-silently posting contract to the non-router posters

### DIFF
--- a/database/src/test/kotlin/database/rps/RpsSessionRegistryTest.kt
+++ b/database/src/test/kotlin/database/rps/RpsSessionRegistryTest.kt
@@ -204,11 +204,15 @@ class RpsSessionRegistryTest {
         val ids = (1..10).map {
             registry.register(guildId, initiatorId + it, opponentId + it, stake = 0L).id
         }
-        // Caffeine performs eviction asynchronously; nudge it with a
-        // synchronous read so the cleanup completes before we assert.
-        ids.forEach { registry.get(it) }
-        Thread.sleep(50)
-        val surviving = ids.count { registry.get(it) != null }
+        // Caffeine evicts asynchronously on its maintenance pass; a fixed
+        // sleep flakes on CPU-starved CI runners. Poll with a generous
+        // deadline instead — every get() also nudges the maintenance pass.
+        val deadline = System.currentTimeMillis() + 5_000
+        var surviving = ids.count { registry.get(it) != null }
+        while (surviving > 3 && System.currentTimeMillis() < deadline) {
+            Thread.sleep(25)
+            surviving = ids.count { registry.get(it) != null }
+        }
         assertTrue(surviving <= 3, "expected at most 3 survivors with maximumSessions=3, got $surviving")
     }
 

--- a/discord-bot/src/main/kotlin/bot/toby/handler/WelcomeAndAutoRoleHandler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/handler/WelcomeAndAutoRoleHandler.kt
@@ -32,9 +32,10 @@ import org.springframework.stereotype.Service
  *
  * Channel resolution prefers the configured `*_CHANNEL`; if that row is
  * blank, unparseable, missing, or non-postable, falls back to the
- * guild's system channel. If neither is postable the listener logs and
- * returns silently — never let a transient JDA-side failure kill the
- * dispatch thread.
+ * guild's system channel. If neither passes the permission check the
+ * post is still attempted on the first channel that exists (a computed-
+ * permission false negative degrades to a logged send failure, never a
+ * silent drop); only a guild with no candidate at all skips.
  */
 @Service
 class WelcomeAndAutoRoleHandler(
@@ -120,13 +121,23 @@ class WelcomeAndAutoRoleHandler(
         configService.getConfigByName(key.configValue, guildId)?.value
 
     private fun resolveChannel(guild: Guild, key: Configurations): TextChannel? {
-        val raw = readConfig(guild.id, key)
-        val configured = raw?.takeIf { it.isNotBlank() }
+        val configured = readConfig(guild.id, key)
+            ?.takeIf { it.isNotBlank() }
             ?.toLongOrNull()
             ?.let { guild.getTextChannelById(it) }
-            ?.takeIf { canPost(guild, it) }
-        if (configured != null) return configured
-        return guild.systemChannel?.takeIf { canPost(guild, it) }
+        val candidates = listOfNotNull(configured, guild.systemChannel)
+        candidates.firstOrNull { canPost(guild, it) }?.let { return it }
+        // Same contract as NotificationRouter.resolveChannel: when no
+        // candidate passes the permission check but one exists, attempt
+        // the send there rather than dropping the announcement — a
+        // computed-permission false negative degrades to a logged send
+        // failure instead of a silent drop.
+        return candidates.firstOrNull()?.also {
+            logger.warn {
+                "No ${key.configValue} candidate for guild ${guild.id} passes the permission check; " +
+                    "attempting best-effort post to #${it.name} anyway."
+            }
+        }
     }
 
     private fun canPost(guild: Guild, channel: TextChannel): Boolean {

--- a/discord-bot/src/main/kotlin/bot/toby/notify/AntiAutoclickNotifier.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/notify/AntiAutoclickNotifier.kt
@@ -180,16 +180,32 @@ class AntiAutoclickNotifier(
     }
 
     private fun resolveChannel(guild: Guild): TextChannel? {
-        val configuredId = configService.getConfigByName(
+        val configured = configService.getConfigByName(
             ConfigDto.Configurations.CASINO_MODLOG_CHANNEL_ID.configValue,
             guild.idLong.toString(),
-        )?.value?.toLongOrNull()
-        if (configuredId != null) {
-            val configured = guild.getTextChannelById(configuredId)
-            if (configured != null && hasWritePermissions(guild, configured)) return configured
-            logger.warn("Configured CASINO_MODLOG_CHANNEL_ID=$configuredId for guild ${guild.idLong} is not usable; falling back to system channel.")
+        )?.value?.toLongOrNull()?.let { id ->
+            guild.getTextChannelById(id).also {
+                if (it == null) {
+                    logger.warn(
+                        "Configured CASINO_MODLOG_CHANNEL_ID=$id for guild ${guild.idLong} no longer " +
+                            "exists; falling back to system channel."
+                    )
+                }
+            }
         }
-        return guild.systemChannel?.takeIf { hasWritePermissions(guild, it) }
+        val candidates = listOfNotNull(configured, guild.systemChannel)
+        candidates.firstOrNull { hasWritePermissions(guild, it) }?.let { return it }
+        // Same contract as NotificationRouter.resolveChannel: when no
+        // candidate passes the permission check but one exists, attempt
+        // the send there rather than dropping the mod-log post — a
+        // computed-permission false negative degrades to a logged send
+        // failure instead of a silent drop.
+        return candidates.firstOrNull()?.also {
+            logger.warn(
+                "No casino mod-log candidate for guild ${guild.idLong} passes the permission check; " +
+                    "attempting best-effort post to #${it.name} anyway."
+            )
+        }
     }
 
     private fun hasWritePermissions(guild: Guild, channel: TextChannel): Boolean =

--- a/discord-bot/src/main/kotlin/bot/toby/scheduling/MonthlyLeaderboardJob.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/scheduling/MonthlyLeaderboardJob.kt
@@ -200,15 +200,21 @@ class MonthlyLeaderboardJob @Autowired constructor(
         val configured = configService.getConfigByName(
             ConfigDto.Configurations.LEADERBOARD_CHANNEL.configValue,
             guild.id
-        )?.value?.toLongOrNull()
-        configured?.let {
-            val channel = guild.getTextChannelById(it)
-            if (channel != null && bot.hasPermission(channel, Permission.MESSAGE_SEND, Permission.MESSAGE_EMBED_LINKS)) {
-                return channel
-            }
-        }
-        return guild.systemChannel?.takeIf {
+        )?.value?.toLongOrNull()?.let { guild.getTextChannelById(it) }
+        val candidates = listOfNotNull(configured, guild.systemChannel)
+        candidates.firstOrNull {
             bot.hasPermission(it, Permission.MESSAGE_SEND, Permission.MESSAGE_EMBED_LINKS)
+        }?.let { return it }
+        // Same contract as NotificationRouter.resolveChannel: when no
+        // candidate passes the permission check but one exists, attempt
+        // the send there rather than dropping the post — a computed-
+        // permission false negative degrades to a logged send failure
+        // instead of a silent drop.
+        return candidates.firstOrNull()?.also {
+            logger.warn(
+                "No leaderboard channel for guild ${guild.idLong} passes the send/embed permission check; " +
+                    "attempting best-effort post to #${it.name} anyway."
+            )
         }
     }
 

--- a/discord-bot/src/test/kotlin/bot/toby/handler/WelcomeAndAutoRoleHandlerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/handler/WelcomeAndAutoRoleHandlerTest.kt
@@ -179,12 +179,49 @@ class WelcomeAndAutoRoleHandlerTest {
     }
 
     @Test
-    fun `welcome enabled with no postable channel skips silently`() {
+    fun `welcome enabled with unwritable system channel still attempts it as the last resort`() {
+        // Same contract as NotificationRouter: a computed-permission "no"
+        // must degrade to an attempted send (failure logged by JDA's
+        // callback), never a silent drop, while a channel exists.
         stubFlag(Configurations.WELCOME_ENABLED, "true")
         stubKey(Configurations.WELCOME_CHANNEL, "")
         every {
             selfMember.hasPermission(systemChannel, *anyVararg<Permission>())
         } returns false
+        every { autoRoleService.listForGuild(guildId) } returns emptyList()
+
+        val event = mockk<GuildMemberJoinEvent>(relaxed = true).also {
+            every { it.guild } returns guild
+            every { it.member } returns joinedMember
+        }
+        handler.onGuildMemberJoin(event)
+
+        verify(exactly = 1) { systemChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `welcome best-effort prefers the unwritable configured channel over the system channel`() {
+        stubFlag(Configurations.WELCOME_ENABLED, "true")
+        stubKey(Configurations.WELCOME_CHANNEL, configuredChannelId.toString())
+        every { guild.getTextChannelById(configuredChannelId) } returns configuredChannel
+        every { selfMember.hasPermission(any<TextChannel>(), *anyVararg<Permission>()) } returns false
+        every { autoRoleService.listForGuild(guildId) } returns emptyList()
+
+        val event = mockk<GuildMemberJoinEvent>(relaxed = true).also {
+            every { it.guild } returns guild
+            every { it.member } returns joinedMember
+        }
+        handler.onGuildMemberJoin(event)
+
+        verify(exactly = 1) { configuredChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 0) { systemChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `welcome enabled with no channel existing at all skips silently`() {
+        stubFlag(Configurations.WELCOME_ENABLED, "true")
+        stubKey(Configurations.WELCOME_CHANNEL, "")
+        every { guild.systemChannel } returns null
         every { autoRoleService.listForGuild(guildId) } returns emptyList()
 
         val event = mockk<GuildMemberJoinEvent>(relaxed = true).also {

--- a/discord-bot/src/test/kotlin/bot/toby/notify/AntiAutoclickNotifierTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/notify/AntiAutoclickNotifierTest.kt
@@ -193,11 +193,31 @@ class AntiAutoclickNotifierTest {
     }
 
     @Test
-    fun `SessionOpened skips when bot lacks permission on the system channel`() {
+    fun `SessionOpened still attempts the system channel when permissions compute false`() {
+        // Same contract as NotificationRouter: a computed-permission "no"
+        // must degrade to an attempted send (failure logged by JDA's
+        // callback), never a silent drop, while a channel exists.
         every { selfMember.hasPermission(systemChannel, *anyVararg<Permission>()) } returns false
 
         notifier.onOpened(openEvent())
 
+        verify(exactly = 1) { systemChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `best-effort prefers the unwritable configured mod-log channel over the system channel`() {
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.CASINO_MODLOG_CHANNEL_ID.configValue,
+                guildId.toString(),
+            )
+        } returns ConfigDto(name = "x", value = configChannelId.toString(), guildId = guildId.toString())
+        every { selfMember.hasPermission(configChannel, *anyVararg<Permission>()) } returns false
+        every { selfMember.hasPermission(systemChannel, *anyVararg<Permission>()) } returns false
+
+        notifier.onOpened(openEvent())
+
+        verify(exactly = 1) { configChannel.sendMessageEmbeds(any<MessageEmbed>()) }
         verify(exactly = 0) { systemChannel.sendMessageEmbeds(any<MessageEmbed>()) }
     }
 

--- a/discord-bot/src/test/kotlin/bot/toby/scheduling/MonthlyLeaderboardJobTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/scheduling/MonthlyLeaderboardJobTest.kt
@@ -352,8 +352,8 @@ class MonthlyLeaderboardJobTest {
         every { snapshotService.listForGuildDate(guildId, any()) } returns emptyList()
         every { voiceSessionService.sumCountedSecondsInRangeByUser(guildId, any(), any()) } returns emptyMap()
         every { configService.getConfigByName(any(), guildId.toString()) } returns null
-        // System channel has no perms → resolveChannel returns null → no post, but snapshot still written.
-        every { guild.selfMember.hasPermission(channel, *anyVararg<Permission>()) } returns false
+        // No channel exists at all → nothing to post to, but snapshot still written.
+        every { guild.systemChannel } returns null
 
         val snapshots = mutableListOf<MonthlyCreditSnapshotDto>()
         every { snapshotService.upsertIfMissing(capture(snapshots)) } answers { firstArg() }
@@ -362,6 +362,48 @@ class MonthlyLeaderboardJobTest {
 
         verify(exactly = 0) { channel.sendMessageEmbeds(any<MessageEmbed>()) }
         assertEquals(1, snapshots.size)
+    }
+
+    @Test
+    fun `system channel failing the permission check is still attempted as the last resort`() {
+        // Same contract as NotificationRouter: a computed-permission "no"
+        // must degrade to an attempted send (failure logged by JDA's
+        // callback), never a silent drop, while a channel exists.
+        val alice = UserDto(discordId = 1L, guildId = guildId).apply { socialCredit = 500L }
+        every { userService.listGuildUsers(guildId) } returns listOf(alice)
+        member(1L, "Alice")
+        every { snapshotService.listForGuildDate(guildId, any()) } returns emptyList()
+        every { voiceSessionService.sumCountedSecondsInRangeByUser(guildId, any(), any()) } returns emptyMap()
+        every { configService.getConfigByName(any(), guildId.toString()) } returns null
+        every { guild.selfMember.hasPermission(channel, *anyVararg<Permission>()) } returns false
+
+        job.postMonthlyLeaderboard()
+
+        verify(exactly = 1) { channel.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `unwritable configured channel is preferred over the system channel in the best-effort attempt`() {
+        val alice = UserDto(discordId = 1L, guildId = guildId).apply { socialCredit = 500L }
+        every { userService.listGuildUsers(guildId) } returns listOf(alice)
+        member(1L, "Alice")
+        every { snapshotService.listForGuildDate(guildId, any()) } returns emptyList()
+        every { voiceSessionService.sumCountedSecondsInRangeByUser(guildId, any(), any()) } returns emptyMap()
+
+        val configuredChannel = mockk<TextChannel>(relaxed = true)
+        val configDto = ConfigDto(name = "LEADERBOARD_CHANNEL", value = "777", guildId = guildId.toString())
+        every { configService.getConfigByName(any(), guildId.toString()) } answers {
+            if (firstArg<String>() == "LEADERBOARD_CHANNEL") configDto else null
+        }
+        every { guild.getTextChannelById(777L) } returns configuredChannel
+        // Nothing passes the perm check; the attempt goes to the
+        // admin-configured channel, not the system channel.
+        every { guild.selfMember.hasPermission(any<TextChannel>(), *anyVararg<Permission>()) } returns false
+
+        job.postMonthlyLeaderboard()
+
+        verify(exactly = 1) { configuredChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 0) { channel.sendMessageEmbeds(any<MessageEmbed>()) }
     }
 
     // ---------------------------------------------------------------------


### PR DESCRIPTION
## Context

Follow-up to #710, answering "will all the other channel posting surfaces be fixed too?"

#710's fix lives in `NotificationRouter.resolveChannel`, so it covers every surface that posts through the router: level-up announcements, achievement shoutouts, lottery draw announcements + winner pings, web tips, web duel offers, and web/activity PvP challenge pings.

Three posters do **not** route through the router and carry their own private copy of the same pre-fix pattern — configured channel and system channel both gated on computed permissions, with a silent drop when neither passes:

- `MonthlyLeaderboardJob` — monthly leaderboard post (`LEADERBOARD_CHANNEL` → system)
- `WelcomeAndAutoRoleHandler` — welcome / goodbye announcements (`WELCOME_CHANNEL`/`GOODBYE_CHANNEL` → system)
- `AntiAutoclickNotifier` — casino mod-log embeds (`CASINO_MODLOG_CHANNEL_ID` → system)

## Changes

Each resolver now applies the same contract #710 restored in the router:

- The first candidate that **passes** the permission check still wins (route-around preserved).
- When **none** passes, the post is attempted best-effort on the first channel that *exists* — configured before system — with a WARN naming the channel. A computed-permission false negative degrades to a logged send failure instead of a silent drop.
- Only a guild with no candidate channel at all skips.

`InstallWelcomeHandler` is intentionally untouched: it already scans every text channel for a writable one and falls back to DMing the owner.

## Tests

Per-class behaviour pins, replacing the old silent-drop pins:
- unwritable system channel is still attempted as the last resort,
- the unwritable *configured* channel is preferred over the system channel in the best-effort attempt,
- no channel existing at all still skips (and, for the leaderboard job, the boundary snapshot is still written).

Full `:discord-bot` suite passes.

https://claude.ai/code/session_01DeLNvgGNwUaFJo4wKSWcN5

---
_Generated by [Claude Code](https://claude.ai/code/session_01DeLNvgGNwUaFJo4wKSWcN5)_