### PR TITLE
Fix horizontal overflow on moderation settings/admin pages on mobile

### DIFF
--- a/web/src/main/resources/static/css/base.css
+++ b/web/src/main/resources/static/css/base.css
@@ -104,9 +104,19 @@ body {
     -webkit-font-smoothing: antialiased;
 }
 
-/* ---- Layout ---- */
-.container { max-width: 900px; margin: 40px auto; padding: 0 var(--space-6); }
-.container-wide { max-width: 1100px; margin: 40px auto; padding: 0 var(--space-6); }
+/* ---- Layout ----
+   `width: 100%` is load-bearing, not redundant with `max-width`. `body`
+   is a column flexbox (sticky-footer mechanism above), which makes these
+   containers flex items. A flex item with `width: auto` is sized by its
+   content's min-content width, so a single non-wrapping child wider than
+   the viewport — e.g. the moderation `.mod-subnav` horizontal-scroll tab
+   strip — would stretch the container past 100vw and push the whole page
+   into horizontal scroll on phones. Pinning the width to 100% (clamped by
+   max-width, centred by the auto margins) gives the flex item a definite
+   cross size so it tracks the viewport and its overflowing children scroll
+   inside their own `overflow-x` boxes instead. */
+.container { width: 100%; max-width: 900px; margin: 40px auto; padding: 0 var(--space-6); }
+.container-wide { width: 100%; max-width: 1100px; margin: 40px auto; padding: 0 var(--space-6); }
 
 h1 { font-size: 1.6rem; color: var(--heading); }
 h2 { font-size: 1.1rem; color: var(--heading-soft); }

--- a/web/src/main/resources/static/css/moderation.css
+++ b/web/src/main/resources/static/css/moderation.css
@@ -1639,6 +1639,11 @@ details.config-section.is-hidden { display: none; }
         justify-content: space-between;
         align-items: center;
         gap: var(--space-2);
+        /* On the narrowest phones (~320px) the data-label caption plus the
+           stake input and its Save button can't share one line; let the
+           input+Save group wrap below the label instead of pushing the
+           card past the viewport edge. */
+        flex-wrap: wrap;
     }
     .settings-stakes-table tbody td::before {
         content: attr(data-label);

--- a/web/src/main/resources/templates/moderation/leveling.html
+++ b/web/src/main/resources/templates/moderation/leveling.html
@@ -169,8 +169,8 @@
                         </thead>
                         <tbody>
                             <tr th:each="r : ${leveling.levelRewards}" th:data-level="${r.level}">
-                                <td th:text="${r.level}">1</td>
-                                <td>
+                                <td data-label="Level" th:text="${r.level}">1</td>
+                                <td data-label="Role">
                                     <span class="title-pill"
                                           th:style="${r.roleColorHex != null ? 'color: ' + r.roleColorHex : ''}"
                                           th:text="${r.roleName}">Role</span>
@@ -357,13 +357,13 @@
                     </thead>
                     <tbody>
                         <tr th:each="t : ${leveling.titles}" th:data-title-id="${t.id}">
-                            <td>
+                            <td data-label="Title">
                                 <span class="title-pill"
                                       th:style="${t.colorHex != null ? 'color: ' + t.colorHex : ''}"
                                       th:text="${t.label}">Title</span>
                             </td>
-                            <td th:text="${t.cost}">0</td>
-                            <td>
+                            <td data-label="Cost" th:text="${t.cost}">0</td>
+                            <td data-label="Required level">
                                 <input type="number" class="leveling-title-level-input"
                                        min="0" max="1000"
                                        th:value="${t.requiredLevel}"

--- a/web/src/main/resources/templates/moderation/welcome.html
+++ b/web/src/main/resources/templates/moderation/welcome.html
@@ -171,7 +171,7 @@
                         </thead>
                         <tbody>
                             <tr th:each="r : ${welcome.autoRoles}" th:data-role-id="${r.roleId}">
-                                <td>
+                                <td data-label="Role">
                                     <span class="title-pill"
                                           th:style="${r.roleColorHex != null ? 'color: ' + r.roleColorHex : ''}"
                                           th:text="${r.roleName}">Role</span>

--- a/web/src/test/e2e/fixtures/moderation-settings.html
+++ b/web/src/test/e2e/fixtures/moderation-settings.html
@@ -1,0 +1,234 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Moderation: Settings (fixture)</title>
+    <link rel="stylesheet" href="/css/base.css">
+    <link rel="stylesheet" href="/css/nav.css">
+    <link rel="stylesheet" href="/css/moderation.css">
+</head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+<nav>
+    <a class="brand" href="#">TobyBot</a>
+    <button class="nav-toggle" type="button" aria-expanded="false"><span class="nav-toggle-icon" aria-hidden="true"></span></button>
+    <div class="nav-links" id="nav-menu">
+        <div class="nav-drawer-header"><span class="nav-drawer-brand">TobyBot</span><button class="nav-drawer-close" type="button">✕</button></div>
+        <div class="nav-section"><div class="nav-section-eyebrow">Main</div><a class="nav-item" href="#"><span class="nav-item-icon">👤</span><span>Profile</span></a></div>
+        <div class="nav-section"><div class="nav-section-eyebrow">Moderation</div><a class="nav-item" href="#"><span class="nav-item-icon">🛡️</span><span>Admin</span></a></div>
+    </div>
+    <div class="nav-backdrop" id="nav-backdrop" hidden></div>
+</nav>
+
+<main id="main" class="container" data-guild-id="1" data-actor-id="1" data-is-owner="true">
+    <div>
+        <header class="mod-page-header">
+            <a class="back-link" href="#">← All servers</a>
+            <div class="mod-page-header__row">
+                <div class="mod-page-header__identity">
+                    <span class="mod-page-header__avatar mod-page-header__avatar--initial" aria-hidden="true">R</span>
+                    <div class="mod-page-header__titles">
+                        <p class="mod-page-header__eyebrow">REAL GAYMERS</p>
+                        <h1 class="mod-page-header__title">Settings</h1>
+                        <p class="mod-page-header__subtitle">Per-guild knobs for economy, casino, leveling, and shared bot behaviour.</p>
+                    </div>
+                </div>
+                <div class="mod-page-header__badges">
+                    <span class="mod-page-header__badge mod-page-header__badge--owner">Server owner</span>
+                </div>
+            </div>
+        </header>
+        <nav class="mod-subnav" aria-label="Moderation sections">
+            <a class="mod-subnav-link" href="#">Users</a>
+            <a class="mod-subnav-link" href="#">Actions</a>
+            <a class="mod-subnav-link active" href="#">Settings</a>
+            <a class="mod-subnav-link" href="#">Voice</a>
+            <a class="mod-subnav-link" href="#">Poll</a>
+            <a class="mod-subnav-link" href="#">Casino</a>
+            <a class="mod-subnav-link" href="#">Lottery</a>
+            <a class="mod-subnav-link" href="#">Leveling</a>
+            <a class="mod-subnav-link" href="#">Activity</a>
+            <a class="mod-subnav-link" href="#">Welcome</a>
+        </nav>
+    </div>
+
+    <section class="mod-panel" data-panel="settings">
+        <div class="settings-shell">
+            <aside class="settings-nav" aria-label="Settings sections">
+                <div class="settings-nav-group">
+                    <p class="settings-nav-heading">Server</p>
+                    <a href="#" class="settings-nav-link">Server features</a>
+                    <a href="#" class="settings-nav-link">Messages &amp; leaderboards</a>
+                    <a href="#" class="settings-nav-link">Magic: The Gathering</a>
+                </div>
+                <div class="settings-nav-group">
+                    <p class="settings-nav-heading">Economy</p>
+                    <a href="#" class="settings-nav-link">Economy</a>
+                </div>
+                <div class="settings-nav-group">
+                    <p class="settings-nav-heading">Casino</p>
+                    <a href="#" class="settings-nav-link">Jackpot</a>
+                    <a href="#" class="settings-nav-link">Anti-autoclicker</a>
+                    <a href="#" class="settings-nav-link">Poker</a>
+                    <a href="#" class="settings-nav-link">Blackjack</a>
+                    <a href="#" class="settings-nav-link">Game stake limits</a>
+                </div>
+            </aside>
+
+            <div class="settings-content">
+                <div class="mod-search config-search-bar">
+                    <label for="config-search" class="sr-only">Search settings</label>
+                    <input id="config-search" type="search" class="mod-search-input"
+                           placeholder="Search settings (e.g. jackpot, RTP, ante)…">
+                    <span id="config-search-count" class="mod-search-count"></span>
+                </div>
+
+                <h2 class="config-pillar">Server</h2>
+
+                <details class="config-section">
+                    <summary>Server features</summary>
+                    <div class="config-grid">
+                        <div class="config-row" data-key="MOVE">
+                            <label>Default move channel</label>
+                            <div class="user-picker" data-placeholder="— none —">
+                                <select data-channel-picker>
+                                    <option value="">— none —</option>
+                                    <option>General Voice Channel With A Long Name</option>
+                                </select>
+                            </div>
+                            <button type="button" class="btn save-config">Save</button>
+                        </div>
+                    </div>
+                </details>
+
+                <details class="config-section" open>
+                    <summary>Messages &amp; leaderboards</summary>
+                    <div class="config-grid">
+                        <div class="config-row" data-key="LEADERBOARD_CHANNEL">
+                            <label>Monthly leaderboard channel</label>
+                            <div class="user-picker"><select data-channel-picker><option value="">— system channel —</option><option>#monthly-leaderboard-channel</option></select></div>
+                            <button type="button" class="btn save-config">Save</button>
+                        </div>
+                        <div class="config-create-channel">
+                            <div class="config-create-channel-text">
+                                <strong>Create a read-only leaderboard channel</strong>
+                                <p class="muted">Creates a new text channel where @everyone can read but only TobyBot can post.</p>
+                            </div>
+                            <form class="config-create-channel-form" data-target-config="LEADERBOARD_CHANNEL" data-default-name="leaderboard">
+                                <label class="config-create-channel-field"><span>Channel name</span><input type="text" name="name" value="leaderboard" maxlength="90"></label>
+                                <label class="config-create-channel-field"><span>Category</span><select name="parentCategoryId"><option value="">— top-level —</option><option>A Very Long Existing Category Name Here</option></select></label>
+                                <label class="config-create-channel-field"><span>or new category name</span><input type="text" name="newCategoryName" maxlength="100" placeholder="(blank = use existing)"></label>
+                                <button type="submit" class="btn config-create-channel-btn">Create</button>
+                            </form>
+                        </div>
+                    </div>
+                </details>
+
+                <details class="config-section" open>
+                    <summary>Jackpot</summary>
+                    <div class="config-grid">
+                        <div class="config-row config-row-wide" data-key="JACKPOT_WHEEL">
+                            <label>Wheel segments</label>
+                            <div class="jackpot-wheel-editor">
+                                <div class="jackpot-wheel-editor-rows">
+                                    <div class="jackpot-wheel-editor-row">
+                                        <span class="jackpot-wheel-row-label">1</span>
+                                        <label>weight<input type="number" value="10"></label>
+                                        <label>payout<input type="number" value="100"><span class="config-suffix">×</span></label>
+                                        <button type="button" class="btn-danger jw-remove">Remove</button>
+                                    </div>
+                                </div>
+                                <div class="jackpot-wheel-editor-actions">
+                                    <button type="button" class="btn btn-sm jackpot-wheel-add">Add segment</button>
+                                    <span class="muted jackpot-wheel-ev">EV: 0.95</span>
+                                </div>
+                            </div>
+                            <button type="button" class="btn jackpot-wheel-save">Save wheel</button>
+                        </div>
+                    </div>
+                </details>
+
+                <details class="config-section" open>
+                    <summary>Magic: The Gathering</summary>
+                    <div class="config-grid">
+                        <div class="config-row" data-key="CARD_MENTIONS">
+                            <label>Inline [[card]] Magic lookups</label>
+                            <select><option>Enabled</option><option>Disabled</option></select>
+                            <button type="button" class="btn save-config">Save</button>
+                        </div>
+                        <div class="config-row" data-key="CUBE_CURRENCY">
+                            <label>Cube value currency</label>
+                            <select><option>US Dollars ($)</option><option>Euros (€)</option><option>MTGO Tix</option></select>
+                            <button type="button" class="btn save-config">Save</button>
+                        </div>
+                    </div>
+                </details>
+
+                <h2 class="config-pillar">Economy</h2>
+
+                <details class="config-section" open>
+                    <summary>Economy</summary>
+                    <div class="config-grid">
+                        <div class="config-row" data-key="TRADE_BUY_FEE_PCT">
+                            <label>Toby Coin BUY fee
+                                <span class="config-hint">Charged per leg and routed to the jackpot pool.</span>
+                            </label>
+                            <span class="config-input-group">
+                                <input type="number" min="0" max="25" step="0.01" placeholder="1">
+                                <span class="config-suffix">%</span>
+                            </span>
+                            <button type="button" class="btn save-config">Save</button>
+                        </div>
+                    </div>
+                </details>
+
+                <h2 class="config-pillar">Casino</h2>
+
+                <details class="config-section" open>
+                    <summary>Game stake limits</summary>
+                    <p class="muted config-section-lead">Min/max stake per game.</p>
+                    <div class="settings-stakes-bulk">
+                        <div class="settings-stakes-bulk-text">
+                            <strong>Set every game at once</strong>
+                            <p class="muted">Applies the same min/max to all games below.</p>
+                        </div>
+                        <form class="settings-stakes-bulk-fields">
+                            <label class="settings-stakes-bulk-field">Minimum<input type="number" min="1"></label>
+                            <label class="settings-stakes-bulk-field">Maximum<input type="number" min="0"></label>
+                            <button type="submit" class="btn">Apply to all</button>
+                        </form>
+                    </div>
+                    <div class="settings-stakes-wrap">
+                        <table class="settings-stakes-table">
+                            <thead>
+                                <tr><th scope="col">Game</th><th scope="col">Minimum stake</th><th scope="col">Maximum stake</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <th scope="row">Dice</th>
+                                    <td data-label="Minimum stake">
+                                        <div class="config-row settings-stake-cell" data-key="DICE_MIN_STAKE">
+                                            <label class="sr-only">Dice minimum stake</label>
+                                            <input type="number" min="1" placeholder="10">
+                                            <button type="button" class="btn btn-sm save-config">Save</button>
+                                        </div>
+                                    </td>
+                                    <td data-label="Maximum stake">
+                                        <div class="config-row settings-stake-cell" data-key="DICE_MAX_STAKE">
+                                            <label class="sr-only">Dice maximum stake</label>
+                                            <input type="number" min="0" placeholder="500">
+                                            <button type="button" class="btn btn-sm save-config">Save</button>
+                                        </div>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </details>
+            </div>
+        </div>
+    </section>
+</main>
+</body>
+</html>

--- a/web/src/test/e2e/fixtures/moderation-users.html
+++ b/web/src/test/e2e/fixtures/moderation-users.html
@@ -24,12 +24,22 @@
         <h1>Moderation — Toby Test Server</h1>
         <p class="lede">Manage members, voice, polls, casino, and per-guild config.</p>
     </div>
+    <!-- Full ten-tab subnav, matching fragments/moderationHeader.html. The
+         real strip is the widest always-present element on these pages —
+         keeping the fixture's tab count in sync with production is what
+         lets the no-overflow contract catch the container shrink-wrap
+         regression on phones. -->
     <nav class="mod-subnav" aria-label="Moderation sections">
         <a class="mod-subnav-link active" href="#">Users</a>
+        <a class="mod-subnav-link" href="#">Actions</a>
+        <a class="mod-subnav-link" href="#">Settings</a>
         <a class="mod-subnav-link" href="#">Voice</a>
         <a class="mod-subnav-link" href="#">Poll</a>
         <a class="mod-subnav-link" href="#">Casino</a>
-        <a class="mod-subnav-link" href="#">Settings</a>
+        <a class="mod-subnav-link" href="#">Lottery</a>
+        <a class="mod-subnav-link" href="#">Leveling</a>
+        <a class="mod-subnav-link" href="#">Activity</a>
+        <a class="mod-subnav-link" href="#">Welcome</a>
     </nav>
     <div class="mod-search">
         <input class="mod-search-input" type="search" placeholder="Filter members…">

--- a/web/src/test/e2e/responsive.spec.js
+++ b/web/src/test/e2e/responsive.spec.js
@@ -15,6 +15,7 @@ const { test, expect } = require('@playwright/test');
 const PAGES = [
     { url: '/home.html', name: 'home' },
     { url: '/moderation-users.html', name: 'moderation-users' },
+    { url: '/moderation-settings.html', name: 'moderation-settings' },
     { url: '/blackjack-table.html', name: 'blackjack' },
     { url: '/roulette.html', name: 'roulette' },
     { url: '/leaderboard.html', name: 'leaderboard' },

--- a/web/src/test/kotlin/web/static/ContainerWidthCssRegressionTest.kt
+++ b/web/src/test/kotlin/web/static/ContainerWidthCssRegressionTest.kt
@@ -1,0 +1,48 @@
+package web.static
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Guards the `width: 100%` on `.container` / `.container-wide` in base.css.
+ *
+ * `body` is a column flexbox (the sticky-footer mechanism), which makes
+ * these layout containers flex items. A flex item sized `width: auto` is
+ * sized by its content's min-content width, so a single non-wrapping child
+ * wider than the viewport — most visibly the moderation `.mod-subnav`
+ * ten-tab horizontal-scroll strip — stretches the container past 100vw and
+ * throws every moderation/admin page into horizontal scroll on phones.
+ *
+ * Pinning `width: 100%` (clamped by the existing `max-width`) gives the
+ * flex item a definite cross size so it tracks the viewport instead of its
+ * content. Dropping the declaration silently reintroduces the phone
+ * overflow, which only the Playwright responsive suite would otherwise
+ * catch — this unit test fails fast in the JVM build.
+ */
+class ContainerWidthCssRegressionTest {
+
+    private val css: String by lazy {
+        javaClass.classLoader
+            .getResourceAsStream("static/css/base.css")
+            ?.bufferedReader()
+            ?.readText()
+            ?: error("base.css is not on the classpath")
+    }
+
+    @Test
+    fun `container rules pin width to 100 percent so the column-flex body cannot shrink-wrap them`() {
+        // Collapse whitespace so the assertion is resilient to reformatting
+        // of the individual declarations within each rule.
+        val flattened = css.replace(Regex("\\s+"), " ")
+        listOf(".container", ".container-wide").forEach { selector ->
+            val rule = Regex(Regex.escape("$selector {") + "[^}]*}")
+                .find(flattened)?.value
+                ?: error("base.css must declare a `$selector { ... }` rule")
+            assertTrue(
+                rule.contains("width: 100%"),
+                "$selector must set `width: 100%` so it cannot shrink-wrap to an " +
+                    "oversized child as a flex item of the column-flex body. Rule was: $rule",
+            )
+        }
+    }
+}


### PR DESCRIPTION
## What & why

On phones, the moderation pages (Settings, Users, Leveling, …) overflowed horizontally — the navbar sat at ~55% of the screen and the whole page scrolled sideways (see the reported screenshot of the Settings tab).

The root cause was **global, not settings-specific**:

`body` is a column flexbox (the sticky-footer mechanism), which makes `.container` / `.container-wide` flex items. A flex item sized `width: auto` is sized to its content's *min-content* width. The moderation `.mod-subnav` ten-tab horizontal-scroll strip is a single non-wrapping child wider than the viewport, so it stretched the container past `100vw` and forced the page into horizontal scroll.

The fix pins `width: 100%` on those containers (still clamped by the existing `max-width`, still centred by the `auto` margins). That gives the flex item a definite cross size so it tracks the viewport, and its overflowing children scroll inside their own `overflow-x` boxes instead.

### How I found it
Reproduced with the repo's Playwright fixture harness + Chromium and measured `documentElement.scrollWidth` vs `clientWidth`. The Settings page measured **719px wide at a 393px viewport**; attributing the overflow element-by-element pinned it on `.mod-subnav` → the container shrink-wrap. Verified the fix drives overflow to 0 across 320/360/375/393/414/768px on every fixture, and confirmed desktop (1280px) is unchanged — Settings container stays 900px, centred, no overflow.

## Changes
- **`base.css`** — `width: 100%` on `.container` / `.container-wide` (the actual fix), with a comment explaining why it's load-bearing.
- **`moderation.css`** — stake-limit table cells wrap below their label on the narrowest (~320px) phones instead of nudging the card past the edge.
- **`leveling.html` / `welcome.html`** — added `data-label` attributes to the reward/title/auto-role table cells so their mobile card transform shows field captions, matching every other moderation table.

## Regression coverage
- New **`moderation-settings`** Playwright fixture (full ten-tab subnav, open config sections, stakes table, channel-create form, jackpot wheel editor) added to the no-horizontal-overflow contract.
- The existing **`moderation-users`** fixture's subnav bumped from 5 → the real 10 tabs — the 5-tab version fit at 393px, which is exactly why the overflow slipped past CI.
- **`ContainerWidthCssRegressionTest`** asserts the `width: 100%` survives future `base.css` refactors.

> Note: the local container couldn't run the full `playwright test` (needs `@playwright/test` installed in `web/`), so I validated the identical contract (`scrollWidth - clientWidth <= 1`) via a direct Chromium script. CI will run the suite with deps installed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WCxrmiJHwwjc1nKytyk7gi)_