### PR TITLE
Fix now-playing message recreated instead of edited between tracks

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/lavaplayer/TrackScheduler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/lavaplayer/TrackScheduler.kt
@@ -164,7 +164,6 @@ class TrackScheduler(val player: AudioPlayer, val guildId: Long, var deleteDelay
         trackClipBounds.remove(track)
         trackRequesters.remove(track)
         val wasIntro = introTracks.remove(track)
-        event?.guild?.idLong.resetMessagesForGuildId()
         logger.info("${track.info.title} by ${track.info.author} ended")
         SchedulerEvents.publish(TrackEndedEvent(guildId, endReason.name))
         // An intro just finished and we have a preempted track waiting: restart
@@ -180,6 +179,8 @@ class TrackScheduler(val player: AudioPlayer, val guildId: Long, var deleteDelay
                 && endReason != AudioTrackEndReason.REPLACED
                 && endReason != AudioTrackEndReason.CLEANUP
         if (shouldResumeAfterIntro) {
+            // Keep the now-playing message: the resumed track's onTrackStart will
+            // edit it back in place rather than spawning a fresh one.
             val resume = resumeAfterIntro!!
             resumeAfterIntro = null
             player.setVolumeToPrevious()
@@ -189,6 +190,11 @@ class TrackScheduler(val player: AudioPlayer, val guildId: Long, var deleteDelay
         }
         if (endReason.mayStartNext) {
             handleNextTrack(player, track)
+        } else if (endReason != AudioTrackEndReason.REPLACED) {
+            // Playback has actually stopped and nothing is taking over (REPLACED
+            // means another track already started and its onTrackStart will
+            // refresh the embed in place). Tear down the now-playing message.
+            event?.guild?.idLong.resetMessagesForGuildId()
         }
     }
 
@@ -204,14 +210,22 @@ class TrackScheduler(val player: AudioPlayer, val guildId: Long, var deleteDelay
 
     private fun handleNextTrack(player: AudioPlayer, track: AudioTrack) {
         if (isLooping) {
+            // The clone's onTrackStart edits the existing now-playing message in
+            // place, so don't tear it down here.
             player.startTrack(track.makeClone(), false)
+            return
+        }
+        PlayerManager.instance.isCurrentlyStoppable = true
+        player.setVolumeToPrevious()
+        if (queue.peek() != null) {
+            // Advance to the next track; its onTrackStart re-uses (edits) the
+            // current now-playing message rather than posting a new one.
+            nextTrack()
+            event?.let { nowPlaying(it, PlayerManager.instance, deleteDelay) }
         } else {
-            PlayerManager.instance.isCurrentlyStoppable = true
-            player.setVolumeToPrevious()
-            queue.peek()?.let {
-                nextTrack()
-                event?.let { nowPlaying(it, PlayerManager.instance, deleteDelay) }
-            }
+            // Queue exhausted — nothing else will play, so clean up the
+            // now-playing message and its scheduled updates.
+            event?.guild?.idLong.resetMessagesForGuildId()
         }
     }
 

--- a/discord-bot/src/test/kotlin/bot/toby/lavaplayer/TrackSchedulerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/lavaplayer/TrackSchedulerTest.kt
@@ -1,11 +1,14 @@
 package bot.toby.lavaplayer
 
+import bot.toby.helpers.MusicPlayerHelper
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayer
 import com.sedmelluq.discord.lavaplayer.track.AudioPlaylist
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack
 import com.sedmelluq.discord.lavaplayer.track.AudioTrackEndReason
 import com.sedmelluq.discord.lavaplayer.track.AudioTrackInfo
 import io.mockk.*
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
@@ -35,6 +38,7 @@ class TrackSchedulerTest {
     fun tearDown() {
         clearAllMocks()
         unmockkObject(PlayerManager.Companion)
+        unmockkObject(MusicPlayerHelper)
     }
 
     @Test
@@ -517,6 +521,79 @@ class TrackSchedulerTest {
         verify(exactly = 1) { player.startTrack(clone, false) }
         // The intro must NOT be re-cloned-and-restarted by the loop branch.
         verify(exactly = 0) { player.startTrack(introClone, false) }
+    }
+
+    /**
+     * Wires up an event/guild on the scheduler and stubs the now-playing helper so
+     * we can assert exactly when the now-playing message is torn down vs. edited in
+     * place across track transitions.
+     */
+    private fun stubMusicPlayerHelperWithEvent(guildId: Long = 1L) {
+        mockkObject(MusicPlayerHelper)
+        every { MusicPlayerHelper.nowPlaying(any(), any(), any(), any(), any()) } just Runs
+        every { MusicPlayerHelper.resetMessages(any()) } just Runs
+        val guild = mockk<Guild>(relaxed = true)
+        every { guild.idLong } returns guildId
+        val event = mockk<SlashCommandInteractionEvent>(relaxed = true)
+        every { event.guild } returns guild
+        scheduler.event = event
+    }
+
+    @Test
+    fun `onTrackEnd does not reset now-playing message when advancing to next track`() {
+        stubMusicPlayerHelperWithEvent()
+        val current = mockTrack("Current")
+        val next = mockTrack("Next", volume = 55)
+        scheduler.queue.offer(next)
+
+        scheduler.onTrackEnd(player, current, AudioTrackEndReason.FINISHED)
+
+        // The next track's now-playing edits the existing message in place — the
+        // message must NOT be deleted/recreated between tracks.
+        verify(exactly = 0) { MusicPlayerHelper.resetMessages(any()) }
+    }
+
+    @Test
+    fun `onTrackEnd resets now-playing message when queue is exhausted`() {
+        stubMusicPlayerHelperWithEvent()
+        val current = mockTrack("Current")
+
+        scheduler.onTrackEnd(player, current, AudioTrackEndReason.FINISHED)
+
+        // Nothing left to play — the now-playing message should be cleaned up.
+        verify(exactly = 1) { MusicPlayerHelper.resetMessages(1L) }
+    }
+
+    @Test
+    fun `onTrackEnd does not reset now-playing message on REPLACED`() {
+        stubMusicPlayerHelperWithEvent()
+        val current = mockTrack("Current")
+
+        // Another track already took over the player and will refresh the embed.
+        scheduler.onTrackEnd(player, current, AudioTrackEndReason.REPLACED)
+
+        verify(exactly = 0) { MusicPlayerHelper.resetMessages(any()) }
+    }
+
+    @Test
+    fun `onTrackEnd resets now-playing message when stopped with nothing taking over`() {
+        stubMusicPlayerHelperWithEvent()
+        val current = mockTrack("Current")
+
+        scheduler.onTrackEnd(player, current, AudioTrackEndReason.STOPPED)
+
+        verify(exactly = 1) { MusicPlayerHelper.resetMessages(1L) }
+    }
+
+    @Test
+    fun `onTrackEnd does not reset now-playing message while looping`() {
+        stubMusicPlayerHelperWithEvent()
+        scheduler.isLooping = true
+        val current = mockTrack("Current")
+
+        scheduler.onTrackEnd(player, current, AudioTrackEndReason.FINISHED)
+
+        verify(exactly = 0) { MusicPlayerHelper.resetMessages(any()) }
     }
 
     @Test


### PR DESCRIPTION
## Problem

When one song finished and the next started from the queue, the player posted a **brand-new** now-playing message instead of editing the existing one in place. The old message would linger/get deleted and the player kept jumping to the bottom of the channel — it didn't clean up properly.

## Root cause

`TrackScheduler.onTrackEnd` called `resetMessagesForGuildId()` **unconditionally** on every track end. `resetNowPlayingMessage` both deletes the Discord message *and* clears the stored message reference. Because this ran before the next track's `onTrackStart`, `MusicPlayerHelper.nowPlaying` found no stored message (`getLastNowPlayingMessage` → `null`) and fell through to `sendNewNowPlayingMessage`, posting a fresh message every transition.

## Fix

Only tear down the now-playing message when playback is **actually ending**:

- **Queue exhausted** (`handleNextTrack` finds no next track) → reset.
- **Stopped with nothing taking over** (non-`REPLACED`, non-`mayStartNext` end reason) → reset.
- **Track transitions / looping / intro-resume** → keep the message so the next `onTrackStart` edits it in place.

`REPLACED` is explicitly excluded because another track has already started and its `onTrackStart` refreshes the embed. The existing `stopSong` and `VoiceEventHandler` (bot leaving voice) reset paths are unchanged.

## Tests

Added 5 cases to `TrackSchedulerTest` covering: no reset when advancing to next track, reset when queue exhausted, no reset on `REPLACED`, reset on `STOPPED` with nothing taking over, and no reset while looping. Existing scheduler, `MusicPlayerHelper`, `NowPlayingManager`, music command, and `VoiceEventHandler` suites all pass.

https://claude.ai/code/session_01DtRFCoWT6XRcCdtvW2vh71

---
_Generated by [Claude Code](https://claude.ai/code/session_01DtRFCoWT6XRcCdtvW2vh71)_