### PR TITLE
Activity: back-links return to the games selector, not the cross-guild pickers

### DIFF
--- a/web/src/main/resources/static/js/api.js
+++ b/web/src/main/resources/static/js/api.js
@@ -35,6 +35,34 @@
         }
     }
 
+    // The activity is single-guild by nature (the launch guild comes from
+    // the Discord voice channel), and the cross-guild pickers can't render
+    // on the activity auth path anyway — they need an OAuth2 authorized
+    // client that activity sessions don't register, so a fresh activity
+    // user would bounce into the external OAuth redirect and the sandbox
+    // would kill the iframe. Remember the launch guild (the selector page
+    // /activity/casino/{guildId} is always the first page in the nested
+    // frame) so picker-bound links can be retargeted to it.
+    function activityGuildId() {
+        try {
+            const fromPath = window.location.pathname.match(/^\/activity\/casino\/(\d+)$/);
+            if (fromPath) {
+                try { sessionStorage.setItem('tobyActivityGuildId', fromPath[1]); } catch (e) { /* sandboxed */ }
+                return fromPath[1];
+            }
+            return sessionStorage.getItem('tobyActivityGuildId') || '';
+        } catch (e) {
+            return '';
+        }
+    }
+    activityGuildId(); // stash at load so later game pages can read it back
+
+    // Matches the `/{section}/guilds` picker landings ("← All servers",
+    // navbar dropdown entries). Query strings (?pick=true, ?game=…) ride
+    // on top of these paths and are dropped on retarget — the activity
+    // selector lists every game already.
+    const GUILD_PICKER_PATH = /^\/[a-z-]+\/guilds$/;
+
     function withActivityAuth(headers) {
         const token = activityToken();
         if (token) headers['Authorization'] = 'Bearer ' + token;
@@ -94,8 +122,11 @@
     // Full-page navigations can't carry a bearer header, so when an
     // activity token is live, append it to same-origin links as they're
     // clicked (capture phase, before the browser follows the href). This
-    // keeps "← All servers" / navbar navigation working inside the
-    // Activity iframe without threading the token through every template.
+    // keeps navbar navigation working inside the Activity iframe without
+    // threading the token through every template. Links bound for a
+    // cross-guild picker are retargeted to the activity's own games
+    // selector first (see activityGuildId for why pickers can't render
+    // inside the activity).
     function rewriteActivityLinks() {
         document.addEventListener('click', function (e) {
             // Resolved per click, not at load: outside the activity this is
@@ -113,12 +144,45 @@
                 return;
             }
             if (url.origin !== window.location.origin) return;
+            if (GUILD_PICKER_PATH.test(url.pathname)) {
+                const guildId = activityGuildId();
+                if (guildId) url = new URL('/activity/casino/' + guildId, window.location.href);
+            }
             if (url.searchParams.get('activityToken')) return;
             url.searchParams.set('activityToken', token);
             anchor.setAttribute('href', url.pathname + url.search + url.hash);
         }, true);
     }
     rewriteActivityLinks();
+
+    // The click-time retarget above is the safety net; the visible
+    // "← All servers" back-links also get rewritten at load so the label
+    // and hover target are honest about where the link now goes. Only the
+    // dedicated back-link anchors are touched (music-player styles its
+    // back-link as btn-tertiary) — navbar entries keep their labels and
+    // rely on the click-time retarget.
+    function retargetActivityBackLinks() {
+        const token = activityToken();
+        const guildId = activityGuildId();
+        if (!token || !guildId) return;
+        document.querySelectorAll('a.back-link[href], a.btn-tertiary[href]').forEach(function (anchor) {
+            let url;
+            try {
+                url = new URL(anchor.getAttribute('href'), window.location.href);
+            } catch (err) {
+                return;
+            }
+            if (url.origin !== window.location.origin) return;
+            if (!GUILD_PICKER_PATH.test(url.pathname)) return;
+            anchor.setAttribute('href', '/activity/casino/' + guildId);
+            anchor.textContent = '← All games';
+        });
+    }
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', retargetActivityBackLinks);
+    } else {
+        retargetActivityBackLinks();
+    }
 
     window.TobyApi = { postJson: postJson, del: del, activityToken: activityToken, authHeaders: authHeaders };
 

--- a/web/src/main/resources/templates/activity-casino.html
+++ b/web/src/main/resources/templates/activity-casino.html
@@ -12,9 +12,12 @@
     the NESTED frame only, so the SDK connection in the shell document
     is untouched.
 
-    api.js is loaded so the ?activityToken= the shell appended gets
-    stashed in sessionStorage and re-appended to every game link on
-    click — each game page then authenticates the same way this one did.
+    api.js is loaded so the ?activityToken= the shell appended (and the
+    launch guild id from this page's path) get stashed in sessionStorage:
+    the token is re-appended to every game link on click — each game page
+    then authenticates the same way this one did — and the guild id lets
+    game pages retarget their "← All servers" back-links here instead of
+    at the cross-guild pickers the activity can't render.
 -->
 <head>
     <meta charset="UTF-8">

--- a/web/src/test/js/activity-back-link.test.js
+++ b/web/src/test/js/activity-back-link.test.js
@@ -1,0 +1,111 @@
+/**
+ * Inside the Discord Activity the cross-guild pickers ("← All servers",
+ * /{section}/guilds) can't render: they need an OAuth2 authorized client
+ * that activity sessions don't register, so following one bounces a fresh
+ * activity user into the external OAuth redirect and the sandbox kills
+ * the iframe. api.js therefore retargets picker-bound links to the
+ * activity's own games selector (/activity/casino/{guildId}) — the
+ * launch guild is stashed when the selector page (always the first page
+ * in the nested frame) loads. Outside the activity nothing may change.
+ */
+
+const API_PATH = '../../main/resources/static/js/api.js';
+
+function loadApi() {
+    let api;
+    jest.isolateModules(() => {
+        api = require(API_PATH);
+    });
+    return api;
+}
+
+function clickThrough(anchor) {
+    document.addEventListener('click', (e) => e.preventDefault());
+    anchor.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+}
+
+describe('api.js activity back-link retargeting', () => {
+    beforeEach(() => {
+        sessionStorage.clear();
+        document.head.innerHTML = '';
+        document.body.innerHTML = '';
+        window.history.pushState({}, '', '/');
+    });
+
+    test('the selector page stashes the launch guild id', () => {
+        window.history.pushState({}, '', '/activity/casino/42?activityToken=act_abc');
+
+        loadApi();
+
+        expect(sessionStorage.getItem('tobyActivityGuildId')).toBe('42');
+    });
+
+    test('clicked picker links retarget to the games selector with the token', () => {
+        window.history.pushState({}, '', '/casino/42/slots?activityToken=act_abc');
+        sessionStorage.setItem('tobyActivityGuildId', '42');
+        loadApi();
+
+        const anchor = document.createElement('a');
+        anchor.setAttribute('href', '/casino/guilds?pick=true');
+        document.body.appendChild(anchor);
+        clickThrough(anchor);
+
+        expect(anchor.getAttribute('href')).toBe('/activity/casino/42?activityToken=act_abc');
+    });
+
+    test('non-picker links only get the token appended', () => {
+        window.history.pushState({}, '', '/casino/42/slots?activityToken=act_abc');
+        sessionStorage.setItem('tobyActivityGuildId', '42');
+        loadApi();
+
+        const anchor = document.createElement('a');
+        anchor.setAttribute('href', '/blackjack/42');
+        document.body.appendChild(anchor);
+        clickThrough(anchor);
+
+        expect(anchor.getAttribute('href')).toBe('/blackjack/42?activityToken=act_abc');
+    });
+
+    test('without a stashed guild id picker links keep their target (token only)', () => {
+        window.history.pushState({}, '', '/casino/42/slots?activityToken=act_abc');
+        loadApi();
+
+        const anchor = document.createElement('a');
+        anchor.setAttribute('href', '/casino/guilds?pick=true');
+        document.body.appendChild(anchor);
+        clickThrough(anchor);
+
+        expect(anchor.getAttribute('href')).toBe('/casino/guilds?pick=true&activityToken=act_abc');
+    });
+
+    test('visible back-links are retargeted and relabelled at load', () => {
+        window.history.pushState({}, '', '/casino/42/slots?activityToken=act_abc');
+        sessionStorage.setItem('tobyActivityGuildId', '42');
+        document.body.innerHTML =
+            '<a class="back-link" href="/casino/guilds?pick=true">&larr; All servers</a>' +
+            '<a class="back-link" href="/leaderboards">&larr; All leaderboards</a>';
+
+        loadApi();
+
+        const [picker, leaderboards] = document.querySelectorAll('a.back-link');
+        expect(picker.getAttribute('href')).toBe('/activity/casino/42');
+        expect(picker.textContent).toBe('← All games');
+        // Non-picker back-links (leaderboard) are not a cross-guild detour
+        // and stay as authored.
+        expect(leaderboards.getAttribute('href')).toBe('/leaderboards');
+        expect(leaderboards.textContent).toBe('← All leaderboards');
+    });
+
+    test('outside the activity back-links and picker clicks are untouched', () => {
+        document.body.innerHTML =
+            '<a class="back-link" href="/casino/guilds?pick=true">&larr; All servers</a>';
+
+        loadApi();
+
+        const anchor = document.querySelector('a.back-link');
+        clickThrough(anchor);
+
+        expect(anchor.getAttribute('href')).toBe('/casino/guilds?pick=true');
+        expect(anchor.textContent).toBe('← All servers');
+    });
+});


### PR DESCRIPTION
## Why

Follow-up to #709. Inside the activity, the "← All servers" back-links on game pages (and the navbar's `/{section}/guilds` entries) detour into the cross-guild pickers. Those pickers only render on the activity auth path when the user happens to have a server-side `OAuth2AuthorizedClient` from a past website login — a fresh activity-only user bounces into the external OAuth redirect and the sandbox kills the iframe. And the activity is single-guild by nature: "all servers" isn't a meaningful destination there.

## What

In api.js (the established home for activity-aware link rewriting):

- The launch guild id is stashed in sessionStorage when the games selector (`/activity/casino/{guildId}` — always the first page in the nested frame) loads, alongside the existing token stash.
- Visible back-links (`a.back-link`, plus music-player's `btn-tertiary`) pointing at a `/{section}/guilds` picker are rewritten at load to the games selector and relabelled "← All games", so the hover target and label are honest.
- The existing click-time rewriter retargets any other picker-bound link (navbar dropdown entries, dynamically added links) the same way before appending the activity token.

Outside the activity (no token / no stashed guild) every link behaves exactly as before — covered by tests.

## Testing

- New `activity-back-link.test.js` jest suite (stash, click retarget, load-time relabel, no-guild and outside-activity no-ops).
- Full web jest suite green: 54 suites, 776 tests.

https://claude.ai/code/session_01QQcvBfo4iXgKVfibA5yvis

---
_Generated by [Claude Code](https://claude.ai/code/session_01QQcvBfo4iXgKVfibA5yvis)_