### PR TITLE
Add low-engagement lottery levers: rollover pot, streaks, scaled winner slots, configurable match odds

### DIFF
--- a/database/src/main/kotlin/database/dto/guild/ConfigDto.kt
+++ b/database/src/main/kotlin/database/dto/guild/ConfigDto.kt
@@ -389,6 +389,39 @@ class ConfigDto(
         LOTTERY_MILESTONE3_TICKETS("LOTTERY_MILESTONE3_TICKETS"),
         LOTTERY_MILESTONE3_PCT("LOTTERY_MILESTONE3_PCT"),
 
+        // Rollover pot for the daily lottery. Boolean ("true"/"false");
+        // defaults to "false". When enabled, a daily draw that cancels
+        // (below LOTTERY_DAILY_MIN_BUYERS / no tickets) or a
+        // NUMBER_MATCH draw whose tiers all go un-won parks the
+        // undistributed pool on the closed lottery row instead of
+        // returning it to the jackpot; the next daily open claims it
+        // into the fresh prize pool. Built for low-engagement guilds:
+        // a quiet day grows tomorrow's pot instead of reading as a dud.
+        LOTTERY_DAILY_ROLLOVER_ENABLED("LOTTERY_DAILY_ROLLOVER_ENABLED"),
+
+        // NUMBER_MATCH draw shape. PICK_COUNT is how many numbers each
+        // player picks (and the draw produces); NUMBER_MAX is the top of
+        // the 1..N range they pick from. Defaults 5 / 49 (Lotto-style).
+        // PICK_COUNT range [2, 6]; NUMBER_MAX range [10, 99] and always
+        // coerced to at least 2× the pick count at open. Small guilds
+        // should shrink both (e.g. pick 3 of 15) so match tiers actually
+        // fire with a handful of tickets — at 5-of-49 with 3 tickets,
+        // ~60% of draws pay nothing. Changes apply from the next open;
+        // the open draw keeps the shape it was opened with.
+        LOTTERY_DAILY_PICK_COUNT("LOTTERY_DAILY_PICK_COUNT"),
+        LOTTERY_DAILY_NUMBER_MAX("LOTTERY_DAILY_NUMBER_MAX"),
+
+        // Lottery participation streak. When a user buys a ticket
+        // (either mode) on N consecutive UTC days where N >=
+        // LOTTERY_STREAK_DAYS, each further participation day pays
+        // LOTTERY_STREAK_BONUS credits, drained from the jackpot pool
+        // (so the bonus never mints credits; an empty jackpot pays 0
+        // while still tracking the streak). DAYS=0 or BONUS=0 disables
+        // the payout (streaks are still tracked). Retention lever for
+        // small guilds where the same 2-3 players are the whole game.
+        LOTTERY_STREAK_DAYS("LOTTERY_STREAK_DAYS"),
+        LOTTERY_STREAK_BONUS("LOTTERY_STREAK_BONUS"),
+
         // Daily streak XP reward shape. Computed as
         // `min(base + per_day_bonus * (streak - 1), max)` inside
         // DefaultLoginStreakService. Streak rewards bypass DAILY_XP_CAP.

--- a/database/src/main/kotlin/database/dto/lottery/JackpotLotteryDto.kt
+++ b/database/src/main/kotlin/database/dto/lottery/JackpotLotteryDto.kt
@@ -129,6 +129,17 @@ class JackpotLotteryDto(
      */
     @Column(name = "milestones_fired", nullable = false)
     var milestonesFired: Long = 0,
+
+    /**
+     * Credits parked on this (closed) row for the next lottery of the
+     * same (guild, mode) to claim into its prize pool at open — the
+     * "rollover pot". Written at cancel/draw time when the guild has
+     * `LOTTERY_DAILY_ROLLOVER_ENABLED`; zeroed when a subsequent open
+     * claims it. 0 for rows that returned their pool to the jackpot
+     * (the pre-rollover behaviour, still the default).
+     */
+    @Column(name = "rollover_out", nullable = false)
+    var rolloverOut: Long = 0,
 ) : Serializable {
 
     companion object {

--- a/database/src/main/kotlin/database/dto/lottery/LotteryStreakDto.kt
+++ b/database/src/main/kotlin/database/dto/lottery/LotteryStreakDto.kt
@@ -1,0 +1,48 @@
+package database.dto.lottery
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.IdClass
+import jakarta.persistence.Table
+import org.springframework.transaction.annotation.Transactional
+import java.io.Serializable
+import java.time.LocalDate
+
+/**
+ * Per-(guild, user) daily-lottery participation streak.
+ *
+ * One row per user per guild: [streakDays] counts consecutive UTC
+ * calendar days on which the user bought at least one lottery ticket
+ * (either mode); [lastParticipationDate] is the most recent such day.
+ * A buy on the day after [lastParticipationDate] extends the streak; a
+ * gap resets it to 1. Same-day repeat buys are no-ops.
+ *
+ * Read/written inside the buy transaction by
+ * [database.service.lottery.JackpotLotteryService] — see
+ * V51__lottery_low_engagement.sql.
+ */
+@Entity
+@Table(name = "toby_coin_lottery_streak", schema = "public")
+@IdClass(LotteryStreakId::class)
+@Transactional
+class LotteryStreakDto(
+    @Id
+    @Column(name = "guild_id")
+    var guildId: Long = 0,
+
+    @Id
+    @Column(name = "discord_id")
+    var discordId: Long = 0,
+
+    @Column(name = "streak_days", nullable = false)
+    var streakDays: Int = 0,
+
+    @Column(name = "last_participation_date")
+    var lastParticipationDate: LocalDate? = null,
+) : Serializable
+
+data class LotteryStreakId(
+    var guildId: Long = 0,
+    var discordId: Long = 0,
+) : Serializable

--- a/database/src/main/kotlin/database/persistence/lottery/LotteryStreakPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/lottery/LotteryStreakPersistence.kt
@@ -1,0 +1,15 @@
+package database.persistence.lottery
+
+import database.dto.lottery.LotteryStreakDto
+
+interface LotteryStreakPersistence {
+    /**
+     * SELECT … FOR UPDATE on the (guild, user) streak row, or null when
+     * the user has never participated. Requires @Transactional — called
+     * from inside the buy transaction so two simultaneous buys can't
+     * double-count the same day.
+     */
+    fun getForUpdate(guildId: Long, discordId: Long): LotteryStreakDto?
+
+    fun upsert(streak: LotteryStreakDto): LotteryStreakDto
+}

--- a/database/src/main/kotlin/database/persistence/lottery/impl/DefaultLotteryStreakPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/lottery/impl/DefaultLotteryStreakPersistence.kt
@@ -1,0 +1,34 @@
+package database.persistence.lottery.impl
+
+import database.dto.lottery.LotteryStreakDto
+import database.dto.lottery.LotteryStreakId
+import database.persistence.lottery.LotteryStreakPersistence
+import database.persistence.saveOrMerge
+import jakarta.persistence.EntityManager
+import jakarta.persistence.LockModeType
+import jakarta.persistence.PersistenceContext
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+
+@Repository
+@Transactional
+class DefaultLotteryStreakPersistence : LotteryStreakPersistence {
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    override fun getForUpdate(guildId: Long, discordId: Long): LotteryStreakDto? =
+        entityManager.find(
+            LotteryStreakDto::class.java,
+            LotteryStreakId(guildId = guildId, discordId = discordId),
+            LockModeType.PESSIMISTIC_WRITE,
+        )
+
+    override fun upsert(streak: LotteryStreakDto): LotteryStreakDto {
+        val existing = entityManager.find(
+            LotteryStreakDto::class.java,
+            LotteryStreakId(guildId = streak.guildId, discordId = streak.discordId)
+        )
+        return entityManager.saveOrMerge(streak, isNew = { existing == null })
+    }
+}

--- a/database/src/main/kotlin/database/service/lottery/JackpotLotteryService.kt
+++ b/database/src/main/kotlin/database/service/lottery/JackpotLotteryService.kt
@@ -3,13 +3,18 @@ package database.service.lottery
 import common.events.lottery.LotteryWonEvent
 import database.dto.lottery.JackpotLotteryDto
 import database.dto.lottery.JackpotLotteryTicketDto
+import database.dto.lottery.LotteryStreakDto
 import database.persistence.lottery.JackpotLotteryPersistence
+import database.persistence.lottery.LotteryStreakPersistence
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.Clock
 import java.time.Instant
+import java.time.LocalDate
 import kotlin.math.max
 import kotlin.random.Random
+import database.dto.user.UserDto
 import database.service.guild.ConfigService
 import database.service.economy.JackpotService
 import database.service.lottery.LotteryHelper
@@ -23,12 +28,13 @@ import database.service.user.UserService
  *     [openLottery] / [buyTickets] / [drawLottery] / [cancelLottery].
  *     Each ticket is a weight; top-K winners share the pool 50/30/20-style.
  *
- *   - **NUMBER_MATCH** (daily auto-drain — Pick 5 of 1-49).
- *     [openMatchLottery] / [buyMatchTicket] / [drawMatchLottery].
- *     Players pick 5 distinct numbers from 1-49; the draw produces 5
- *     winning numbers; payouts tier by match count
- *     (5/4/3/2 → 60/25/10/5 % of pool). 0 / 1 matches pay nothing —
- *     those tickets are the credit sink.
+ *   - **NUMBER_MATCH** (daily auto-drain — Pick N of 1-M, default
+ *     5 of 49). [openMatchLottery] / [buyMatchTicket] / [drawMatchLottery].
+ *     Players pick N distinct numbers from 1-M; the draw produces N
+ *     winning numbers; payouts tier by match count (N down to 2, per
+ *     [LotteryHelper.matchTierPcts] — 60/25/10/5 % for the 5-pick
+ *     default). 0 / 1 matches pay nothing — those tickets are the
+ *     credit sink.
  *
  * V28 added a partial unique index on (guild_id, mode) where status =
  * 'OPEN'; both modes can be open simultaneously without clashing.
@@ -47,6 +53,13 @@ class JackpotLotteryService(
     private val configService: ConfigService,
     private val random: Random = Random.Default,
     private val eventPublisher: ApplicationEventPublisher? = null,
+    /**
+     * Nullable so pre-existing direct constructions (tests) keep
+     * working; Spring injects the repository bean. When null, streak
+     * tracking is a silent no-op.
+     */
+    private val streakPersistence: LotteryStreakPersistence? = null,
+    private val clock: Clock = Clock.systemUTC(),
 ) {
 
     // ===================================================================
@@ -54,7 +67,16 @@ class JackpotLotteryService(
     // ===================================================================
 
     sealed interface OpenOutcome {
-        data class Ok(val lottery: JackpotLotteryDto, val seeded: Long) : OpenOutcome
+        /**
+         * [rolledIn] is the rollover pot claimed from the previous
+         * closed lottery of the same (guild, mode) — already included
+         * in the new row's pool. 0 when nothing was parked.
+         */
+        data class Ok(
+            val lottery: JackpotLotteryDto,
+            val seeded: Long,
+            val rolledIn: Long = 0L,
+        ) : OpenOutcome
         data object AlreadyOpen : OpenOutcome
         data class InvalidParams(val reason: String) : OpenOutcome
         data object EmptyPool : OpenOutcome
@@ -72,6 +94,10 @@ class JackpotLotteryService(
             val totalBonusTickets: Long = 0L,
             /** Pool-growth milestones that fired during this purchase. */
             val milestoneBonuses: List<MilestoneBonus> = emptyList(),
+            /** Consecutive participation days including today (0 = untracked). */
+            val streakDays: Int = 0,
+            /** Streak bonus credits paid on this purchase (0 = none). */
+            val streakBonusAwarded: Long = 0L,
         ) : BuyOutcome
         data object NoOpenLottery : BuyOutcome
         data class InvalidCount(val ticketCount: Int) : BuyOutcome
@@ -114,7 +140,18 @@ class JackpotLotteryService(
     }
 
     sealed interface CancelOutcome {
-        data class Ok(val refundedUsers: Int, val refundedTotal: Long, val returnedToPool: Long) : CancelOutcome
+        /**
+         * Exactly one of [returnedToPool] / [rolledOver] is non-zero
+         * (or both zero): the undistributed seed either went back to
+         * the jackpot (default) or was parked as the rollover pot for
+         * the next open of the same mode.
+         */
+        data class Ok(
+            val refundedUsers: Int,
+            val refundedTotal: Long,
+            val returnedToPool: Long,
+            val rolledOver: Long = 0L,
+        ) : CancelOutcome
         data object NoOpenLottery : CancelOutcome
     }
 
@@ -131,6 +168,10 @@ class JackpotLotteryService(
             val newBalance: Long,
             val newPool: Long,
             val jackpotInflow: Long,
+            /** Consecutive participation days including today (0 = untracked). */
+            val streakDays: Int = 0,
+            /** Streak bonus credits paid on this purchase (0 = none). */
+            val streakBonusAwarded: Long = 0L,
         ) : BuyMatchOutcome
         data object NoOpenLottery : BuyMatchOutcome
         data class InvalidPicks(val reason: String) : BuyMatchOutcome
@@ -146,6 +187,8 @@ class JackpotLotteryService(
             val totalPaid: Long,
             val drained: Long,
             val rolledBackToJackpot: Long,
+            /** Unpaid remainder parked for tomorrow's draw instead of the jackpot. */
+            val rolledOver: Long = 0L,
         ) : DrawMatchOutcome
         data object NoOpenLottery : DrawMatchOutcome
         data object NoTickets : DrawMatchOutcome
@@ -187,23 +230,31 @@ class JackpotLotteryService(
         ) return OpenOutcome.AlreadyOpen
 
         val poolBefore = jackpotService.getPool(guildId)
-        if (poolBefore == 0L) return OpenOutcome.EmptyPool
-        val seed = kotlin.math.floor(poolBefore * drainPct).toLong().coerceAtMost(poolBefore).coerceAtLeast(1L)
+        // A parked rollover pot counts as funding: a guild whose jackpot
+        // ran dry can still open when yesterday's pot rolled over.
+        val pendingRollover = peekRollover(guildId, JackpotLotteryDto.MODE_TICKET_WEIGHTED)
+        if (poolBefore == 0L && pendingRollover <= 0L) return OpenOutcome.EmptyPool
+        // Preserve the pre-rollover "always seed at least 1" floor when
+        // the jackpot has anything in it; a rollover-only open seeds 0.
+        val seed = kotlin.math.floor(poolBefore * drainPct).toLong()
+            .coerceAtMost(poolBefore)
+            .coerceAtLeast(if (poolBefore > 0L) 1L else 0L)
 
         val drained = drainFromPool(guildId, seed)
+        val rolledIn = claimRollover(guildId, JackpotLotteryDto.MODE_TICKET_WEIGHTED)
 
         val now = Instant.now()
         val lottery = JackpotLotteryDto(
             guildId = guildId,
             ticketPrice = ticketPrice,
-            poolAmount = drained,
+            poolAmount = drained + rolledIn,
             winnerCount = winnerCount,
             openedAt = now,
             closesAt = now.plusSeconds(durationHours * 3600L),
             status = JackpotLotteryDto.STATUS_OPEN,
             mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
         )
-        return OpenOutcome.Ok(lotteryPersistence.upsert(lottery), seeded = drained)
+        return OpenOutcome.Ok(lotteryPersistence.upsert(lottery), seeded = drained, rolledIn = rolledIn)
     }
 
     fun buyTickets(guildId: Long, discordId: Long, ticketCount: Int): BuyOutcome {
@@ -287,6 +338,8 @@ class JackpotLotteryService(
 
         lotteryPersistence.upsert(lottery)
 
+        val streak = recordParticipationAndAward(guildId, discordId, user)
+
         return BuyOutcome.Ok(
             ticketCount = updatedTicket.ticketCount,
             totalSpent = updatedTicket.spent,
@@ -295,6 +348,8 @@ class JackpotLotteryService(
             bonusTicketsGranted = bulkBonus,
             totalBonusTickets = updatedTicket.bonusTickets,
             milestoneBonuses = firedBonuses,
+            streakDays = streak.days,
+            streakBonusAwarded = streak.bonusAwarded,
         )
     }
 
@@ -317,7 +372,12 @@ class JackpotLotteryService(
             return DrawOutcome.BelowMinBuyers(have = distinctBuyers, need = minBuyers)
         }
 
-        val winnerSlots = lottery.winnerCount.coerceAtLeast(1)
+        // Winner slots never exceed the distinct buyer count (one ticket
+        // row per buyer): with 2 buyers a 3-slot 50/30/20 schedule would
+        // leak 20% of the pool back to the jackpot every draw — scaling
+        // to 2 slots pays the full pot 60/40 instead. Matters most for
+        // small guilds where the daily WEIGHTED draw has 2-3 buyers.
+        val winnerSlots = lottery.winnerCount.coerceAtLeast(1).coerceAtMost(tickets.size)
         val multiplierTiers = LotteryHelper.volumeMultiplierTiers(configService, guildId)
         val winners = drawWinners(tickets, winnerSlots, random, multiplierTiers)
         val shares = prizeShares(winnerSlots, lottery.poolAmount)
@@ -355,7 +415,16 @@ class JackpotLotteryService(
         )
     }
 
-    fun cancelLottery(guildId: Long): CancelOutcome {
+    /**
+     * Cancel the open TICKET_WEIGHTED lottery, refunding every buyer.
+     * The undistributed seed returns to the jackpot pool by default;
+     * with [rolloverPot] it is parked on the cancelled row instead, for
+     * the next weighted open to claim (the daily job passes the guild's
+     * `LOTTERY_DAILY_ROLLOVER_ENABLED`; the admin `/jackpotadmin cancel`
+     * path keeps the default so a manually killed event returns its
+     * seed immediately).
+     */
+    fun cancelLottery(guildId: Long, rolloverPot: Boolean = false): CancelOutcome {
         val lottery = lotteryPersistence.getOpenByGuildAndModeForUpdate(
             guildId, JackpotLotteryDto.MODE_TICKET_WEIGHTED
         ) ?: return CancelOutcome.NoOpenLottery
@@ -374,13 +443,26 @@ class JackpotLotteryService(
         }
 
         val seedReturn = (lottery.poolAmount - refundedTotal).coerceAtLeast(0L)
-        if (seedReturn > 0L) jackpotService.addToPool(guildId, seedReturn)
+        var returnedToPool = 0L
+        var rolledOver = 0L
+        if (seedReturn > 0L) {
+            if (rolloverPot) {
+                lottery.rolloverOut = seedReturn
+                rolledOver = seedReturn
+            } else {
+                jackpotService.addToPool(guildId, seedReturn)
+                returnedToPool = seedReturn
+            }
+        }
 
         lottery.poolAmount = 0L
         lottery.status = JackpotLotteryDto.STATUS_CANCELLED
         lotteryPersistence.upsert(lottery)
 
-        return CancelOutcome.Ok(refundedUsers, refundedTotal, returnedToPool = seedReturn)
+        return CancelOutcome.Ok(
+            refundedUsers, refundedTotal,
+            returnedToPool = returnedToPool, rolledOver = rolledOver,
+        )
     }
 
     /** Read-only summary for `/lottery status` and the moderation tab. */
@@ -399,21 +481,36 @@ class JackpotLotteryService(
 
     /**
      * Open a NUMBER_MATCH daily lottery for [guildId]. Seeds the prize
-     * pool with `floor(currentJackpot * seedPct/100)`, sets pick_count =
-     * 5 and number_max = 49 (Lotto-style), and stays open for
+     * pool with `floor(currentJackpot * seedPct/100)` plus any rollover
+     * pot parked by the previous match draw, and stays open for
      * [durationHours]. Rejects if a NUMBER_MATCH lottery is already
      * open. Unlike weighted, an empty jackpot is OK — players' tickets
      * still grow the prize pool.
+     *
+     * [pickCount] / [numberMax] define the draw shape (default
+     * Lotto-style Pick 5 of 1-49). Callers pass the guild's
+     * `LOTTERY_DAILY_PICK_COUNT` / `LOTTERY_DAILY_NUMBER_MAX` so small
+     * guilds can run winnable odds (e.g. pick 3 of 15). [numberMax] is
+     * coerced to at least `2 × pickCount` so a degenerate near-
+     * guaranteed-win range can't be configured.
      */
     fun openMatchLottery(
         guildId: Long,
         ticketPrice: Long,
         seedPct: Long,
         durationHours: Long,
+        pickCount: Int = LotteryHelper.MATCH_PICK_COUNT,
+        numberMax: Int = LotteryHelper.MATCH_NUMBER_MAX,
     ): OpenOutcome {
         if (ticketPrice <= 0L) return OpenOutcome.InvalidParams("ticket price must be > 0")
         if (durationHours <= 0L) return OpenOutcome.InvalidParams("duration must be > 0 hours")
         if (seedPct < 0L || seedPct > 100L) return OpenOutcome.InvalidParams("seed pct must be in [0, 100]")
+        if (pickCount !in LotteryHelper.MIN_DAILY_PICK_COUNT..LotteryHelper.MAX_DAILY_PICK_COUNT) {
+            return OpenOutcome.InvalidParams(
+                "pick count must be in [${LotteryHelper.MIN_DAILY_PICK_COUNT}, ${LotteryHelper.MAX_DAILY_PICK_COUNT}]"
+            )
+        }
+        val effectiveNumberMax = numberMax.coerceAtLeast(pickCount * 2)
 
         if (lotteryPersistence.getOpenByGuildAndModeForUpdate(
                 guildId, JackpotLotteryDto.MODE_NUMBER_MATCH
@@ -425,21 +522,22 @@ class JackpotLotteryService(
         val seed = if (poolBefore <= 0L || seedPct <= 0L) 0L else
             kotlin.math.floor(poolBefore * (seedPct.toDouble() / 100.0)).toLong().coerceAtMost(poolBefore)
         val drained = if (seed > 0L) drainFromPool(guildId, seed) else 0L
+        val rolledIn = claimRollover(guildId, JackpotLotteryDto.MODE_NUMBER_MATCH)
 
         val now = Instant.now()
         val lottery = JackpotLotteryDto(
             guildId = guildId,
             ticketPrice = ticketPrice,
-            poolAmount = drained,
+            poolAmount = drained + rolledIn,
             winnerCount = 0,                 // unused for NUMBER_MATCH
             openedAt = now,
             closesAt = now.plusSeconds(durationHours * 3600L),
             status = JackpotLotteryDto.STATUS_OPEN,
             mode = JackpotLotteryDto.MODE_NUMBER_MATCH,
-            pickCount = LotteryHelper.MATCH_PICK_COUNT,
-            numberMax = LotteryHelper.MATCH_NUMBER_MAX,
+            pickCount = pickCount,
+            numberMax = effectiveNumberMax,
         )
-        return OpenOutcome.Ok(lotteryPersistence.upsert(lottery), seeded = drained)
+        return OpenOutcome.Ok(lotteryPersistence.upsert(lottery), seeded = drained, rolledIn = rolledIn)
     }
 
     /**
@@ -456,14 +554,15 @@ class JackpotLotteryService(
      * engagement grow the prize pool.
      */
     fun buyMatchTicket(guildId: Long, discordId: Long, picks: List<Int>): BuyMatchOutcome {
-        val pickCount = LotteryHelper.MATCH_PICK_COUNT
-        val numberMax = LotteryHelper.MATCH_NUMBER_MAX
-        val validation = validatePicks(picks, pickCount, numberMax)
-        if (validation != null) return BuyMatchOutcome.InvalidPicks(validation)
-
         val lottery = lotteryPersistence.getOpenByGuildAndModeForUpdate(
             guildId, JackpotLotteryDto.MODE_NUMBER_MATCH
         ) ?: return BuyMatchOutcome.NoOpenLottery
+
+        // Validate against the open row's shape (not the live config):
+        // an admin editing pick count mid-draw must not orphan tickets
+        // already bought against the old shape.
+        val validation = validatePicks(picks, lottery.pickCount, lottery.numberMax)
+        if (validation != null) return BuyMatchOutcome.InvalidPicks(validation)
 
         val lotteryId = lottery.id ?: error("Open lottery has no id")
         if (lotteryPersistence.getTicketForUpdate(lotteryId, discordId) != null) {
@@ -502,34 +601,40 @@ class JackpotLotteryService(
             jackpotService.addToPool(guildId, toJackpot)
         }
 
+        val streak = recordParticipationAndAward(guildId, discordId, user)
+
         return BuyMatchOutcome.Ok(
             pickedNumbers = sortedPicks,
             totalSpent = cost,
             newBalance = user.socialCredit ?: (balance - cost),
             newPool = lottery.poolAmount,
             jackpotInflow = toJackpot,
+            streakDays = streak.days,
+            streakBonusAwarded = streak.bonusAwarded,
         )
     }
 
     /**
-     * Draw a NUMBER_MATCH lottery: pick 5 winning numbers, compute
-     * match counts per ticket, distribute the prize pool by tier.
+     * Draw a NUMBER_MATCH lottery: pick the row's `pick_count` winning
+     * numbers, compute match counts per ticket, distribute the prize
+     * pool by tier.
      *
-     * Tier shares (60/25/10/5 % of pool, see [LotteryHelper.TIER_PCTS_5_4_3_2]):
-     *   - 5/5 matches share 60% equally
-     *   - 4/5 share 25% equally
-     *   - 3/5 share 10% equally
-     *   - 2/5 share 5% equally
-     *   - 0/5 and 1/5 win nothing — sink for the day.
+     * Tier shares follow [LotteryHelper.matchTierPcts] for the row's
+     * pick count — e.g. the 5-pick default pays 5/4/3/2 matches
+     * 60/25/10/5 % of the pool; a small-guild 3-pick draw pays 3/2
+     * matches 70/30. 0 / 1 matches always win nothing — sink for the
+     * day.
      *
      * Empty tiers and rounding remainders roll back into the per-guild
-     * jackpot pool so credits never vanish.
+     * jackpot pool so credits never vanish — or, with
+     * [rolloverRemainder], are parked on the drawn row as the rollover
+     * pot for the next open to claim.
      *
      * Returns [DrawMatchOutcome.NoTickets] when no one bought today —
      * the caller (scheduler) is expected to refund the seed in that
      * case via [cancelMatchLottery].
      */
-    fun drawMatchLottery(guildId: Long): DrawMatchOutcome {
+    fun drawMatchLottery(guildId: Long, rolloverRemainder: Boolean = false): DrawMatchOutcome {
         val lottery = lotteryPersistence.getOpenByGuildAndModeForUpdate(
             guildId, JackpotLotteryDto.MODE_NUMBER_MATCH
         ) ?: return DrawMatchOutcome.NoOpenLottery
@@ -559,12 +664,17 @@ class JackpotLotteryService(
         }
 
         val totalPool = lottery.poolAmount
-        val tierShares = computeTierShares(totalPool, LotteryHelper.TIER_PCTS_5_4_3_2)
+        // Tier schedule follows the row's pick count (pay pickCount..2
+        // matches) so a small-guild pick-3 draw pays 70/30 instead of
+        // leaving the 5-pick tiers unreachable.
+        val effectivePickCount = lottery.pickCount
+            .coerceIn(LotteryHelper.MIN_DAILY_PICK_COUNT, LotteryHelper.MAX_DAILY_PICK_COUNT)
+        val tierShares = computeTierShares(totalPool, LotteryHelper.matchTierPcts(effectivePickCount))
         val payouts = mutableListOf<MatchTierPayout>()
         var totalPaid = 0L
 
-        // Tier order: 5, 4, 3, 2 matches → indexes 0..3 in tierShares.
-        val tierMatchCounts = listOf(5, 4, 3, 2)
+        // Tier order: pickCount, pickCount-1, …, 2 matches → indexes 0.. in tierShares.
+        val tierMatchCounts = (effectivePickCount downTo 2).toList()
         tierMatchCounts.forEachIndexed { tierIndex, matchCount ->
             val share = tierShares[tierIndex]
             if (share <= 0L) return@forEachIndexed
@@ -586,13 +696,23 @@ class JackpotLotteryService(
         lottery.drawnNumbers = drawn.joinToString(",")
         lottery.poolAmount = 0L
         lottery.status = JackpotLotteryDto.STATUS_DRAWN
-        lotteryPersistence.upsert(lottery)
 
+        // Unpaid remainder (empty tiers + rounding crumbs): back to the
+        // jackpot by default, or parked as the rollover pot so
+        // tomorrow's prize pool visibly grows on a no-winner day.
         val remainder = totalPool - totalPaid
-        val rolledBack = if (remainder > 0L) {
-            jackpotService.addToPool(guildId, remainder)
-            remainder
-        } else 0L
+        var rolledBack = 0L
+        var rolledOver = 0L
+        if (remainder > 0L) {
+            if (rolloverRemainder) {
+                lottery.rolloverOut = remainder
+                rolledOver = remainder
+            } else {
+                jackpotService.addToPool(guildId, remainder)
+                rolledBack = remainder
+            }
+        }
+        lotteryPersistence.upsert(lottery)
 
         return DrawMatchOutcome.Ok(
             drawnNumbers = drawn,
@@ -600,6 +720,7 @@ class JackpotLotteryService(
             totalPaid = totalPaid,
             drained = totalPool,
             rolledBackToJackpot = rolledBack,
+            rolledOver = rolledOver,
         )
     }
 
@@ -607,12 +728,15 @@ class JackpotLotteryService(
      * Cancel an open NUMBER_MATCH lottery: refund every buyer their
      * spend (the prize portion of their ticket cost — the jackpot
      * portion already left the user's wallet on buy and isn't here to
-     * refund). Returns the seed share to the per-guild jackpot pool.
+     * refund). Returns the seed share to the per-guild jackpot pool,
+     * or — with [rolloverPot] — parks it on the cancelled row for the
+     * next match open to claim.
      *
      * Used by the scheduler when a draw rolls but no tickets were
-     * bought (no one to draw against).
+     * bought (no one to draw against) or participation was below the
+     * min-buyer threshold.
      */
-    fun cancelMatchLottery(guildId: Long): CancelOutcome {
+    fun cancelMatchLottery(guildId: Long, rolloverPot: Boolean = false): CancelOutcome {
         val lottery = lotteryPersistence.getOpenByGuildAndModeForUpdate(
             guildId, JackpotLotteryDto.MODE_NUMBER_MATCH
         ) ?: return CancelOutcome.NoOpenLottery
@@ -631,13 +755,26 @@ class JackpotLotteryService(
         }
 
         val seedReturn = (lottery.poolAmount - refundedTotal).coerceAtLeast(0L)
-        if (seedReturn > 0L) jackpotService.addToPool(guildId, seedReturn)
+        var returnedToPool = 0L
+        var rolledOver = 0L
+        if (seedReturn > 0L) {
+            if (rolloverPot) {
+                lottery.rolloverOut = seedReturn
+                rolledOver = seedReturn
+            } else {
+                jackpotService.addToPool(guildId, seedReturn)
+                returnedToPool = seedReturn
+            }
+        }
 
         lottery.poolAmount = 0L
         lottery.status = JackpotLotteryDto.STATUS_CANCELLED
         lotteryPersistence.upsert(lottery)
 
-        return CancelOutcome.Ok(refundedUsers, refundedTotal, returnedToPool = seedReturn)
+        return CancelOutcome.Ok(
+            refundedUsers, refundedTotal,
+            returnedToPool = returnedToPool, rolledOver = rolledOver,
+        )
     }
 
     /** Read-only: current open NUMBER_MATCH lottery for [guildId], if any. */
@@ -860,6 +997,75 @@ class JackpotLotteryService(
     internal fun parsePicks(csv: String?): List<Int> {
         if (csv.isNullOrBlank()) return emptyList()
         return csv.split(',').mapNotNull { it.trim().toIntOrNull() }
+    }
+
+    /**
+     * Rollover pot still parked on the most recent closed lottery of
+     * (guild, mode), without claiming it. Used by [openLottery] to
+     * decide whether a dry jackpot can still open.
+     */
+    private fun peekRollover(guildId: Long, mode: String): Long =
+        lotteryPersistence.getLatestByGuildAndMode(guildId, mode)?.rolloverOut?.coerceAtLeast(0L) ?: 0L
+
+    /**
+     * Claim (and zero) the rollover pot parked on the most recent
+     * closed lottery of (guild, mode). Claimed unconditionally at open
+     * — even when the guild has since disabled the rollover toggle —
+     * so parked credits can never strand on an old row.
+     */
+    private fun claimRollover(guildId: Long, mode: String): Long {
+        val latest = lotteryPersistence.getLatestByGuildAndMode(guildId, mode) ?: return 0L
+        val amount = latest.rolloverOut
+        if (amount <= 0L) return 0L
+        latest.rolloverOut = 0L
+        lotteryPersistence.upsert(latest)
+        return amount
+    }
+
+    /** Result of a per-buy streak update. [days] = 0 when tracking is unavailable. */
+    internal data class StreakProgress(val days: Int, val bonusAwarded: Long)
+
+    /**
+     * Record a lottery participation for (guild, user) on today's UTC
+     * date and, when the resulting streak is at/above the configured
+     * `LOTTERY_STREAK_DAYS` threshold, pay the `LOTTERY_STREAK_BONUS`
+     * once for the day — drained from the jackpot pool so the bonus
+     * never mints credits (an empty jackpot pays 0 but the streak
+     * still advances).
+     *
+     * Same-day repeat buys are no-ops (streak unchanged, no second
+     * bonus): the award only fires on the transition to a new
+     * participation day. Buying on the day after the last recorded one
+     * extends the streak; any gap resets it to 1.
+     */
+    private fun recordParticipationAndAward(
+        guildId: Long,
+        discordId: Long,
+        user: UserDto,
+    ): StreakProgress {
+        val persistence = streakPersistence ?: return StreakProgress(days = 0, bonusAwarded = 0L)
+        val today = LocalDate.now(clock)
+        val row = persistence.getForUpdate(guildId, discordId)
+            ?: LotteryStreakDto(guildId = guildId, discordId = discordId)
+
+        val last = row.lastParticipationDate
+        if (last == today) return StreakProgress(days = row.streakDays, bonusAwarded = 0L)
+
+        row.streakDays = if (last == today.minusDays(1)) row.streakDays + 1 else 1
+        row.lastParticipationDate = today
+        persistence.upsert(row)
+
+        val threshold = LotteryHelper.streakThresholdDays(configService, guildId)
+        val bonus = LotteryHelper.streakBonusCredits(configService, guildId)
+        var awarded = 0L
+        if (threshold > 0 && bonus > 0L && row.streakDays >= threshold) {
+            awarded = drainFromPool(guildId, bonus)
+            if (awarded > 0L) {
+                user.socialCredit = (user.socialCredit ?: 0L) + awarded
+                userService.updateUser(user)
+            }
+        }
+        return StreakProgress(days = row.streakDays, bonusAwarded = awarded)
     }
 
     /**

--- a/database/src/main/kotlin/database/service/lottery/LotteryHelper.kt
+++ b/database/src/main/kotlin/database/service/lottery/LotteryHelper.kt
@@ -17,12 +17,22 @@ import database.service.guild.ConfigService
 object LotteryHelper {
 
     /**
-     * Pick 5 of 1-49 — Lotto-style. Hardcoded for now because the prize
-     * tier schedule was tuned to these odds; varying pick count would
-     * need a fresh schedule and is out of scope for the daily MVP.
+     * Pick 5 of 1-49 — Lotto-style defaults. Per-guild overrides via
+     * `LOTTERY_DAILY_PICK_COUNT` / `LOTTERY_DAILY_NUMBER_MAX` (see
+     * [dailyPickCount] / [dailyNumberMax]) let small guilds shrink the
+     * odds so match tiers actually fire with a handful of tickets; the
+     * prize-tier schedule adapts via [matchTierPcts].
      */
     const val MATCH_PICK_COUNT: Int = 5
     const val MATCH_NUMBER_MAX: Int = 49
+
+    /** Configurable pick-count bounds — each count has a tuned tier schedule in [matchTierPcts]. */
+    const val MIN_DAILY_PICK_COUNT: Int = 2
+    const val MAX_DAILY_PICK_COUNT: Int = 6
+
+    /** Configurable number-range bounds for NUMBER_MATCH. */
+    const val MIN_DAILY_NUMBER_MAX: Int = 10
+    const val MAX_DAILY_NUMBER_MAX: Int = 99
 
     /** Daily auto-draw is opt-in per guild. */
     const val DEFAULT_DAILY_ENABLED: Boolean = false
@@ -75,13 +85,41 @@ object LotteryHelper {
     const val MAX_DAILY_MIN_BUYERS: Int = 50
 
     /**
-     * Tier prize percentages for a match-numbers draw. Order: 5/5, 4/5,
-     * 3/5, 2/5. Sum = 100; un-won tier shares roll back into the
-     * per-guild jackpot pool via the remainder-handling in
-     * [JackpotLotteryService.drawMatchLottery]. 0 / 1 matches pay
-     * nothing — those tickets are the sink.
+     * Tier prize percentages for a 5-pick match-numbers draw. Order:
+     * 5/5, 4/5, 3/5, 2/5. Sum = 100; un-won tier shares roll back into
+     * the per-guild jackpot pool (or the rollover pot) via the
+     * remainder-handling in [JackpotLotteryService.drawMatchLottery].
+     * 0 / 1 matches pay nothing — those tickets are the sink.
      */
     val TIER_PCTS_5_4_3_2: IntArray = intArrayOf(60, 25, 10, 5)
+
+    /**
+     * Prize-tier schedule for a NUMBER_MATCH draw with [pickCount]
+     * picks. Tiers pay match counts `pickCount` down to 2 (0 / 1
+     * matches always pay nothing); each schedule sums to 100. Hand-
+     * tuned per pick count — top tier stays the headline prize, lower
+     * tiers keep small "almost!" returns so low-odds days still feel
+     * alive. Out-of-range counts clamp to the nearest supported
+     * schedule so a bad stored value can't crash a draw.
+     */
+    fun matchTierPcts(pickCount: Int): IntArray = when (
+        pickCount.coerceIn(MIN_DAILY_PICK_COUNT, MAX_DAILY_PICK_COUNT)
+    ) {
+        2 -> intArrayOf(100)
+        3 -> intArrayOf(70, 30)
+        4 -> intArrayOf(60, 25, 15)
+        5 -> TIER_PCTS_5_4_3_2
+        else -> intArrayOf(50, 25, 12, 8, 5)  // 6
+    }
+
+    /** Rollover pot for cancelled / un-won daily draws is opt-in per guild. */
+    const val DEFAULT_DAILY_ROLLOVER_ENABLED: Boolean = false
+
+    /** Streak payout defaults — 0 threshold means the bonus is disabled. */
+    const val DEFAULT_STREAK_DAYS: Int = 0
+    const val MAX_STREAK_DAYS: Int = 365
+    const val DEFAULT_STREAK_BONUS: Long = 0L
+    const val MAX_STREAK_BONUS: Long = 1_000_000L
 
     /** Live boolean toggle for the daily auto-draw. */
     fun dailyEnabled(configService: ConfigService, guildId: Long): Boolean {
@@ -156,6 +194,78 @@ object LotteryHelper {
         )
         val raw = cfg?.value?.toIntOrNull() ?: return DEFAULT_DAILY_MIN_BUYERS
         return raw.coerceIn(1, MAX_DAILY_MIN_BUYERS)
+    }
+
+    /**
+     * Live rollover-pot toggle. When true, a cancelled daily draw (or a
+     * NUMBER_MATCH draw whose tiers all go un-won) parks its
+     * undistributed pool for the next open to claim, instead of
+     * returning it to the jackpot.
+     */
+    fun dailyRolloverEnabled(configService: ConfigService, guildId: Long): Boolean {
+        val raw = configService.getConfigByName(
+            ConfigDto.Configurations.LOTTERY_DAILY_ROLLOVER_ENABLED.configValue,
+            guildId.toString()
+        )?.value?.trim()?.lowercase()
+        return when (raw) {
+            "true", "1", "yes", "on" -> true
+            null -> DEFAULT_DAILY_ROLLOVER_ENABLED
+            else -> false
+        }
+    }
+
+    /** Live NUMBER_MATCH pick count, clamped to a supported tier schedule. */
+    fun dailyPickCount(configService: ConfigService, guildId: Long): Int {
+        val cfg = configService.getConfigByName(
+            ConfigDto.Configurations.LOTTERY_DAILY_PICK_COUNT.configValue,
+            guildId.toString()
+        )
+        val raw = cfg?.value?.toIntOrNull() ?: return MATCH_PICK_COUNT
+        return raw.coerceIn(MIN_DAILY_PICK_COUNT, MAX_DAILY_PICK_COUNT)
+    }
+
+    /**
+     * Live NUMBER_MATCH number range top (players pick from 1..N).
+     * Clamped to [MIN_DAILY_NUMBER_MAX, MAX_DAILY_NUMBER_MAX] here;
+     * [JackpotLotteryService.openMatchLottery] additionally coerces it
+     * to at least 2× the pick count so a degenerate near-guaranteed-win
+     * config can't drain the pool.
+     */
+    fun dailyNumberMax(configService: ConfigService, guildId: Long): Int {
+        val cfg = configService.getConfigByName(
+            ConfigDto.Configurations.LOTTERY_DAILY_NUMBER_MAX.configValue,
+            guildId.toString()
+        )
+        val raw = cfg?.value?.toIntOrNull() ?: return MATCH_NUMBER_MAX
+        return raw.coerceIn(MIN_DAILY_NUMBER_MAX, MAX_DAILY_NUMBER_MAX)
+    }
+
+    /**
+     * Live participation-streak threshold in consecutive UTC days.
+     * 0 disables the streak payout (streaks are still tracked so
+     * enabling later picks up existing history).
+     */
+    fun streakThresholdDays(configService: ConfigService, guildId: Long): Int {
+        val cfg = configService.getConfigByName(
+            ConfigDto.Configurations.LOTTERY_STREAK_DAYS.configValue,
+            guildId.toString()
+        )
+        val raw = cfg?.value?.toIntOrNull() ?: return DEFAULT_STREAK_DAYS
+        return raw.coerceIn(0, MAX_STREAK_DAYS)
+    }
+
+    /**
+     * Live per-day streak bonus in credits, paid once per participation
+     * day while the streak is at/above [streakThresholdDays]. Drained
+     * from the jackpot pool at award time — never minted.
+     */
+    fun streakBonusCredits(configService: ConfigService, guildId: Long): Long {
+        val cfg = configService.getConfigByName(
+            ConfigDto.Configurations.LOTTERY_STREAK_BONUS.configValue,
+            guildId.toString()
+        )
+        val raw = cfg?.value?.toLongOrNull() ?: return DEFAULT_STREAK_BONUS
+        return raw.coerceIn(0L, MAX_STREAK_BONUS)
     }
 
     /**

--- a/database/src/main/resources/db/migration/V51__lottery_low_engagement.sql
+++ b/database/src/main/resources/db/migration/V51__lottery_low_engagement.sql
@@ -1,0 +1,28 @@
+-- Low-engagement lottery improvements, aimed at guilds where only a
+-- handful of players (2-3) buy in each day:
+--
+--   1. Rollover pot: when a daily draw cancels (below the min-buyer
+--      threshold / no tickets) or a NUMBER_MATCH draw pays out nothing,
+--      the undistributed pool can be parked on the closed lottery row
+--      (`rollover_out`) instead of returning to the jackpot. The next
+--      open for the same (guild, mode) claims it into the fresh prize
+--      pool, so quiet days visibly grow tomorrow's pot instead of
+--      reading as duds. Opt-in via LOTTERY_DAILY_ROLLOVER_ENABLED.
+--
+--   2. Participation streaks: one row per (guild, user) tracking
+--      consecutive calendar days (UTC) with at least one lottery ticket
+--      bought. When the streak reaches the configured threshold
+--      (LOTTERY_STREAK_DAYS), each further participation day pays a
+--      bonus (LOTTERY_STREAK_BONUS) drained from the jackpot pool.
+
+ALTER TABLE toby_coin_jackpot_lottery
+    ADD COLUMN rollover_out BIGINT NOT NULL DEFAULT 0;
+
+CREATE TABLE toby_coin_lottery_streak
+(
+    guild_id                BIGINT NOT NULL,
+    discord_id              BIGINT NOT NULL,
+    streak_days             INT    NOT NULL DEFAULT 0,
+    last_participation_date DATE,
+    PRIMARY KEY (guild_id, discord_id)
+);

--- a/database/src/test/kotlin/database/service/JackpotLotteryServiceTest.kt
+++ b/database/src/test/kotlin/database/service/JackpotLotteryServiceTest.kt
@@ -1181,4 +1181,452 @@ class JackpotLotteryServiceTest {
         assertEquals(11L, r.bonusTicketsAwarded, "8 + 3 across both buyers")
         assertEquals(50L, r.highestMilestoneFired)
     }
+
+    // ===================================================================
+    // Winner slots scale to distinct buyer count
+    // ===================================================================
+
+    @Test
+    fun `drawLottery with 2 buyers and 3 slots pays the full pool 60-40`() {
+        val lottery = JackpotLotteryDto(
+            id = 1L, guildId = guildId, ticketPrice = 100L, poolAmount = 1_000L,
+            winnerCount = 3, status = JackpotLotteryDto.STATUS_OPEN,
+            mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
+        )
+        every {
+            lotteryPersistence.getOpenByGuildAndModeForUpdate(guildId, JackpotLotteryDto.MODE_TICKET_WEIGHTED)
+        } returns lottery
+        every { lotteryPersistence.ticketsByLottery(1L) } returns listOf(
+            JackpotLotteryTicketDto(lotteryId = 1L, discordId = 1L, ticketCount = 1, spent = 100L),
+            JackpotLotteryTicketDto(lotteryId = 1L, discordId = 2L, ticketCount = 1, spent = 100L),
+        )
+        (1L..2L).forEach { id ->
+            every { userService.getUserByIdForUpdate(id, guildId) } returns
+                UserDto(discordId = id, guildId = guildId).apply { socialCredit = 0L }
+        }
+
+        val r = service.drawLottery(guildId)
+        assertTrue(r is JackpotLotteryService.DrawOutcome.Ok)
+        r as JackpotLotteryService.DrawOutcome.Ok
+        // Pre-change this paid 50/30 and leaked 20% back to the jackpot;
+        // scaled slots pay the 2-winner 60/40 schedule instead.
+        assertEquals(setOf(600L, 400L), r.payouts.map { it.amount }.toSet())
+        assertEquals(1_000L, r.totalPaid)
+        verify(exactly = 0) { jackpotService.addToPool(guildId, any()) }
+    }
+
+    // ===================================================================
+    // Rollover pot
+    // ===================================================================
+
+    @Test
+    fun `cancelLottery with rolloverPot parks the seed on the row instead of the jackpot`() {
+        val lottery = JackpotLotteryDto(
+            id = 1L, guildId = guildId, ticketPrice = 100L, poolAmount = 1_500L,
+            status = JackpotLotteryDto.STATUS_OPEN, mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
+        )
+        every {
+            lotteryPersistence.getOpenByGuildAndModeForUpdate(guildId, JackpotLotteryDto.MODE_TICKET_WEIGHTED)
+        } returns lottery
+        every { lotteryPersistence.ticketsByLottery(1L) } returns listOf(
+            JackpotLotteryTicketDto(lotteryId = 1L, discordId = 1L, ticketCount = 5, spent = 500L),
+            JackpotLotteryTicketDto(lotteryId = 1L, discordId = 2L, ticketCount = 3, spent = 300L),
+        )
+        (1L..2L).forEach { id ->
+            every { userService.getUserByIdForUpdate(id, guildId) } returns
+                UserDto(discordId = id, guildId = guildId).apply { socialCredit = 0L }
+        }
+
+        val r = service.cancelLottery(guildId, rolloverPot = true)
+        assertTrue(r is JackpotLotteryService.CancelOutcome.Ok)
+        r as JackpotLotteryService.CancelOutcome.Ok
+        assertEquals(800L, r.refundedTotal, "buyers are always refunded")
+        assertEquals(0L, r.returnedToPool)
+        assertEquals(700L, r.rolledOver)
+        assertEquals(700L, lottery.rolloverOut)
+        verify(exactly = 0) { jackpotService.addToPool(guildId, any()) }
+        assertEquals(JackpotLotteryDto.STATUS_CANCELLED, lottery.status)
+    }
+
+    @Test
+    fun `openLottery claims a parked rollover pot into the new pool`() {
+        every {
+            lotteryPersistence.getOpenByGuildAndModeForUpdate(guildId, JackpotLotteryDto.MODE_TICKET_WEIGHTED)
+        } returns null
+        val previous = JackpotLotteryDto(
+            id = 41L, guildId = guildId, status = JackpotLotteryDto.STATUS_CANCELLED,
+            mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED, rolloverOut = 700L,
+        )
+        every {
+            lotteryPersistence.getLatestByGuildAndMode(guildId, JackpotLotteryDto.MODE_TICKET_WEIGHTED)
+        } returns previous
+        every { jackpotService.getPool(guildId) } returns 10_000L
+        every { jackpotService.resetPool(guildId) } returns 10_000L
+        val saved = mutableListOf<JackpotLotteryDto>()
+        every { lotteryPersistence.upsert(capture(saved)) } answers { firstArg() }
+
+        val r = service.openLottery(guildId, ticketPrice = 100L, durationHours = 24, winnerCount = 3, drainPct = 0.5)
+        assertTrue(r is JackpotLotteryService.OpenOutcome.Ok)
+        r as JackpotLotteryService.OpenOutcome.Ok
+        assertEquals(5_000L, r.seeded)
+        assertEquals(700L, r.rolledIn)
+        assertEquals(5_700L, r.lottery.poolAmount)
+        assertEquals(0L, previous.rolloverOut, "claimed pot is zeroed on the old row")
+    }
+
+    @Test
+    fun `openLottery with an empty jackpot still opens when a rollover pot is parked`() {
+        every {
+            lotteryPersistence.getOpenByGuildAndModeForUpdate(guildId, JackpotLotteryDto.MODE_TICKET_WEIGHTED)
+        } returns null
+        every {
+            lotteryPersistence.getLatestByGuildAndMode(guildId, JackpotLotteryDto.MODE_TICKET_WEIGHTED)
+        } returns JackpotLotteryDto(
+            id = 41L, guildId = guildId, status = JackpotLotteryDto.STATUS_CANCELLED,
+            mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED, rolloverOut = 500L,
+        )
+        every { jackpotService.getPool(guildId) } returns 0L
+        every { lotteryPersistence.upsert(any()) } answers { firstArg() }
+
+        val r = service.openLottery(guildId, ticketPrice = 100L, durationHours = 24, winnerCount = 3, drainPct = 0.5)
+        assertTrue(r is JackpotLotteryService.OpenOutcome.Ok, "rollover-funded open must not report EmptyPool")
+        r as JackpotLotteryService.OpenOutcome.Ok
+        assertEquals(0L, r.seeded)
+        assertEquals(500L, r.rolledIn)
+        assertEquals(500L, r.lottery.poolAmount)
+    }
+
+    @Test
+    fun `drawMatchLottery with rolloverRemainder parks an unwon pool on the row`() {
+        val lottery = JackpotLotteryDto(
+            id = 1L, guildId = guildId, ticketPrice = 50L, poolAmount = 1_000L,
+            status = JackpotLotteryDto.STATUS_OPEN, mode = JackpotLotteryDto.MODE_NUMBER_MATCH,
+            pickCount = 5, numberMax = 49,
+        )
+        every {
+            lotteryPersistence.getOpenByGuildAndModeForUpdate(guildId, JackpotLotteryDto.MODE_NUMBER_MATCH)
+        } returns lottery
+        // Single ticket that never matches any drawn number.
+        val expectedDraw = service.drawNumbers(49, 5, Random(42))
+        val nonDrawn = (1..49).filter { it !in expectedDraw }.take(5)
+        every { lotteryPersistence.ticketsByLottery(1L) } returns listOf(
+            JackpotLotteryTicketDto(
+                lotteryId = 1L, discordId = 7L, ticketCount = 1, spent = 50L,
+                pickedNumbers = nonDrawn.joinToString(","),
+            )
+        )
+        every { userService.getUserByIdForUpdate(7L, guildId) } returns
+            UserDto(discordId = 7L, guildId = guildId).apply { socialCredit = 0L }
+
+        val r = service.drawMatchLottery(guildId, rolloverRemainder = true)
+        assertTrue(r is JackpotLotteryService.DrawMatchOutcome.Ok)
+        r as JackpotLotteryService.DrawMatchOutcome.Ok
+        assertEquals(0L, r.totalPaid)
+        assertEquals(0L, r.rolledBackToJackpot)
+        assertEquals(1_000L, r.rolledOver)
+        assertEquals(1_000L, lottery.rolloverOut)
+        verify(exactly = 0) { jackpotService.addToPool(guildId, any()) }
+    }
+
+    @Test
+    fun `openMatchLottery claims a parked rollover pot into the new prize pool`() {
+        every {
+            lotteryPersistence.getOpenByGuildAndModeForUpdate(guildId, JackpotLotteryDto.MODE_NUMBER_MATCH)
+        } returns null
+        val previous = JackpotLotteryDto(
+            id = 41L, guildId = guildId, status = JackpotLotteryDto.STATUS_DRAWN,
+            mode = JackpotLotteryDto.MODE_NUMBER_MATCH, rolloverOut = 900L,
+        )
+        every {
+            lotteryPersistence.getLatestByGuildAndMode(guildId, JackpotLotteryDto.MODE_NUMBER_MATCH)
+        } returns previous
+        every { jackpotService.getPool(guildId) } returns 0L
+        val saved = slot<JackpotLotteryDto>()
+        every { lotteryPersistence.upsert(capture(saved)) } answers { firstArg() }
+
+        val r = service.openMatchLottery(guildId, ticketPrice = 50L, seedPct = 5L, durationHours = 24)
+        assertTrue(r is JackpotLotteryService.OpenOutcome.Ok)
+        r as JackpotLotteryService.OpenOutcome.Ok
+        assertEquals(900L, r.rolledIn)
+        assertEquals(900L, r.lottery.poolAmount)
+        assertEquals(0L, previous.rolloverOut)
+    }
+
+    // ===================================================================
+    // Configurable match odds (pick count / number max)
+    // ===================================================================
+
+    @Test
+    fun `openMatchLottery stores the configured pick count and number range`() {
+        every {
+            lotteryPersistence.getOpenByGuildAndModeForUpdate(guildId, JackpotLotteryDto.MODE_NUMBER_MATCH)
+        } returns null
+        every { jackpotService.getPool(guildId) } returns 0L
+        val saved = slot<JackpotLotteryDto>()
+        every { lotteryPersistence.upsert(capture(saved)) } answers { firstArg() }
+
+        val r = service.openMatchLottery(
+            guildId, ticketPrice = 50L, seedPct = 5L, durationHours = 24,
+            pickCount = 3, numberMax = 15,
+        )
+        assertTrue(r is JackpotLotteryService.OpenOutcome.Ok)
+        assertEquals(3, saved.captured.pickCount)
+        assertEquals(15, saved.captured.numberMax)
+    }
+
+    @Test
+    fun `openMatchLottery coerces the number range to at least twice the pick count`() {
+        every {
+            lotteryPersistence.getOpenByGuildAndModeForUpdate(guildId, JackpotLotteryDto.MODE_NUMBER_MATCH)
+        } returns null
+        every { jackpotService.getPool(guildId) } returns 0L
+        val saved = slot<JackpotLotteryDto>()
+        every { lotteryPersistence.upsert(capture(saved)) } answers { firstArg() }
+
+        service.openMatchLottery(
+            guildId, ticketPrice = 50L, seedPct = 5L, durationHours = 24,
+            pickCount = 6, numberMax = 10,
+        )
+        assertEquals(12, saved.captured.numberMax, "6 picks of 1-10 is degenerate; floor is 2x picks")
+    }
+
+    @Test
+    fun `openMatchLottery rejects an unsupported pick count`() {
+        val r = service.openMatchLottery(
+            guildId, ticketPrice = 50L, seedPct = 5L, durationHours = 24,
+            pickCount = 9, numberMax = 49,
+        )
+        assertTrue(r is JackpotLotteryService.OpenOutcome.InvalidParams)
+    }
+
+    @Test
+    fun `buyMatchTicket validates picks against the open row's shape`() {
+        every {
+            lotteryPersistence.getOpenByGuildAndModeForUpdate(guildId, JackpotLotteryDto.MODE_NUMBER_MATCH)
+        } returns JackpotLotteryDto(
+            id = 1L, guildId = guildId, ticketPrice = 50L, status = JackpotLotteryDto.STATUS_OPEN,
+            mode = JackpotLotteryDto.MODE_NUMBER_MATCH, pickCount = 3, numberMax = 15,
+        )
+        every { lotteryPersistence.getTicketForUpdate(1L, 7L) } returns null
+        val user = UserDto(discordId = 7L, guildId = guildId).apply { socialCredit = 1_000L }
+        every { userService.getUserByIdForUpdate(7L, guildId) } returns user
+
+        // 5 picks against a pick-3 draw: rejected.
+        assertTrue(
+            service.buyMatchTicket(guildId, 7L, listOf(1, 2, 3, 4, 5))
+                is JackpotLotteryService.BuyMatchOutcome.InvalidPicks
+        )
+        // Out-of-range pick for numberMax 15: rejected.
+        assertTrue(
+            service.buyMatchTicket(guildId, 7L, listOf(1, 2, 16))
+                is JackpotLotteryService.BuyMatchOutcome.InvalidPicks
+        )
+        // Correct shape: accepted.
+        assertTrue(
+            service.buyMatchTicket(guildId, 7L, listOf(1, 7, 15))
+                is JackpotLotteryService.BuyMatchOutcome.Ok
+        )
+    }
+
+    @Test
+    fun `drawMatchLottery pays the pick-3 tier schedule 70-30`() {
+        val lottery = JackpotLotteryDto(
+            id = 1L, guildId = guildId, ticketPrice = 50L, poolAmount = 1_000L,
+            status = JackpotLotteryDto.STATUS_OPEN, mode = JackpotLotteryDto.MODE_NUMBER_MATCH,
+            pickCount = 3, numberMax = 15,
+        )
+        every {
+            lotteryPersistence.getOpenByGuildAndModeForUpdate(guildId, JackpotLotteryDto.MODE_NUMBER_MATCH)
+        } returns lottery
+        val expectedDraw = service.drawNumbers(15, 3, Random(42))
+        val nonDrawn = (1..15).filter { it !in expectedDraw }
+        every { lotteryPersistence.ticketsByLottery(1L) } returns listOf(
+            JackpotLotteryTicketDto(
+                lotteryId = 1L, discordId = 1L, ticketCount = 1, spent = 50L,
+                pickedNumbers = expectedDraw.joinToString(","),        // 3/3
+            ),
+            JackpotLotteryTicketDto(
+                lotteryId = 1L, discordId = 2L, ticketCount = 1, spent = 50L,
+                pickedNumbers = (expectedDraw.take(2) + nonDrawn[0]).joinToString(","),  // 2/3
+            ),
+        )
+        (1L..2L).forEach { id ->
+            every { userService.getUserByIdForUpdate(id, guildId) } returns
+                UserDto(discordId = id, guildId = guildId).apply { socialCredit = 0L }
+        }
+
+        val r = service.drawMatchLottery(guildId)
+        assertTrue(r is JackpotLotteryService.DrawMatchOutcome.Ok)
+        r as JackpotLotteryService.DrawMatchOutcome.Ok
+        val byMatches = r.tierPayouts.associate { it.matches to it.share }
+        assertEquals(700L, byMatches[3], "top tier of a pick-3 draw is 70%")
+        assertEquals(300L, byMatches[2], "second tier of a pick-3 draw is 30%")
+        assertEquals(1_000L, r.totalPaid)
+    }
+
+    // ===================================================================
+    // Participation streak bonus
+    // ===================================================================
+
+    private fun streakService(
+        streakPersistence: database.persistence.lottery.LotteryStreakPersistence,
+        today: java.time.LocalDate,
+    ) = JackpotLotteryService(
+        lotteryPersistence, jackpotService, userService, configService,
+        random = Random(42),
+        streakPersistence = streakPersistence,
+        clock = java.time.Clock.fixed(
+            today.atStartOfDay(java.time.ZoneOffset.UTC).toInstant(),
+            java.time.ZoneOffset.UTC,
+        ),
+    )
+
+    private fun stubStreakConfig(days: Int, bonus: Long) {
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.LOTTERY_STREAK_DAYS.configValue, guildId.toString()
+            )
+        } returns ConfigDto(
+            name = ConfigDto.Configurations.LOTTERY_STREAK_DAYS.configValue,
+            value = days.toString(), guildId = guildId.toString(),
+        )
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.LOTTERY_STREAK_BONUS.configValue, guildId.toString()
+            )
+        } returns ConfigDto(
+            name = ConfigDto.Configurations.LOTTERY_STREAK_BONUS.configValue,
+            value = bonus.toString(), guildId = guildId.toString(),
+        )
+    }
+
+    private fun stubOpenWeightedForBuy(): UserDto {
+        every {
+            lotteryPersistence.getOpenByGuildAndModeForUpdate(guildId, JackpotLotteryDto.MODE_TICKET_WEIGHTED)
+        } returns JackpotLotteryDto(
+            id = 1L, guildId = guildId, ticketPrice = 100L, poolAmount = 1_000L,
+            status = JackpotLotteryDto.STATUS_OPEN, mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
+        )
+        every { lotteryPersistence.getTicketForUpdate(1L, 7L) } returns null
+        val user = UserDto(discordId = 7L, guildId = guildId).apply { socialCredit = 1_000L }
+        every { userService.getUserByIdForUpdate(7L, guildId) } returns user
+        return user
+    }
+
+    @Test
+    fun `buyTickets extends a consecutive-day streak and pays the bonus from the jackpot`() {
+        val today = java.time.LocalDate.of(2026, 7, 4)
+        val streakPersistence =
+            mockk<database.persistence.lottery.LotteryStreakPersistence>(relaxed = true)
+        every { streakPersistence.getForUpdate(guildId, 7L) } returns
+            database.dto.lottery.LotteryStreakDto(
+                guildId = guildId, discordId = 7L, streakDays = 2,
+                lastParticipationDate = today.minusDays(1),
+            )
+        stubStreakConfig(days = 3, bonus = 100L)
+        every { jackpotService.resetPool(guildId) } returns 5_000L
+        val user = stubOpenWeightedForBuy()
+
+        val svc = streakService(streakPersistence, today)
+        val r = svc.buyTickets(guildId, discordId = 7L, ticketCount = 1)
+        assertTrue(r is JackpotLotteryService.BuyOutcome.Ok)
+        r as JackpotLotteryService.BuyOutcome.Ok
+        assertEquals(3, r.streakDays)
+        assertEquals(100L, r.streakBonusAwarded)
+        // 1000 - 100 (ticket) + 100 (streak bonus).
+        assertEquals(1_000L, user.socialCredit)
+        // Bonus drained from the jackpot: 5000 reset, 4900 put back.
+        verify { jackpotService.addToPool(guildId, 4_900L) }
+    }
+
+    @Test
+    fun `buyTickets same-day repeat buy neither extends the streak nor double-pays`() {
+        val today = java.time.LocalDate.of(2026, 7, 4)
+        val streakPersistence =
+            mockk<database.persistence.lottery.LotteryStreakPersistence>(relaxed = true)
+        every { streakPersistence.getForUpdate(guildId, 7L) } returns
+            database.dto.lottery.LotteryStreakDto(
+                guildId = guildId, discordId = 7L, streakDays = 4,
+                lastParticipationDate = today,
+            )
+        stubStreakConfig(days = 3, bonus = 100L)
+        stubOpenWeightedForBuy()
+
+        val svc = streakService(streakPersistence, today)
+        val r = svc.buyTickets(guildId, discordId = 7L, ticketCount = 1)
+        assertTrue(r is JackpotLotteryService.BuyOutcome.Ok)
+        r as JackpotLotteryService.BuyOutcome.Ok
+        assertEquals(4, r.streakDays)
+        assertEquals(0L, r.streakBonusAwarded)
+        verify(exactly = 0) { streakPersistence.upsert(any()) }
+    }
+
+    @Test
+    fun `buyTickets resets the streak to 1 after a gap`() {
+        val today = java.time.LocalDate.of(2026, 7, 4)
+        val streakPersistence =
+            mockk<database.persistence.lottery.LotteryStreakPersistence>(relaxed = true)
+        every { streakPersistence.getForUpdate(guildId, 7L) } returns
+            database.dto.lottery.LotteryStreakDto(
+                guildId = guildId, discordId = 7L, streakDays = 9,
+                lastParticipationDate = today.minusDays(3),
+            )
+        stubStreakConfig(days = 3, bonus = 100L)
+        stubOpenWeightedForBuy()
+
+        val svc = streakService(streakPersistence, today)
+        val r = svc.buyTickets(guildId, discordId = 7L, ticketCount = 1)
+        assertTrue(r is JackpotLotteryService.BuyOutcome.Ok)
+        r as JackpotLotteryService.BuyOutcome.Ok
+        assertEquals(1, r.streakDays)
+        assertEquals(0L, r.streakBonusAwarded, "below threshold after reset")
+    }
+
+    @Test
+    fun `streak below threshold is tracked but pays nothing`() {
+        val today = java.time.LocalDate.of(2026, 7, 4)
+        val streakPersistence =
+            mockk<database.persistence.lottery.LotteryStreakPersistence>(relaxed = true)
+        every { streakPersistence.getForUpdate(guildId, 7L) } returns null
+        stubStreakConfig(days = 3, bonus = 100L)
+        stubOpenWeightedForBuy()
+
+        val svc = streakService(streakPersistence, today)
+        val r = svc.buyTickets(guildId, discordId = 7L, ticketCount = 1)
+        assertTrue(r is JackpotLotteryService.BuyOutcome.Ok)
+        r as JackpotLotteryService.BuyOutcome.Ok
+        assertEquals(1, r.streakDays)
+        assertEquals(0L, r.streakBonusAwarded)
+        verify(exactly = 1) { streakPersistence.upsert(any()) }
+    }
+
+    @Test
+    fun `buyMatchTicket also advances the participation streak`() {
+        val today = java.time.LocalDate.of(2026, 7, 4)
+        val streakPersistence =
+            mockk<database.persistence.lottery.LotteryStreakPersistence>(relaxed = true)
+        every { streakPersistence.getForUpdate(guildId, 7L) } returns
+            database.dto.lottery.LotteryStreakDto(
+                guildId = guildId, discordId = 7L, streakDays = 2,
+                lastParticipationDate = today.minusDays(1),
+            )
+        stubStreakConfig(days = 3, bonus = 50L)
+        every { jackpotService.resetPool(guildId) } returns 5_000L
+        every {
+            lotteryPersistence.getOpenByGuildAndModeForUpdate(guildId, JackpotLotteryDto.MODE_NUMBER_MATCH)
+        } returns JackpotLotteryDto(
+            id = 1L, guildId = guildId, ticketPrice = 50L, status = JackpotLotteryDto.STATUS_OPEN,
+            mode = JackpotLotteryDto.MODE_NUMBER_MATCH, pickCount = 5, numberMax = 49,
+        )
+        every { lotteryPersistence.getTicketForUpdate(1L, 7L) } returns null
+        val user = UserDto(discordId = 7L, guildId = guildId).apply { socialCredit = 1_000L }
+        every { userService.getUserByIdForUpdate(7L, guildId) } returns user
+
+        val svc = streakService(streakPersistence, today)
+        val r = svc.buyMatchTicket(guildId, 7L, listOf(1, 2, 3, 4, 5))
+        assertTrue(r is JackpotLotteryService.BuyMatchOutcome.Ok)
+        r as JackpotLotteryService.BuyMatchOutcome.Ok
+        assertEquals(3, r.streakDays)
+        assertEquals(50L, r.streakBonusAwarded)
+    }
 }

--- a/database/src/test/kotlin/database/service/lottery/LotteryHelperTest.kt
+++ b/database/src/test/kotlin/database/service/lottery/LotteryHelperTest.kt
@@ -198,4 +198,63 @@ class LotteryHelperTest {
         // already fired up to 300 → nothing new
         assertTrue(LotteryHelper.milestonesBetween(150, 350, milestones, alreadyFiredHighest = 300).isEmpty())
     }
+
+    // --- low-engagement additions -----------------------------------------
+
+    @Test
+    fun `matchTierPcts returns a 100-sum schedule for every supported pick count`() {
+        for (picks in LotteryHelper.MIN_DAILY_PICK_COUNT..LotteryHelper.MAX_DAILY_PICK_COUNT) {
+            val pcts = LotteryHelper.matchTierPcts(picks)
+            assertEquals(picks - 1, pcts.size, "one tier per match count from $picks down to 2")
+            assertEquals(100, pcts.sum(), "schedule for $picks picks must be a partition")
+        }
+        // Out-of-range clamps to the nearest supported schedule.
+        assertEquals(LotteryHelper.matchTierPcts(2).toList(), LotteryHelper.matchTierPcts(0).toList())
+        assertEquals(LotteryHelper.matchTierPcts(6).toList(), LotteryHelper.matchTierPcts(9).toList())
+    }
+
+    @Test
+    fun `dailyRolloverEnabled defaults off and reads truthy aliases`() {
+        assertEquals(LotteryHelper.DEFAULT_DAILY_ROLLOVER_ENABLED, LotteryHelper.dailyRolloverEnabled(config, guildId))
+        stub(Configurations.LOTTERY_DAILY_ROLLOVER_ENABLED, "true")
+        assertTrue(LotteryHelper.dailyRolloverEnabled(config, guildId))
+        stub(Configurations.LOTTERY_DAILY_ROLLOVER_ENABLED, "nope")
+        assertEquals(false, LotteryHelper.dailyRolloverEnabled(config, guildId))
+    }
+
+    @Test
+    fun `dailyPickCount defaults and clamps into the supported range`() {
+        assertEquals(LotteryHelper.MATCH_PICK_COUNT, LotteryHelper.dailyPickCount(config, guildId))
+        stub(Configurations.LOTTERY_DAILY_PICK_COUNT, "3")
+        assertEquals(3, LotteryHelper.dailyPickCount(config, guildId))
+        stub(Configurations.LOTTERY_DAILY_PICK_COUNT, "1")
+        assertEquals(LotteryHelper.MIN_DAILY_PICK_COUNT, LotteryHelper.dailyPickCount(config, guildId))
+        stub(Configurations.LOTTERY_DAILY_PICK_COUNT, "42")
+        assertEquals(LotteryHelper.MAX_DAILY_PICK_COUNT, LotteryHelper.dailyPickCount(config, guildId))
+    }
+
+    @Test
+    fun `dailyNumberMax defaults and clamps into 10 to 99`() {
+        assertEquals(LotteryHelper.MATCH_NUMBER_MAX, LotteryHelper.dailyNumberMax(config, guildId))
+        stub(Configurations.LOTTERY_DAILY_NUMBER_MAX, "15")
+        assertEquals(15, LotteryHelper.dailyNumberMax(config, guildId))
+        stub(Configurations.LOTTERY_DAILY_NUMBER_MAX, "5")
+        assertEquals(LotteryHelper.MIN_DAILY_NUMBER_MAX, LotteryHelper.dailyNumberMax(config, guildId))
+        stub(Configurations.LOTTERY_DAILY_NUMBER_MAX, "500")
+        assertEquals(LotteryHelper.MAX_DAILY_NUMBER_MAX, LotteryHelper.dailyNumberMax(config, guildId))
+    }
+
+    @Test
+    fun `streak getters default to disabled and clamp`() {
+        assertEquals(0, LotteryHelper.streakThresholdDays(config, guildId))
+        assertEquals(0L, LotteryHelper.streakBonusCredits(config, guildId))
+        stub(Configurations.LOTTERY_STREAK_DAYS, "5")
+        assertEquals(5, LotteryHelper.streakThresholdDays(config, guildId))
+        stub(Configurations.LOTTERY_STREAK_DAYS, "-3")
+        assertEquals(0, LotteryHelper.streakThresholdDays(config, guildId))
+        stub(Configurations.LOTTERY_STREAK_BONUS, "250")
+        assertEquals(250L, LotteryHelper.streakBonusCredits(config, guildId))
+        stub(Configurations.LOTTERY_STREAK_BONUS, "9999999999")
+        assertEquals(LotteryHelper.MAX_STREAK_BONUS, LotteryHelper.streakBonusCredits(config, guildId))
+    }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/game/lottery/LotteryCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/game/lottery/LotteryCommand.kt
@@ -156,6 +156,11 @@ class LotteryCommand @Autowired constructor(
             }
             lines += "🚀 Milestone reached! Jackpot top-up: $parts."
         }
+        if (r.streakBonusAwarded > 0L) {
+            lines += "🔥 **${r.streakDays}-day** lottery streak — bonus **+${r.streakBonusAwarded}** credits!"
+        } else if (r.streakDays > 1) {
+            lines += "🔥 Lottery streak: **${r.streakDays}** days."
+        }
         return lines.joinToString("\n")
     }
 

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
@@ -8,6 +8,7 @@ import bot.toby.modal.modals.setconfig.SetConfigGeneralModal
 import bot.toby.modal.modals.setconfig.SetConfigJackpotActivityModal
 import bot.toby.modal.modals.setconfig.SetConfigJackpotModal
 import bot.toby.modal.modals.setconfig.SetConfigLotteryBasicsModal
+import bot.toby.modal.modals.setconfig.SetConfigLotteryEngagementModal
 import bot.toby.modal.modals.setconfig.SetConfigLotteryPoolsModal
 import bot.toby.modal.modals.setconfig.SetConfigPokerStakesModal
 import bot.toby.modal.modals.setconfig.SetConfigPokerTableModal
@@ -56,6 +57,7 @@ class SetConfigCommand @Autowired constructor(
     private val blackjackTable: SetConfigBlackjackTableModal,
     private val lotteryBasics: SetConfigLotteryBasicsModal,
     private val lotteryPools: SetConfigLotteryPoolsModal,
+    private val lotteryEngagement: SetConfigLotteryEngagementModal,
     private val stakes: SetConfigStakesModal,
 ) : ModerationCommand {
 
@@ -76,6 +78,7 @@ class SetConfigCommand @Autowired constructor(
         SubcommandData(SUB_BLACKJACK_TABLE, "Blackjack seats + natural payout ratio"),
         SubcommandData(SUB_LOTTERY_BASICS, "Daily lottery on/off, ticket price, mode, ping"),
         SubcommandData(SUB_LOTTERY_POOLS, "Lottery seed/revenue split + announce channel"),
+        SubcommandData(SUB_LOTTERY_ENGAGEMENT, "Lottery rollover pot, streak bonus, match odds"),
         SubcommandData(SUB_STAKES, "Per-game stake bounds (and bot-suspicion edge cap where applicable)")
             .addOptions(
                 OptionData(OptionType.STRING, OPT_GAME, "Which game's stake bounds to edit", true)
@@ -119,6 +122,8 @@ class SetConfigCommand @Autowired constructor(
             SUB_BLACKJACK_TABLE -> blackjackTable.buildModal(SetConfigBlackjackTableModal.MODAL_NAME, guild, reader)
             SUB_LOTTERY_BASICS -> lotteryBasics.buildModal(SetConfigLotteryBasicsModal.MODAL_NAME, guild, reader)
             SUB_LOTTERY_POOLS -> lotteryPools.buildModal(SetConfigLotteryPoolsModal.MODAL_NAME, guild, reader)
+            SUB_LOTTERY_ENGAGEMENT ->
+                lotteryEngagement.buildModal(SetConfigLotteryEngagementModal.MODAL_NAME, guild, reader)
             SUB_STAKES -> {
                 val token = event.getOption(OPT_GAME)?.asString
                 val game = token?.let { SetConfigStakesModal.Game.byToken(it) } ?: run {
@@ -148,6 +153,7 @@ class SetConfigCommand @Autowired constructor(
         const val SUB_BLACKJACK_TABLE = "blackjack_table"
         const val SUB_LOTTERY_BASICS = "lottery_basics"
         const val SUB_LOTTERY_POOLS = "lottery_pools"
+        const val SUB_LOTTERY_ENGAGEMENT = "lottery_engagement"
         const val SUB_STAKES = "stakes"
         const val OPT_GAME = "game"
     }

--- a/discord-bot/src/main/kotlin/bot/toby/modal/modals/LotteryBuyModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/modal/modals/LotteryBuyModal.kt
@@ -44,6 +44,11 @@ class LotteryBuyModal(
                             "**+${m.creditsAdded}** credits drawn into the prize pool!"
                     )
                 }
+                if (r.streakBonusAwarded > 0) {
+                    append("\n🔥 **${r.streakDays}-day** lottery streak — bonus **+${r.streakBonusAwarded}** credits!")
+                } else if (r.streakDays > 1) {
+                    append("\n🔥 Lottery streak: **${r.streakDays}** days.")
+                }
             }).setEphemeral(true).queue()
 
             BuyOutcome.NoOpenLottery ->

--- a/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigLotteryEngagementModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigLotteryEngagementModal.kt
@@ -1,0 +1,46 @@
+package bot.toby.modal.modals.setconfig
+
+import bot.toby.modal.modals.setconfig.SetConfigFieldValidator.FieldSpec
+import database.dto.guild.ConfigDto.Configurations
+import database.service.guild.ConfigService
+import org.springframework.stereotype.Component
+
+/**
+ * `/setconfig lottery_engagement` — low-engagement levers for the
+ * daily lottery: the rollover pot, participation-streak bonus, and the
+ * NUMBER_MATCH draw shape (pick count / number range). Pairs with
+ * `/setconfig lottery_basics` and `/setconfig lottery_pools`.
+ */
+@Component
+class SetConfigLotteryEngagementModal(
+    configService: ConfigService,
+) : SimpleSetConfigCategoryModal(configService) {
+
+    override val name = MODAL_NAME
+    override val title = "Lottery engagement & odds"
+
+    override val specs: LinkedHashMap<Configurations, FieldSpec> = linkedMapOf(
+        Configurations.LOTTERY_DAILY_ROLLOVER_ENABLED to FieldSpec.BoolStrict("Rollover pot enabled"),
+        Configurations.LOTTERY_STREAK_DAYS to FieldSpec.IntRange("Streak threshold (days, 0=off)", 0..365),
+        Configurations.LOTTERY_STREAK_BONUS to FieldSpec.IntRange("Streak bonus (credits/day)", 0..1_000_000),
+        Configurations.LOTTERY_DAILY_PICK_COUNT to FieldSpec.IntRange("Match picks (2-6)", 2..6),
+        Configurations.LOTTERY_DAILY_NUMBER_MAX to FieldSpec.IntRange("Match number range (10-99)", 10..99),
+    )
+
+    override val fieldIds: Map<Configurations, String> = mapOf(
+        Configurations.LOTTERY_DAILY_ROLLOVER_ENABLED to FIELD_ROLLOVER,
+        Configurations.LOTTERY_STREAK_DAYS to FIELD_STREAK_DAYS,
+        Configurations.LOTTERY_STREAK_BONUS to FIELD_STREAK_BONUS,
+        Configurations.LOTTERY_DAILY_PICK_COUNT to FIELD_PICK_COUNT,
+        Configurations.LOTTERY_DAILY_NUMBER_MAX to FIELD_NUMBER_MAX,
+    )
+
+    companion object {
+        const val MODAL_NAME = "setconfig_lottery_engagement"
+        const val FIELD_ROLLOVER = "rollover"
+        const val FIELD_STREAK_DAYS = "streak_days"
+        const val FIELD_STREAK_BONUS = "streak_bonus"
+        const val FIELD_PICK_COUNT = "pick_count"
+        const val FIELD_NUMBER_MAX = "number_max"
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/scheduling/LotteryAnnouncer.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/scheduling/LotteryAnnouncer.kt
@@ -305,7 +305,7 @@ class LotteryAnnouncer @Autowired constructor(
             ticketPrice = lottery.ticketPrice,
             poolAmount = lottery.poolAmount,
         )
-        val freshTodayBody = renderOpenSummary(mode, freshSummary)
+        val freshTodayBody = renderOpenSummary(mode, freshSummary, guildId)
         val freshIncentives = if (mode == LotteryHelper.MODE_WEIGHTED) {
             renderActiveIncentives(guildId)
         } else null
@@ -349,6 +349,8 @@ class LotteryAnnouncer @Autowired constructor(
             val tierPayouts: List<JackpotLotteryService.MatchTierPayout>,
             val totalPaid: Long,
             val rolledBack: Long,
+            /** Unpaid pool parked as tomorrow's rollover pot (0 = feature off / all paid). */
+            val rolledOver: Long = 0L,
         ) : PriorOutcome
 
         data class WeightedDrawn(
@@ -362,9 +364,17 @@ class LotteryAnnouncer @Autowired constructor(
             val highestMilestoneFired: Long = 0L,
         ) : PriorOutcome
 
-        data class BelowMinBuyers(val have: Int, val need: Int) : PriorOutcome
+        data class BelowMinBuyers(
+            val have: Int,
+            val need: Int,
+            /** Seed parked as tomorrow's rollover pot instead of returning to the jackpot. */
+            val rolledOver: Long = 0L,
+        ) : PriorOutcome
 
-        data object NoTickets : PriorOutcome
+        data class NoTickets(
+            /** Seed parked as tomorrow's rollover pot instead of returning to the jackpot. */
+            val rolledOver: Long = 0L,
+        ) : PriorOutcome
     }
 
     /**
@@ -386,6 +396,8 @@ class LotteryAnnouncer @Autowired constructor(
             val seeded: Long,
             val ticketPrice: Long,
             val poolAmount: Long,
+            /** Rollover pot claimed into today's pool (already included in [poolAmount]). */
+            val rolledIn: Long = 0L,
         ) : OpenSummary
         data object Skipped : OpenSummary
     }
@@ -434,7 +446,7 @@ class LotteryAnnouncer @Autowired constructor(
                 false
             )
         }
-        builder.addField(TODAYS_DRAW_FIELD, renderOpenSummary(mode, openOutcome), false)
+        builder.addField(TODAYS_DRAW_FIELD, renderOpenSummary(mode, openOutcome, guild.idLong), false)
         // Incentives apply to TICKET_WEIGHTED draws only — the daily
         // NUMBER_MATCH already caps each user at one ticket per draw.
         if (mode == LotteryHelper.MODE_WEIGHTED) {
@@ -447,7 +459,12 @@ class LotteryAnnouncer @Autowired constructor(
         builder.setFooter(
             when (mode) {
                 LotteryHelper.MODE_WEIGHTED -> "Top-3 weighted draw • 50/30/20 share"
-                else -> "Pick 5 of 49 • tier payouts 60/25/10/5%"
+                else -> {
+                    val pickCount = LotteryHelper.dailyPickCount(configService, guild.idLong)
+                    val numberMax = LotteryHelper.dailyNumberMax(configService, guild.idLong)
+                    val tiers = LotteryHelper.matchTierPcts(pickCount).joinToString("/")
+                    "Pick $pickCount of $numberMax • tier payouts $tiers%"
+                }
             }
         )
         return builder.build()
@@ -504,13 +521,18 @@ class LotteryAnnouncer @Autowired constructor(
     private fun renderPriorOutcome(prior: PriorOutcome): String = when (prior) {
         is PriorOutcome.MatchDrawn -> {
             val numbers = prior.drawnNumbers.joinToString(" · ")
+            val pickCount = prior.drawnNumbers.size
             val winners = if (prior.tierPayouts.isEmpty()) {
-                "No tier matched — rolled back **${prior.rolledBack}** to jackpot."
+                if (prior.rolledOver > 0L) {
+                    "No tier matched — 🔄 **${prior.rolledOver}** credits roll over into today's pot!"
+                } else {
+                    "No tier matched — rolled back **${prior.rolledBack}** to jackpot."
+                }
             } else {
                 prior.tierPayouts
                     .sortedByDescending { it.matches }
                     .joinToString("\n") {
-                        "${it.matches}/5: <@${it.discordId}> — **${it.share}** credits"
+                        "${it.matches}/$pickCount: <@${it.discordId}> — **${it.share}** credits"
                     }
             }
             "Winning numbers: **$numbers**\n$winners"
@@ -529,17 +551,33 @@ class LotteryAnnouncer @Autowired constructor(
             val impact = renderBonusImpact(prior)
             if (impact.isEmpty()) body else "$body\n$impact"
         }
-        is PriorOutcome.BelowMinBuyers ->
-            "Only **${prior.have}** buyer(s) — need **${prior.need}**. Refunded; seed returned to jackpot."
-        PriorOutcome.NoTickets ->
-            "No tickets bought. Seed returned to jackpot."
+        is PriorOutcome.BelowMinBuyers -> {
+            val seedLine = if (prior.rolledOver > 0L) {
+                "Refunded; 🔄 **${prior.rolledOver}** credits roll over into today's pot!"
+            } else {
+                "Refunded; seed returned to jackpot."
+            }
+            "Only **${prior.have}** buyer(s) — need **${prior.need}**. $seedLine"
+        }
+        is PriorOutcome.NoTickets -> {
+            if (prior.rolledOver > 0L) {
+                "No tickets bought. 🔄 **${prior.rolledOver}** credits roll over into today's pot!"
+            } else {
+                "No tickets bought. Seed returned to jackpot."
+            }
+        }
     }
 
-    private fun renderOpenSummary(mode: String, open: OpenSummary): String = when (open) {
+    private fun renderOpenSummary(mode: String, open: OpenSummary, guildId: Long): String = when (open) {
         is OpenSummary.Ok -> {
-            val modeLabel = if (mode == LotteryHelper.MODE_WEIGHTED) "Top-3 weighted" else "Pick 5 of 49"
+            val modeLabel = if (mode == LotteryHelper.MODE_WEIGHTED) "Top-3 weighted"
+            else "Pick ${LotteryHelper.dailyPickCount(configService, guildId)} of " +
+                "${LotteryHelper.dailyNumberMax(configService, guildId)}"
+            val rolloverLine = if (open.rolledIn > 0L) {
+                " · 🔄 includes **${open.rolledIn}** rolled over from yesterday"
+            } else ""
             "**${open.poolAmount}** credits in the pool · Ticket: **${open.ticketPrice}** · " +
-                "Mode: **$modeLabel** · Closes 24h."
+                "Mode: **$modeLabel** · Closes 24h.$rolloverLine"
         }
         OpenSummary.Skipped ->
             "Today's draw was not opened — see logs / moderation tab."

--- a/discord-bot/src/main/kotlin/bot/toby/scheduling/LotteryDailyJob.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/scheduling/LotteryDailyJob.kt
@@ -122,31 +122,36 @@ class LotteryDailyJob @Autowired constructor(
     private fun closePriorMatch(guildId: Long): LotteryAnnouncer.PriorOutcome? {
         val openMatch = jackpotLotteryService.getOpenMatch(guildId)
         if (openMatch?.status != JackpotLotteryDto.STATUS_OPEN) return null
-        return when (val drawResult = jackpotLotteryService.drawMatchLottery(guildId)) {
+        val rollover = LotteryHelper.dailyRolloverEnabled(configService, guildId)
+        return when (val drawResult = jackpotLotteryService.drawMatchLottery(guildId, rollover)) {
             is JackpotLotteryService.DrawMatchOutcome.Ok -> {
                 logger.info {
                     "Daily NUMBER_MATCH drew for guild $guildId: drawn=${drawResult.drawnNumbers} " +
-                        "totalPaid=${drawResult.totalPaid} rolledBack=${drawResult.rolledBackToJackpot}"
+                        "totalPaid=${drawResult.totalPaid} rolledBack=${drawResult.rolledBackToJackpot} " +
+                        "rolledOver=${drawResult.rolledOver}"
                 }
                 LotteryAnnouncer.PriorOutcome.MatchDrawn(
                     drawnNumbers = drawResult.drawnNumbers,
                     tierPayouts = drawResult.tierPayouts,
                     totalPaid = drawResult.totalPaid,
                     rolledBack = drawResult.rolledBackToJackpot,
+                    rolledOver = drawResult.rolledOver,
                 )
             }
             JackpotLotteryService.DrawMatchOutcome.NoTickets -> {
                 logger.info { "Daily NUMBER_MATCH for guild $guildId had no tickets; cancelling and refunding seed." }
-                jackpotLotteryService.cancelMatchLottery(guildId)
-                LotteryAnnouncer.PriorOutcome.NoTickets
+                val cancel = jackpotLotteryService.cancelMatchLottery(guildId, rollover)
+                LotteryAnnouncer.PriorOutcome.NoTickets(rolledOver = rolledOverFrom(cancel))
             }
             is JackpotLotteryService.DrawMatchOutcome.BelowMinBuyers -> {
                 logger.info {
                     "Daily NUMBER_MATCH for guild $guildId below buyer threshold " +
                         "(${drawResult.have}/${drawResult.need}); cancelling and refunding."
                 }
-                jackpotLotteryService.cancelMatchLottery(guildId)
-                LotteryAnnouncer.PriorOutcome.BelowMinBuyers(drawResult.have, drawResult.need)
+                val cancel = jackpotLotteryService.cancelMatchLottery(guildId, rollover)
+                LotteryAnnouncer.PriorOutcome.BelowMinBuyers(
+                    drawResult.have, drawResult.need, rolledOver = rolledOverFrom(cancel),
+                )
             }
             JackpotLotteryService.DrawMatchOutcome.NoOpenLottery -> null
         }
@@ -158,17 +163,20 @@ class LotteryDailyJob @Autowired constructor(
         return when (val open = jackpotLotteryService.openMatchLottery(
             guildId = guildId, ticketPrice = ticketPrice,
             seedPct = seedPct, durationHours = DURATION_HOURS,
+            pickCount = LotteryHelper.dailyPickCount(configService, guildId),
+            numberMax = LotteryHelper.dailyNumberMax(configService, guildId),
         )) {
             is JackpotLotteryService.OpenOutcome.Ok -> {
                 logger.info {
                     "Daily NUMBER_MATCH opened for guild $guildId: ticketPrice=$ticketPrice " +
-                        "seeded=${open.seeded} seedPct=$seedPct"
+                        "seeded=${open.seeded} seedPct=$seedPct rolledIn=${open.rolledIn}"
                 }
                 LotteryAnnouncer.OpenSummary.Ok(
                     lotteryId = open.lottery.id,
                     seeded = open.seeded,
                     ticketPrice = ticketPrice,
                     poolAmount = open.lottery.poolAmount,
+                    rolledIn = open.rolledIn,
                 ) to true
             }
             JackpotLotteryService.OpenOutcome.AlreadyOpen -> {
@@ -199,6 +207,7 @@ class LotteryDailyJob @Autowired constructor(
     private fun closePriorWeighted(guildId: Long): LotteryAnnouncer.PriorOutcome? {
         val openWeighted = jackpotLotteryService.getOpenWeighted(guildId)
         if (openWeighted?.status != JackpotLotteryDto.STATUS_OPEN) return null
+        val rollover = LotteryHelper.dailyRolloverEnabled(configService, guildId)
         return when (val drawResult = jackpotLotteryService.drawLottery(guildId)) {
             is JackpotLotteryService.DrawOutcome.Ok -> {
                 logger.info {
@@ -215,20 +224,26 @@ class LotteryDailyJob @Autowired constructor(
             }
             JackpotLotteryService.DrawOutcome.NoTickets -> {
                 logger.info { "Daily WEIGHTED for guild $guildId had no tickets; cancelling and refunding seed." }
-                jackpotLotteryService.cancelLottery(guildId)
-                LotteryAnnouncer.PriorOutcome.NoTickets
+                val cancel = jackpotLotteryService.cancelLottery(guildId, rollover)
+                LotteryAnnouncer.PriorOutcome.NoTickets(rolledOver = rolledOverFrom(cancel))
             }
             is JackpotLotteryService.DrawOutcome.BelowMinBuyers -> {
                 logger.info {
                     "Daily WEIGHTED for guild $guildId below buyer threshold " +
                         "(${drawResult.have}/${drawResult.need}); cancelling and refunding."
                 }
-                jackpotLotteryService.cancelLottery(guildId)
-                LotteryAnnouncer.PriorOutcome.BelowMinBuyers(drawResult.have, drawResult.need)
+                val cancel = jackpotLotteryService.cancelLottery(guildId, rollover)
+                LotteryAnnouncer.PriorOutcome.BelowMinBuyers(
+                    drawResult.have, drawResult.need, rolledOver = rolledOverFrom(cancel),
+                )
             }
             JackpotLotteryService.DrawOutcome.NoOpenLottery -> null
         }
     }
+
+    /** Rollover amount from a cancel outcome (0 when the cancel found nothing open). */
+    private fun rolledOverFrom(cancel: JackpotLotteryService.CancelOutcome): Long =
+        (cancel as? JackpotLotteryService.CancelOutcome.Ok)?.rolledOver ?: 0L
 
     private fun openWeighted(guildId: Long): Pair<LotteryAnnouncer.OpenSummary, Boolean> {
         val ticketPrice = LotteryHelper.dailyTicketPrice(configService, guildId)
@@ -244,13 +259,15 @@ class LotteryDailyJob @Autowired constructor(
             is JackpotLotteryService.OpenOutcome.Ok -> {
                 logger.info {
                     "Daily WEIGHTED opened for guild $guildId: ticketPrice=$ticketPrice " +
-                        "seeded=${open.seeded} seedPct=$seedPct winners=${LotteryHelper.WEIGHTED_DAILY_WINNER_COUNT}"
+                        "seeded=${open.seeded} seedPct=$seedPct winners=${LotteryHelper.WEIGHTED_DAILY_WINNER_COUNT} " +
+                        "rolledIn=${open.rolledIn}"
                 }
                 LotteryAnnouncer.OpenSummary.Ok(
                     lotteryId = open.lottery.id,
                     seeded = open.seeded,
                     ticketPrice = ticketPrice,
                     poolAmount = open.lottery.poolAmount,
+                    rolledIn = open.rolledIn,
                 ) to true
             }
             JackpotLotteryService.OpenOutcome.AlreadyOpen -> {

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/moderation/SetConfigCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/moderation/SetConfigCommandTest.kt
@@ -15,6 +15,7 @@ import bot.toby.modal.modals.setconfig.SetConfigGeneralModal
 import bot.toby.modal.modals.setconfig.SetConfigJackpotActivityModal
 import bot.toby.modal.modals.setconfig.SetConfigJackpotModal
 import bot.toby.modal.modals.setconfig.SetConfigLotteryBasicsModal
+import bot.toby.modal.modals.setconfig.SetConfigLotteryEngagementModal
 import bot.toby.modal.modals.setconfig.SetConfigLotteryPoolsModal
 import bot.toby.modal.modals.setconfig.SetConfigPokerStakesModal
 import bot.toby.modal.modals.setconfig.SetConfigPokerTableModal
@@ -64,6 +65,7 @@ internal class SetConfigCommandTest : CommandTest {
     private lateinit var blackjackTable: SetConfigBlackjackTableModal
     private lateinit var lotteryBasics: SetConfigLotteryBasicsModal
     private lateinit var lotteryPools: SetConfigLotteryPoolsModal
+    private lateinit var lotteryEngagement: SetConfigLotteryEngagementModal
     private lateinit var stakes: SetConfigStakesModal
     private lateinit var command: SetConfigCommand
 
@@ -84,12 +86,13 @@ internal class SetConfigCommandTest : CommandTest {
         blackjackTable = mockk(relaxed = true)
         lotteryBasics = mockk(relaxed = true)
         lotteryPools = mockk(relaxed = true)
+        lotteryEngagement = mockk(relaxed = true)
         stakes = mockk(relaxed = true)
         command = SetConfigCommand(
             configService,
             general, activity, fees, jackpot, jackpotActivity,
             pokerStakes, pokerTable, blackjackRules, blackjackTable,
-            lotteryBasics, lotteryPools, stakes,
+            lotteryBasics, lotteryPools, lotteryEngagement, stakes,
         )
         // CommandTest's shared stub makes `event.reply(any<String>())`
         // suspend forever via `just awaits`. SetConfigCommand uses
@@ -230,6 +233,15 @@ internal class SetConfigCommandTest : CommandTest {
             SetConfigCommand.SUB_LOTTERY_POOLS,
             SetConfigLotteryPoolsModal.MODAL_NAME,
             { every { lotteryPools.buildModal(SetConfigLotteryPoolsModal.MODAL_NAME, any(), any()) } returns it },
+        )
+    }
+
+    @Test
+    fun `lottery_engagement subcommand opens the lottery_engagement modal`() {
+        assertOpensModal(
+            SetConfigCommand.SUB_LOTTERY_ENGAGEMENT,
+            SetConfigLotteryEngagementModal.MODAL_NAME,
+            { every { lotteryEngagement.buildModal(SetConfigLotteryEngagementModal.MODAL_NAME, any(), any()) } returns it },
         )
     }
 

--- a/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryAnnouncerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryAnnouncerTest.kt
@@ -278,7 +278,7 @@ class LotteryAnnouncerTest {
         // still ships to drive ticket purchases.
         announcer.announceCycle(
             guild, mode = "WEIGHTED",
-            priorOutcome = LotteryAnnouncer.PriorOutcome.NoTickets,
+            priorOutcome = LotteryAnnouncer.PriorOutcome.NoTickets(),
             openOutcome = LotteryAnnouncer.OpenSummary.Ok(
                 seeded = 500L, ticketPrice = 50L, poolAmount = 500L,
             ),
@@ -294,7 +294,7 @@ class LotteryAnnouncerTest {
         val mentions = captureMentions()
         announcer.announceCycle(
             guild, mode = "WEIGHTED",
-            priorOutcome = LotteryAnnouncer.PriorOutcome.NoTickets,
+            priorOutcome = LotteryAnnouncer.PriorOutcome.NoTickets(),
             openOutcome = LotteryAnnouncer.OpenSummary.Ok(
                 seeded = 500L, ticketPrice = 50L, poolAmount = 500L,
             ),
@@ -431,7 +431,7 @@ class LotteryAnnouncerTest {
 
         announcer.announceCycle(
             guild, mode = "NUMBER_MATCH",
-            priorOutcome = LotteryAnnouncer.PriorOutcome.NoTickets,
+            priorOutcome = LotteryAnnouncer.PriorOutcome.NoTickets(),
             openOutcome = LotteryAnnouncer.OpenSummary.Ok(
                 seeded = 500L, ticketPrice = 50L, poolAmount = 500L,
             ),
@@ -454,7 +454,7 @@ class LotteryAnnouncerTest {
 
         announcer.announceCycle(
             guild, mode = "WEIGHTED",
-            priorOutcome = LotteryAnnouncer.PriorOutcome.NoTickets,
+            priorOutcome = LotteryAnnouncer.PriorOutcome.NoTickets(),
             openOutcome = LotteryAnnouncer.OpenSummary.Ok(
                 seeded = 500L, ticketPrice = 50L, poolAmount = 500L,
             ),
@@ -472,7 +472,7 @@ class LotteryAnnouncerTest {
 
         announcer.announceCycle(
             guild, mode = "WEIGHTED",
-            priorOutcome = LotteryAnnouncer.PriorOutcome.NoTickets,
+            priorOutcome = LotteryAnnouncer.PriorOutcome.NoTickets(),
             openOutcome = LotteryAnnouncer.OpenSummary.Ok(
                 seeded = 500L, ticketPrice = 50L, poolAmount = 500L,
             ),
@@ -491,7 +491,7 @@ class LotteryAnnouncerTest {
 
         announcer.announceCycle(
             guild, mode = "WEIGHTED",
-            priorOutcome = LotteryAnnouncer.PriorOutcome.NoTickets,
+            priorOutcome = LotteryAnnouncer.PriorOutcome.NoTickets(),
             openOutcome = LotteryAnnouncer.OpenSummary.Ok(
                 seeded = 500L, ticketPrice = 50L, poolAmount = 500L,
             ),
@@ -509,7 +509,7 @@ class LotteryAnnouncerTest {
 
         announcer.announceCycle(
             guild, mode = "WEIGHTED",
-            priorOutcome = LotteryAnnouncer.PriorOutcome.NoTickets,
+            priorOutcome = LotteryAnnouncer.PriorOutcome.NoTickets(),
             openOutcome = LotteryAnnouncer.OpenSummary.Ok(
                 seeded = 500L, ticketPrice = 50L, poolAmount = 500L,
             ),
@@ -1276,7 +1276,7 @@ class LotteryAnnouncerTest {
         fun `NoTickets cycle publishes no in-page events`() {
             announcer.announceCycle(
                 guild, mode = "WEIGHTED",
-                priorOutcome = LotteryAnnouncer.PriorOutcome.NoTickets,
+                priorOutcome = LotteryAnnouncer.PriorOutcome.NoTickets(),
                 openOutcome = LotteryAnnouncer.OpenSummary.Ok(
                     seeded = 500L, ticketPrice = 50L, poolAmount = 500L,
                 ),

--- a/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryDailyJobTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryDailyJobTest.kt
@@ -428,6 +428,56 @@ class LotteryDailyJobTest {
     }
 
     @Test
+    fun `runDaily with rollover enabled threads the pot through cancel and announcer`() {
+        stubEnabled(true)
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.LOTTERY_DAILY_ROLLOVER_ENABLED.configValue,
+                guildId.toString(),
+            )
+        } returns ConfigDto(
+            name = ConfigDto.Configurations.LOTTERY_DAILY_ROLLOVER_ENABLED.configValue,
+            value = "true",
+            guildId = guildId.toString(),
+        )
+        every { lotteryDailyService.alreadyRan(guildId, today) } returns false
+        every { jackpotLotteryService.getOpenMatch(guildId) } returns JackpotLotteryDto(
+            id = 5L, guildId = guildId,
+            status = JackpotLotteryDto.STATUS_OPEN,
+            mode = JackpotLotteryDto.MODE_NUMBER_MATCH,
+        )
+        every { jackpotLotteryService.drawMatchLottery(guildId, true) } returns
+            JackpotLotteryService.DrawMatchOutcome.NoTickets
+        every { jackpotLotteryService.cancelMatchLottery(guildId, true) } returns
+            JackpotLotteryService.CancelOutcome.Ok(
+                refundedUsers = 0, refundedTotal = 0L,
+                returnedToPool = 0L, rolledOver = 750L,
+            )
+        every { jackpotLotteryService.openMatchLottery(guildId, any(), any(), any()) } returns
+            JackpotLotteryService.OpenOutcome.Ok(
+                lottery = JackpotLotteryDto(id = 6L, guildId = guildId, poolAmount = 750L),
+                seeded = 0L,
+                rolledIn = 750L,
+            )
+        val priorSlot = slot<LotteryAnnouncer.PriorOutcome>()
+        val openSlot = slot<LotteryAnnouncer.OpenSummary>()
+        every {
+            lotteryAnnouncer.announceCycle(any(), any(), capture(priorSlot), capture(openSlot))
+        } just runs
+
+        job.runDaily()
+
+        verify(exactly = 1) { jackpotLotteryService.drawMatchLottery(guildId, true) }
+        verify(exactly = 1) { jackpotLotteryService.cancelMatchLottery(guildId, true) }
+        val prior = priorSlot.captured
+        assertTrue(prior is LotteryAnnouncer.PriorOutcome.NoTickets)
+        assertEquals(750L, (prior as LotteryAnnouncer.PriorOutcome.NoTickets).rolledOver)
+        val open = openSlot.captured
+        assertTrue(open is LotteryAnnouncer.OpenSummary.Ok)
+        assertEquals(750L, (open as LotteryAnnouncer.OpenSummary.Ok).rolledIn)
+    }
+
+    @Test
     fun `runDaily handles NUMBER_MATCH BelowMinBuyers same way`() {
         stubEnabled(true)
         // Default mode is NUMBER_MATCH.

--- a/web/src/main/kotlin/web/controller/LotteryController.kt
+++ b/web/src/main/kotlin/web/controller/LotteryController.kt
@@ -85,6 +85,8 @@ class LotteryController(
                     newBalance = outcome.newBalance,
                     newPool = outcome.newPool,
                     jackpotInflow = outcome.jackpotInflow,
+                    streakDays = outcome.streakDays.takeIf { it > 0 },
+                    streakBonusAwarded = outcome.streakBonusAwarded.takeIf { it > 0L },
                 )
             )
 
@@ -134,6 +136,8 @@ class LotteryController(
                     milestoneBonuses = outcome.milestoneBonuses
                         .map { MilestoneBonusView(threshold = it.threshold, creditsAdded = it.creditsAdded) }
                         .takeIf { it.isNotEmpty() },
+                    streakDays = outcome.streakDays.takeIf { it > 0 },
+                    streakBonusAwarded = outcome.streakBonusAwarded.takeIf { it > 0L },
                 )
             )
 
@@ -163,6 +167,10 @@ data class BuyMatchResponse(
     val newBalance: Long? = null,
     val newPool: Long? = null,
     val jackpotInflow: Long? = null,
+    /** Consecutive participation days after this buy. Null when untracked. */
+    val streakDays: Int? = null,
+    /** Streak bonus credits paid on this buy. Null when none. */
+    val streakBonusAwarded: Long? = null,
 ) : CasinoResponseLike
 
 data class BuyWeightedRequest(val count: Int = 0)
@@ -194,6 +202,10 @@ data class BuyWeightedResponse(
      * list to know there's nothing to render).
      */
     val milestoneBonuses: List<MilestoneBonusView>? = null,
+    /** Consecutive participation days after this buy. Null when untracked. */
+    val streakDays: Int? = null,
+    /** Streak bonus credits paid on this buy. Null when none. */
+    val streakBonusAwarded: Long? = null,
 ) : CasinoResponseLike
 
 /**

--- a/web/src/main/kotlin/web/service/CasinoAuditService.kt
+++ b/web/src/main/kotlin/web/service/CasinoAuditService.kt
@@ -137,6 +137,7 @@ class CasinoAuditService(
         var priorBelowMinBuyers = false
         var priorBuyersHave = 0
         var priorBuyersNeed = 0
+        val rollover = LotteryHelper.dailyRolloverEnabled(configService, guildId)
         if (mode == LotteryHelper.MODE_WEIGHTED) {
             when (val drawResult = jackpotLotteryService.drawLottery(guildId)) {
                 is JackpotLotteryService.DrawOutcome.Ok -> {
@@ -145,11 +146,11 @@ class CasinoAuditService(
                     priorRolledBack = (drawResult.drained - drawResult.totalPaid).coerceAtLeast(0L)
                 }
                 JackpotLotteryService.DrawOutcome.NoTickets -> {
-                    jackpotLotteryService.cancelLottery(guildId)
+                    jackpotLotteryService.cancelLottery(guildId, rollover)
                     drewPrior = true
                 }
                 is JackpotLotteryService.DrawOutcome.BelowMinBuyers -> {
-                    jackpotLotteryService.cancelLottery(guildId)
+                    jackpotLotteryService.cancelLottery(guildId, rollover)
                     drewPrior = true
                     priorBelowMinBuyers = true
                     priorBuyersHave = drawResult.have
@@ -158,7 +159,7 @@ class CasinoAuditService(
                 JackpotLotteryService.DrawOutcome.NoOpenLottery -> Unit
             }
         } else {
-            when (val drawResult = jackpotLotteryService.drawMatchLottery(guildId)) {
+            when (val drawResult = jackpotLotteryService.drawMatchLottery(guildId, rollover)) {
                 is JackpotLotteryService.DrawMatchOutcome.Ok -> {
                     drewPrior = true
                     priorTotalPaid = drawResult.totalPaid
@@ -166,11 +167,11 @@ class CasinoAuditService(
                     priorDrawn = drawResult.drawnNumbers
                 }
                 JackpotLotteryService.DrawMatchOutcome.NoTickets -> {
-                    jackpotLotteryService.cancelMatchLottery(guildId)
+                    jackpotLotteryService.cancelMatchLottery(guildId, rollover)
                     drewPrior = true
                 }
                 is JackpotLotteryService.DrawMatchOutcome.BelowMinBuyers -> {
-                    jackpotLotteryService.cancelMatchLottery(guildId)
+                    jackpotLotteryService.cancelMatchLottery(guildId, rollover)
                     drewPrior = true
                     priorBelowMinBuyers = true
                     priorBuyersHave = drawResult.have
@@ -196,6 +197,8 @@ class CasinoAuditService(
                 ticketPrice = ticketPrice,
                 seedPct = seedPct,
                 durationHours = 24L,
+                pickCount = LotteryHelper.dailyPickCount(configService, guildId),
+                numberMax = LotteryHelper.dailyNumberMax(configService, guildId),
             )
         }
         return when (open) {

--- a/web/src/main/kotlin/web/service/LotteryWebService.kt
+++ b/web/src/main/kotlin/web/service/LotteryWebService.kt
@@ -147,6 +147,16 @@ class LotteryWebService(
             )
         } else LotteryIncentivesView.empty()
 
+        // Draw shape: the OPEN row's pick count / number range wins (a
+        // mid-draw config edit must not desync the picker from tickets
+        // already bought); fall back to live config so a paused / not-
+        // yet-opened guild still previews the shape the next open will
+        // use.
+        val pickCount = dailyOpen?.pickCount?.takeIf { it > 0 }
+            ?: LotteryHelper.dailyPickCount(configService, guildId)
+        val numberMax = dailyOpen?.numberMax?.takeIf { it > 0 }
+            ?: LotteryHelper.dailyNumberMax(configService, guildId)
+
         return LotteryPageSnapshot(
             dailyOpen = dailyOpen,
             dailyLatestDrawn = dailyLatest,
@@ -156,9 +166,9 @@ class LotteryWebService(
             weightedMyTicket = weightedMyTicket,
             weightedTopHolders = weightedTop,
             weightedTotalTickets = weightedTotal,
-            pickCount = LotteryHelper.MATCH_PICK_COUNT,
-            numberMax = LotteryHelper.MATCH_NUMBER_MAX,
-            tierPercents = LotteryHelper.TIER_PCTS_5_4_3_2.toList(),
+            pickCount = pickCount,
+            numberMax = numberMax,
+            tierPercents = LotteryHelper.matchTierPcts(pickCount).toList(),
             revenueJackpotPct = LotteryHelper.dailyRevenueJackpotPct(configService, guildId),
             dailyMode = LotteryHelper.dailyMode(configService, guildId),
             dailyEnabled = LotteryHelper.dailyEnabled(configService, guildId),

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -1174,6 +1174,40 @@ class ModerationWebService(
                 if (n !in 0..50) return "Value must be between 0 and 50."
                 n.toString()
             }
+            ConfigDto.Configurations.LOTTERY_DAILY_ROLLOVER_ENABLED -> {
+                val v = rawValue.trim().lowercase()
+                if (v !in setOf("true", "false")) return "Value must be true or false."
+                v
+            }
+            // NUMBER_MATCH draw shape. Pick count is bounded by the tier
+            // schedules in LotteryHelper.matchTierPcts; number range is
+            // additionally coerced to >= 2× pick count at open time.
+            ConfigDto.Configurations.LOTTERY_DAILY_PICK_COUNT -> {
+                val n = rawValue.trim().toIntOrNull()
+                    ?: return "Value must be a whole number (2-6; default 5)."
+                if (n !in 2..6) return "Value must be between 2 and 6."
+                n.toString()
+            }
+            ConfigDto.Configurations.LOTTERY_DAILY_NUMBER_MAX -> {
+                val n = rawValue.trim().toIntOrNull()
+                    ?: return "Value must be a whole number (10-99; default 49)."
+                if (n !in 10..99) return "Value must be between 10 and 99."
+                n.toString()
+            }
+            // Lottery participation streak. 0 on either key disables the
+            // payout (streaks are still tracked).
+            ConfigDto.Configurations.LOTTERY_STREAK_DAYS -> {
+                val n = rawValue.trim().toIntOrNull()
+                    ?: return "Value must be a whole number of days (0-365; 0 disables)."
+                if (n !in 0..365) return "Value must be between 0 and 365 days."
+                n.toString()
+            }
+            ConfigDto.Configurations.LOTTERY_STREAK_BONUS -> {
+                val n = rawValue.trim().toLongOrNull()
+                    ?: return "Value must be a whole number of credits (0-1000000; 0 disables)."
+                if (n !in 0L..1_000_000L) return "Value must be between 0 and 1,000,000 credits."
+                n.toString()
+            }
             ConfigDto.Configurations.LOTTERY_CHANNEL,
             ConfigDto.Configurations.CASINO_MODLOG_CHANNEL_ID,
             ConfigDto.Configurations.ACHIEVEMENT_ANNOUNCE_CHANNEL -> {

--- a/web/src/main/resources/static/js/lottery.js
+++ b/web/src/main/resources/static/js/lottery.js
@@ -135,6 +135,12 @@
                         `Bought ticket • picked <strong>${selected.join(', ')}</strong>. ` +
                         `<span class="casino-loss-tribute">+${body.jackpotInflow} to jackpot</span>`;
                 }
+                if (typeof toast === 'function' && body.streakBonusAwarded && body.streakBonusAwarded > 0) {
+                    toast(
+                        `🔥 ${body.streakDays}-day lottery streak — bonus +${body.streakBonusAwarded} credits!`,
+                        'success'
+                    );
+                }
                 // Reload so the server-rendered "Your ticket" panel + live
                 // pool numbers appear without us having to maintain a JS
                 // shadow copy of the snapshot.
@@ -207,6 +213,12 @@
                                 'success'
                             );
                         });
+                    }
+                    if (body.streakBonusAwarded && body.streakBonusAwarded > 0) {
+                        toast(
+                            `🔥 ${body.streakDays}-day lottery streak — bonus +${body.streakBonusAwarded} credits!`,
+                            'success'
+                        );
                     }
                 }
             } catch (err) {

--- a/web/src/main/resources/templates/lottery.html
+++ b/web/src/main/resources/templates/lottery.html
@@ -454,14 +454,13 @@
             </thead>
             <tbody>
                 <tr th:each="i, iter : ${snapshot.tierPercents}"
-                    th:with="match=${5 - iter.index}">
+                    th:with="match=${snapshot.pickCount - iter.index}">
                     <td><strong th:text="${match} + ' / ' + ${snapshot.pickCount}">5 / 5</strong></td>
                     <td><strong th:text="${snapshot.tierPercents[iter.index]} + '%'">60%</strong></td>
                     <td class="muted">
-                        <span th:if="${match == 5}">Top tier — split equally if multiple jackpot winners.</span>
-                        <span th:if="${match == 4}">Second tier.</span>
-                        <span th:if="${match == 3}">Third tier — frequent at this odds level.</span>
-                        <span th:if="${match == 2}">Consolation tier — small return.</span>
+                        <span th:if="${match == snapshot.pickCount}">Top tier — split equally if multiple jackpot winners.</span>
+                        <span th:if="${match != snapshot.pickCount and match != 2}">Mid tier.</span>
+                        <span th:if="${match == 2 and snapshot.pickCount != 2}">Consolation tier — small return.</span>
                     </td>
                 </tr>
                 <tr>

--- a/web/src/main/resources/templates/moderation/lottery.html
+++ b/web/src/main/resources/templates/moderation/lottery.html
@@ -76,7 +76,7 @@
                         <select th:disabled="${!isOwner}">
                             <option value="NUMBER_MATCH"
                                     th:selected="${overview.config['LOTTERY_DAILY_MODE'] == null or overview.config['LOTTERY_DAILY_MODE'] != 'WEIGHTED'}">
-                                Pick 5 of 49
+                                Number match (default: pick 5 of 49)
                             </option>
                             <option value="WEIGHTED"
                                     th:selected="${overview.config['LOTTERY_DAILY_MODE'] == 'WEIGHTED'}">
@@ -145,6 +145,100 @@
                         <input type="number" min="1" max="50"
                                th:value="${overview.config['LOTTERY_DAILY_MIN_BUYERS']}"
                                placeholder="2"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                </div>
+            </details>
+
+            <details class="config-section" open>
+                <summary>Low-engagement boosters</summary>
+                <p class="muted config-section-lead">
+                    Levers for servers where only a handful of players buy in each
+                    day: roll un-won pots forward instead of quietly returning them
+                    to the jackpot, reward showing up daily, and shrink the match
+                    odds so small ticket counts still produce winners.
+                </p>
+                <div class="config-grid">
+                    <div class="config-row" data-key="LOTTERY_DAILY_ROLLOVER_ENABLED">
+                        <label>
+                            Rollover pot
+                            <span class="config-hint">
+                                When a draw cancels (too few buyers / no tickets) or no
+                                match tier hits, carry the undistributed pool into the
+                                next day's prize pool instead of returning it to the
+                                jackpot — the pot visibly grows on quiet days.
+                            </span>
+                        </label>
+                        <select th:disabled="${!isOwner}">
+                            <option value="false"
+                                    th:selected="${overview.config['LOTTERY_DAILY_ROLLOVER_ENABLED'] == null or overview.config['LOTTERY_DAILY_ROLLOVER_ENABLED'] != 'true'}">
+                                Disabled
+                            </option>
+                            <option value="true"
+                                    th:selected="${overview.config['LOTTERY_DAILY_ROLLOVER_ENABLED'] == 'true'}">
+                                Enabled
+                            </option>
+                        </select>
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="LOTTERY_STREAK_DAYS">
+                        <label>
+                            Streak threshold (days)
+                            <span class="config-hint">
+                                Buy a ticket this many UTC days in a row to start earning
+                                the streak bonus. 0 disables the payout (streaks are
+                                still tracked). Default 0.
+                            </span>
+                        </label>
+                        <input type="number" min="0" max="365"
+                               th:value="${overview.config['LOTTERY_STREAK_DAYS']}"
+                               placeholder="0"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="LOTTERY_STREAK_BONUS">
+                        <label>
+                            Streak bonus (credits/day)
+                            <span class="config-hint">
+                                Paid once per participation day while the streak is at or
+                                above the threshold. Drained from the jackpot pool — an
+                                empty jackpot pays 0. Default 0 (off).
+                            </span>
+                        </label>
+                        <input type="number" min="0" max="1000000"
+                               th:value="${overview.config['LOTTERY_STREAK_BONUS']}"
+                               placeholder="0"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="LOTTERY_DAILY_PICK_COUNT">
+                        <label>
+                            Match draw: picks
+                            <span class="config-hint">
+                                Numbers each player picks in NUMBER_MATCH mode (2&ndash;6).
+                                Fewer picks + a smaller range = far more frequent wins with
+                                only a few tickets. Applies from the next daily open. Default 5.
+                            </span>
+                        </label>
+                        <input type="number" min="2" max="6"
+                               th:value="${overview.config['LOTTERY_DAILY_PICK_COUNT']}"
+                               placeholder="5"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="LOTTERY_DAILY_NUMBER_MAX">
+                        <label>
+                            Match draw: number range
+                            <span class="config-hint">
+                                Players pick from 1 up to this number (10&ndash;99; always at
+                                least 2&times; the pick count). Try picks 3 of 15 for a 2-3
+                                player server. Applies from the next daily open. Default 49.
+                            </span>
+                        </label>
+                        <input type="number" min="10" max="99"
+                               th:value="${overview.config['LOTTERY_DAILY_NUMBER_MAX']}"
+                               placeholder="49"
                                th:disabled="${!isOwner}">
                         <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                     </div>


### PR DESCRIPTION
## Why

On a server where only 2–3 people play the daily lottery, the current mechanics work against them:

- At the 5-of-49 default, ~60% of NUMBER_MATCH draws pay **nothing** with 3 tickets in play — the pool quietly rolls back to the jackpot and the announcement reads like a dud day.
- The weighted draw always uses 3 winner slots (50/30/20), so with 2 buyers 20% of the pot leaks back to the jackpot every single draw.
- A cancelled draw (below `LOTTERY_DAILY_MIN_BUYERS`) silently returns its seed — a quiet day produces no forward momentum.
- There's nothing rewarding the small core of regulars for showing up daily, and retention *is* the whole game at that scale.

## What

Four opt-in levers, all per-guild config:

**1. Rollover pot** (`LOTTERY_DAILY_ROLLOVER_ENABLED`, default off)
A daily draw that cancels (below min buyers / no tickets) or a NUMBER_MATCH draw whose tiers all go un-won parks the undistributed pool on the closed row (new `rollover_out` column) instead of returning it to the jackpot. The next open of the same (guild, mode) claims it into the fresh prize pool — the pot visibly grows on quiet days, and the announcer says so ("🔄 750 credits roll over into today's pot!"). Buyers are still always refunded on cancels; parked credits are claimed unconditionally at the next open so they can never strand, and a rollover-funded weighted open no longer requires a non-empty jackpot.

**2. Winner slots scale to distinct buyers** (no config, strict improvement)
`drawLottery` now uses `min(winnerCount, buyer count)` for the prize-share schedule: 2 buyers split the full pot 60/40 instead of 50/30 + 20% leak.

**3. Configurable match odds** (`LOTTERY_DAILY_PICK_COUNT` 2–6, `LOTTERY_DAILY_NUMBER_MAX` 10–99)
Small guilds can run e.g. pick 3 of 15, where match tiers actually fire with a handful of tickets. Tier schedules adapt per pick count (pay `pickCount..2` matches, each schedule sums to 100%; e.g. pick-3 pays 70/30). Number range is coerced to ≥ 2× pick count so a degenerate near-guaranteed-win shape can't be configured. Tickets validate against the **open row's** shape (not live config), so a mid-draw config edit can't orphan already-bought tickets. The web number picker, tier table, announcer footer, and embeds all render the configured shape.

**4. Participation streak bonus** (`LOTTERY_STREAK_DAYS` / `LOTTERY_STREAK_BONUS`, default off)
Consecutive UTC participation days are tracked per (guild, user) in a new `toby_coin_lottery_streak` table (either mode counts; same-day repeat buys are no-ops; a gap resets to 1). Once the streak reaches the threshold, each further participation day pays the bonus — **drained from the jackpot pool**, never minted; an empty jackpot pays 0 while the streak still advances. Surfaced in Discord buy replies ("🔥 3-day lottery streak — bonus +100 credits!"), web toasts, and the buy response JSON.

## Where it's wired

- `/setconfig lottery_engagement` — new Discord modal (rollover, streak days/bonus, pick count, number max)
- Web moderation → Lottery tab — new "Low-engagement boosters" section, with server-side validation for all five keys
- `LotteryDailyJob` + the moderation force-draw path both pass the rollover flag and configured draw shape
- `LotteryAnnouncer` — rollover copy on cancelled/no-winner days, "includes X rolled over" on opens, dynamic "Pick N of M" footer/labels

## Migration

`V51__lottery_low_engagement.sql` — adds `rollover_out` to `toby_coin_jackpot_lottery` and creates `toby_coin_lottery_streak`.

## Tests

- `JackpotLotteryServiceTest`: slot scaling pays full pot at 2 buyers; rollover park/claim on cancel, draw, and both opens (incl. empty-jackpot + parked-pot open); pick-count validation against the open row; pick-3 70/30 tier payout; number-range coercion; streak extend/reset/same-day/threshold/bonus-drain cases
- `LotteryHelperTest`: `matchTierPcts` is a 100-sum partition for every supported pick count; new config getters default and clamp
- `LotteryDailyJobTest`: rollover flag threads through draw → cancel → announcer, and `rolledIn` reaches the open summary
- Full `common` / `core-api` / `database` / `discord-bot` / `web` suites pass locally. The `application` module's testcontainers-based integration tests could not run in this sandbox (no Docker daemon) — they should be covered by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DvF681L8tZ6BZzEKhazMF

---
_Generated by [Claude Code](https://claude.ai/code/session_017DvF681L8tZ6BZzEKhazMF)_