### PR TITLE
Fix intro volume slider triggering row reorder

### DIFF
--- a/web/src/main/resources/static/js/intros.js
+++ b/web/src/main/resources/static/js/intros.js
@@ -1116,7 +1116,19 @@ function initIntroPage() {
     if (tbody) {
         let draggedRow = null;
         tbody.querySelectorAll('tr[data-intro-id]').forEach(row => {
-            row.setAttribute('draggable', 'true');
+            // Only allow reordering when the drag begins from the drag handle.
+            // Otherwise interactive controls inside the row (e.g. the volume
+            // slider) would start a row reorder when the user drags them.
+            const handle = row.querySelector('.drag-handle');
+            if (handle) {
+                handle.addEventListener('pointerdown', function () {
+                    row.setAttribute('draggable', 'true');
+                });
+                ['pointerup', 'pointercancel'].forEach(ev =>
+                    handle.addEventListener(ev, function () {
+                        row.removeAttribute('draggable');
+                    }));
+            }
             row.addEventListener('dragstart', function (e) {
                 draggedRow = row;
                 row.classList.add('dragging');
@@ -1124,6 +1136,7 @@ function initIntroPage() {
                 e.dataTransfer.setData('text/plain', row.dataset.introId);
             });
             row.addEventListener('dragend', function () {
+                row.removeAttribute('draggable');
                 row.classList.remove('dragging');
                 tbody.querySelectorAll('tr').forEach(r => r.classList.remove('drag-over'));
             });


### PR DESCRIPTION
## Problem

On the intros page, dragging the **volume slider** would start dragging the table row to **reorder intros** instead of changing the volume.

## Root cause

Every intro table row (`<tr>`) was unconditionally set to `draggable="true"` (`intros.js`). The volume control is an `<input type="range">` nested inside that row. When the user drags the slider thumb, the pointer drag bubbles up and the browser starts an HTML5 drag-and-drop operation on the row, firing `dragstart` and beginning a reorder — the slider's `input`/`change` events never get a chance. The `⋮⋮` drag handle existed visually but didn't actually gate dragging.

## Fix

Only allow a reorder drag to begin from the drag handle:

- The row is no longer `draggable` by default.
- `pointerdown` on `.drag-handle` sets `draggable="true"` on the row.
- `pointerup` / `pointercancel` on the handle, and `dragend` on the row, clear it again.

Now the volume slider (and other in-row controls) can be dragged freely without triggering a reorder, while drag-to-reorder still works from the handle. Drop-target rows don't need `draggable` set, so the `dragover`/`drop` handlers are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013dqX7VrFuAMPvkuimfbyWT)_