### PR TITLE
Add TISM coin, a user portfolio page, and an all-coin wealth leaderboard

### DIFF
--- a/common/src/main/kotlin/common/economy/Coin.kt
+++ b/common/src/main/kotlin/common/economy/Coin.kt
@@ -82,6 +82,20 @@ enum class Coin(
         volatility = 6.0,
         tradeImpact = 0.00025,
     ),
+
+    /**
+     * The wildest coin on the board — even more volatile than MOON. Swings
+     * are violent and a single order shoves the price hard. Strictly for
+     * adrenaline; blink and the chart has done something insane.
+     */
+    TISM(
+        displayName = "Tismcoin",
+        blurb = "Maximum chaos — the most unhinged coin here. Astronomical swings, zero chill.",
+        riskLabel = "Unhinged",
+        initialPrice = 100.0,
+        volatility = 10.0,
+        tradeImpact = 0.0004,
+    ),
     ;
 
     /** Stored code / ticker. Same as the enum constant name. */

--- a/common/src/test/kotlin/common/economy/CoinTest.kt
+++ b/common/src/test/kotlin/common/economy/CoinTest.kt
@@ -54,6 +54,7 @@ internal class CoinTest {
         assertTrue(Coin.TOBL.volatility < Coin.TOBY.volatility, "TOBL calmer than TOBY")
         assertTrue(Coin.TOBY.volatility < Coin.RUFF.volatility, "TOBY calmer than RUFF")
         assertTrue(Coin.RUFF.volatility < Coin.MOON.volatility, "RUFF calmer than MOON")
+        assertTrue(Coin.MOON.volatility < Coin.TISM.volatility, "MOON calmer than TISM")
     }
 
     @Test
@@ -61,6 +62,7 @@ internal class CoinTest {
         assertTrue(Coin.TOBL.tradeImpact < Coin.TOBY.tradeImpact)
         assertTrue(Coin.TOBY.tradeImpact < Coin.RUFF.tradeImpact)
         assertTrue(Coin.RUFF.tradeImpact < Coin.MOON.tradeImpact)
+        assertTrue(Coin.MOON.tradeImpact < Coin.TISM.tradeImpact)
     }
 
     @Test

--- a/common/src/test/kotlin/common/economy/TobyCoinEngineMultiCoinTest.kt
+++ b/common/src/test/kotlin/common/economy/TobyCoinEngineMultiCoinTest.kt
@@ -32,9 +32,11 @@ internal class TobyCoinEngineMultiCoinTest {
         val toby = dailySpread(Coin.TOBY)
         val ruff = dailySpread(Coin.RUFF)
         val moon = dailySpread(Coin.MOON)
+        val tism = dailySpread(Coin.TISM)
         assertTrue(stbl < toby, "TOBL spread $stbl should be < TOBY $toby")
         assertTrue(toby < ruff, "TOBY spread $toby should be < RUFF $ruff")
         assertTrue(ruff < moon, "RUFF spread $ruff should be < MOON $moon")
+        assertTrue(moon < tism, "MOON spread $moon should be < TISM $tism")
     }
 
     @Test

--- a/database/src/main/kotlin/database/persistence/economy/UserCoinHoldingPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/economy/UserCoinHoldingPersistence.kt
@@ -18,4 +18,7 @@ interface UserCoinHoldingPersistence {
 
     /** All non-zero holdings a user has in a guild, for portfolio views. */
     fun listForUser(discordId: Long, guildId: Long): List<UserCoinHoldingDto>
+
+    /** Every non-zero holding in a guild, for leaderboard aggregation. */
+    fun listForGuild(guildId: Long): List<UserCoinHoldingDto>
 }

--- a/database/src/main/kotlin/database/persistence/economy/impl/DefaultUserCoinHoldingPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/economy/impl/DefaultUserCoinHoldingPersistence.kt
@@ -54,4 +54,12 @@ class DefaultUserCoinHoldingPersistence : UserCoinHoldingPersistence {
             .setParameter("guildId", guildId)
             .resultList
     }
+
+    override fun listForGuild(guildId: Long): List<UserCoinHoldingDto> {
+        return entityManager.createQuery(
+            "select h from UserCoinHoldingDto h where h.guildId = :guildId and h.amount > 0",
+            UserCoinHoldingDto::class.java
+        ).setParameter("guildId", guildId)
+            .resultList
+    }
 }

--- a/database/src/main/kotlin/database/service/economy/UserCoinHoldingService.kt
+++ b/database/src/main/kotlin/database/service/economy/UserCoinHoldingService.kt
@@ -11,4 +11,7 @@ import database.dto.economy.UserCoinHoldingDto
 interface UserCoinHoldingService {
     fun getAmount(discordId: Long, guildId: Long, coin: Coin): Long
     fun listForUser(discordId: Long, guildId: Long): List<UserCoinHoldingDto>
+
+    /** Every non-zero holding in a guild — used to value all portfolios for the leaderboard. */
+    fun listForGuild(guildId: Long): List<UserCoinHoldingDto>
 }

--- a/database/src/main/kotlin/database/service/economy/impl/DefaultUserCoinHoldingService.kt
+++ b/database/src/main/kotlin/database/service/economy/impl/DefaultUserCoinHoldingService.kt
@@ -16,4 +16,7 @@ class DefaultUserCoinHoldingService(
 
     override fun listForUser(discordId: Long, guildId: Long): List<UserCoinHoldingDto> =
         persistence.listForUser(discordId, guildId)
+
+    override fun listForGuild(guildId: Long): List<UserCoinHoldingDto> =
+        persistence.listForGuild(guildId)
 }

--- a/web/src/main/kotlin/web/controller/EconomyController.kt
+++ b/web/src/main/kotlin/web/controller/EconomyController.kt
@@ -91,6 +91,53 @@ class EconomyController(
         "economy"
     }
 
+    @GetMapping("/portfolio")
+    fun portfolioPicker(
+        @RegisteredOAuth2AuthorizedClient("discord") client: OAuth2AuthorizedClient,
+        @AuthenticationPrincipal user: OAuth2User,
+        @RequestParam(required = false, defaultValue = "false") pick: Boolean,
+        request: HttpServletRequest,
+        model: Model
+    ): String {
+        val discordId = user.discordIdOrNull()
+        val guilds = if (discordId != null) {
+            economyWebService.getGuildsWhereUserCanView(client.accessToken.tokenValue, discordId)
+        } else emptyList()
+
+        val defaultGuildId = DefaultGuildCookie.read(request)
+        GuildPickerSupport.resolveRedirect(
+            guildIds = guilds.mapNotNull { it.id.toLongOrNull() },
+            cookieGuildId = defaultGuildId,
+            pick = pick,
+        ) { "/economy/$it/portfolio" }?.let { return it }
+
+        // Zero or many guilds with no default — fall back to the market guild
+        // list so the user can pick which server's portfolio to view.
+        model.addAttribute("guilds", guilds)
+        model.addAttribute("username", user.displayName())
+        model.addAttribute("defaultGuildId", defaultGuildId)
+        return "economy-guilds"
+    }
+
+    @GetMapping("/{guildId}/portfolio")
+    fun portfolioPage(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+        model: Model,
+        ra: RedirectAttributes
+    ): String = WebGuildAccess.requireMemberForPage(
+        user, guildId, economyWebService, ra, lobbyPath = "/economy/guilds"
+    ) { discordId ->
+        val view = economyWebService.getPortfolio(guildId, discordId) ?: run {
+            ra.addFlashAttribute("error", "Bot is not in that server.")
+            return@requireMemberForPage "redirect:/economy/guilds"
+        }
+        model.addAttribute("portfolio", view)
+        model.addAttribute("guildId", guildId.toString())
+        model.addAttribute("username", user.displayName())
+        "economy-portfolio"
+    }
+
     @GetMapping("/{guildId}/history")
     @ResponseBody
     fun history(

--- a/web/src/main/kotlin/web/service/EconomyWebService.kt
+++ b/web/src/main/kotlin/web/service/EconomyWebService.kt
@@ -223,6 +223,36 @@ class EconomyWebService(
     fun currentPrice(guildId: Long, coin: Coin = Coin.DEFAULT): Double =
         tradeService.loadOrCreateMarket(guildId, coin).price
 
+    /**
+     * The signed-in user's whole portfolio in [guildId]: every coin they
+     * hold (TOBY from the legacy column, the rest from `user_coin_holding`)
+     * with its live value, plus their social-credit balance. `null` when
+     * the bot isn't in the guild.
+     */
+    fun getPortfolio(guildId: Long, discordId: Long): PortfolioView? {
+        val guild = jda.getGuildById(guildId) ?: return null
+        val user = userService.getUserById(discordId, guildId)
+        val holdings = Coin.entries.mapNotNull { coin ->
+            val amount = balanceOf(user, discordId, guildId, coin)
+            if (amount <= 0L) return@mapNotNull null
+            val price = marketService.getMarket(guildId, coin)?.price ?: coin.initialPrice
+            PortfolioHolding(
+                symbol = coin.symbol,
+                name = coin.displayName,
+                riskLabel = coin.riskLabel,
+                amount = amount,
+                price = price,
+                value = (amount.toDouble() * price).toLong(),
+            )
+        }
+        return PortfolioView(
+            guildName = guild.name,
+            credits = user?.socialCredit ?: 0L,
+            holdings = holdings,
+            totalCoinValue = holdings.sumOf { it.value },
+        )
+    }
+
     private fun UserPriceTriggerDto.toView() = WatchView(
         id = id ?: 0L,
         side = side,
@@ -289,6 +319,23 @@ data class EconomyCoinTab(
     val name: String,
     val riskLabel: String,
     val selected: Boolean,
+)
+
+data class PortfolioView(
+    val guildName: String,
+    val credits: Long,
+    val holdings: List<PortfolioHolding>,
+    /** Sum of every holding's market value, in credits. */
+    val totalCoinValue: Long,
+)
+
+data class PortfolioHolding(
+    val symbol: String,
+    val name: String,
+    val riskLabel: String,
+    val amount: Long,
+    val price: Double,
+    val value: Long,
 )
 
 data class PricePoint(

--- a/web/src/main/kotlin/web/service/LeaderboardWebService.kt
+++ b/web/src/main/kotlin/web/service/LeaderboardWebService.kt
@@ -1,8 +1,10 @@
 package web.service
 
+import common.economy.Coin
 import database.service.guild.AchievementService
 import database.service.activity.ActivityMonthlyRollupService
 import database.service.economy.MonthlyCreditSnapshotService
+import database.service.economy.UserCoinHoldingService
 import database.service.guild.TitleService
 import database.service.economy.TobyCoinMarketService
 import database.service.user.UserService
@@ -25,6 +27,7 @@ class LeaderboardWebService(
     private val membership: GuildMembership,
     private val rollupService: ActivityMonthlyRollupService,
     private val achievementService: AchievementService,
+    private val holdingService: UserCoinHoldingService,
 ) {
 
     companion object {
@@ -331,7 +334,16 @@ class LeaderboardWebService(
 
     private fun buildTobyCoinLeaders(guildId: Long): List<TobyCoinLeaderRow> {
         val guild = jda.getGuildById(guildId) ?: return emptyList()
-        val price = marketService.getMarket(guildId)?.price ?: 0.0
+        // Current price for every coin (0.0 when a coin's market isn't seeded
+        // yet). The leaderboard ranks by total portfolio value across ALL
+        // coins, not just TOBY.
+        val prices = Coin.entries.associateWith { marketService.getMarket(guildId, it)?.price ?: 0.0 }
+        val tobyPrice = prices[Coin.TOBY] ?: 0.0
+        // Non-TOBY balances, grouped by user. Best-effort so a holdings read
+        // failure degrades to TOBY-only rather than 500-ing the page.
+        val holdingsByUser = runCatching {
+            holdingService.listForGuild(guildId).groupBy { it.discordId }
+        }.getOrDefault(emptyMap())
         val thisMonthStart = LocalDate.now(ZoneOffset.UTC).withDayOfMonth(1)
         // Best-effort: if the snapshot table read fails (schema drift on an old
         // deploy), degrade gracefully and skip the delta rather than 500 the page.
@@ -365,10 +377,23 @@ class LeaderboardWebService(
         }
 
         return allUsers.asSequence()
-            .filter { it.tobyCoins > 0L }
-            .sortedByDescending { it.tobyCoins }
+            .map { dto ->
+                // Total portfolio value = TOBY (legacy column) + every other
+                // coin held, each at its current market price.
+                var value = floor(dto.tobyCoins.toDouble() * tobyPrice).toLong()
+                val userHoldings = holdingsByUser[dto.discordId]
+                userHoldings?.forEach { h ->
+                    value += floor(h.amount.toDouble() * (prices[Coin.fromSymbol(h.coin)] ?: 0.0)).toLong()
+                }
+                val holdsAnyCoin = dto.tobyCoins > 0L || !userHoldings.isNullOrEmpty()
+                Triple(dto, value, holdsAnyCoin)
+            }
+            // Anyone holding any coin appears (even at a 0-price market); rank
+            // is by total portfolio value across all coins.
+            .filter { it.third }
+            .sortedByDescending { it.second }
             .take(TOBY_COIN_LEADERBOARD_LIMIT)
-            .mapIndexed { index, dto ->
+            .mapIndexed { index, (dto, value, _) ->
                 val member = guild.getMemberById(dto.discordId)
                 val title = runCatching {
                     dto.activeTitleId?.let { titleService.getById(it) }?.label
@@ -383,7 +408,7 @@ class LeaderboardWebService(
                     level = common.leveling.LevelCurve.progress(dto.xp).level,
                     coins = dto.tobyCoins,
                     coinsThisMonth = coinsThisMonth,
-                    portfolioCredits = floor(dto.tobyCoins.toDouble() * price).toLong()
+                    portfolioCredits = value
                 )
             }
             .toList()

--- a/web/src/main/resources/static/css/economy.css
+++ b/web/src/main/resources/static/css/economy.css
@@ -86,6 +86,63 @@
     font-size: 0.72rem;
 }
 
+/* Portfolio page — one tappable row per held coin. */
+.economy-portfolio-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+}
+
+.economy-portfolio-link {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-4);
+    padding: var(--space-3) var(--space-4);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md, 10px);
+    background: var(--surface-elevated, rgba(255, 255, 255, 0.02));
+    color: var(--text, #e0e0e0);
+    text-decoration: none;
+    transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.economy-portfolio-link:hover {
+    background: var(--surface-hover, rgba(255, 255, 255, 0.04));
+    border-color: var(--accent, #57F287);
+}
+
+.economy-portfolio-coin {
+    display: flex;
+    flex-direction: column;
+    min-width: 140px;
+}
+
+.economy-portfolio-sym {
+    font-weight: 700;
+}
+
+.economy-portfolio-name {
+    font-size: 0.75rem;
+}
+
+.economy-portfolio-amount {
+    font-variant-numeric: tabular-nums;
+}
+
+.economy-portfolio-value {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+}
+
+.economy-portfolio-price {
+    display: block;
+    font-size: 0.72rem;
+}
+
 .economy-chart-card {
     background: var(--bg-elevated);
     border: 1px solid var(--border);

--- a/web/src/main/resources/templates/economy-portfolio.html
+++ b/web/src/main/resources/templates/economy-portfolio.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: head('TobyBot - Portfolio', '/css/economy.css')}"></head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<main id="main" class="container-wide">
+    <div class="economy-header">
+        <div>
+            <a class="back-link" th:href="@{/economy/{g}(g=${guildId})}">&larr; Market</a>
+            <h1 th:text="'Your portfolio • ' + ${portfolio.guildName}">Your portfolio</h1>
+            <p class="economy-coin-sub muted">Every coin you hold here, valued at the live market price.</p>
+        </div>
+    </div>
+
+    <div th:replace="~{fragments/alerts :: error}"></div>
+
+    <section class="economy-card">
+        <div class="economy-row">
+            <span class="muted">Social credit</span>
+            <strong th:text="${portfolio.credits} + ' credits'">0 credits</strong>
+        </div>
+        <div class="economy-row">
+            <span class="muted">Total coin value</span>
+            <strong th:text="${portfolio.totalCoinValue} + ' credits'">0 credits</strong>
+        </div>
+    </section>
+
+    <section class="economy-card" th:if="${not #lists.isEmpty(portfolio.holdings)}">
+        <h2>Your coins</h2>
+        <ul class="economy-portfolio-list">
+            <li class="economy-portfolio-row" th:each="h : ${portfolio.holdings}">
+                <a class="economy-portfolio-link"
+                   th:href="@{/economy/{g}(g=${guildId}, coin=${h.symbol})}"
+                   th:title="'Trade ' + ${h.symbol}">
+                    <span class="economy-portfolio-coin">
+                        <span class="economy-portfolio-sym" th:text="${h.symbol}">TOBY</span>
+                        <span class="economy-portfolio-name muted"
+                              th:text="${h.name} + ' · ' + ${h.riskLabel}">Toby Coin · Baseline</span>
+                    </span>
+                    <span class="economy-portfolio-amount"><strong th:text="${h.amount}">0</strong> coins</span>
+                    <span class="economy-portfolio-value">
+                        <strong th:text="${h.value} + ' cr'">0 cr</strong>
+                        <span class="muted economy-portfolio-price"
+                              th:text="'@ ' + ${#numbers.formatDecimal(h.price, 1, 2)}">@ 0.00</span>
+                    </span>
+                </a>
+            </li>
+        </ul>
+    </section>
+
+    <div class="empty-hero" th:if="${#lists.isEmpty(portfolio.holdings)}">
+        <span class="emoji" aria-hidden="true">🪙</span>
+        <h2>No coins yet</h2>
+        <p class="mb-5">
+            You don't hold any coins in this server. Head to the
+            <a th:href="@{/economy/{g}(g=${guildId})}">market</a> to buy some.
+        </p>
+    </div>
+</main>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
+</body>
+</html>

--- a/web/src/main/resources/templates/economy.html
+++ b/web/src/main/resources/templates/economy.html
@@ -18,6 +18,7 @@
     <div class="economy-header">
         <div>
             <a class="back-link" th:href="@{/economy/guilds(pick=true)}">&larr; All markets</a>
+            <a class="back-link" th:href="@{/economy/{g}/portfolio(g=${guildId})}">Your portfolio &rarr;</a>
             <h1 th:text="${view.coin} + ' • ' + ${view.guildName}">TOBY</h1>
             <p class="economy-coin-sub muted"
                th:text="${view.coinName} + ' · ' + ${view.riskLabel}">Toby Coin · Baseline</p>

--- a/web/src/main/resources/templates/fragments/navbar.html
+++ b/web/src/main/resources/templates/fragments/navbar.html
@@ -140,6 +140,7 @@
                         onclick="toggleDropdown(this)"><span class="nav-item-icon" aria-hidden="true">&#128176;</span><span class="nav-dropdown-label">Economy</span><span class="nav-dropdown-caret" aria-hidden="true">&#9662;</span></button>
                 <div class="nav-dropdown-menu" role="menu">
                     <a href="/economy/guilds" role="menuitem">Market</a>
+                    <a href="/economy/portfolio" role="menuitem">Portfolio</a>
                     <a href="/titles/guilds" role="menuitem">Titles</a>
                     <a href="/tip/guilds" role="menuitem">Tip</a>
                 </div>

--- a/web/src/test/kotlin/web/service/EconomyWebServiceMultiCoinTest.kt
+++ b/web/src/test/kotlin/web/service/EconomyWebServiceMultiCoinTest.kt
@@ -16,6 +16,7 @@ import io.mockk.verify
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.Guild
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -129,6 +130,34 @@ internal class EconomyWebServiceMultiCoinTest {
 
         val toby = service.listWatches(discordId, guildId, Coin.TOBY)
         assertEquals(listOf(1L), toby.map { it.id })
+    }
+
+    @Test
+    fun `getPortfolio lists every held coin with its value plus the credit balance`() {
+        every { userService.getUserById(discordId, guildId) } returns
+                UserDto(discordId, guildId).apply { tobyCoins = 5L; socialCredit = 250L }
+        every { holdingService.getAmount(discordId, guildId, Coin.MOON) } returns 10L
+        every { marketService.getMarket(guildId, Coin.TOBY) } returns market(Coin.TOBY, 100.0)
+        every { marketService.getMarket(guildId, Coin.MOON) } returns market(Coin.MOON, 50.0)
+
+        val view = service.getPortfolio(guildId, discordId)!!
+
+        assertEquals(250L, view.credits)
+        // Only the coins with a positive balance appear, in catalogue order.
+        assertEquals(listOf("TOBY", "MOON"), view.holdings.map { it.symbol })
+        val toby = view.holdings.first { it.symbol == "TOBY" }
+        assertEquals(5L, toby.amount)
+        assertEquals(500L, toby.value, "5 TOBY @ 100")
+        val moon = view.holdings.first { it.symbol == "MOON" }
+        assertEquals(10L, moon.amount)
+        assertEquals(500L, moon.value, "10 MOON @ 50")
+        assertEquals(1_000L, view.totalCoinValue)
+    }
+
+    @Test
+    fun `getPortfolio returns null when the bot is not in the guild`() {
+        every { jda.getGuildById(guildId) } returns null
+        assertNull(service.getPortfolio(guildId, discordId))
     }
 
     @Test

--- a/web/src/test/kotlin/web/service/LeaderboardWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/LeaderboardWebServiceTest.kt
@@ -45,6 +45,7 @@ class LeaderboardWebServiceTest {
             GuildMembership(jda),
             mockk(relaxed = true),
             achievementService,
+            mockk(relaxed = true),
         )
     }
 

--- a/web/src/test/kotlin/web/service/LeaderboardWebServiceTobyCoinTest.kt
+++ b/web/src/test/kotlin/web/service/LeaderboardWebServiceTobyCoinTest.kt
@@ -1,10 +1,13 @@
 package web.service
 
+import common.economy.Coin
 import database.dto.economy.MonthlyCreditSnapshotDto
 import database.dto.guild.TitleDto
 import database.dto.economy.TobyCoinMarketDto
+import database.dto.economy.UserCoinHoldingDto
 import database.dto.user.UserDto
 import database.service.economy.MonthlyCreditSnapshotService
+import database.service.economy.UserCoinHoldingService
 import database.service.guild.TitleService
 import database.service.economy.TobyCoinMarketService
 import database.service.user.UserService
@@ -31,6 +34,7 @@ class LeaderboardWebServiceTobyCoinTest {
     private lateinit var marketService: TobyCoinMarketService
     private lateinit var titleService: TitleService
     private lateinit var snapshotService: MonthlyCreditSnapshotService
+    private lateinit var holdingService: UserCoinHoldingService
     private lateinit var service: LeaderboardWebService
 
     @BeforeEach
@@ -41,6 +45,7 @@ class LeaderboardWebServiceTobyCoinTest {
         marketService = mockk(relaxed = true)
         titleService = mockk(relaxed = true)
         snapshotService = mockk(relaxed = true)
+        holdingService = mockk(relaxed = true)
         every { jda.getGuildById(guildId) } returns guild
         every { guild.name } returns "Test Guild"
 
@@ -57,6 +62,7 @@ class LeaderboardWebServiceTobyCoinTest {
             membership = GuildMembership(jda),
             rollupService = mockk(relaxed = true),
             achievementService = mockk(relaxed = true),
+            holdingService = holdingService,
         )
     }
 
@@ -178,6 +184,53 @@ class LeaderboardWebServiceTobyCoinTest {
 
         assertEquals(LeaderboardWebService.TOBY_COIN_LEADERBOARD_LIMIT, leaders.size)
         assertEquals("U15", leaders.first().name)
+    }
+
+    // ---- multi-coin portfolio valuation ----
+
+    @Test
+    fun `tobyCoinLeaders values every coin held and ranks by total portfolio value`() {
+        // TOBY @ 1, MOON @ 10.
+        every { marketService.getMarket(guildId, Coin.TOBY) } returns
+            TobyCoinMarketDto(guildId = guildId, coin = Coin.TOBY.symbol, price = 1.0, lastTickAt = Instant.now())
+        every { marketService.getMarket(guildId, Coin.MOON) } returns
+            TobyCoinMarketDto(guildId = guildId, coin = Coin.MOON.symbol, price = 10.0, lastTickAt = Instant.now())
+        every { userService.listGuildUsers(guildId) } returns listOf(
+            UserDto(discordId = 1L, guildId = guildId).apply { tobyCoins = 50L },   // value 50
+            UserDto(discordId = 2L, guildId = guildId).apply { tobyCoins = 0L },    // 20 MOON → value 200
+            UserDto(discordId = 3L, guildId = guildId).apply { tobyCoins = 300L },  // value 300
+        )
+        every { holdingService.listForGuild(guildId) } returns listOf(
+            UserCoinHoldingDto(discordId = 2L, guildId = guildId, coin = Coin.MOON.symbol, amount = 20L),
+        )
+        every { guild.getMemberById(1L) } returns member(1L, "Alice")
+        every { guild.getMemberById(2L) } returns member(2L, "Bob")
+        every { guild.getMemberById(3L) } returns member(3L, "Carol")
+
+        val leaders = checkNotNull(service.getGuildView(guildId)).tobyCoinLeaders
+
+        // Ranked by total value: Carol 300, Bob 200 (MOON-only!), Alice 50.
+        assertEquals(listOf("Carol", "Bob", "Alice"), leaders.map { it.name })
+        assertEquals(300L, leaders[0].portfolioCredits)
+        assertEquals(200L, leaders[1].portfolioCredits, "a MOON-only holder is valued from holdings")
+        assertEquals(50L, leaders[2].portfolioCredits)
+        assertEquals(0L, leaders.first { it.name == "Bob" }.coins, "Bob holds 0 TOBY but still ranks by portfolio")
+    }
+
+    @Test
+    fun `tobyCoinLeaders degrades to TOBY-only when the holdings read fails`() {
+        every { marketService.getMarket(guildId, Coin.TOBY) } returns
+            TobyCoinMarketDto(guildId = guildId, coin = Coin.TOBY.symbol, price = 2.0, lastTickAt = Instant.now())
+        every { userService.listGuildUsers(guildId) } returns listOf(
+            UserDto(discordId = 1L, guildId = guildId).apply { tobyCoins = 10L }
+        )
+        every { holdingService.listForGuild(guildId) } throws RuntimeException("holdings table unavailable")
+        every { guild.getMemberById(1L) } returns member(1L, "Alice")
+
+        val leaders = checkNotNull(service.getGuildView(guildId)).tobyCoinLeaders
+
+        assertEquals(1, leaders.size, "page still renders on a holdings failure")
+        assertEquals(20L, leaders[0].portfolioCredits, "falls back to TOBY-only value (10 * 2)")
     }
 
     // ---- +/- this month ----

--- a/web/src/test/kotlin/web/service/LeaderboardWebServiceTopGamesTest.kt
+++ b/web/src/test/kotlin/web/service/LeaderboardWebServiceTopGamesTest.kt
@@ -56,6 +56,7 @@ class LeaderboardWebServiceTopGamesTest {
             membership = GuildMembership(jda),
             rollupService = rollupService,
             achievementService = mockk(relaxed = true),
+            holdingService = mockk(relaxed = true),
         )
     }
 


### PR DESCRIPTION
Follow-ups to the multi-coin market (PR #718, merged).

## TISM — an even more volatile coin
A new top tier above MOON: **volatility 10** and the hardest trade impact on the board (`Tismcoin`, ticker `TISM`, "Unhinged"). No migration needed — the `coin` column already accepts any ticker and markets/holdings are created lazily; the catalogue enum stays the single source of truth and every surface iterates `Coin.entries`. Spectrum tests extended to assert TISM is the wildest.

## User portfolio page
A per-guild page at **`/economy/{guildId}/portfolio`** listing every coin a user holds — TOBY (legacy column) plus the rest from `user_coin_holding` — with each holding's live value, their social-credit balance, and total coin value. Each row links through to that coin's market to trade.

- `EconomyWebService.getPortfolio` builds the view; `EconomyController` serves the page plus a `/economy/portfolio` picker that redirects to the default guild (mirroring `/economy/guilds`).
- **Reachable from the navbar** (Economy menu → Portfolio) and from the market page header.

## Wealth leaderboard values all coins
The coin leaderboard was tied solely to TOBY. It now values **every coin a user holds** at its current market price and **ranks by total portfolio value** — so a player whose wealth is in MOON/RUFF/TISM (and holds zero TOBY) still places.

- New `UserCoinHoldingPersistence.listForGuild` aggregates all of a guild's holdings in one query.
- `LeaderboardWebService` sums TOBY + per-coin holdings at live prices, keeps anyone holding any coin in the list, and ranks by total value. A holdings-read failure degrades gracefully to TOBY-only. The TOBY column and its monthly delta are unchanged.

## Tests
- `common`: TISM spectrum assertions (volatility/impact/daily-spread chains).
- `web`: `getPortfolio` (multi-coin totals, null-guild) and new leaderboard cases — values across coins, a MOON-only holder ranking by portfolio, and graceful degradation on a holdings failure. Existing leaderboard tests still pass (TOBY-only ranking is unchanged).
- `database`: `listForGuild` wired through the holdings service.
- `common`, `database`, `discord-bot`, and `web` suites all pass locally; the Docker integration tests and Jest run in CI.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JLymURfcnsPnVgdv13i42Z)_