### PR TITLE
Refresh profile Level and Economy cards on streak claim

### DIFF
--- a/web/src/main/kotlin/web/controller/EngagementApiController.kt
+++ b/web/src/main/kotlin/web/controller/EngagementApiController.kt
@@ -1,10 +1,12 @@
 package web.controller
 
+import common.leveling.LevelCurve
 import common.notification.NotificationChannelKind
 import common.notification.Surface
 import database.service.guild.AchievementService
 import database.service.social.LoginStreakService
 import database.service.user.UserNotificationPrefService
+import database.service.user.UserService
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.oauth2.core.user.OAuth2User
@@ -39,6 +41,7 @@ class EngagementApiController(
     private val loginStreakService: LoginStreakService,
     private val achievementService: AchievementService,
     private val notificationPrefService: UserNotificationPrefService,
+    private val userService: UserService,
     private val membership: GuildMembership,
 ) {
 
@@ -50,9 +53,14 @@ class EngagementApiController(
         val discordId = user?.discordIdOrNull() ?: return ResponseEntity.status(401).build()
         if (!membership.isMember(discordId, guildId)) return ResponseEntity.status(403).build()
 
+        // The claim mutates XP and credits in the user row; re-read it so the
+        // response carries the post-claim level/XP/balance and the profile
+        // page can refresh the Level and Economy cards in place — no reload.
         return when (val result = loginStreakService.claim(discordId, guildId)) {
             is LoginStreakService.ClaimResult.Granted -> ResponseEntity.ok(
-                DailyClaimResponse(
+                dailyClaimResponse(
+                    discordId = discordId,
+                    guildId = guildId,
                     status = "granted",
                     currentStreak = result.currentStreak,
                     longestStreak = result.longestStreak,
@@ -62,7 +70,9 @@ class EngagementApiController(
                 )
             )
             is LoginStreakService.ClaimResult.AlreadyClaimed -> ResponseEntity.ok(
-                DailyClaimResponse(
+                dailyClaimResponse(
+                    discordId = discordId,
+                    guildId = guildId,
                     status = "already_claimed",
                     currentStreak = result.currentStreak,
                     longestStreak = result.longestStreak,
@@ -72,6 +82,38 @@ class EngagementApiController(
                 )
             )
         }
+    }
+
+    private fun dailyClaimResponse(
+        discordId: Long,
+        guildId: Long,
+        status: String,
+        currentStreak: Int,
+        longestStreak: Int,
+        xpGranted: Long,
+        creditsGranted: Long,
+        newBest: Boolean,
+    ): DailyClaimResponse {
+        val user = userService.getUserById(discordId, guildId)
+        val totalXp = user?.xp ?: 0L
+        val balance = user?.socialCredit ?: 0L
+        val progress = LevelCurve.progress(totalXp)
+        return DailyClaimResponse(
+            status = status,
+            currentStreak = currentStreak,
+            longestStreak = longestStreak,
+            xpGranted = xpGranted,
+            creditsGranted = creditsGranted,
+            newBest = newBest,
+            totalXp = totalXp,
+            level = progress.level,
+            xpIntoLevel = progress.xpIntoLevel,
+            xpForNextLevel = progress.xpForNextLevel,
+            xpProgressPercent = if (progress.xpForNextLevel > 0)
+                ((progress.xpIntoLevel.toDouble() / progress.xpForNextLevel) * 100).toInt().coerceIn(0, 100)
+            else 100,
+            balance = balance,
+        )
     }
 
     @GetMapping("/daily")
@@ -187,7 +229,15 @@ class EngagementApiController(
         val longestStreak: Int,
         val xpGranted: Long,
         val creditsGranted: Long,
-        val newBest: Boolean
+        val newBest: Boolean,
+        // Post-claim snapshot of the user's level/XP/balance so the profile
+        // page can update the Level and Economy cards without a reload.
+        val totalXp: Long = 0L,
+        val level: Int = 0,
+        val xpIntoLevel: Long = 0L,
+        val xpForNextLevel: Long = 0L,
+        val xpProgressPercent: Int = 0,
+        val balance: Long = 0L,
     )
 
     data class StreakStatusResponse(

--- a/web/src/main/resources/static/js/profile.js
+++ b/web/src/main/resources/static/js/profile.js
@@ -39,6 +39,51 @@
         if (!isNaN(n)) total.textContent = String(n + 1);
     }
 
+    // Reflect the claim's XP award on the Level card so level, progress bar,
+    // and totals stay accurate without a reload. The claim response carries
+    // the authoritative post-claim figures computed server-side.
+    function updateLevelCard(resp) {
+        const levelCard = document.querySelector('.level-card');
+        if (!levelCard) return;
+        if (typeof resp.xpForNextLevel !== 'number' || resp.xpForNextLevel <= 0) return;
+
+        const badge = levelCard.querySelector('.level-badge-value');
+        if (badge) badge.textContent = String(resp.level);
+
+        const current = levelCard.querySelector('.level-current');
+        if (current) current.textContent = resp.xpIntoLevel + ' XP';
+
+        const next = levelCard.querySelector('.level-next');
+        if (next) next.textContent = resp.xpForNextLevel + ' XP';
+
+        const progress = levelCard.querySelector('.level-progress');
+        if (progress) progress.setAttribute('aria-valuenow', String(resp.xpProgressPercent));
+
+        const bar = levelCard.querySelector('.level-progress-bar');
+        if (bar) bar.style.width = resp.xpProgressPercent + '%';
+
+        const totalXp = levelCard.querySelector('.level-total-xp');
+        if (totalXp) totalXp.textContent = String(resp.totalXp);
+
+        // Keep the tier styling (bronze/silver/gold/diamond) in sync with the
+        // new level — mirrors the Thymeleaf threshold logic.
+        const tier = resp.level >= 50 ? 'diamond'
+            : resp.level >= 25 ? 'gold'
+            : resp.level >= 10 ? 'silver' : 'bronze';
+        levelCard.classList.remove(
+            'level-tier-bronze', 'level-tier-silver', 'level-tier-gold', 'level-tier-diamond'
+        );
+        levelCard.classList.add('level-tier-' + tier);
+    }
+
+    // Reflect granted credits on the Economy card's balance line.
+    function updateBalance(resp) {
+        if (typeof resp.balance !== 'number') return;
+        const el = document.querySelector('.profile-balance');
+        if (!el) return;
+        el.textContent = resp.balance + ' credits';
+    }
+
     // "N days to your next 7-day milestone" — mirrors the Thymeleaf
     // calculation so the line stays correct after an in-place claim.
     function updateMilestone(card, currentStreak) {
@@ -135,6 +180,12 @@
                     if (countdownId) { window.clearInterval(countdownId); countdownId = null; }
                     card.querySelectorAll('.profile-streak-alert, .profile-streak-preview')
                         .forEach(function (n) { n.remove(); });
+
+                    // The claim mutates XP and credits server-side; mirror
+                    // those onto the Level and Economy cards so the page
+                    // doesn't need a manual refresh to reflect the reward.
+                    updateLevelCard(resp);
+                    updateBalance(resp);
 
                     if (!alreadyClaimed) {
                         bumpTotal(card);

--- a/web/src/main/resources/templates/profile.html
+++ b/web/src/main/resources/templates/profile.html
@@ -35,7 +35,7 @@
             <h2>Economy</h2>
             <div class="profile-row">
                 <span class="muted">Balance</span>
-                <strong th:text="${profile.balance} + ' credits'">0 credits</strong>
+                <strong class="profile-balance" th:text="${profile.balance} + ' credits'">0 credits</strong>
             </div>
             <div class="profile-row">
                 <span class="muted">Equipped title</span>

--- a/web/src/test/kotlin/web/controller/EngagementApiControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/EngagementApiControllerTest.kt
@@ -4,12 +4,14 @@ import common.notification.NotificationChannelKind
 import common.notification.Surface
 import database.dto.guild.AchievementDto
 import database.dto.social.LoginStreakDto
+import database.dto.user.UserDto
 import database.dto.user.UserNotificationPrefDto
 import database.service.guild.AchievementService
 import database.service.guild.AchievementService.AchievementView
 import database.service.social.LoginStreakService
 import database.service.social.LoginStreakService.ClaimResult
 import database.service.user.UserNotificationPrefService
+import database.service.user.UserService
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -33,6 +35,7 @@ class EngagementApiControllerTest {
     private lateinit var loginStreakService: LoginStreakService
     private lateinit var achievementService: AchievementService
     private lateinit var notificationPrefService: UserNotificationPrefService
+    private lateinit var userService: UserService
     private lateinit var membership: GuildMembership
     private lateinit var user: OAuth2User
     private lateinit var controller: EngagementApiController
@@ -42,13 +45,14 @@ class EngagementApiControllerTest {
         loginStreakService = mockk(relaxed = true)
         achievementService = mockk(relaxed = true)
         notificationPrefService = mockk(relaxed = true)
+        userService = mockk(relaxed = true)
         membership = mockk(relaxed = true)
         user = mockk {
             every { getAttribute<String>("id") } returns discordId.toString()
         }
         every { membership.isMember(discordId, guildId) } returns true
         controller = EngagementApiController(
-            loginStreakService, achievementService, notificationPrefService, membership
+            loginStreakService, achievementService, notificationPrefService, userService, membership
         )
     }
 
@@ -79,6 +83,9 @@ class EngagementApiControllerTest {
                 creditsGranted = 45L,
                 isNewBest = true
             )
+        // Post-claim user state drives the Level/Economy card refresh fields.
+        every { userService.getUserById(discordId, guildId) } returns
+            UserDto(discordId = discordId, guildId = guildId, xp = 355L, socialCredit = 500L)
 
         val response = controller.claimDaily(guildId, user)
 
@@ -90,6 +97,13 @@ class EngagementApiControllerTest {
         assertEquals(70L, body.xpGranted)
         assertEquals(45L, body.creditsGranted)
         assertTrue(body.newBest)
+        // Authoritative post-claim level snapshot (xp 355 -> level 2, 100/220 in).
+        assertEquals(355L, body.totalXp)
+        assertEquals(2, body.level)
+        assertEquals(100L, body.xpIntoLevel)
+        assertEquals(220L, body.xpForNextLevel)
+        assertEquals(45, body.xpProgressPercent)
+        assertEquals(500L, body.balance)
     }
 
     @Test

--- a/web/src/test/kotlin/web/static/ProfileStreakCardTemplateTest.kt
+++ b/web/src/test/kotlin/web/static/ProfileStreakCardTemplateTest.kt
@@ -156,6 +156,28 @@ class ProfileStreakCardTemplateTest {
     }
 
     @Test
+    fun `claim JS refreshes the Level and Economy cards in place`() {
+        val js = resource("static/js/profile.js")
+        assertTrue(
+            js.contains("updateLevelCard") && js.contains("updateBalance"),
+            "profile.js must update the Level and Economy cards after a claim — the " +
+                "claim awards XP and credits, and previously only the streak card moved " +
+                "so the user had to reload to see their new XP/balance.",
+        )
+        assertTrue(
+            js.contains(".level-progress-bar") && js.contains(".level-total-xp") &&
+                js.contains(".level-badge-value"),
+            "the Level card refresh must drive the progress bar, total XP, and level " +
+                "badge off the claim response's post-claim snapshot.",
+        )
+        assertTrue(
+            html.contains("class=\"profile-balance\""),
+            "profile.html must mark the balance with `.profile-balance` so the claim " +
+                "handler can update it without a reload.",
+        )
+    }
+
+    @Test
     fun `profile css styles the streak card so it is not plain`() {
         // The bug this redesign fixed: the markup existed but no CSS did,
         // so the card rendered unstyled. Pin that the styling is present.


### PR DESCRIPTION
## Problem

Claiming the daily streak on the profile card grants XP and credits, but the client only updated the **streak card**. The **Level card** (level badge, XP-into-level, progress bar, total XP) and the **Economy card** balance stayed stale until you manually refreshed the page — exactly the "claiming streak doesn't update my XP" symptom.

## Fix

- **`EngagementApiController`** — after a claim (granted or already-claimed), re-read the user row and return the authoritative post-claim snapshot: `totalXp`, `level`, `xpIntoLevel`, `xpForNextLevel`, `xpProgressPercent`, and `balance`. These are computed with the same `LevelCurve` the server-rendered profile uses, so the values always agree.
- **`profile.js`** — `updateLevelCard()` drives the level badge, current/next XP, progress bar (width + `aria-valuenow`), total XP, and the bronze/silver/gold/diamond tier class; `updateBalance()` updates the Economy card balance. Both run after a successful claim. No reload.
- **`profile.html`** — tagged the balance `<strong>` with `.profile-balance` so the handler can target it.

## Other places checked

I swept the other client mutation handlers for the same class of bug and found the profile streak claim was the genuine instance:
- `titles.js`, `lottery.js` (match/daily), `intros.js` already `location.reload()` after their mutations.
- `tip.js` already updates balance + sent-today + headroom; `economy.js` updates coins + credits + portfolio.
- Casino games update balance via `TobyBalance.update`; casino pages don't display XP (gameplay XP is awarded via `WebGameplayXpInterceptor` and only surfaces on the profile/leaderboard), so nothing goes stale there.

## Tests

- `EngagementApiControllerTest` — wires the new `UserService` dependency and asserts the enriched claim response (xp 355 → level 2, 100/220 into the level, balance 500).
- `ProfileStreakCardTemplateTest` — pins that `profile.js` refreshes the Level/Economy cards and that `.profile-balance` exists.

https://claude.ai/code/session_01XKdEZKFxoEAAYarT5QoUbG

---
_Generated by [Claude Code](https://claude.ai/code/session_01XKdEZKFxoEAAYarT5QoUbG)_