### PR TITLE
Make the site footer stick to the bottom on short pages

### DIFF
--- a/web/src/main/resources/static/css/base.css
+++ b/web/src/main/resources/static/css/base.css
@@ -93,6 +93,13 @@ body {
     background: var(--bg);
     color: var(--text);
     min-height: 100vh;
+    /* Column flex + `margin-top:auto` on .site-footer (footer.css) is the
+       sticky-footer mechanism: short pages (e.g. the coin portfolio) push
+       the footer to the viewport bottom instead of leaving it floating
+       mid-screen. On tall pages the auto-margin collapses, so the footer
+       sits naturally after the content. */
+    display: flex;
+    flex-direction: column;
     line-height: 1.5;
     -webkit-font-smoothing: antialiased;
 }

--- a/web/src/main/resources/static/css/footer.css
+++ b/web/src/main/resources/static/css/footer.css
@@ -7,6 +7,10 @@
    fragment does, which is why the head fragment links this directly. */
 .site-footer {
     position: relative;
+    /* Sticky footer: with body as a flex column (base.css), auto top margin
+       eats the leftover space on short pages so the footer hugs the bottom;
+       on tall pages it collapses to 0 and the footer follows the content. */
+    margin-top: auto;
     padding: 36px 24px;
     text-align: center;
     color: var(--text-dim);


### PR DESCRIPTION
## Why
The footer looked "off" on the new coin **portfolio** page: it floated in the middle of the screen with empty space beneath it. Root cause isn't portfolio-specific — `base.css` set `body { min-height: 100vh }` but **nothing pinned the footer to the bottom**. Tall pages (the market, leaderboard) happened to fill the viewport so the footer landed at the bottom; short pages (portfolio, empty states) exposed the gap. So it was a uniformity gap, not a one-page bug.

## Fix
The standard sticky-footer pattern, applied globally (the footer fragment + `base.css`/`footer.css` load on every page):

- `body` → `display: flex; flex-direction: column;` (already had `min-height: 100vh`)
- `.site-footer` → `margin-top: auto;`

On short pages the auto top-margin eats the leftover space so the footer hugs the bottom; on tall pages it collapses to 0 and the footer follows the content. Fixed/sticky elements (toast stack, mobile nav drawer, sticky sub-nav) are out of flow and unaffected; `.container`/`.container-wide`'s `margin: 40px auto` still centers correctly as flex items.

## Testing
`web` static/CSS regression tests pass. 11 lines across 2 CSS files; no markup or logic changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JLymURfcnsPnVgdv13i42Z)_