### PR TITLE
Stop double now-playing render and clean up player when channel empties

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/handler/VoiceEventHandler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/handler/VoiceEventHandler.kt
@@ -256,14 +256,31 @@ class VoiceEventHandler(
     }
 
     private fun AudioManager.checkAudioManagerToCloseConnectionOnEmptyChannel() {
-        val connectedChannel = this.connectedChannel
-        if (connectedChannel != null) {
-            if (connectedChannel.members.nonBots().isEmpty()) {
-                this.closeAudioConnection()
-                logger.info("Audio connection closed due to empty channel.")
-                lastConnectedChannelTracker.clear(this.guild.idLong)
-            }
+        val connectedChannel = this.connectedChannel ?: return
+        if (connectedChannel.members.nonBots().isEmpty()) {
+            // Nobody is left to listen — stop playback and tear down the
+            // now-playing message so it doesn't keep ticking to an empty room,
+            // then drop the voice connection. Mirrors onGuildLeave's teardown.
+            stopPlaybackAndClearNowPlaying(this.guild)
+            this.closeAudioConnection()
+            logger.info("Audio connection closed due to empty channel.")
+            lastConnectedChannelTracker.clear(this.guild.idLong)
         }
+    }
+
+    private fun stopPlaybackAndClearNowPlaying(guild: Guild) {
+        runCatching {
+            val musicManager = PlayerManager.instance.getMusicManager(guild)
+            musicManager.scheduler.apply {
+                stopTrack(true)
+                queue.clear()
+                isLooping = false
+            }
+            musicManager.audioPlayer.isPaused = false
+        }.onFailure {
+            logger.error("Failed to stop playback on empty channel for guild ${guild.idLong}: ${it.message}")
+        }
+        nowPlayingManager.resetNowPlayingMessage(guild.idLong)
     }
 
     private fun deleteTemporaryChannelIfEmpty(nonBotConnectedMembersEmpty: Boolean, channelLeft: AudioChannel) {

--- a/discord-bot/src/main/kotlin/bot/toby/lavaplayer/TrackScheduler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/lavaplayer/TrackScheduler.kt
@@ -218,10 +218,11 @@ class TrackScheduler(val player: AudioPlayer, val guildId: Long, var deleteDelay
         PlayerManager.instance.isCurrentlyStoppable = true
         player.setVolumeToPrevious()
         if (queue.peek() != null) {
-            // Advance to the next track; its onTrackStart re-uses (edits) the
-            // current now-playing message rather than posting a new one.
+            // Advance to the next track. nextTrack() -> player.startTrack fires
+            // onTrackStart, which renders the (clip-aware) now-playing and edits
+            // the existing message in place — same path the loop branch relies
+            // on — so we don't render it a second time here.
             nextTrack()
-            event?.let { nowPlaying(it, PlayerManager.instance, deleteDelay) }
         } else {
             // Queue exhausted — nothing else will play, so clean up the
             // now-playing message and its scheduled updates.

--- a/discord-bot/src/main/kotlin/bot/toby/lavaplayer/TrackScheduler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/lavaplayer/TrackScheduler.kt
@@ -164,7 +164,6 @@ class TrackScheduler(val player: AudioPlayer, val guildId: Long, var deleteDelay
         trackClipBounds.remove(track)
         trackRequesters.remove(track)
         val wasIntro = introTracks.remove(track)
-        event?.guild?.idLong.resetMessagesForGuildId()
         logger.info("${track.info.title} by ${track.info.author} ended")
         SchedulerEvents.publish(TrackEndedEvent(guildId, endReason.name))
         // An intro just finished and we have a preempted track waiting: restart
@@ -180,6 +179,8 @@ class TrackScheduler(val player: AudioPlayer, val guildId: Long, var deleteDelay
                 && endReason != AudioTrackEndReason.REPLACED
                 && endReason != AudioTrackEndReason.CLEANUP
         if (shouldResumeAfterIntro) {
+            // Keep the now-playing message: the resumed track's onTrackStart will
+            // edit it back in place rather than spawning a fresh one.
             val resume = resumeAfterIntro!!
             resumeAfterIntro = null
             player.setVolumeToPrevious()
@@ -189,6 +190,11 @@ class TrackScheduler(val player: AudioPlayer, val guildId: Long, var deleteDelay
         }
         if (endReason.mayStartNext) {
             handleNextTrack(player, track)
+        } else if (endReason != AudioTrackEndReason.REPLACED) {
+            // Playback has actually stopped and nothing is taking over (REPLACED
+            // means another track already started and its onTrackStart will
+            // refresh the embed in place). Tear down the now-playing message.
+            event?.guild?.idLong.resetMessagesForGuildId()
         }
     }
 
@@ -204,14 +210,22 @@ class TrackScheduler(val player: AudioPlayer, val guildId: Long, var deleteDelay
 
     private fun handleNextTrack(player: AudioPlayer, track: AudioTrack) {
         if (isLooping) {
+            // The clone's onTrackStart edits the existing now-playing message in
+            // place, so don't tear it down here.
             player.startTrack(track.makeClone(), false)
+            return
+        }
+        PlayerManager.instance.isCurrentlyStoppable = true
+        player.setVolumeToPrevious()
+        if (queue.peek() != null) {
+            // Advance to the next track; its onTrackStart re-uses (edits) the
+            // current now-playing message rather than posting a new one.
+            nextTrack()
+            event?.let { nowPlaying(it, PlayerManager.instance, deleteDelay) }
         } else {
-            PlayerManager.instance.isCurrentlyStoppable = true
-            player.setVolumeToPrevious()
-            queue.peek()?.let {
-                nextTrack()
-                event?.let { nowPlaying(it, PlayerManager.instance, deleteDelay) }
-            }
+            // Queue exhausted — nothing else will play, so clean up the
+            // now-playing message and its scheduled updates.
+            event?.guild?.idLong.resetMessagesForGuildId()
         }
     }
 

--- a/discord-bot/src/test/kotlin/bot/toby/handler/VoiceEventHandlerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/handler/VoiceEventHandlerTest.kt
@@ -468,6 +468,13 @@ class VoiceEventHandlerTest {
         every { member.user.isBot } returns false
         every { newChannel.members } returns listOf(member)
 
+        // The relaxed audioManager reports an empty connected channel, so closing
+        // the connection now also stops playback — stub the player manager so that
+        // teardown doesn't reach into the real singleton.
+        val playerManager = mockk<PlayerManager>(relaxed = true)
+        mockkObject(PlayerManager)
+        every { PlayerManager.instance } returns playerManager
+
         // Mock configuration service
         every {
             configService.getConfigByName(
@@ -478,9 +485,48 @@ class VoiceEventHandlerTest {
 
         handler.onGuildVoiceUpdate(event)
 
-        // Verify that the bot checked to close connection and joined the new channel
+        // Verify that the bot stopped playback, cleared the now-playing message,
+        // closed the connection, and joined the new channel.
+        verify(exactly = 1) { nowPlayingManager.resetNowPlayingMessage(1L) }
         verify(exactly = 1) { audioManager.closeAudioConnection() }
         verify(exactly = 1) { audioManager.openAudioConnection(newChannel) }
+
+        unmockkObject(PlayerManager)
+    }
+
+    @Test
+    fun `voice leave that empties the channel stops playback and clears now-playing`() {
+        val guild = mockk<Guild>(relaxed = true)
+        val event = mockk<GuildVoiceUpdateEvent>(relaxed = true)
+        val audioManager = mockk<AudioManager>(relaxed = true)
+        val member = mockk<Member>(relaxed = true)
+        val emptyChannel = mockk<AudioChannelUnion>(relaxed = true)
+
+        every { event.guild } returns guild
+        every { event.jda.selfUser } returns selfUser
+        every { event.member } returns member
+        every { event.channelJoined } returns null
+        every { event.channelLeft } returns emptyChannel
+        every { guild.audioManager } returns audioManager
+        every { audioManager.guild } returns guild
+        every { guild.idLong } returns 99L
+        every { member.user.idLong } returns 54321L  // Not bot's ID
+        every { member.idLong } returns 54321L
+        // Bot is still connected but the channel has no humans left.
+        every { audioManager.connectedChannel } returns emptyChannel
+        every { emptyChannel.members } returns emptyList()
+
+        val playerManager = mockk<PlayerManager>(relaxed = true)
+        mockkObject(PlayerManager)
+        every { PlayerManager.instance } returns playerManager
+
+        handler.onGuildVoiceUpdate(event)
+
+        verify(exactly = 1) { playerManager.getMusicManager(guild) }
+        verify(exactly = 1) { nowPlayingManager.resetNowPlayingMessage(99L) }
+        verify(exactly = 1) { audioManager.closeAudioConnection() }
+
+        unmockkObject(PlayerManager)
     }
 
     @Test

--- a/discord-bot/src/test/kotlin/bot/toby/lavaplayer/TrackSchedulerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/lavaplayer/TrackSchedulerTest.kt
@@ -1,11 +1,14 @@
 package bot.toby.lavaplayer
 
+import bot.toby.helpers.MusicPlayerHelper
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayer
 import com.sedmelluq.discord.lavaplayer.track.AudioPlaylist
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack
 import com.sedmelluq.discord.lavaplayer.track.AudioTrackEndReason
 import com.sedmelluq.discord.lavaplayer.track.AudioTrackInfo
 import io.mockk.*
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
@@ -35,6 +38,7 @@ class TrackSchedulerTest {
     fun tearDown() {
         clearAllMocks()
         unmockkObject(PlayerManager.Companion)
+        unmockkObject(MusicPlayerHelper)
     }
 
     @Test
@@ -517,6 +521,79 @@ class TrackSchedulerTest {
         verify(exactly = 1) { player.startTrack(clone, false) }
         // The intro must NOT be re-cloned-and-restarted by the loop branch.
         verify(exactly = 0) { player.startTrack(introClone, false) }
+    }
+
+    /**
+     * Wires up an event/guild on the scheduler and stubs the now-playing helper so
+     * we can assert exactly when the now-playing message is torn down vs. edited in
+     * place across track transitions.
+     */
+    private fun stubMusicPlayerHelperWithEvent(guildId: Long = 1L) {
+        mockkObject(MusicPlayerHelper)
+        every { MusicPlayerHelper.nowPlaying(any(), any(), any(), any(), any()) } just Runs
+        every { MusicPlayerHelper.resetMessages(any()) } just Runs
+        val guild = mockk<Guild>(relaxed = true)
+        every { guild.idLong } returns guildId
+        val event = mockk<SlashCommandInteractionEvent>(relaxed = true)
+        every { event.guild } returns guild
+        scheduler.event = event
+    }
+
+    @Test
+    fun `onTrackEnd does not reset now-playing message when advancing to next track`() {
+        stubMusicPlayerHelperWithEvent()
+        val current = mockTrack("Current")
+        val next = mockTrack("Next", volume = 55)
+        scheduler.queue.offer(next)
+
+        scheduler.onTrackEnd(player, current, AudioTrackEndReason.FINISHED)
+
+        // The next track's now-playing edits the existing message in place — the
+        // message must NOT be deleted/recreated between tracks.
+        verify(exactly = 0) { MusicPlayerHelper.resetMessages(any()) }
+    }
+
+    @Test
+    fun `onTrackEnd resets now-playing message when queue is exhausted`() {
+        stubMusicPlayerHelperWithEvent()
+        val current = mockTrack("Current")
+
+        scheduler.onTrackEnd(player, current, AudioTrackEndReason.FINISHED)
+
+        // Nothing left to play — the now-playing message should be cleaned up.
+        verify(exactly = 1) { MusicPlayerHelper.resetMessages(1L) }
+    }
+
+    @Test
+    fun `onTrackEnd does not reset now-playing message on REPLACED`() {
+        stubMusicPlayerHelperWithEvent()
+        val current = mockTrack("Current")
+
+        // Another track already took over the player and will refresh the embed.
+        scheduler.onTrackEnd(player, current, AudioTrackEndReason.REPLACED)
+
+        verify(exactly = 0) { MusicPlayerHelper.resetMessages(any()) }
+    }
+
+    @Test
+    fun `onTrackEnd resets now-playing message when stopped with nothing taking over`() {
+        stubMusicPlayerHelperWithEvent()
+        val current = mockTrack("Current")
+
+        scheduler.onTrackEnd(player, current, AudioTrackEndReason.STOPPED)
+
+        verify(exactly = 1) { MusicPlayerHelper.resetMessages(1L) }
+    }
+
+    @Test
+    fun `onTrackEnd does not reset now-playing message while looping`() {
+        stubMusicPlayerHelperWithEvent()
+        scheduler.isLooping = true
+        val current = mockTrack("Current")
+
+        scheduler.onTrackEnd(player, current, AudioTrackEndReason.FINISHED)
+
+        verify(exactly = 0) { MusicPlayerHelper.resetMessages(any()) }
     }
 
     @Test


### PR DESCRIPTION
Two follow-up quality fixes to the now-playing message lifecycle (builds on #725).

## 1. Redundant now-playing render on track transition

`TrackScheduler.handleNextTrack` rendered the now-playing embed **twice** per transition: `nextTrack()` → `player.startTrack` already fires `onTrackStart`, which renders the (clip-aware) now-playing and edits the message in place. The extra explicit `nowPlaying(...)` call caused:

- a redundant Discord message edit + a redundant `scheduleNowPlayingUpdate` cancel/reschedule cycle, and
- a brief wrong render for clipped tracks, because the explicit call passed **no clip bounds** (showed full duration/progress).

The `isLooping` branch already relies solely on `onTrackStart`, confirming the explicit call is redundant. Removed it so both paths are consistent.

## 2. Player left running when the voice channel empties

When the last human left, `VoiceEventHandler.checkAudioManagerToCloseConnectionOnEmptyChannel` closed the audio connection but left the player playing and the now-playing message ticking (its 3s updater kept editing) to an empty room. Now it stops the scheduler (`stopTrack` + clear queue + un-loop), un-pauses, and resets the now-playing message before dropping the connection — mirroring `onGuildLeave`'s teardown. The player-manager access is wrapped in `runCatching` so a teardown hiccup can't block the disconnect.

## Tests

- `TrackSchedulerTest` (existing): unaffected — the message-lifecycle assertions added in #725 still pass.
- `VoiceEventHandlerTest`: updated the existing move-close test to mock `PlayerManager` and assert the now-playing reset; added a new test for a voice-leave that empties the channel (verifies playback stop + now-playing reset + connection close).
- Full `:discord-bot:test` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DtRFCoWT6XRcCdtvW2vh71)_