### PR TITLE
Open card details in a dismissible overlay

### DIFF
--- a/web/src/main/resources/static/css/magic.css
+++ b/web/src/main/resources/static/css/magic.css
@@ -1626,6 +1626,53 @@ details[open] > .cube-section-summary .cube-collapse-chevron {
     margin-top: var(--space-2);
 }
 
+/* An explicit click on a search result lifts the same detail panel into a
+   dismissible overlay — a centered, scrollable sheet over a dark backdrop —
+   so the card's info (price, rulings, combos) appears in focus instead of
+   parked below a long grid. A one-match auto-open stays inline (no class). */
+.cube-cardlookup-wrap.is-modal {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 1100;
+    width: min(760px, calc(100vw - 2 * var(--space-4)));
+    max-height: 88vh;
+    overflow-y: auto;
+    margin: 0;
+    padding: var(--space-4);
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-lg);
+}
+
+.cube-detail-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 1099;
+    background: rgba(0, 0, 0, 0.82);
+}
+
+.cube-detail-backdrop[hidden] {
+    display: none;
+}
+
+.cube-detail-close {
+    position: fixed;
+    top: var(--space-3);
+    right: var(--space-3);
+    z-index: 1101;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    border: 1px solid var(--border-strong);
+    background: var(--bg-elevated);
+    color: var(--text);
+    font-size: 1.1rem;
+    cursor: pointer;
+}
+
 @media (max-width: 600px) {
     .cube-hero h1 {
         font-size: 1.7rem;

--- a/web/src/main/resources/static/js/magic.js
+++ b/web/src/main/resources/static/js/magic.js
@@ -1457,6 +1457,49 @@
         field.addEventListener('blur', function () { setTimeout(close, 150); });
     }
 
+    /**
+     * Presents the card-detail panel as a dismissible modal overlay. Creates
+     * one shared backdrop + close button in the document and toggles the
+     * panel's `is-modal` class to lift it into a centered, scrollable sheet
+     * over the backdrop. Dismissed by the close button, a backdrop click, or
+     * Escape, each running `onClose` (to clear the panel and restore focus).
+     * Returns { open, close, isOpen }, or null when there's nowhere to mount.
+     */
+    function cardDetailModal(doc, panel, onClose) {
+        if (!doc.body || !panel) return null;
+        const backdrop = doc.createElement('div');
+        backdrop.className = 'cube-detail-backdrop';
+        backdrop.hidden = true;
+        const closeBtn = doc.createElement('button');
+        closeBtn.type = 'button';
+        closeBtn.className = 'cube-detail-close';
+        closeBtn.setAttribute('aria-label', 'Close');
+        closeBtn.textContent = '✕';
+        backdrop.appendChild(closeBtn);
+        doc.body.appendChild(backdrop);
+
+        let isOpen = false;
+        function open() {
+            isOpen = true;
+            panel.classList.add('is-modal');
+            backdrop.hidden = false;
+            if (closeBtn.focus) closeBtn.focus();
+        }
+        function close() {
+            if (!isOpen) return;
+            isOpen = false;
+            panel.classList.remove('is-modal');
+            backdrop.hidden = true;
+            if (typeof onClose === 'function') onClose();
+        }
+        // A click on the dark backdrop dismisses; the lifted panel is a
+        // separate subtree, so clicks inside it never reach here.
+        backdrop.addEventListener('click', function (e) { if (e.target === backdrop) close(); });
+        closeBtn.addEventListener('click', close);
+        doc.addEventListener('keydown', function (e) { if (e.key === 'Escape' && isOpen) close(); });
+        return { open: open, close: close, isOpen: function () { return isOpen; } };
+    }
+
     function wireSearch(doc) {
         const form = q(doc, '[data-form="search"]');
         if (!form) return;
@@ -1472,12 +1515,33 @@
         // touch it, so a slow load can't overwrite (or a clear can't wipe) a
         // newer one's card.
         let detailSeq = 0;
+        // The tile that opened the modal, so focus returns to it on dismiss.
+        let lastTrigger = null;
 
-        // Loads a card's full details into the shared panel. `opts.scroll`
-        // brings it into view (for an explicit click), but not when a one-match
-        // search auto-opens it under the grid.
+        // Hides the detail panel and drops any pending/stale load. The visual
+        // teardown, shared by an explicit dismiss and a fresh search.
+        function hideDetailPanel() {
+            detailSeq++;
+            setStatus(cardStatus, '');
+            hide(cardResult);
+        }
+
+        // The detail panel can be lifted into a dismissible overlay (for an
+        // explicit click). Dismissing it tears the panel down and hands focus
+        // back to the tile that opened it.
+        const modal = cardDetailModal(doc, cardResult, function () {
+            hideDetailPanel();
+            if (lastTrigger && lastTrigger.focus) lastTrigger.focus();
+        });
+
+        // Loads a card's full details into the shared panel. `opts.modal` lifts
+        // it into a centered overlay (an explicit click on a result); without
+        // it the panel renders inline and `opts.scroll` brings it into view —
+        // used when a one-match search auto-opens the detail under the grid.
         function openDetail(name, opts) {
             if (!name || !cardResult) return;
+            const wantModal = !!(opts && opts.modal && modal);
+            if (opts && opts.trigger) lastTrigger = opts.trigger;
             const token = ++detailSeq;
             setStatus(cardStatus, 'Loading ' + name + '…');
             hide(cardResult);
@@ -1488,23 +1552,26 @@
                     setStatus(cardStatus, '');
                     renderCardLookup(cardResult, json.card);
                     show(cardResult);
-                    if (opts && opts.scroll && cardResult.scrollIntoView) {
+                    if (wantModal) {
+                        modal.open();
+                    } else if (opts && opts.scroll && cardResult.scrollIntoView) {
                         cardResult.scrollIntoView({ behavior: 'smooth', block: 'start' });
                     }
                 })
                 .catch(function () { if (token === detailSeq) setStatus(cardStatus, 'Something went wrong. Try again.'); });
         }
 
-        // Drops any pending/stale detail load and hides the panel.
+        // Closes the overlay (if open) and hides the panel — funnelled so a
+        // dismiss and a fresh search share one teardown without double-firing.
         function clearDetail() {
-            detailSeq++;
-            setStatus(cardStatus, '');
-            hide(cardResult);
+            if (modal && modal.isOpen()) modal.close(); // its onClose hides the panel
+            else hideDetailPanel();
         }
 
         // Delegated so it survives each grid re-render: a left-click on a result
-        // tile loads that card's detail panel instead of leaving for Scryfall.
-        // Modifier/middle clicks fall through to the tile's href (open Scryfall).
+        // tile opens that card's full details in a dismissible overlay instead
+        // of leaving for Scryfall. Modifier/middle clicks fall through to the
+        // tile's href (open Scryfall).
         result.addEventListener('click', function (e) {
             if (e.defaultPrevented || e.button === 1 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
             const tile = e.target.closest && e.target.closest('.cube-card');
@@ -1512,7 +1579,7 @@
             const name = tile.getAttribute('data-card-name') || tile.getAttribute('title');
             if (!name || !cardResult) return;
             e.preventDefault();
-            openDetail(name, { scroll: true });
+            openDetail(name, { modal: true, trigger: tile });
         });
 
         let timer = null;
@@ -2353,6 +2420,7 @@
         totalValueText: totalValueText,
         formatMoney: formatMoney,
         renderCardLookup: renderCardLookup,
+        cardDetailModal: cardDetailModal,
         renderRulings: renderRulings,
         renderTotalValue: renderTotalValue,
         renderValueExtremes: renderValueExtremes,

--- a/web/src/test/js/magic.test.js
+++ b/web/src/test/js/magic.test.js
@@ -1402,6 +1402,72 @@ describe('tap-to-enlarge (touch / no-hover devices)', () => {
     });
 });
 
+describe('cardDetailModal (the dismissible detail overlay)', () => {
+    // Each build mounts its own panel + backdrop and cleans up after, so the
+    // shared document keydown listener can't cross-fire between cases.
+    let panel;
+    let backdrop;
+    let modal;
+    let closed;
+
+    afterEach(() => {
+        // Close first so the (never-unregistered) document keydown listener is
+        // inert — close() early-returns once shut — and can't cross-fire into a
+        // later test's Escape.
+        if (modal) modal.close();
+        if (backdrop && backdrop.parentNode) backdrop.parentNode.removeChild(backdrop);
+        if (panel && panel.parentNode) panel.parentNode.removeChild(panel);
+        panel = backdrop = modal = null;
+    });
+
+    function build() {
+        panel = document.createElement('div');
+        panel.className = 'cube-cardlookup-wrap';
+        document.body.appendChild(panel);
+        closed = 0;
+        modal = Cube.cardDetailModal(document, panel, () => { closed += 1; });
+        backdrop = document.querySelector('.cube-detail-backdrop');
+        return modal;
+    }
+
+    test('open lifts the panel into a modal over a shown backdrop', () => {
+        const modal = build();
+        expect(modal.isOpen()).toBe(false);
+        modal.open();
+        expect(modal.isOpen()).toBe(true);
+        expect(panel.classList.contains('is-modal')).toBe(true);
+        expect(backdrop.hidden).toBe(false);
+    });
+
+    test('Escape dismisses and runs onClose, dropping the modal class', () => {
+        const modal = build();
+        modal.open();
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+        expect(modal.isOpen()).toBe(false);
+        expect(panel.classList.contains('is-modal')).toBe(false);
+        expect(backdrop.hidden).toBe(true);
+        expect(closed).toBe(1);
+    });
+
+    test('the close button dismisses', () => {
+        const modal = build();
+        modal.open();
+        backdrop.querySelector('.cube-detail-close').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        expect(modal.isOpen()).toBe(false);
+        expect(closed).toBe(1);
+    });
+
+    test('a backdrop click dismisses, but a click inside the lifted panel does not', () => {
+        const modal = build();
+        modal.open();
+        panel.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        expect(modal.isOpen()).toBe(true);
+        backdrop.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        expect(modal.isOpen()).toBe(false);
+        expect(closed).toBe(1);
+    });
+});
+
 describe('renderDistribution (the secondary balance bars)', () => {
     test('renders one colour-coded, length-scaled bar per category', () => {
         const container = document.createElement('div');


### PR DESCRIPTION
## Problem

Clicking a card in the unified search rendered the detail panel **inline below the results grid**. With a full grid of matches that meant being yanked past every tile to the bottom of the page (even with the smooth-scroll), and losing your place in the results when you went back.

## Change

The same detail panel is now lifted into a **dismissible overlay** for an explicit click: a centered, scrollable sheet over a dimmed backdrop, dismissed by a close button, a backdrop click, or Escape. The card's full info — image, price, oracle, legal formats, and the lazy **Show rulings** / **Show combos** buttons — appears in focus, and dismissing returns focus to the tile you clicked, leaving the grid scroll untouched.

A search that **auto-narrows to a single match** still renders inline where the grid was (popping a modal open mid-keystroke would be jarring, and there's nothing to scroll past in that case).

### How it's wired

- New `cardDetailModal(doc, panel, onClose)` factory: creates one shared backdrop + close button, toggles an `is-modal` class to lift the panel, and wires the three dismissals. Returns `{ open, close, isOpen }`.
- `openDetail` gains an `opts.modal` path; the tile-click handler passes `{ modal: true, trigger: tile }`, the one-match auto-open stays inline.
- The overlay **reuses the existing `[data-result="card"]` container**, so `wireCardLookup`'s delegated rulings/combos handlers are unchanged.
- The lightbox (preview/generate grids) is untouched.

## Testing

- `npx jest src/test/js/magic.test.js` → **129 passed** (added 4 covering open / Escape / close-button / backdrop-vs-panel-click dismissal)
- `npx stylelint src/main/resources/static/css/magic.css` → clean
- HTML template and Kotlin untouched, so `MagicTemplateRenderTest` is unaffected.

https://claude.ai/code/session_01WybziU9C2THDXRKH11cPRi

---
_Generated by [Claude Code](https://claude.ai/code/session_01WybziU9C2THDXRKH11cPRi)_