### PR TITLE
Fix price-alert receipt mislabelling every trade as TOBY

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/notify/PriceAlertReceiptBuilder.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/notify/PriceAlertReceiptBuilder.kt
@@ -54,11 +54,11 @@ object PriceAlertReceiptBuilder {
         val title = "TobyCoin price alert"
         val body = when (outcome) {
             is TradeOutcome.Ok ->
-                "${pastTense(trigger.sideEnum)} ${outcome.amount} TOBY at ${"%.4f".format(outcome.newPrice)}."
+                "${pastTense(trigger.sideEnum)} ${outcome.amount} ${trigger.coin} at ${"%.4f".format(outcome.newPrice)}."
             is TradeOutcome.InsufficientCredits ->
-                "Trigger #${trigger.id} fired but you lacked credits to BUY."
+                "Trigger #${trigger.id} fired but you lacked credits to BUY ${trigger.coin}."
             is TradeOutcome.InsufficientCoins ->
-                "Trigger #${trigger.id} fired but you lacked TOBY to SELL."
+                "Trigger #${trigger.id} fired but you lacked ${trigger.coin} to SELL."
             TradeOutcome.InvalidAmount ->
                 "Trigger #${trigger.id} fired but the trade was rejected as invalid."
             TradeOutcome.UnknownUser ->
@@ -98,7 +98,7 @@ object PriceAlertReceiptBuilder {
             )
             .addField(
                 "Trade",
-                "**$verb ${ok.amount} TOBY** @ ${"%.4f".format(executionPrice)}",
+                "**$verb ${ok.amount} ${trigger.coin}** @ ${"%.4f".format(executionPrice)}",
                 false
             )
 
@@ -122,7 +122,7 @@ object PriceAlertReceiptBuilder {
 
         embed.addField(
             "New balance",
-            "**${ok.newCoins}** TOBY • **${ok.newCredits}** credits",
+            "**${ok.newCoins}** ${trigger.coin} • **${ok.newCredits}** credits",
             false
         )
         embed.setFooter("Trigger one-shot — use /pricealert add to set another.")
@@ -137,7 +137,7 @@ object PriceAlertReceiptBuilder {
         .setColor(FAILURE_COLOR)
         .setDescription(
             "Target ${"%.4f".format(trigger.thresholdPrice)} was reached, but you didn't " +
-                    "have enough credits to BUY ${trigger.amount} TOBY: needed " +
+                    "have enough credits to BUY ${trigger.amount} ${trigger.coin}: needed " +
                     "**${outcome.needed}** credits (price + fee), had **${outcome.have}**. " +
                     "No trade made. Trigger disabled."
         )
@@ -151,7 +151,7 @@ object PriceAlertReceiptBuilder {
         .setColor(FAILURE_COLOR)
         .setDescription(
             "Target ${"%.4f".format(trigger.thresholdPrice)} was reached, but you didn't " +
-                    "have enough TOBY to SELL ${trigger.amount}: needed **${outcome.needed}** " +
+                    "have enough ${trigger.coin} to SELL ${trigger.amount}: needed **${outcome.needed}** " +
                     "coins, had **${outcome.have}**. No trade made. Trigger disabled."
         )
         .build()

--- a/discord-bot/src/test/kotlin/bot/toby/notify/PriceAlertReceiptBuilderTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/notify/PriceAlertReceiptBuilderTest.kt
@@ -10,10 +10,15 @@ import org.junit.jupiter.api.Test
 
 class PriceAlertReceiptBuilderTest {
 
-    private fun trigger(side: UserPriceTriggerDto.Side, amount: Long = 10) = UserPriceTriggerDto(
+    private fun trigger(
+        side: UserPriceTriggerDto.Side,
+        amount: Long = 10,
+        coin: String = "TOBY",
+    ) = UserPriceTriggerDto(
         id = 42,
         discordId = 1L,
         guildId = 100L,
+        coin = coin,
         thresholdPrice = 100.0,
         priceAtCreation = 120.0,
         side = side.name,
@@ -150,6 +155,38 @@ class PriceAlertReceiptBuilderTest {
         assertTrue(text.contains("Trigger #42"), "embed should mention trigger id 42: $text")
         assertTrue(text.contains("invalid") || text.contains("Invalid") || text.contains("failed"),
                 "embed should describe the failure: $text")
+    }
+
+    @Test
+    fun `receipt labels the trigger's coin, not a hardcoded TOBY`() {
+        // Regression: the embed used to hardcode "TOBY" everywhere, so a
+        // TISM (or any non-default coin) trigger fired a receipt that
+        // mislabelled the asset. The trade/balance lines must echo the
+        // trigger's own coin symbol.
+        val ok = TradeOutcome.Ok(
+            amount = 250L,
+            transactedCredits = 47811L,
+            newCoins = 0L,
+            newCredits = 70899L,
+            newPrice = 181.1803,
+            fee = 0L,
+        )
+        val dm = PriceAlertReceiptBuilder.buildDm(
+            trigger(UserPriceTriggerDto.Side.SELL, amount = 250, coin = "TISM"),
+            ok,
+        )
+        val text = renderedText(dm)
+        assertTrue(text.contains("250 TISM"), "Trade line must label TISM: $text")
+        assertTrue(text.contains("0 TISM"), "Balance line must label TISM: $text")
+        assertFalse(text.contains("TOBY"), "must not mislabel the coin as TOBY: $text")
+
+        // The push payload carries the same label.
+        val push = PriceAlertReceiptBuilder.buildPush(
+            trigger(UserPriceTriggerDto.Side.SELL, amount = 250, coin = "TISM"),
+            ok,
+        )
+        assertTrue(push.body.contains("250 TISM"), "push must label TISM: ${push.body}")
+        assertFalse(push.body.contains("TOBY"), "push must not mislabel as TOBY: ${push.body}")
     }
 
     @Test


### PR DESCRIPTION
## Problem

The auto-trade price-alert receipt (DM embed + push notification) hardcoded the ticker `TOBY` in every label. A trigger fired on any other coin — e.g. the `TISM` SELL in the reported screenshot — showed the correct amount, price, and balances but labelled the asset as **TOBY** instead of the actual coin.

`UserPriceTriggerDto` already carries the real `coin` symbol, so the data was right — only the rendering was wrong.

## Fix

`PriceAlertReceiptBuilder` now reads `trigger.coin` for the asset name in:

- the **Trade** line (`Sold 250 TISM @ …`)
- the **New balance** line (`0 TISM • … credits`)
- the push notification body
- the **InsufficientCredits / InsufficientCoins** shortfall messages

## Tests

Added a regression test asserting a `TISM` trigger renders `TISM` (and never `TOBY`) across both the DM embed and the push payload. Full `PriceAlertReceiptBuilderTest` suite passes.

https://claude.ai/code/session_01UDbc7HtA6Qu4yfmWjMBPas

---
_Generated by [Claude Code](https://claude.ai/code/session_01UDbc7HtA6Qu4yfmWjMBPas)_