### PR TITLE
Polish the unified card search on mobile

### DIFF
--- a/web/src/main/resources/static/css/magic.css
+++ b/web/src/main/resources/static/css/magic.css
@@ -1643,6 +1643,13 @@ details[open] > .cube-section-summary .cube-collapse-chevron {
         align-items: stretch;
     }
 
+    /* Stacked into a column, the search filters must size to their content —
+       otherwise the desktop `flex: 1 1 180px` (meant to share one row) grows
+       each field down the panel's full height, ballooning the inputs. */
+    .cube-search-form label {
+        flex: 0 0 auto;
+    }
+
     .cube-submit {
         align-self: start;
     }

--- a/web/src/main/resources/static/css/magic.css
+++ b/web/src/main/resources/static/css/magic.css
@@ -1654,6 +1654,23 @@ details[open] > .cube-section-summary .cube-collapse-chevron {
         align-self: start;
     }
 
+    /* Tighten the card detail panel on phones. By default the 240px image
+       wraps to its own full-width row, pushing the facts — and the
+       rulings/combos buttons below them — a whole screen down. Shrink the
+       image and drop the facts' min-width so the two sit side by side as a
+       compact thumbnail + details block, keeping the actions in view. */
+    .cube-cardlookup {
+        gap: var(--space-3);
+    }
+
+    .cube-cardlookup-img {
+        width: 140px;
+    }
+
+    .cube-cardlookup-facts {
+        min-width: 0;
+    }
+
     .cube-bar-row,
     .cube-group-head {
         grid-template-columns: 90px 1fr;

--- a/web/src/main/resources/static/js/magic.js
+++ b/web/src/main/resources/static/js/magic.js
@@ -2229,10 +2229,14 @@
             // A flip-button tap is handled by wireCardFlip, not the lightbox.
             if (e.target.closest && e.target.closest('.cube-card-flip')) return;
             const card = e.target.closest && e.target.closest('.cube-card[data-large]');
-            if (card && prefersTap()) {
-                e.preventDefault();
-                open(card);
-            }
+            if (!card || !prefersTap()) return;
+            // Search-result tiles open the full detail panel (price, rulings,
+            // combos) instead — same as a desktop click — so the bare-image
+            // lightbox is reserved for the preview/generate grids, which have
+            // no panel to open.
+            if (card.closest && card.closest('[data-result="search"]')) return;
+            e.preventDefault();
+            open(card);
         });
         closeBtn.addEventListener('click', close);
         modal.addEventListener('click', function (e) {

--- a/web/src/test/js/magic.test.js
+++ b/web/src/test/js/magic.test.js
@@ -1380,6 +1380,26 @@ describe('tap-to-enlarge (touch / no-hover devices)', () => {
 
         document.body.removeChild(card);
     });
+
+    test('a search-result tile is left to the detail panel — no lightbox', () => {
+        fakeHoverNone(true);
+        // A tile inside the search grid opens the full detail panel (price,
+        // rulings, combos) on tap, the same as a desktop click — so the
+        // bare-image lightbox must not also fire over the top.
+        const grid = document.createElement('div');
+        grid.setAttribute('data-result', 'search');
+        const card = document.createElement('a');
+        card.className = 'cube-card';
+        card.setAttribute('data-large', 'https://img/big.jpg');
+        card.href = 'https://scryfall.com/x';
+        grid.appendChild(card);
+        document.body.appendChild(grid);
+
+        card.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+        expect(document.querySelector('.cube-lightbox').hidden).toBe(true);
+
+        document.body.removeChild(grid);
+    });
 });
 
 describe('renderDistribution (the secondary balance bars)', () => {


### PR DESCRIPTION
Three mobile refinements to the unified card search/viewer.

## 1. Ballooning filter inputs

On mobile, the search form's three filter inputs (Name includes / Card type / Advanced) grew to enormous heights, each taking most of the viewport.

The desktop layout gives each search label `flex: 1 1 180px` so the filters share one row, growing horizontally. The mobile breakpoint switches `.cube-form` to `flex-direction: column` — and that same `flex-grow: 1` then applies to the **vertical** axis, growing every field down the panel's full height.

**Fix:** in the `max-width: 600px` query, reset `.cube-search-form label` to `flex: 0 0 auto` so stacked filters size to their content (still full width via `align-items: stretch`).

## 2. Detail panel buried the actions

When you tap a card (or narrow the search to one match), the detail panel's 240px image wrapped to its own full-width row on phones, pushing the facts — and the **Show rulings** / **Show combos** buttons below them — a whole screen down.

**Fix:** on mobile, shrink the image to 140px and drop the facts' `min-width` so the image and details sit side by side as a compact thumbnail + details block.

## 3. Tap on a search result opened a bare image, not the panel

On touch devices the document-level tap-to-enlarge **lightbox** fired on every card tap. For a search-result tile it popped the bare image over the detail panel that was *also* loading underneath — so mobile got just an image where a desktop click gets the full panel (price, rulings, combos).

**Fix:** the lightbox now skips tiles inside `[data-result="search"]`, so a tap there opens the detail panel on both desktop and mobile. The lightbox still serves the preview/generate grids, which have no panel to open. Added a Jest test for the exclusion.

## Testing

- `npx jest src/test/js/magic.test.js` → **125 passed**
- `npx stylelint src/main/resources/static/css/magic.css` → clean

https://claude.ai/code/session_01WybziU9C2THDXRKH11cPRi