### PR TITLE
Bring the Discord intro commands up to parity with the web dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Toby Bot is a feature-rich Discord bot built using Kotlin and powered by various
 - **JDA:** Utilising JDA, a robust Java library for interacting with the Discord API.
 - **JPA and Hibernate:** Storing and managing data in a relational database for efficient data management.
 - **Web dashboard + OAuth2:** Companion web UI (Spring MVC + Thymeleaf) for profile, achievements, notification preferences, and admin moderation. Logs in via Discord OAuth2.
+- **Intro songs, everywhere:** Up to three per user per server, from a link or an MP3, each with its own volume and optional clip bounds. Discord (`/setintro`, `/listintros`, `/editintro`, `/deleteintro`) and the web dashboard write the same rows and share one set of rules (`common.intro.IntroClip` / `IntroSlots`), so the 15-second cap, the `mm:ss` grammar and the validation messages can't drift between surfaces.
 - **Per-surface notifications:** Each notification kind (achievement unlock, level-up, duel offer, tip received, streak reminder, lottery draw) ships across three surfaces — DM, channel post, and Web Push — independently opt-in per user. The router enforces "every supported surface is wired" at dispatch time so a kind can never silently drop a surface again.
 - **Web Push (RFC 8030/8291/8292):** Browser push notifications via VAPID. A service worker handles delivery and deep-links the recipient back into the dashboard.
 

--- a/application/src/test/kotlin/integration/bot/ButtonManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/ButtonManagerTest.kt
@@ -58,6 +58,7 @@ import bot.toby.button.buttons.misc.RandomButton
 import bot.toby.button.buttons.misc.RollButton
 import bot.toby.button.buttons.pvp.rps.RpsButton
 import bot.toby.button.buttons.music.StopButton
+import bot.toby.button.buttons.music.UndoDeleteIntroButton
 import bot.toby.button.buttons.team.TeamCancelButton
 import bot.toby.button.buttons.team.TeamConfirmButton
 import bot.toby.button.buttons.team.TeamRerollButton
@@ -119,6 +120,7 @@ class ButtonManagerTest {
             RollButton::class.java,
             RpsButton::class.java,
             StopButton::class.java,
+            UndoDeleteIntroButton::class.java,
             TeamCancelButton::class.java,
             TeamConfirmButton::class.java,
             TeamRerollButton::class.java,

--- a/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
@@ -39,6 +39,7 @@ import bot.toby.command.commands.music.channel.JoinCommand
 import bot.toby.command.commands.music.channel.LeaveCommand
 import bot.toby.command.commands.music.intro.DeleteIntroCommand
 import bot.toby.command.commands.music.intro.EditIntroCommand
+import bot.toby.command.commands.music.intro.ListIntrosCommand
 import bot.toby.command.commands.music.intro.SetIntroCommand
 import bot.toby.command.commands.music.player.*
 import bot.toby.helpers.*
@@ -139,6 +140,7 @@ class CommandManagerTest {
             SetIntroCommand::class.java,
             EditIntroCommand::class.java,
             DeleteIntroCommand::class.java,
+            ListIntrosCommand::class.java,
             UserInfoCommand::class.java,
             LevelCommand::class.java,
             RandomCommand::class.java,

--- a/application/src/test/kotlin/web/controller/IntroWebControllerTest.kt
+++ b/application/src/test/kotlin/web/controller/IntroWebControllerTest.kt
@@ -1,14 +1,19 @@
 package web.controller
 
+import database.dto.music.MusicDto
+import database.dto.user.UserDto
 import database.service.music.MusicFileService
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.unmockkAll
 import io.mockk.verify
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpSession
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
@@ -19,6 +24,7 @@ import org.springframework.web.multipart.MultipartFile
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.service.GuildInfo
 import web.service.IntroWebService
+import web.service.YouTubePreview
 
 class IntroWebControllerTest {
 
@@ -211,4 +217,233 @@ class IntroWebControllerTest {
         assertEquals(false, response.body?.ok)
         assertEquals("End time must be greater than start time.", response.body?.error)
     }
+
+    // updateVolume / updateName / reorder
+
+    @Test
+    fun `updateVolume returns ok on success`() {
+        every { introWebService.updateIntroVolume(any(), any(), any(), any()) } returns null
+
+        val response = controller.updateVolume(
+            guildId, UpdateVolumeRequest("${guildId}_${discordId}_1", 55), mockUser, null
+        )
+
+        assertEquals(200, response.statusCode.value())
+        assertEquals(true, response.body?.ok)
+        verify { introWebService.updateIntroVolume(discordId.toLong(), guildId, "${guildId}_${discordId}_1", 55) }
+    }
+
+    @Test
+    fun `updateVolume surfaces the service error`() {
+        every { introWebService.updateIntroVolume(any(), any(), any(), any()) } returns "Intro does not belong to you."
+
+        val response = controller.updateVolume(
+            guildId, UpdateVolumeRequest("999_999_1", 55), mockUser, null
+        )
+
+        assertEquals(400, response.statusCode.value())
+        assertEquals("Intro does not belong to you.", response.body?.error)
+    }
+
+    @Test
+    fun `updateName returns ok on success`() {
+        every { introWebService.updateIntroName(any(), any(), any(), any()) } returns null
+
+        val response = controller.updateName(
+            guildId, UpdateNameRequest("${guildId}_${discordId}_1", "New name"), mockUser, null
+        )
+
+        assertEquals(200, response.statusCode.value())
+        verify { introWebService.updateIntroName(discordId.toLong(), guildId, "${guildId}_${discordId}_1", "New name") }
+    }
+
+    @Test
+    fun `updateName surfaces the service error`() {
+        every { introWebService.updateIntroName(any(), any(), any(), any()) } returns "Name cannot be empty."
+
+        val response = controller.updateName(
+            guildId, UpdateNameRequest("${guildId}_${discordId}_1", "  "), mockUser, null
+        )
+
+        assertEquals(400, response.statusCode.value())
+        assertEquals("Name cannot be empty.", response.body?.error)
+    }
+
+    @Test
+    fun `reorder returns ok on success`() {
+        every { introWebService.reorderIntros(any(), any(), any()) } returns null
+        val ordered = listOf("${guildId}_${discordId}_2", "${guildId}_${discordId}_1")
+
+        val response = controller.reorder(guildId, ReorderRequest(ordered), mockUser, null)
+
+        assertEquals(200, response.statusCode.value())
+        verify { introWebService.reorderIntros(discordId.toLong(), guildId, ordered) }
+    }
+
+    @Test
+    fun `reorder surfaces the service error`() {
+        every { introWebService.reorderIntros(any(), any(), any()) } returns "Reorder list does not match your intros."
+
+        val response = controller.reorder(guildId, ReorderRequest(listOf("nope")), mockUser, null)
+
+        assertEquals(400, response.statusCode.value())
+        assertEquals("Reorder list does not match your intros.", response.body?.error)
+    }
+
+    // preview
+
+    @Test
+    fun `preview rejects a blank url`() {
+        val response = controller.preview("")
+
+        assertEquals(400, response.statusCode.value())
+        assertEquals("URL is required.", response.body?.error)
+    }
+
+    @Test
+    fun `preview reports a non-youtube url as unavailable rather than failing`() {
+        every { introWebService.fetchYouTubePreview(any()) } returns null
+
+        val response = controller.preview("https://example.com/a.mp3")
+
+        assertEquals(200, response.statusCode.value())
+        assertEquals(true, response.body?.ok)
+        assertEquals("Not a YouTube URL — title/duration unavailable.", response.body?.error)
+    }
+
+    @Test
+    fun `preview passes a short video`() {
+        every { introWebService.fetchYouTubePreview(any()) } returns YouTubePreview("abc", "Title", "thumb", 10)
+
+        val response = controller.preview("https://youtu.be/abc")
+
+        assertEquals(true, response.body?.ok)
+        assertEquals("abc", response.body?.videoId)
+        assertEquals(10, response.body?.durationSeconds)
+        assertNull(response.body?.error)
+    }
+
+    @Test
+    fun `preview flags a video longer than the cap but still returns its metadata`() {
+        every { introWebService.fetchYouTubePreview(any()) } returns YouTubePreview("abc", "Title", "thumb", 60)
+
+        val response = controller.preview("https://youtu.be/abc")
+
+        assertEquals(false, response.body?.ok)
+        assertEquals("abc", response.body?.videoId)
+        assertNotNull(response.body?.error)
+    }
+
+    // undo-delete
+
+    @Test
+    fun `deleteIntro snapshots the intro so it can be restored`() {
+        val dto = MusicDto(UserDto(discordId.toLong(), guildId), 2, "track", 40, byteArrayOf(1, 2, 3), 1_000, 5_000)
+        every { musicFileService.getMusicFileById(any()) } returns dto
+        every { introWebService.deleteIntro(any(), any(), any()) } returns null
+
+        controller.deleteIntro(guildId, dto.id!!, mockUser, null, mockSession, mockRa)
+
+        val snapshot = slot<DeletedIntroSnapshot>()
+        verify { mockSession.setAttribute("undoDelete:$guildId:$discordId", capture(snapshot)) }
+        assertEquals(2, snapshot.captured.index)
+        assertEquals("track", snapshot.captured.fileName)
+        assertEquals(1_000, snapshot.captured.startMs)
+        assertEquals(5_000, snapshot.captured.endMs)
+        verify { mockRa.addFlashAttribute("undoDelete", true) }
+    }
+
+    @Test
+    fun `undoDelete restores the snapshot into its original slot`() {
+        val user = UserDto(discordId.toLong(), guildId).apply { musicDtos = mutableListOf() }
+        every { mockSession.getAttribute(any()) } returns snapshot(index = 2)
+        every { introWebService.getOrCreateUser(any(), any()) } returns user
+
+        val view = controller.undoDelete(guildId, mockUser, null, mockSession, mockRa)
+
+        val restored = slot<MusicDto>()
+        verify { musicFileService.createNewMusicFile(capture(restored)) }
+        assertEquals(2, restored.captured.index)
+        assertEquals("track", restored.captured.fileName)
+        assertEquals(1_000, restored.captured.startMs)
+        assertEquals(5_000, restored.captured.endMs)
+        verify { mockRa.addFlashAttribute("success", "Intro restored.") }
+        assertEquals("redirect:/intro/$guildId", view)
+    }
+
+    @Test
+    fun `undoDelete reports when there is nothing to undo`() {
+        every { mockSession.getAttribute(any()) } returns null
+
+        controller.undoDelete(guildId, mockUser, null, mockSession, mockRa)
+
+        verify(exactly = 0) { musicFileService.createNewMusicFile(any()) }
+        verify { mockRa.addFlashAttribute("error", "Nothing to undo.") }
+    }
+
+    @Test
+    fun `undoDelete refuses once the window has expired`() {
+        every { mockSession.getAttribute(any()) } returns
+            snapshot(index = 2, timestampMs = System.currentTimeMillis() - 11 * 60 * 1000)
+
+        controller.undoDelete(guildId, mockUser, null, mockSession, mockRa)
+
+        verify(exactly = 0) { musicFileService.createNewMusicFile(any()) }
+        verify { mockRa.addFlashAttribute("error", "Undo window has expired.") }
+    }
+
+    @Test
+    fun `undoDelete refuses when the slots have filled back up`() {
+        val full = UserDto(discordId.toLong(), guildId).apply {
+            musicDtos = (1..IntroWebService.MAX_INTRO_COUNT)
+                .map { MusicDto(UserDto(discordId.toLong(), guildId), it, "x", 90, byteArrayOf(1)) }
+                .toMutableList()
+        }
+        every { mockSession.getAttribute(any()) } returns snapshot(index = 2)
+        every { introWebService.getOrCreateUser(any(), any()) } returns full
+
+        controller.undoDelete(guildId, mockUser, null, mockSession, mockRa)
+
+        verify(exactly = 0) { musicFileService.createNewMusicFile(any()) }
+        verify { mockRa.addFlashAttribute("error", "Cannot restore — intro limit already reached.") }
+    }
+
+    @Test
+    fun `undoDelete falls back to a new slot when the original was reclaimed`() {
+        val user = UserDto(discordId.toLong(), guildId).apply {
+            musicDtos = mutableListOf(MusicDto(UserDto(discordId.toLong(), guildId), 2, "other", 90, byteArrayOf(1)))
+        }
+        every { mockSession.getAttribute(any()) } returns snapshot(index = 2)
+        every { introWebService.getOrCreateUser(any(), any()) } returns user
+
+        controller.undoDelete(guildId, mockUser, null, mockSession, mockRa)
+
+        val restored = slot<MusicDto>()
+        verify { musicFileService.createNewMusicFile(capture(restored)) }
+        assertEquals(3, restored.captured.index)
+    }
+
+    @Test
+    fun `undoDelete clears the snapshot so it cannot be replayed`() {
+        every { mockSession.getAttribute(any()) } returns snapshot(index = 1)
+        every { introWebService.getOrCreateUser(any(), any()) } returns
+            UserDto(discordId.toLong(), guildId).apply { musicDtos = mutableListOf() }
+
+        controller.undoDelete(guildId, mockUser, null, mockSession, mockRa)
+
+        verify { mockSession.removeAttribute("undoDelete:$guildId:$discordId") }
+    }
+
+    private fun snapshot(index: Int, timestampMs: Long = System.currentTimeMillis()) = DeletedIntroSnapshot(
+        id = "${guildId}_${discordId}_$index",
+        index = index,
+        fileName = "track",
+        introVolume = 40,
+        musicBlob = byteArrayOf(1, 2, 3),
+        startMs = 1_000,
+        endMs = 5_000,
+        discordId = discordId.toLong(),
+        guildId = guildId,
+        timestampMs = timestampMs,
+    )
 }

--- a/common/src/main/kotlin/common/intro/IntroClip.kt
+++ b/common/src/main/kotlin/common/intro/IntroClip.kt
@@ -1,0 +1,126 @@
+package common.intro
+
+/**
+ * Single source of truth for intro clip rules — the 15 second cap, the
+ * `mm:ss` timestamp grammar, and the validation messages.
+ *
+ * Three surfaces need to agree on all three: the web form
+ * (`IntroWebService` server-side, `intros.js` client-side), the Discord
+ * slash commands (`/setintro`, `/editintro`), and anything that renders a
+ * clip back to the user. Before this object existed the rules lived only
+ * in `IntroWebService`, which meant Discord had no clip support at all and
+ * simply rejected any source longer than the cap.
+ *
+ * Pure Kotlin with no framework dependencies so both the `web` and
+ * `discord-bot` modules can depend on it.
+ */
+object IntroClip {
+
+    /** Longest stretch of audio an intro may play for. */
+    const val MAX_DURATION_SECONDS = 15
+
+    const val MAX_CLIP_DURATION_MS: Int = MAX_DURATION_SECONDS * 1000
+
+    /** Label used wherever an unclipped intro is described. */
+    const val FULL_TRACK_LABEL = "full track"
+
+    /** Outcome of parsing a user-supplied timestamp. */
+    sealed interface Parsed {
+        /** [ms] is null when the field was blank — i.e. "no bound set". */
+        data class Ok(val ms: Int?) : Parsed
+        data class Invalid(val message: String) : Parsed
+    }
+
+    /**
+     * Parses `mm:ss`, `mm:ss.s`, or raw (possibly decimal) seconds into
+     * milliseconds. Blank/null input parses to `Ok(null)` so callers can
+     * treat "field left empty" as "clear this bound".
+     *
+     * Mirrors `parseTimeInput` in `intros.js`; the two are exercised by
+     * matching test suites so the client and server can't drift.
+     */
+    fun parseTimestamp(raw: String?, fieldLabel: String = "Timestamp"): Parsed {
+        val s = raw?.trim().orEmpty()
+        if (s.isEmpty()) return Parsed.Ok(null)
+
+        val invalid = Parsed.Invalid("$fieldLabel must look like `mm:ss` or a number of seconds.")
+
+        if (!s.contains(':')) {
+            val seconds = s.toDoubleOrNull() ?: return invalid
+            if (!seconds.isFinite() || seconds < 0) return invalid
+            return Parsed.Ok(Math.round(seconds * 1000).toInt())
+        }
+
+        val parts = s.split(':')
+        if (parts.size != 2) return invalid
+        val minutes = parts[0].toDoubleOrNull() ?: return invalid
+        val seconds = parts[1].toDoubleOrNull() ?: return invalid
+        if (!minutes.isFinite() || !seconds.isFinite()) return invalid
+        if (minutes < 0 || seconds < 0 || seconds >= 60) return invalid
+        return Parsed.Ok(Math.round((minutes * 60 + seconds) * 1000).toInt())
+    }
+
+    /** Renders milliseconds as `m:ss`, keeping one decimal for sub-second precision. */
+    fun format(ms: Int?): String {
+        if (ms == null || ms < 0) return ""
+        val totalSeconds = ms / 1000.0
+        val minutes = (totalSeconds / 60).toInt()
+        val seconds = totalSeconds - minutes * 60
+        val secondsLabel = if (ms % 1000 == 0) {
+            "%02d".format(seconds.toInt())
+        } else {
+            "%04.1f".format(seconds)
+        }
+        return "$minutes:$secondsLabel"
+    }
+
+    /**
+     * Human-readable description of a clip range, e.g. `0:03 – 0:12`,
+     * `from 0:03`, `up to 0:12`, or [FULL_TRACK_LABEL] when unclipped.
+     */
+    fun describe(startMs: Int?, endMs: Int?): String = when {
+        startMs == null && endMs == null -> FULL_TRACK_LABEL
+        startMs != null && endMs != null -> "${format(startMs)} – ${format(endMs)}"
+        startMs != null -> "from ${format(startMs)}"
+        else -> "up to ${format(endMs)}"
+    }
+
+    /**
+     * Validates a clip range against the source duration.
+     *
+     * - Both null: no clipping. Only reject when the source duration is
+     *   known and exceeds the cap.
+     * - start/end present: start must be < end, and the span must be
+     *   within [MAX_CLIP_DURATION_MS].
+     * - When [sourceDurationMs] is known, end must be <= it.
+     *
+     * @return an error message, or null when the clip is valid.
+     */
+    fun validate(startMs: Int?, endMs: Int?, sourceDurationMs: Int?): String? {
+        if (startMs == null && endMs == null) {
+            if (sourceDurationMs != null && sourceDurationMs > MAX_CLIP_DURATION_MS) {
+                val seconds = sourceDurationMs / 1000
+                return "Video is too long (${seconds}s). Max allowed is ${MAX_DURATION_SECONDS}s — " +
+                    "set a start/end clip to use a longer source."
+            }
+            return null
+        }
+        val start = startMs ?: 0
+        if (start < 0) return "Start time cannot be negative."
+        if (endMs != null) {
+            if (endMs <= start) return "End time must be greater than start time."
+            if (sourceDurationMs != null && endMs > sourceDurationMs) {
+                return "End time exceeds the source duration."
+            }
+            if (endMs - start > MAX_CLIP_DURATION_MS) {
+                return "Clip is too long (${(endMs - start) / 1000}s). Max allowed is ${MAX_DURATION_SECONDS}s."
+            }
+        } else if (sourceDurationMs != null) {
+            // Only start was provided; the clip runs from start to end of source.
+            if (sourceDurationMs - start > MAX_CLIP_DURATION_MS) {
+                return "Clip is too long (${(sourceDurationMs - start) / 1000}s). Max allowed is ${MAX_DURATION_SECONDS}s."
+            }
+        }
+        return null
+    }
+}

--- a/common/src/main/kotlin/common/intro/IntroSlots.kt
+++ b/common/src/main/kotlin/common/intro/IntroSlots.kt
@@ -1,0 +1,12 @@
+package common.intro
+
+/**
+ * How many intros a user may hold per guild.
+ *
+ * The number was previously declared three times — `SetIntroCommand.LIMIT`,
+ * `IntroWebService.MAX_INTRO_COUNT` and the `maxIntros` model attribute — with
+ * nothing tying them together, so raising the cap meant remembering all three.
+ */
+object IntroSlots {
+    const val MAX_INTRO_COUNT = 3
+}

--- a/common/src/test/kotlin/common/intro/IntroClipTest.kt
+++ b/common/src/test/kotlin/common/intro/IntroClipTest.kt
@@ -1,0 +1,116 @@
+package common.intro
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class IntroClipTest {
+
+    // --- parseTimestamp -----------------------------------------------------
+
+    @Test
+    fun `blank input parses to no bound`() {
+        assertEquals(IntroClip.Parsed.Ok(null), IntroClip.parseTimestamp(null))
+        assertEquals(IntroClip.Parsed.Ok(null), IntroClip.parseTimestamp(""))
+        assertEquals(IntroClip.Parsed.Ok(null), IntroClip.parseTimestamp("   "))
+    }
+
+    @Test
+    fun `raw seconds parse to milliseconds`() {
+        assertEquals(IntroClip.Parsed.Ok(12_000), IntroClip.parseTimestamp("12"))
+        assertEquals(IntroClip.Parsed.Ok(12_500), IntroClip.parseTimestamp("12.5"))
+        assertEquals(IntroClip.Parsed.Ok(0), IntroClip.parseTimestamp("0"))
+    }
+
+    @Test
+    fun `mm ss parses to milliseconds`() {
+        assertEquals(IntroClip.Parsed.Ok(72_000), IntroClip.parseTimestamp("1:12"))
+        assertEquals(IntroClip.Parsed.Ok(3_500), IntroClip.parseTimestamp("0:03.5"))
+        assertEquals(IntroClip.Parsed.Ok(630_000), IntroClip.parseTimestamp("10:30"))
+    }
+
+    @Test
+    fun `malformed input is rejected with the field label`() {
+        val result = IntroClip.parseTimestamp("abc", "Clip start")
+        assertTrue(result is IntroClip.Parsed.Invalid)
+        assertTrue((result as IntroClip.Parsed.Invalid).message.startsWith("Clip start"))
+    }
+
+    @Test
+    fun `seconds component must be under sixty`() {
+        assertTrue(IntroClip.parseTimestamp("1:60") is IntroClip.Parsed.Invalid)
+        assertTrue(IntroClip.parseTimestamp("1:2:3") is IntroClip.Parsed.Invalid)
+        assertTrue(IntroClip.parseTimestamp("-5") is IntroClip.Parsed.Invalid)
+    }
+
+    // --- format / describe --------------------------------------------------
+
+    @Test
+    fun `format pads seconds and keeps sub-second precision`() {
+        assertEquals("0:03", IntroClip.format(3_000))
+        assertEquals("1:12", IntroClip.format(72_000))
+        assertEquals("0:03.5", IntroClip.format(3_500))
+        assertEquals("", IntroClip.format(null))
+    }
+
+    @Test
+    fun `format round-trips through parseTimestamp`() {
+        listOf(0, 3_000, 12_500, 72_000, 630_000).forEach { ms ->
+            assertEquals(IntroClip.Parsed.Ok(ms), IntroClip.parseTimestamp(IntroClip.format(ms)), "round-trip of $ms")
+        }
+    }
+
+    @Test
+    fun `describe covers every combination of bounds`() {
+        assertEquals("full track", IntroClip.describe(null, null))
+        assertEquals("0:03 – 0:12", IntroClip.describe(3_000, 12_000))
+        assertEquals("from 0:03", IntroClip.describe(3_000, null))
+        assertEquals("up to 0:12", IntroClip.describe(null, 12_000))
+    }
+
+    // --- validate -----------------------------------------------------------
+
+    @Test
+    fun `unclipped intro is fine when the source fits`() {
+        assertNull(IntroClip.validate(null, null, 10_000))
+        assertNull(IntroClip.validate(null, null, null))
+    }
+
+    @Test
+    fun `unclipped intro is rejected when the source is longer than the cap`() {
+        val error = IntroClip.validate(null, null, 60_000)
+        assertNotNull(error)
+        assertTrue(error!!.contains("set a start/end clip"), "should point the user at clipping: $error")
+    }
+
+    @Test
+    fun `a tight clip rescues a long source`() {
+        assertNull(IntroClip.validate(10_000, 22_000, 120_000))
+    }
+
+    @Test
+    fun `clip longer than the cap is rejected`() {
+        assertNotNull(IntroClip.validate(0, IntroClip.MAX_CLIP_DURATION_MS + 1, 60_000))
+        assertNull(IntroClip.validate(0, IntroClip.MAX_CLIP_DURATION_MS, 60_000))
+    }
+
+    @Test
+    fun `end must be after start and within the source`() {
+        assertNotNull(IntroClip.validate(5_000, 5_000, 60_000))
+        assertNotNull(IntroClip.validate(5_000, 3_000, 60_000))
+        assertNotNull(IntroClip.validate(0, 20_000, 10_000))
+        assertNotNull(IntroClip.validate(-1, 1_000, 60_000))
+    }
+
+    @Test
+    fun `open-ended clip is measured against the rest of the source`() {
+        // 120s source, start at 10s -> 110s of playback, way over the cap.
+        assertNotNull(IntroClip.validate(10_000, null, 120_000))
+        // Start late enough and the remainder fits.
+        assertNull(IntroClip.validate(110_000, null, 120_000))
+        // Unknown source duration can't be checked, so it passes.
+        assertNull(IntroClip.validate(10_000, null, null))
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/music/UndoDeleteIntroButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/music/UndoDeleteIntroButton.kt
@@ -1,0 +1,95 @@
+package bot.toby.button.buttons.music
+
+import bot.toby.helpers.IntroHelper
+import bot.toby.intro.IntroPresenter
+import bot.toby.intro.IntroUndoStore
+import common.intro.IntroSlots
+import core.button.Button
+import core.button.ButtonContext
+import database.dto.music.MusicDto
+import database.dto.user.UserDto
+import net.dv8tion.jda.api.components.buttons.Button as JdaButton
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+/**
+ * Restores the intro the clicking user most recently removed via
+ * `/deleteintro`, from the snapshot [IntroUndoStore] kept for them.
+ *
+ * Same safety net the web dashboard has had: a select-menu mis-click used to
+ * be unrecoverable on Discord, with the only remedy being to find the original
+ * file or URL again.
+ */
+@Component
+class UndoDeleteIntroButton @Autowired constructor(
+    private val introHelper: IntroHelper,
+    private val undoStore: IntroUndoStore,
+) : Button {
+
+    override val name: String = BUTTON_NAME
+    override val description: String = "Restore the intro you just deleted."
+
+    // Edits the confirmation in place so the Undo button disappears once used —
+    // no second ephemeral, and no stale button to double-click.
+    override val defersReply: Boolean = false
+
+    override fun handle(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        logger.setGuildAndMemberContext(ctx.guild, ctx.member)
+
+        val guildId = ctx.guild.idLong
+        val snapshot = undoStore.take(guildId, event.user.idLong)
+        if (snapshot == null) {
+            logger.info { "No intro snapshot to restore for user '${event.user.idLong}' on guild '$guildId'" }
+            event.editMessage(
+                "Nothing to undo — the ${IntroUndoStore.UNDO_WINDOW_MINUTES}-minute window may have passed, " +
+                    "or the intro was already restored."
+            ).setComponents().queue()
+            return
+        }
+
+        val user = introHelper.findUserById(snapshot.discordId, snapshot.guildId)
+        val existing = user.musicDtos
+        if (existing.size >= IntroSlots.MAX_INTRO_COUNT) {
+            event.editMessage("Can't restore — you're back at ${IntroSlots.MAX_INTRO_COUNT} intros already.")
+                .setComponents().queue()
+            return
+        }
+
+        // Prefer the original slot, but take the lowest free one if something
+        // else claimed it while the undo was pending. Walking 1..MAX (rather
+        // than max + 1) keeps the restored row inside the slot range even when
+        // the remaining intros leave a gap — same rule as
+        // IntroWebService.nextFreeIndex.
+        val used = existing.mapNotNull { it.index }.toSet()
+        val targetIndex = snapshot.index.takeIf { it !in used }
+            ?: (1..IntroSlots.MAX_INTRO_COUNT).first { it !in used }
+
+        val restored = MusicDto(
+            user,
+            targetIndex,
+            snapshot.fileName,
+            snapshot.introVolume,
+            snapshot.musicBlob,
+            snapshot.startMs,
+            snapshot.endMs,
+        )
+        val saved = introHelper.createIntro(restored)
+        if (saved == null) {
+            logger.warn { "Failed to restore intro '${snapshot.fileName}' into slot $targetIndex" }
+            event.editMessage("Couldn't restore that intro — it may already exist in another slot.")
+                .setComponents().queue()
+            return
+        }
+
+        logger.info { "Restored intro '${snapshot.fileName}' into slot $targetIndex" }
+        event.editMessage("Restored **${IntroPresenter.displayName(restored)}** to slot #$targetIndex.")
+            .setComponents().queue()
+    }
+
+    companion object {
+        const val BUTTON_NAME = "undointro"
+
+        fun button(): JdaButton = JdaButton.secondary(BUTTON_NAME, "Undo")
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/music/intro/DeleteIntroCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/music/intro/DeleteIntroCommand.kt
@@ -2,14 +2,16 @@ package bot.toby.command.commands.music.intro
 
 import bot.toby.command.commands.music.MusicCommand
 import bot.toby.helpers.MenuHelper.DELETE_INTRO
-import bot.toby.helpers.UserDtoHelper.Companion.produceMusicFileDataStringForPrinting
 import bot.toby.lavaplayer.PlayerManager
 import core.command.CommandContext
 import database.dto.user.UserDto
-import net.dv8tion.jda.api.components.actionrow.ActionRow
-import net.dv8tion.jda.api.components.selections.StringSelectMenu
 import org.springframework.stereotype.Component
 
+/**
+ * `/deleteintro` — pick an intro to remove. The confirmation carries an
+ * **Undo** button ([bot.toby.button.buttons.music.UndoDeleteIntroButton]) so a
+ * mis-click on the menu is recoverable, matching the web dashboard.
+ */
 @Component
 class DeleteIntroCommand : MusicCommand {
 
@@ -25,26 +27,13 @@ class DeleteIntroCommand : MusicCommand {
         requestingUserDto: UserDto,
         deleteDelay: Int
     ) {
-        val event = ctx.event
-
-        // Fetch the user's intros
-        val introList = requestingUserDto.musicDtos
-        if (introList.isEmpty()) {
-            event.hook.sendMessage("You have no intros to delete.").setEphemeral(true).queue()
-            return
-        }
-
-        // Create the string select menu with the user's intros
-        val builder = StringSelectMenu.create(DELETE_INTRO).setPlaceholder("Select an intro to delete")
-
-        introList.forEach { intro -> builder.addOption(intro.fileName ?: "Unknown", intro.id.toString()) }
-
-        val stringSelectMenu = builder.build()
-        val introMessage = produceMusicFileDataStringForPrinting(event.member!!, requestingUserDto)
-
-        // Send the select menu to the user
-        event.hook.sendMessage("$introMessage \nPlease select an intro to delete.").addComponents(ActionRow.of(stringSelectMenu))
-            .setEphemeral(true).queue()
+        sendIntroSelection(
+            event = ctx.event,
+            requestingUserDto = requestingUserDto,
+            menuId = DELETE_INTRO,
+            placeholder = "Select an intro to delete",
+            emptyMessage = "You have no intros to delete.",
+        )
     }
 
     override val name: String

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/music/intro/EditIntroCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/music/intro/EditIntroCommand.kt
@@ -2,14 +2,17 @@ package bot.toby.command.commands.music.intro
 
 import bot.toby.command.commands.music.MusicCommand
 import bot.toby.helpers.MenuHelper.EDIT_INTRO
-import bot.toby.helpers.UserDtoHelper.Companion.produceMusicFileDataStringForPrinting
 import bot.toby.lavaplayer.PlayerManager
 import core.command.CommandContext
 import database.dto.user.UserDto
-import net.dv8tion.jda.api.components.actionrow.ActionRow
-import net.dv8tion.jda.api.components.selections.StringSelectMenu
 import org.springframework.stereotype.Component
 
+/**
+ * `/editintro` — pick an intro, then edit it in a modal
+ * ([bot.toby.modal.modals.EditIntroModal]): name, volume and clip bounds in
+ * one form. This used to change volume only, and only by typing a bare number
+ * into the channel within ten seconds of selecting.
+ */
 @Component
 class EditIntroCommand : MusicCommand {
 
@@ -25,31 +28,18 @@ class EditIntroCommand : MusicCommand {
         requestingUserDto: UserDto,
         deleteDelay: Int
     ) {
-        val event = ctx.event
-
-        // Fetch the user's intros
-        val introList = requestingUserDto.musicDtos
-        if (introList.isEmpty()) {
-            event.hook.sendMessage("You have no intros to edit.").setEphemeral(true).queue()
-            return
-        }
-
-        // Create the string select menu with the user's intros
-        val builder = StringSelectMenu.create(EDIT_INTRO).setPlaceholder("Select an intro to edit")
-
-        introList.forEach { intro -> builder.addOption(intro.fileName ?: "Unknown", intro.id.toString()) }
-
-        val stringSelectMenu = builder.build()
-        val introMessage = produceMusicFileDataStringForPrinting(event.member!!, requestingUserDto)
-
-        // Send the select menu to the user
-        event.hook.sendMessage("$introMessage \nPlease select an intro to edit.").addComponents(ActionRow.of(stringSelectMenu))
-            .setEphemeral(true).queue()
+        sendIntroSelection(
+            event = ctx.event,
+            requestingUserDto = requestingUserDto,
+            menuId = EDIT_INTRO,
+            placeholder = "Select an intro to edit",
+            emptyMessage = "You have no intros to edit. Add one with `/setintro`.",
+        )
     }
 
     override val name: String
         get() = "editintro"
 
     override val description: String
-        get() = "Edit one of your intros."
+        get() = "Edit one of your intros — name, volume and clip start/end."
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/music/intro/IntroSelectionSupport.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/music/intro/IntroSelectionSupport.kt
@@ -1,0 +1,44 @@
+package bot.toby.command.commands.music.intro
+
+import bot.toby.intro.IntroPresenter
+import common.intro.IntroSlots
+import database.dto.user.UserDto
+import net.dv8tion.jda.api.components.actionrow.ActionRow
+import net.dv8tion.jda.api.components.selections.StringSelectMenu
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+
+/**
+ * Shared "pick one of your intros" reply behind `/editintro` and
+ * `/deleteintro`. Both used to build the menu themselves, in raw list order
+ * and with unbounded option labels — see [IntroPresenter] for what that broke.
+ *
+ * The reply is ephemeral: whatever follows (an edit modal, a delete
+ * confirmation) is private too, and the menu shouldn't linger in the channel.
+ */
+internal fun sendIntroSelection(
+    event: SlashCommandInteractionEvent,
+    requestingUserDto: UserDto,
+    menuId: String,
+    placeholder: String,
+    emptyMessage: String,
+) {
+    val intros = requestingUserDto.musicDtos
+    if (intros.isEmpty()) {
+        event.hook.sendMessage(emptyMessage).setEphemeral(true).queue()
+        return
+    }
+
+    val menu = StringSelectMenu.create(menuId)
+        .setPlaceholder(placeholder)
+        .addOptions(IntroPresenter.selectOptions(intros))
+        .build()
+
+    val member = event.member
+    val action = if (member != null) {
+        event.hook.sendMessageEmbeds(IntroPresenter.listEmbed(member, intros, IntroSlots.MAX_INTRO_COUNT))
+    } else {
+        event.hook.sendMessage(placeholder)
+    }
+
+    action.addComponents(ActionRow.of(menu)).setEphemeral(true).queue()
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/music/intro/ListIntrosCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/music/intro/ListIntrosCommand.kt
@@ -1,0 +1,87 @@
+package bot.toby.command.commands.music.intro
+
+import bot.toby.command.commands.music.MusicCommand
+import bot.toby.helpers.IntroHelper
+import bot.toby.intro.IntroPresenter
+import bot.toby.lavaplayer.PlayerManager
+import common.intro.IntroSlots
+import core.command.CommandContext
+import database.dto.user.UserDto
+import net.dv8tion.jda.api.components.actionrow.ActionRow
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.interactions.commands.build.OptionData
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+/**
+ * `/listintros` — read-only view of the intros configured for this server.
+ *
+ * Until now the only way to see what you had set was to start `/editintro` or
+ * `/deleteintro` and read the prompt before backing out, which is a strange
+ * thing to ask of someone who just wants to check their volume. The embed
+ * shows slot, volume, clip range and source type for each intro, and links
+ * across to the web dashboard for the richer editor (drag-reorder, waveform
+ * trim bar, previews).
+ *
+ * Super-users can pass `user:` to inspect someone else's, the same permission
+ * rule `/setintro` applies to setting them.
+ */
+@Component
+class ListIntrosCommand @Autowired constructor(
+    private val introHelper: IntroHelper,
+) : MusicCommand {
+
+    override val ephemeral: Boolean = true
+
+    override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        handleMusicCommand(ctx, PlayerManager.instance, requestingUserDto, deleteDelay)
+    }
+
+    override fun handleMusicCommand(
+        ctx: CommandContext,
+        instance: PlayerManager,
+        requestingUserDto: UserDto,
+        deleteDelay: Int
+    ) {
+        val event = ctx.event
+        logger.setGuildAndMemberContext(ctx.guild, ctx.member)
+
+        val requestedMember: Member? = event.getOption(USER)?.asMember
+        if (requestedMember != null && requestedMember.idLong != event.user.idLong && !requestingUserDto.superUser) {
+            sendErrorMessage(event, deleteDelay)
+            return
+        }
+
+        val targetMember = requestedMember ?: event.member ?: run {
+            event.hook.sendMessage("Intros are per-server — run this inside the server you want to see.")
+                .setEphemeral(true).queue()
+            return
+        }
+
+        val targetDto = if (targetMember.idLong == event.user.idLong) {
+            requestingUserDto
+        } else {
+            introHelper.findUserById(targetMember.idLong, targetMember.guild.idLong)
+        }
+
+        val embed = IntroPresenter.listEmbed(targetMember, targetDto.musicDtos, IntroSlots.MAX_INTRO_COUNT)
+        event.hook.sendMessageEmbeds(embed)
+            .addComponents(ActionRow.of(IntroPresenter.webDashboardButton(targetMember.guild.idLong)))
+            .setEphemeral(true)
+            .queue()
+    }
+
+    override val name: String get() = "listintros"
+
+    override val description: String get() = "Show the intro songs you have set on this server."
+
+    override val optionData: List<OptionData>
+        get() = listOf(
+            OptionData(OptionType.USER, USER, "Whose intros to show (super-users only)", false)
+        )
+
+    companion object {
+        private const val USER = "user"
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/music/intro/SetIntroCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/music/intro/SetIntroCommand.kt
@@ -2,25 +2,36 @@ package bot.toby.command.commands.music.intro
 
 import bot.toby.command.commands.music.MusicCommand
 import bot.toby.helpers.IntroHelper
-import bot.toby.helpers.IntroHelper.Companion.INTRO_LIMIT
 import bot.toby.helpers.MenuHelper.SET_INTRO
+import bot.toby.helpers.PendingIntro
 import bot.toby.helpers.URLHelper
-import bot.toby.helpers.UserDtoHelper.Companion.produceMusicFileDataStringForPrinting
+import bot.toby.intro.IntroPresenter
 import bot.toby.lavaplayer.PlayerManager
+import common.intro.IntroClip
+import common.intro.IntroSlots
 import core.command.CommandContext
 import database.dto.user.UserDto
+import net.dv8tion.jda.api.components.actionrow.ActionRow
+import net.dv8tion.jda.api.components.selections.StringSelectMenu
 import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.interactions.InteractionHook
 import net.dv8tion.jda.api.interactions.commands.OptionMapping
 import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData
-import net.dv8tion.jda.api.components.actionrow.ActionRow
-import net.dv8tion.jda.api.components.selections.SelectOption
-import net.dv8tion.jda.api.components.selections.StringSelectMenu
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
+/**
+ * `/setintro link|attachment` — add or replace an intro.
+ *
+ * Both subcommands take optional `start`/`end` clip bounds. Without them a
+ * source longer than [IntroClip.MAX_DURATION_SECONDS] is still rejected, as
+ * before; with them a long track is fair game as long as the *clip* fits.
+ * That's how the web form has always behaved, and how the player has always
+ * read `MusicDto.startMs`/`endMs` back at join time — the slash command was
+ * the only place that couldn't express it.
+ */
 @Component
 class SetIntroCommand @Autowired constructor(
     private val introHelper: IntroHelper
@@ -50,6 +61,9 @@ class SetIntroCommand @Autowired constructor(
             return
         }
 
+        // Returns null after replying with the specific parse error.
+        val clip = parseClipOptions(event) ?: return
+
         val mentionedMembers = event.getOptionMentionedMembers()
 
         if (mentionedMembers.isEmpty()) {
@@ -61,15 +75,34 @@ class SetIntroCommand @Autowired constructor(
                 event.user.effectiveName,
                 deleteDelay,
                 introVolume,
-                attachmentOption
+                attachmentOption,
+                clip
             )
         } else {
             // Mentions: map each member to their DTO inside the loop
             mentionedMembers.forEach { member ->
                 val memberDto = introHelper.findUserById(member.idLong, member.guild.idLong)
-                checkAndSetIntro(event, memberDto, linkOption, member.effectiveName, deleteDelay, introVolume, attachmentOption)
+                checkAndSetIntro(
+                    event, memberDto, linkOption, member.effectiveName, deleteDelay,
+                    introVolume, attachmentOption, clip
+                )
             }
         }
+    }
+
+    /** Reads the optional `start`/`end` options into milliseconds. */
+    private fun parseClipOptions(event: SlashCommandInteractionEvent): Clip? {
+        val start = IntroClip.parseTimestamp(event.getOption(START)?.asString, "Clip start")
+        if (start is IntroClip.Parsed.Invalid) {
+            event.hook.sendMessage(start.message).setEphemeral(true).queue()
+            return null
+        }
+        val end = IntroClip.parseTimestamp(event.getOption(END)?.asString, "Clip end")
+        if (end is IntroClip.Parsed.Invalid) {
+            event.hook.sendMessage(end.message).setEphemeral(true).queue()
+            return null
+        }
+        return Clip((start as IntroClip.Parsed.Ok).ms, (end as IntroClip.Parsed.Ok).ms)
     }
 
     private fun checkAndSetIntro(
@@ -79,17 +112,25 @@ class SetIntroCommand @Autowired constructor(
         userName: String,
         deleteDelay: Int,
         introVolume: Int,
-        attachmentOption: OptionMapping?
+        attachmentOption: OptionMapping?,
+        clip: Clip
     ) {
-        introHelper.validateIntroLength(linkOption) { isOverLimit ->
-            if (isOverLimit) {
-                logger.info { "Intro was rejected for being over the specified intro limit length of $INTRO_LIMIT" }
-                event.hook
-                    .sendMessage("Intro provided was over $INTRO_LIMIT long, out of courtesy please pick a shorter intro.")
+        // One duration lookup, then the shared clip rules decide. Replaces the
+        // old boolean "is this over 15 seconds" gate, which had no way to
+        // account for a user-supplied clip and so rejected every long source.
+        introHelper.validateClipAgainstSource(
+            linkOption.takeIf { it.isNotEmpty() }, clip.startMs, clip.endMs
+        ) { error ->
+            if (error != null) {
+                logger.info { "Intro was rejected: $error" }
+                event.hook.sendMessage(error)
+                    .setEphemeral(true)
                     .queue(core.command.Command.invokeDeleteOnMessageResponse(deleteDelay))
-                return@validateIntroLength
             } else {
-                validateAndSetIntro(event, requestingUserDto, linkOption, attachmentOption, introVolume, userName, deleteDelay)
+                validateAndSetIntro(
+                    event, requestingUserDto, linkOption, attachmentOption,
+                    introVolume, userName, deleteDelay, clip
+                )
             }
         }
     }
@@ -101,12 +142,21 @@ class SetIntroCommand @Autowired constructor(
         attachmentOption: OptionMapping?,
         introVolume: Int,
         userName: String,
-        deleteDelay: Int
+        deleteDelay: Int,
+        clip: Clip
     ) {
         when {
-            checkForOverIntroLimit(event.hook, event.member!!, requestingUserDto, linkOption, attachmentOption, introVolume) -> return
-            linkOption.isNotEmpty() -> introHelper.handleUrl(event, requestingUserDto, userName, deleteDelay, URLHelper.fromUrlString(linkOption), introVolume)
-            attachmentOption != null -> introHelper.handleAttachment(event, requestingUserDto, userName, deleteDelay, attachmentOption.asAttachment, introVolume)
+            checkForOverIntroLimit(
+                event.hook, event.member!!, requestingUserDto, linkOption, attachmentOption, introVolume, clip
+            ) -> return
+            linkOption.isNotEmpty() -> introHelper.handleUrl(
+                event, requestingUserDto, userName, deleteDelay, URLHelper.fromUrlString(linkOption),
+                introVolume, null, clip.startMs, clip.endMs
+            )
+            attachmentOption != null -> introHelper.handleAttachment(
+                event, requestingUserDto, userName, deleteDelay, attachmentOption.asAttachment,
+                introVolume, null, clip.startMs, clip.endMs
+            )
             else -> event.hook.sendMessage("Please provide a valid link or attachment")
                 .queue(core.command.Command.invokeDeleteOnMessageResponse(deleteDelay))
         }
@@ -118,17 +168,27 @@ class SetIntroCommand @Autowired constructor(
         requestingUserDto: UserDto,
         linkOption: String? = null,
         attachmentOption: OptionMapping? = null,
-        introVolume: Int
+        introVolume: Int,
+        clip: Clip
     ): Boolean {
         val introList = requestingUserDto.musicDtos
         if (introList.size >= LIMIT) {
-            introHelper.pendingIntros[requestingUserDto.discordId] =
-                Triple(attachmentOption?.asAttachment, linkOption, introVolume)
-            val builder = StringSelectMenu.create(SET_INTRO).setPlaceholder(null)
-            introList.sortedBy { it.index }.forEach { builder.addOptions(SelectOption.of(it.fileName!!, it.id.toString())) }
-            val stringSelectMenu = builder.build()
-            val musicFileDataStringForPrinting = produceMusicFileDataStringForPrinting(member, requestingUserDto)
-            hook.sendMessage("$musicFileDataStringForPrinting\n Select the intro you'd like to replace with your new upload as we only allow $LIMIT intros")
+            introHelper.pendingIntros[requestingUserDto.discordId] = PendingIntro(
+                attachment = attachmentOption?.asAttachment,
+                url = linkOption,
+                volume = introVolume,
+                startMs = clip.startMs,
+                endMs = clip.endMs,
+            )
+            val stringSelectMenu = StringSelectMenu.create(SET_INTRO)
+                .setPlaceholder("Select the intro to replace")
+                .addOptions(IntroPresenter.selectOptions(introList))
+                .build()
+            hook.sendMessageEmbeds(IntroPresenter.listEmbed(member, introList, LIMIT))
+                .addContent(
+                    "Select the intro you'd like to replace with your new upload — " +
+                        "we only allow $LIMIT intros."
+                )
                 .setComponents(ActionRow.of(stringSelectMenu))
                 .setEphemeral(true)
                 .queue()
@@ -140,6 +200,9 @@ class SetIntroCommand @Autowired constructor(
     private fun SlashCommandInteractionEvent.getOptionMentionedMembers(): List<Member> =
         this.getOption(USERS)?.mentions?.members.orEmpty()
 
+    /** Parsed `start`/`end` options, in milliseconds; null means "no bound". */
+    private data class Clip(val startMs: Int?, val endMs: Int?)
+
     override val name: String get() = "setintro"
     override val description: String get() = "Upload an **MP3** file or link to play when you join a voice channel."
 
@@ -148,10 +211,20 @@ class SetIntroCommand @Autowired constructor(
             SubcommandData(LINK, "Set intro via YouTube link")
                 .addOption(OptionType.STRING, LINK, "Link to set as your discord intro", true)
                 .addOption(OptionType.INTEGER, VOLUME, "Volume to set your intro to")
+                .addOption(OptionType.STRING, START, "Clip start, e.g. 0:12 — lets you use a longer video")
+                .addOption(
+                    OptionType.STRING, END,
+                    "Clip end, e.g. 0:24 (max ${IntroClip.MAX_DURATION_SECONDS}s of clip)"
+                )
                 .addOption(OptionType.MENTIONABLE, USERS, "User whose intro to change"),
             SubcommandData(ATTACHMENT, "Set intro via file upload")
                 .addOption(OptionType.ATTACHMENT, ATTACHMENT, "Attachment (file) to set as your discord intro", true)
                 .addOption(OptionType.INTEGER, VOLUME, "Volume to set your intro to")
+                .addOption(OptionType.STRING, START, "Clip start, e.g. 0:12")
+                .addOption(
+                    OptionType.STRING, END,
+                    "Clip end, e.g. 0:24 (max ${IntroClip.MAX_DURATION_SECONDS}s of clip)"
+                )
                 .addOption(OptionType.MENTIONABLE, USERS, "User whose intro to change")
         )
 
@@ -160,6 +233,8 @@ class SetIntroCommand @Autowired constructor(
         private const val USERS = "users"
         private const val LINK = "link"
         private const val ATTACHMENT = "attachment"
-        private const val LIMIT = 3
+        private const val START = "start"
+        private const val END = "end"
+        private val LIMIT = IntroSlots.MAX_INTRO_COUNT
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/handler/VoiceEventHandler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/handler/VoiceEventHandler.kt
@@ -5,6 +5,7 @@ import bot.toby.helpers.MusicPlayerHelper.playUserIntro
 import bot.toby.helpers.UserDtoHelper
 import bot.toby.helpers.UserDtoHelper.Companion.getRequestingUserDto
 import bot.toby.helpers.nonBots
+import bot.toby.intro.IntroPlaybackTracker
 import bot.toby.lavaplayer.PlayerManager
 import bot.toby.managers.NowPlayingManager
 import bot.toby.voice.LastConnectedChannelTracker
@@ -38,6 +39,7 @@ class VoiceEventHandler(
     private val awardService: SocialCreditAwardService,
     private val xpAwardService: XpAwardService,
     private val nowPlayingManager: NowPlayingManager,
+    private val introPlaybackTracker: IntroPlaybackTracker = IntroPlaybackTracker(),
 ) : ListenerAdapter() {
 
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
@@ -219,13 +221,27 @@ class VoiceEventHandler(
     ) {
         val member = event.member
         if (requestingUserDto.musicDtos.isNotEmpty()) {
+            // Discord fires a join for every channel hop and every reconnect.
+            // Without this the intro replayed each time — and paid out the
+            // credit and XP below each time too.
+            if (introPlaybackTracker.onCooldown(guild.idLong, requestingUserDto.discordId)) {
+                logger.info {
+                    "Intro for ${requestingUserDto.discordId} played within the last " +
+                        "${IntroPlaybackTracker.COOLDOWN.seconds}s; skipping replay"
+                }
+                return
+            }
             logger.info { "User has musicDto associated with them, preparing to play intro" }
-            playUserIntro(
+            val played = playUserIntro(
                 requestingUserDto,
                 guild,
                 deleteDelay = deleteDelay,
-                member = member
+                member = member,
+                lastPlayedIntroId = introPlaybackTracker.lastPlayedIntroId(
+                    guild.idLong, requestingUserDto.discordId
+                ),
             )
+            introPlaybackTracker.record(guild.idLong, requestingUserDto.discordId, played?.id)
             awardService.award(
                 discordId = requestingUserDto.discordId,
                 guildId = requestingUserDto.guildId,

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/IntroHelper.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/IntroHelper.kt
@@ -4,6 +4,7 @@ import bot.toby.handler.EventWaiter
 import bot.toby.intro.IntroMediaLoader
 import bot.toby.intro.IntroNotificationService
 import bot.toby.intro.IntroValidationService
+import common.intro.IntroClip
 import common.logging.DiscordLogger
 import core.command.Command.Companion.invokeDeleteOnMessageResponse
 import core.command.Command.Companion.replyAndDelete
@@ -55,7 +56,10 @@ class IntroHelper(
     // Per-user pending intro cache, written by /setintro and read by the
     // confirmation menu. Distinct from the DM prompt flow, which lives in
     // IntroNotificationService.
-    val pendingIntros = mutableMapOf<Long, Triple<Attachment?, String?, Int>?>()
+    //
+    // Was a Triple; became a named type once clip bounds joined the payload,
+    // since `pending.startMs` beats `pending.fourth` for readability.
+    val pendingIntros = mutableMapOf<Long, PendingIntro?>()
 
     fun calculateIntroVolume(event: SlashCommandInteractionEvent): Int {
         val volumePropertyName = ConfigDto.Configurations.INTRO_VOLUME.configValue
@@ -72,7 +76,9 @@ class IntroHelper(
         input: InputData?,
         introVolume: Int,
         selectedMusicDto: MusicDto?,
-        userName: String = event.user.effectiveName
+        userName: String = event.user.effectiveName,
+        startMs: Int? = null,
+        endMs: Int? = null
     ) {
         logger.setGuildAndMemberContext(event.guild, event.member)
         logger.info { "Handling media inside intro helper ..." }
@@ -86,7 +92,10 @@ class IntroHelper(
                     )
                     return
                 }
-                handleAttachment(event, requestingUserDto, userName, deleteDelay, input.attachment, introVolume, selectedMusicDto)
+                handleAttachment(
+                    event, requestingUserDto, userName, deleteDelay, input.attachment,
+                    introVolume, selectedMusicDto, startMs, endMs
+                )
             }
 
             is InputData.Url -> {
@@ -96,7 +105,10 @@ class IntroHelper(
                     return
                 }
                 val uri = URI.create(uriString)
-                handleUrl(event, requestingUserDto, userName, deleteDelay, uri, introVolume, selectedMusicDto)
+                handleUrl(
+                    event, requestingUserDto, userName, deleteDelay, uri,
+                    introVolume, selectedMusicDto, startMs, endMs
+                )
             }
 
             else -> {
@@ -112,7 +124,9 @@ class IntroHelper(
         deleteDelay: Int,
         attachment: Attachment,
         introVolume: Int,
-        selectedMusicDto: MusicDto? = null
+        selectedMusicDto: MusicDto? = null,
+        startMs: Int? = null,
+        endMs: Int? = null
     ) {
         logger.setGuildAndMemberContext(event.guild, event.member)
         logger.info { "Handling attachment inside intro helper..." }
@@ -133,7 +147,10 @@ class IntroHelper(
             else -> {
                 val inputStream = downloadAttachment(attachment)
                 inputStream?.let {
-                    persistMusicFile(event, requestingUserDto, userName, deleteDelay, attachment.fileName, introVolume, it, selectedMusicDto)
+                    persistMusicFile(
+                        event, requestingUserDto, userName, deleteDelay, attachment.fileName,
+                        introVolume, it, selectedMusicDto, startMs, endMs
+                    )
                 }
             }
         }
@@ -146,20 +163,32 @@ class IntroHelper(
         deleteDelay: Int,
         uri: URI?,
         introVolume: Int,
-        selectedMusicDto: MusicDto? = null
+        selectedMusicDto: MusicDto? = null,
+        startMs: Int? = null,
+        endMs: Int? = null
     ) {
         logger.setGuildAndMemberContext(event.guild, event.member)
         logger.info { "Handling URL inside intro helper..." }
         val urlString = validationService.convertShortsUrls(uri.toString())
         coroutineScope.launch {
             val title = runCatching { httpHelper.getYouTubeVideoTitle(urlString) }.getOrNull()
-            persistMusicUrl(event, requestingUserDto, deleteDelay, title ?: urlString, urlString, userName, introVolume, selectedMusicDto)
+            persistMusicUrl(
+                event, requestingUserDto, deleteDelay, title ?: urlString, urlString,
+                userName, introVolume, selectedMusicDto, startMs, endMs
+            )
         }
     }
 
-    fun findUserById(discordId: Long, guildId: Long) = userDtoHelper.calculateUserDto(guildId, discordId)
+    // NB: (discordId, guildId), matching UserDtoHelper.calculateUserDto and
+    // every other call site. This used to forward the pair reversed, so the
+    // super-user path in `/setintro users:@someone` resolved — and lazily
+    // created — a row keyed (guildId, discordId), whose intros could never be
+    // found again by the normal lookup.
+    fun findUserById(discordId: Long, guildId: Long) = userDtoHelper.calculateUserDto(discordId, guildId)
 
     fun findIntroById(musicFileId: String) = musicFileService.getMusicFileById(musicFileId)
+
+    fun createIntro(musicDto: MusicDto) = musicFileService.createNewMusicFile(musicDto)
 
     fun updateIntro(musicDto: MusicDto) = musicFileService.updateMusicFile(musicDto)
 
@@ -176,7 +205,9 @@ class IntroHelper(
         filename: String,
         introVolume: Int,
         inputStream: InputStream,
-        selectedMusicDto: MusicDto? = null
+        selectedMusicDto: MusicDto? = null,
+        startMs: Int? = null,
+        endMs: Int? = null
     ) {
         logger.setGuildAndMemberContext(event.guild, event.member)
         logger.info { "Persisting music file" }
@@ -193,15 +224,21 @@ class IntroHelper(
             this.fileName = filename
             this.introVolume = introVolume
             this.userDto = targetDto
-        } ?: MusicDto(targetDto, index, filename, introVolume, fileContents)
+            this.startMs = startMs
+            this.endMs = endMs
+        } ?: MusicDto(targetDto, index, filename, introVolume, fileContents, startMs, endMs)
 
         if (selectedMusicDto == null) {
             musicFileService.createNewMusicFile(musicDto)
-                ?.let { sendSuccessMessage(event, userName, filename, introVolume, index, deleteDelay) }
+                ?.let { sendSuccessMessage(event, userName, filename, introVolume, index, deleteDelay, startMs, endMs) }
                 ?: rejectIntroForDuplication(event, userName, filename, deleteDelay)
         } else {
             musicFileService.updateMusicFile(musicDto)
-                ?.let { sendUpdateMessage(event, userName, filename, introVolume, musicDto.index!!, deleteDelay) }
+                ?.let {
+                    sendUpdateMessage(
+                        event, userName, filename, introVolume, musicDto.index!!, deleteDelay, startMs, endMs
+                    )
+                }
                 ?: rejectIntroForDuplication(event, userName, filename, deleteDelay)
         }
     }
@@ -214,7 +251,9 @@ class IntroHelper(
         url: String,
         memberName: String,
         introVolume: Int,
-        selectedMusicDto: MusicDto? = null
+        selectedMusicDto: MusicDto? = null,
+        startMs: Int? = null,
+        endMs: Int? = null
     ) {
         logger.setGuildAndMemberContext(event.guild, event.member)
         logger.info { "Persisting music URL for user '$memberName' on guild: ${event.guild?.idLong}" }
@@ -230,20 +269,33 @@ class IntroHelper(
             this.musicBlobHash = computeHash(urlBytes)
             this.fileName = filename
             this.introVolume = introVolume
-        } ?: MusicDto(targetDto, index, filename, introVolume, urlBytes)
+            this.startMs = startMs
+            this.endMs = endMs
+        } ?: MusicDto(targetDto, index, filename, introVolume, urlBytes, startMs, endMs)
 
         if (selectedMusicDto == null) {
             logger.info { "Creating new music file $musicDto" }
             musicFileService.createNewMusicFile(musicDto)
-                ?.let { sendSuccessMessage(event, memberName, filename, introVolume, index, deleteDelay) }
+                ?.let { sendSuccessMessage(event, memberName, filename, introVolume, index, deleteDelay, startMs, endMs) }
                 ?: rejectIntroForDuplication(event, memberName, filename, deleteDelay)
         } else {
             logger.info { "Updating music file $musicDto" }
             musicFileService.updateMusicFile(musicDto)
-                ?.let { sendUpdateMessage(event, memberName, filename, introVolume, musicDto.index!!, deleteDelay) }
+                ?.let {
+                    sendUpdateMessage(
+                        event, memberName, filename, introVolume, musicDto.index!!, deleteDelay, startMs, endMs
+                    )
+                }
                 ?: rejectIntroForDuplication(event, memberName, filename, deleteDelay)
         }
     }
+
+    /**
+     * Trailing " (clip 0:03 – 0:12)" for a clipped intro, empty otherwise, so
+     * the confirmation echoes exactly what will play back on join.
+     */
+    private fun clipSuffix(startMs: Int?, endMs: Int?): String =
+        if (startMs == null && endMs == null) "" else " (clip ${IntroClip.describe(startMs, endMs)})"
 
     private fun sendSuccessMessage(
         event: IReplyCallback,
@@ -251,14 +303,15 @@ class IntroHelper(
         filename: String,
         introVolume: Int,
         index: Int,
-        deleteDelay: Int
+        deleteDelay: Int,
+        startMs: Int? = null,
+        endMs: Int? = null
     ) {
         logger.setGuildAndMemberContext(event.guild, event.member)
-        logger.info { "Successfully set $memberName's intro song #${index} to '$filename' with volume '$introVolume'" }
-        event.hook.replyEphemeralAndDelete(
-            "Successfully set $memberName's intro song #${index} to '$filename' with volume '$introVolume'",
-            deleteDelay,
-        )
+        val message = "Successfully set $memberName's intro song #${index} to '$filename' " +
+            "with volume '$introVolume'${clipSuffix(startMs, endMs)}"
+        logger.info { message }
+        event.hook.replyEphemeralAndDelete(message, deleteDelay)
     }
 
     private fun sendUpdateMessage(
@@ -267,10 +320,13 @@ class IntroHelper(
         filename: String,
         introVolume: Int,
         index: Int,
-        deleteDelay: Int
+        deleteDelay: Int,
+        startMs: Int? = null,
+        endMs: Int? = null
     ) {
         event.hook.replyEphemeralAndDelete(
-            "Successfully updated $memberName's intro song #${index} to '$filename' with volume '$introVolume'",
+            "Successfully updated $memberName's intro song #${index} to '$filename' " +
+                "with volume '$introVolume'${clipSuffix(startMs, endMs)}",
             deleteDelay,
         )
     }
@@ -309,6 +365,14 @@ class IntroHelper(
     fun validateIntroLength(url: String, onResult: (Boolean) -> Unit) =
         validationService.validateIntroLength(url, onResult)
 
+    /**
+     * Clip-aware length check. Replaces the plain [validateIntroLength] on the
+     * `/setintro` path so a source longer than the cap is accepted when the
+     * user supplies a start/end inside it — matching the web form.
+     */
+    fun validateClipAgainstSource(url: String?, startMs: Int?, endMs: Int?, onResult: (String?) -> Unit) =
+        validationService.validateClipAgainstSource(url, startMs, endMs, onResult)
+
     suspend fun checkForOverlyLongIntroDuration(url: String): Boolean =
         validationService.checkForOverlyLongIntroDuration(url)
 
@@ -330,3 +394,17 @@ sealed class InputData {
     data class Attachment(val attachment: Message.Attachment) : InputData()
     data class Url(val uri: String) : InputData()
 }
+
+/**
+ * An intro `/setintro` has accepted but can't save yet, because the user is at
+ * their slot limit and still has to choose which existing intro to replace.
+ * Held in [IntroHelper.pendingIntros] until [bot.toby.menu.menus.SetIntroMenu]
+ * resolves the choice.
+ */
+data class PendingIntro(
+    val attachment: Message.Attachment?,
+    val url: String?,
+    val volume: Int,
+    val startMs: Int? = null,
+    val endMs: Int? = null,
+)

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/MusicPlayerHelper.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/MusicPlayerHelper.kt
@@ -2,6 +2,7 @@ package bot.toby.helpers
 
 import bot.toby.BOT_WEB_URL
 import bot.toby.command.commands.music.MusicCommand.Companion.sendDeniedStoppableMessage
+import bot.toby.intro.IntroSelection
 import bot.toby.lavaplayer.GuildMusicManager
 import bot.toby.lavaplayer.PlayerManager
 import bot.toby.managers.NowPlayingManager
@@ -28,37 +29,48 @@ object MusicPlayerHelper {
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
     val nowPlayingManager = NowPlayingManager()
 
+    /**
+     * @param lastPlayedIntroId the intro played for this user last time, so
+     *        [IntroSelection] can avoid repeating it back to back.
+     * @return the intro that was played, or null when the user has none (or
+     *         playback failed) — callers record it as the new "last played".
+     */
     fun playUserIntro(
         dbUser: UserDto,
         guild: Guild,
         event: SlashCommandInteractionEvent? = null,
         deleteDelay: Int,
         startPosition: Long = 0,
-        member: Member? = null
-    ) {
+        member: Member? = null,
+        lastPlayedIntroId: String? = null
+    ): MusicDto? {
         logger.setGuildAndMemberContext(guild, member)
         logger.info { "Finding intro to play ..." }
-        val musicDto = dbUser.musicDtos
         val instance = PlayerManager.instance
         val currentVolume = instance.getMusicManager(guild).audioPlayer.volume
 
-        runCatching {
-            musicDto.random().let {
-                logger.info { "User has a musicDto. Preparing to play intro." }
-                val introVolume = it.introVolume
-                instance.setPreviousVolume(currentVolume)
-                val url = determineUrlFromMusicDto(it)
-                val clipStart = it.startMs?.toLong() ?: startPosition
-                val clipEnd = it.endMs?.toLong()
-                logger.info { "Url to play is: '$url' (clip ${clipStart}ms -> ${clipEnd ?: "end"})" }
-                instance.loadAndPlayIntro(
-                    guild, event, url, deleteDelay, clipStart,
-                    introVolume ?: currentVolume, clipEnd
-                )
-            }
-        }.onFailure {
+        val selected = IntroSelection.pick(dbUser.musicDtos, lastPlayedIntroId)
+        if (selected == null) {
             logger.warn { "User does not have a musicDto. Cannot play intro." }
+            return null
         }
+
+        return runCatching {
+            logger.info { "User has a musicDto. Preparing to play intro." }
+            val introVolume = selected.introVolume
+            instance.setPreviousVolume(currentVolume)
+            val url = determineUrlFromMusicDto(selected)
+            val clipStart = selected.startMs?.toLong() ?: startPosition
+            val clipEnd = selected.endMs?.toLong()
+            logger.info { "Url to play is: '$url' (clip ${clipStart}ms -> ${clipEnd ?: "end"})" }
+            instance.loadAndPlayIntro(
+                guild, event, url, deleteDelay, clipStart,
+                introVolume ?: currentVolume, clipEnd
+            )
+            selected
+        }.onFailure {
+            logger.warn { "Failed to play intro '${selected.id}': ${it.message}" }
+        }.getOrNull()
     }
 
     fun nowPlaying(

--- a/discord-bot/src/main/kotlin/bot/toby/intro/IntroNotificationService.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/intro/IntroNotificationService.kt
@@ -4,6 +4,7 @@ import bot.toby.handler.EventWaiter
 import bot.toby.helpers.HttpHelper
 import bot.toby.helpers.InputData
 import bot.toby.util.isUrl
+import com.github.benmanes.caffeine.cache.Caffeine
 import common.logging.DiscordLogger
 import common.notification.NotificationChannelKind
 import common.notification.Surface
@@ -23,6 +24,7 @@ import net.dv8tion.jda.api.entities.User
 import net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 import org.springframework.stereotype.Service
+import java.util.concurrent.TimeUnit
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.DurationUnit
 
@@ -52,6 +54,12 @@ class IntroNotificationService(
     private val supervisorJob = SupervisorJob()
     private val coroutineScope = CoroutineScope(supervisorJob + dispatcher)
 
+    /** (guild, user) pairs nudged inside [PROMPT_COOLDOWN_HOURS]. */
+    private val recentlyPrompted = Caffeine.newBuilder()
+        .expireAfterWrite(PROMPT_COOLDOWN_HOURS, TimeUnit.HOURS)
+        .maximumSize(10_000)
+        .build<String, Boolean>()
+
     fun promptUserForMusicInfo(user: User, guild: Guild) {
         logger.setGuildAndUserContext(guild, user)
         // Honour the per-user INTRO_PROMPT opt-out. Default is opt-in so
@@ -66,6 +74,18 @@ class IntroNotificationService(
             logger.info { "User opted out of INTRO_PROMPT; skipping prompt for guild '${guild.name}'." }
             return
         }
+        // The caller fires on every voice join while the user has no intro, so
+        // without this a channel-hopper got a DM per hop — and, five minutes
+        // later, a "you didn't respond in time" DM per hop as well, since each
+        // prompt armed its own EventWaiter. One nudge a day is a nudge; ten in
+        // an evening is why people mute the bot.
+        val promptKey = "${guild.idLong}:${user.idLong}"
+        if (recentlyPrompted.getIfPresent(promptKey) != null) {
+            logger.info { "Already prompted this user for an intro recently; skipping." }
+            return
+        }
+        recentlyPrompted.put(promptKey, true)
+
         logger.info { "Prompting user to set an intro for the server that they don't have one on" }
         user.openPrivateChannel().queue { channel ->
             channel.sendMessage(
@@ -198,5 +218,14 @@ class IntroNotificationService(
     fun determineFileName(input: InputData): String = when (input) {
         is InputData.Url -> input.uri.takeIf { it.isNotBlank() } ?: ""
         is InputData.Attachment -> input.attachment.fileName
+    }
+
+    companion object {
+        /**
+         * How long to leave a user alone after nudging them for an intro.
+         * In-memory, so a redeploy may cost someone one extra nudge — much
+         * cheaper than persisting it.
+         */
+        const val PROMPT_COOLDOWN_HOURS = 24L
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/intro/IntroPlaybackTracker.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/intro/IntroPlaybackTracker.kt
@@ -1,0 +1,64 @@
+package bot.toby.intro
+
+import com.github.benmanes.caffeine.cache.Caffeine
+import org.springframework.stereotype.Service
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.TimeUnit
+
+/**
+ * Remembers, per (guild, user), when an intro last played and which one.
+ *
+ * Two problems this solves, both from the voice-join path having no memory:
+ *
+ *  - **Replay spam.** Every `GuildVoiceUpdateEvent` join re-triggered the
+ *    intro, so channel-hopping — or a flaky connection reconnecting — replayed
+ *    it each time, and awarded the intro-play credit and XP each time too.
+ *  - **Repeats.** The pick was uniform over all slots, with nothing stopping
+ *    the same intro coming up several joins running (see [IntroSelection]).
+ *
+ * In-memory: a redeploy forgetting that someone joined a minute ago is
+ * harmless, and it keeps a hot path off the database.
+ */
+@Service
+class IntroPlaybackTracker {
+
+    private data class Play(val introId: String?, val at: Instant)
+
+    // Entries only matter for the length of the cooldown; expiring a little
+    // after that keeps `lastPlayedIntroId` useful across a short absence
+    // without holding state for idle users.
+    private val plays = Caffeine.newBuilder()
+        .expireAfterWrite(RETENTION_MINUTES, TimeUnit.MINUTES)
+        .maximumSize(10_000)
+        .build<String, Play>()
+
+    /**
+     * True when this user's intro played recently enough that joining again
+     * shouldn't retrigger it.
+     */
+    fun onCooldown(guildId: Long, discordId: Long, now: Instant = Instant.now()): Boolean {
+        val last = plays.getIfPresent(key(guildId, discordId)) ?: return false
+        return Duration.between(last.at, now) < COOLDOWN
+    }
+
+    /** The intro played last time, so the next pick can avoid repeating it. */
+    fun lastPlayedIntroId(guildId: Long, discordId: Long): String? =
+        plays.getIfPresent(key(guildId, discordId))?.introId
+
+    fun record(guildId: Long, discordId: Long, introId: String?, now: Instant = Instant.now()) {
+        plays.put(key(guildId, discordId), Play(introId, now))
+    }
+
+    private fun key(guildId: Long, discordId: Long) = "$guildId:$discordId"
+
+    companion object {
+        /**
+         * Long enough to absorb channel hops and reconnect flapping, short
+         * enough that genuinely leaving and coming back still plays you in.
+         */
+        val COOLDOWN: Duration = Duration.ofSeconds(60)
+
+        private const val RETENTION_MINUTES = 30L
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/intro/IntroPresenter.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/intro/IntroPresenter.kt
@@ -1,0 +1,100 @@
+package bot.toby.intro
+
+import bot.toby.BOT_WEB_URL
+import common.discord.embed
+import common.discord.field
+import common.intro.IntroClip
+import database.dto.music.MusicDto
+import net.dv8tion.jda.api.components.buttons.Button
+import net.dv8tion.jda.api.components.selections.SelectOption
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.MessageEmbed
+import java.awt.Color
+
+/**
+ * Rendering for everything intro-shaped that Discord shows: the select-menu
+ * options behind `/editintro` and `/deleteintro`, the `/listintros` embed,
+ * and the deep link across to the web dashboard.
+ *
+ * Centralising it fixes two problems the per-command copies had:
+ *  - options were built in raw insertion order, so the numbering a user saw
+ *    in the menu could disagree with the slot numbering everywhere else;
+ *  - labels were passed to JDA unbounded, and a YouTube title over Discord's
+ *    100-character select-option limit made `/editintro` and `/deleteintro`
+ *    throw instead of opening.
+ */
+object IntroPresenter {
+
+    /** Discord's hard cap on select-option labels and descriptions. */
+    private const val SELECT_TEXT_LIMIT = 100
+
+    private val INTRO_COLOR: Color = Color(88, 101, 242) // Discord blurple
+
+    fun sorted(intros: Collection<MusicDto>): List<MusicDto> = intros.sortedBy { it.index ?: Int.MAX_VALUE }
+
+    /** True when the intro's blob holds a URL rather than uploaded audio. */
+    fun isUrlIntro(intro: MusicDto): Boolean = intro.musicBlob
+        ?.let { String(it) }
+        ?.let { it.startsWith("http://") || it.startsWith("https://") }
+        ?: false
+
+    fun displayName(intro: MusicDto): String = intro.fileName?.takeIf { it.isNotBlank() } ?: "Unknown"
+
+    /**
+     * `Slot #2 · Volume 90% · 0:03 – 0:12` — the at-a-glance summary shown
+     * under each select-menu option and inside the `/listintros` embed.
+     */
+    fun summary(intro: MusicDto): String = buildString {
+        append("Slot #${intro.index ?: '?'}")
+        append(" · Volume ${intro.introVolume ?: 100}%")
+        append(" · ${IntroClip.describe(intro.startMs, intro.endMs)}")
+    }
+
+    /**
+     * Select options in slot order, with labels and descriptions clamped to
+     * Discord's limits so a long track title can't break the menu.
+     */
+    fun selectOptions(intros: Collection<MusicDto>): List<SelectOption> = sorted(intros).map { intro ->
+        SelectOption.of(truncate(displayName(intro)), intro.id.orEmpty())
+            .withDescription(truncate(summary(intro)))
+    }
+
+    fun listEmbed(member: Member, intros: Collection<MusicDto>, maxIntros: Int): MessageEmbed {
+        val ordered = sorted(intros)
+        return embed(
+            title = "Intro songs — ${member.effectiveName}",
+            color = INTRO_COLOR,
+            description = if (ordered.isEmpty()) {
+                "No intros set yet. Use `/setintro link` or `/setintro attachment` to add one."
+            } else {
+                "TobyBot plays one of these at random when you join a voice channel."
+            },
+        ) {
+            // EmbedBuilder rejects anything that isn't a real http(s) URL, and
+            // a member without a resolvable avatar is not worth an exception.
+            member.effectiveAvatarUrl
+                .takeIf { it.startsWith("http://") || it.startsWith("https://") }
+                ?.let { setThumbnail(it) }
+            ordered.forEach { intro ->
+                field(
+                    name = "#${intro.index ?: '?'} · ${truncate(displayName(intro), FIELD_NAME_LIMIT)}",
+                    value = buildString {
+                        append("Volume **${intro.introVolume ?: 100}%**")
+                        append(" · Clip **${IntroClip.describe(intro.startMs, intro.endMs)}**")
+                        append(" · ${if (isUrlIntro(intro)) "Link" else "Uploaded file"}")
+                    },
+                )
+            }
+            setFooter("${ordered.size}/$maxIntros slots used · edit with /editintro, remove with /deleteintro")
+        }
+    }
+
+    /** Deep link to the guild's intro page on the web dashboard. */
+    fun webDashboardButton(guildId: Long): Button =
+        Button.link("$BOT_WEB_URL/intro/$guildId", "Manage on the web")
+
+    private const val FIELD_NAME_LIMIT = 200
+
+    private fun truncate(text: String, limit: Int = SELECT_TEXT_LIMIT): String =
+        if (text.length <= limit) text else text.take(limit - 1).trimEnd() + "…"
+}

--- a/discord-bot/src/main/kotlin/bot/toby/intro/IntroSelection.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/intro/IntroSelection.kt
@@ -1,0 +1,36 @@
+package bot.toby.intro
+
+import database.dto.music.MusicDto
+import kotlin.random.Random
+
+/**
+ * Chooses which of a user's intros to play on join.
+ *
+ * This used to be a bare `musicDtos.random()`. With the three-slot cap that
+ * meant a 1-in-3 chance of hearing the same intro twice running and a 1-in-9
+ * chance of three in a row — often enough that "TobyBot picks one at random"
+ * didn't feel random. Excluding the previous pick keeps every join a change
+ * while staying uniform across the rest.
+ */
+object IntroSelection {
+
+    /**
+     * @param intros the user's intros for this guild.
+     * @param lastPlayedId id of the intro played last time, if known.
+     * @return the intro to play, or null when the user has none.
+     */
+    fun pick(
+        intros: Collection<MusicDto>,
+        lastPlayedId: String? = null,
+        random: Random = Random.Default,
+    ): MusicDto? {
+        val candidates = intros.toList()
+        if (candidates.size <= 1) return candidates.firstOrNull()
+
+        // With only one intro left after excluding the previous pick there is
+        // still a choice; with none left (every id matches, i.e. duplicates)
+        // fall back to the full set rather than playing nothing.
+        val fresh = candidates.filter { it.id != lastPlayedId }
+        return (if (fresh.isEmpty()) candidates else fresh).random(random)
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/intro/IntroUndoStore.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/intro/IntroUndoStore.kt
@@ -1,0 +1,77 @@
+package bot.toby.intro
+
+import com.github.benmanes.caffeine.cache.Caffeine
+import database.dto.music.MusicDto
+import org.springframework.stereotype.Service
+import java.util.concurrent.TimeUnit
+
+/**
+ * Short-lived snapshots of intros deleted through `/deleteintro`, so the
+ * confirmation's **Undo** button can put one back.
+ *
+ * The web dashboard has had undo since it stored a `DeletedIntroSnapshot` in
+ * the HTTP session; Discord had nothing — a mis-click on the select menu was
+ * final, and re-uploading meant finding the file or URL again. This is the
+ * Discord-side equivalent, keyed the same way (guild + user) and with the same
+ * ten-minute window.
+ *
+ * In-memory on purpose: a redeploy dropping a few pending undos is fine, and
+ * it keeps deleted audio out of long-term storage.
+ */
+@Service
+class IntroUndoStore {
+
+    data class Snapshot(
+        val guildId: Long,
+        val discordId: Long,
+        val index: Int,
+        val fileName: String?,
+        val introVolume: Int,
+        val musicBlob: ByteArray?,
+        val startMs: Int?,
+        val endMs: Int?,
+    ) {
+        // ByteArray in a data class gives reference equality; MusicDto has the
+        // same shape. Nothing compares snapshots today, so rather than a subtly
+        // wrong generated equals, make it explicit that identity is the id.
+        override fun equals(other: Any?): Boolean = this === other
+        override fun hashCode(): Int = System.identityHashCode(this)
+    }
+
+    private val snapshots = Caffeine.newBuilder()
+        .expireAfterWrite(UNDO_WINDOW_MINUTES, TimeUnit.MINUTES)
+        .maximumSize(1_000)
+        .build<String, Snapshot>()
+
+    fun remember(intro: MusicDto) {
+        val user = intro.userDto ?: return
+        val guildId = user.guildId
+        val discordId = user.discordId
+        snapshots.put(
+            key(guildId, discordId),
+            Snapshot(
+                guildId = guildId,
+                discordId = discordId,
+                index = intro.index ?: 1,
+                fileName = intro.fileName,
+                introVolume = intro.introVolume ?: 100,
+                musicBlob = intro.musicBlob?.copyOf(),
+                startMs = intro.startMs,
+                endMs = intro.endMs,
+            ),
+        )
+    }
+
+    /** Returns and clears the pending snapshot — undo is single-use. */
+    fun take(guildId: Long, discordId: Long): Snapshot? {
+        val cacheKey = key(guildId, discordId)
+        return snapshots.getIfPresent(cacheKey)?.also { snapshots.invalidate(cacheKey) }
+    }
+
+    private fun key(guildId: Long, discordId: Long) = "$guildId:$discordId"
+
+    companion object {
+        /** Matches the web dashboard's undo window. */
+        const val UNDO_WINDOW_MINUTES = 10L
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/intro/IntroValidationService.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/intro/IntroValidationService.kt
@@ -28,10 +28,22 @@ class IntroValidationService(
 
     fun isValidUrl(url: String): Boolean = URLHelper.isValidURL(url)
 
-    fun parseVolume(content: String): Int? {
-        val volumeRegex = """\b(\d{1,3})\b""".toRegex()
-        return volumeRegex.find(content)?.value?.toIntOrNull()?.takeIf { it in 0..100 }
-    }
+    /**
+     * Pulls the optional volume out of a DM reply like
+     * `https://www.youtube.com/watch?v=ID 90`.
+     *
+     * Only a whitespace-separated token that is *entirely* digits counts.
+     * The previous `\b(\d{1,3})\b` scan matched digits inside the URL itself,
+     * so `https://youtu.be/ID?t=42` silently set the intro to 42% and
+     * `...&list=PL9&index=7` set it to 7% — neither of which the user asked
+     * for. Either order works (`URL 90` or `90 URL`), since the token has to
+     * stand alone to match at all.
+     */
+    fun parseVolume(content: String): Int? = content
+        .split(WHITESPACE)
+        .firstOrNull { it.isNotEmpty() && it.length <= 3 && it.all(Char::isDigit) }
+        ?.toIntOrNull()
+        ?.takeIf { it in 0..100 }
 
     fun convertShortsUrls(url: String): String = url.replace("/shorts/", "/watch?v=")
 
@@ -94,6 +106,8 @@ class IntroValidationService(
     }
 
     companion object {
+        private val WHITESPACE = Regex("\\s+")
+
         const val MAX_FILE_SIZE = 550 * 1024
         const val MAX_FILE_SIZE_KB = "${MAX_FILE_SIZE / 1024}"
 

--- a/discord-bot/src/main/kotlin/bot/toby/intro/IntroValidationService.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/intro/IntroValidationService.kt
@@ -2,6 +2,7 @@ package bot.toby.intro
 
 import bot.toby.helpers.HttpHelper
 import bot.toby.helpers.URLHelper
+import common.intro.IntroClip
 import common.logging.DiscordLogger
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -44,6 +45,38 @@ class IntroValidationService(
     }
 
     /**
+     * Source duration in milliseconds, or null when it can't be determined
+     * (non-YouTube URL, API key missing, lookup failure). Callers feed this
+     * into [IntroClip.validate]; a null simply relaxes the "end must be
+     * within the source" rule, exactly as the web form does for uploads.
+     *
+     * Note this fails *open* where [validateIntroLength] fails closed: a
+     * YouTube API blip lets an intro through rather than rejecting every
+     * intro until the API recovers. That matches the web form, which has
+     * always treated an unavailable preview as "duration unknown".
+     */
+    suspend fun sourceDurationMs(url: String): Int? = runCatching {
+        withContext(dispatcher) { httpHelper.getYouTubeVideoDuration(url) }?.inWholeMilliseconds?.toInt()
+    }.onFailure {
+        logger.warn { "Could not determine source duration for '$url': ${it::class.simpleName}: ${it.message}" }
+    }.getOrNull()
+
+    /**
+     * Clip-aware replacement for [validateIntroLength]. Looks the source
+     * duration up once, then defers to the shared [IntroClip] rules so a
+     * long video can be accepted when the user clips it — the behaviour the
+     * web form has always had and the slash command never did.
+     *
+     * @return an error message to show the user, or null when the intro is fine.
+     */
+    fun validateClipAgainstSource(url: String?, startMs: Int?, endMs: Int?, onResult: (String?) -> Unit) {
+        scope.launch {
+            val sourceDurationMs = url?.takeIf { it.isNotBlank() }?.let { sourceDurationMs(it) }
+            onResult(IntroClip.validate(startMs, endMs, sourceDurationMs))
+        }
+    }
+
+    /**
      * Async wrapper around [checkForOverlyLongIntroDuration]. The async path
      * conservatively reports "over limit" on failure so an error can't sneak
      * a too-long intro past the check.
@@ -63,6 +96,9 @@ class IntroValidationService(
     companion object {
         const val MAX_FILE_SIZE = 550 * 1024
         const val MAX_FILE_SIZE_KB = "${MAX_FILE_SIZE / 1024}"
-        val INTRO_LIMIT = 15.seconds
+
+        // Shared with the web form via IntroClip so the two surfaces can't
+        // disagree on how long an intro is allowed to play for.
+        val INTRO_LIMIT = IntroClip.MAX_DURATION_SECONDS.seconds
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/menu/menus/DeleteIntroMenu.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/menu/menus/DeleteIntroMenu.kt
@@ -1,25 +1,38 @@
 package bot.toby.menu.menus
 
+import bot.toby.button.buttons.music.UndoDeleteIntroButton
 import bot.toby.helpers.IntroHelper
 import bot.toby.helpers.MenuHelper.DELETE_INTRO
-import core.command.Command.Companion.deleteAfter
+import bot.toby.intro.IntroPresenter
+import bot.toby.intro.IntroUndoStore
 import core.menu.Menu
 import core.menu.MenuContext
+import net.dv8tion.jda.api.components.actionrow.ActionRow
+import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
 class DeleteIntroMenu @Autowired constructor(
-    private val introHelper: IntroHelper
+    private val introHelper: IntroHelper,
+    private val undoStore: IntroUndoStore,
 ) : Menu {
 
     override fun handle(ctx: MenuContext, deleteDelay: Int) {
         val selectedIntro = resolveSelectedIntroOrElse(ctx, introHelper, deleteDelay) ?: return
-        introHelper.deleteIntro(selectedIntro)
-        ctx.event.hook.sendMessage("Successfully deleted intro '${selectedIntro.fileName}'").setEphemeral(true)
-            .queue { it?.deleteAfter(deleteDelay) }
-    }
 
+        // Snapshot before deleting so the Undo button has something to put
+        // back. The confirmation isn't auto-deleted any more — it has to
+        // outlive the delete delay for the undo to be reachable.
+        undoStore.remember(selectedIntro)
+        introHelper.deleteIntro(selectedIntro)
+
+        val confirmation = MessageCreateBuilder()
+            .setContent("Successfully deleted intro '${IntroPresenter.displayName(selectedIntro)}'")
+            .setComponents(ActionRow.of(UndoDeleteIntroButton.button()))
+            .build()
+        ctx.event.hook.sendMessage(confirmation).setEphemeral(true).queue()
+    }
 
     override val name: String get() = DELETE_INTRO
 }

--- a/discord-bot/src/main/kotlin/bot/toby/menu/menus/EditIntroMenu.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/menu/menus/EditIntroMenu.kt
@@ -1,67 +1,43 @@
 package bot.toby.menu.menus
 
-import bot.toby.handler.EventWaiter
 import bot.toby.helpers.IntroHelper
 import bot.toby.helpers.MenuHelper.EDIT_INTRO
-import core.command.Command.Companion.deleteAfter
+import bot.toby.modal.modals.EditIntroModal
 import core.menu.Menu
 import core.menu.MenuContext
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import kotlin.time.Duration.Companion.seconds
 
+/**
+ * Second half of `/editintro`: the user has picked an intro from the select
+ * menu, so open [EditIntroModal] pre-filled with its current values.
+ *
+ * Deliberately does *not* defer — a modal must be the first response to a
+ * component interaction. `DefaultMenuManager` leaves ephemeral menu messages
+ * un-acked (it only disables components on non-ephemeral ones) and
+ * `/editintro` always sends its menu ephemerally, so the interaction is still
+ * open when we get here.
+ */
 @Component
 class EditIntroMenu @Autowired constructor(
     private val introHelper: IntroHelper,
-    private val eventWaiter: EventWaiter
 ) : Menu {
 
     override fun handle(ctx: MenuContext, deleteDelay: Int) {
         val event = ctx.event
-        val selectedIntro = resolveSelectedIntroOrElse(ctx, introHelper, deleteDelay) ?: return
+        logger.setGuildAndMemberContext(ctx.guild, event.member)
 
-        logger.info { "Valid musicDto selected." }
-        event.hook.sendMessage("You've selected ${selectedIntro.fileName}. Please reply with the new volume (0-100).")
-            .setEphemeral(true)
-            .queue { messageHook ->
-                // Wait for the user's next message
-                eventWaiter.waitForMessage(
-                    condition = { msgEvent ->
-                        msgEvent.author.idLong == event.user.idLong && msgEvent.channel.idLong == event.channel.idLong
-                    },
-                    action = { msgEvent ->
-                        logger.info { "Waiting for a response from the user for the new volume" }
+        val selectedIntroId = event.values.firstOrNull() ?: return
+        val selectedIntro = introHelper.findIntroById(selectedIntroId)
+        if (selectedIntro == null) {
+            logger.info { "No intro found for id '$selectedIntroId'" }
+            event.reply("Unable to find the selected intro.").setEphemeral(true).queue()
+            return
+        }
 
-                        val newVolume = msgEvent.message.contentRaw.toIntOrNull()
-
-                        if (newVolume != null && newVolume in 0..100) {
-                            selectedIntro.introVolume = newVolume
-                            introHelper.updateIntro(selectedIntro)
-
-                            messageHook.editMessage("Volume updated successfully to $newVolume!")
-                                .queue { it?.deleteAfter(deleteDelay) }
-
-                            logger.info { "Volume updated successfully to $newVolume!" }
-                            msgEvent.message.deleteAfter(0)
-                        } else {
-                            logger.warn { "Invalid volume was sent" }
-
-                            messageHook.editMessage("Invalid volume. Please enter a number between 0 and 100.")
-                                .queue { it?.deleteAfter(deleteDelay) }
-
-                            msgEvent.message.deleteAfter(0)
-                        }
-                    },
-                    timeout = 10.seconds,
-                    timeoutAction = {
-                        messageHook
-                            .editMessage("No response received. Volume update canceled.")
-                            .queue { it?.deleteAfter(deleteDelay) }
-                    }
-                )
-            }
+        logger.info { "Opening intro edit modal for '$selectedIntroId'" }
+        event.replyModal(EditIntroModal.buildFor(selectedIntro)).queue()
     }
-
 
     override val name: String get() = EDIT_INTRO
 }

--- a/discord-bot/src/main/kotlin/bot/toby/menu/menus/IntroMenuHelpers.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/menu/menus/IntroMenuHelpers.kt
@@ -7,10 +7,13 @@ import core.menu.MenuContext
 import database.dto.music.MusicDto
 
 /**
- * Shared preamble for the select-menu handlers that operate on a single
- * intro (DeleteIntroMenu, EditIntroMenu). Defers the interaction, resolves
- * the selected intro via IntroHelper, and surfaces the standard
- * "Unable to find" ephemeral on miss so each menu can focus on its own flow.
+ * Deferring preamble for select-menu handlers that operate on a single intro
+ * and reply through the interaction hook. Defers the interaction, resolves the
+ * selected intro via IntroHelper, and surfaces the standard "Unable to find"
+ * ephemeral on miss so each menu can focus on its own flow.
+ *
+ * `EditIntroMenu` deliberately doesn't use this — opening a modal requires the
+ * interaction to be un-acked, so it resolves the intro itself.
  *
  * Returns `null` if either nothing was selected (swallowed silently, as in
  * the original per-menu code) or the intro couldn't be fetched (user is

--- a/discord-bot/src/main/kotlin/bot/toby/menu/menus/SetIntroMenu.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/menu/menus/SetIntroMenu.kt
@@ -40,19 +40,25 @@ class SetIntroMenu @Autowired constructor(
                 .queue()
             return
         }
-        val pendingIntroTriple = introHelper.pendingIntros[requestingUserDto.discordId]
-        if (pendingIntroTriple != null) {
-            val (pendingDtoAttachment, url, introVolume) = pendingIntroTriple
+        val pendingIntro = introHelper.pendingIntros[requestingUserDto.discordId]
+        if (pendingIntro != null) {
             runCatching {
-                val input = if (pendingDtoAttachment!= null) InputData.Attachment(pendingDtoAttachment) else InputData.Url(url!!)
+                val pendingDtoAttachment = pendingIntro.attachment
+                val input = if (pendingDtoAttachment != null) {
+                    InputData.Attachment(pendingDtoAttachment)
+                } else {
+                    InputData.Url(pendingIntro.url!!)
+                }
                 introHelper.handleMedia(
                     event,
                     requestingUserDto,
                     deleteDelay,
                     input,
-                    introVolume,
+                    pendingIntro.volume,
                     musicDtoToReplace,
-                    ctx.event.user.effectiveName
+                    ctx.event.user.effectiveName,
+                    pendingIntro.startMs,
+                    pendingIntro.endMs,
                 )
             }.onSuccess {
                 logger.info { "Successfully set pending intro, removing from the cache for user '${requestingUserDto.discordId}'" }

--- a/discord-bot/src/main/kotlin/bot/toby/modal/modals/EditIntroModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/modal/modals/EditIntroModal.kt
@@ -1,0 +1,170 @@
+package bot.toby.modal.modals
+
+import bot.toby.helpers.IntroHelper
+import bot.toby.intro.IntroPresenter
+import common.intro.IntroClip
+import core.modal.Modal
+import core.modal.ModalContext
+import database.dto.music.MusicDto
+import net.dv8tion.jda.api.components.label.Label
+import net.dv8tion.jda.api.components.textinput.TextInput
+import net.dv8tion.jda.api.components.textinput.TextInputStyle
+import net.dv8tion.jda.api.modals.Modal as JdaModal
+import org.springframework.stereotype.Component
+
+/**
+ * Submission handler for the intro editor opened by `/editintro`.
+ *
+ * The previous flow asked the user to type a bare number into the channel and
+ * raced a 10-second [bot.toby.handler.EventWaiter] against them: miss the
+ * window and the edit was silently cancelled, hit it and the bot deleted your
+ * message afterwards. It also only ever exposed volume, so renaming an intro
+ * or trimming it to a clip was web-only.
+ *
+ * A modal replaces all of that — name, volume and clip bounds in one form,
+ * pre-filled with the current values, with no timer and nothing posted to the
+ * channel. Blank fields are meaningful: leaving a clip bound empty clears it,
+ * which is how a clipped intro is restored to the full track.
+ *
+ * The target intro id is encoded into the modal `customId`
+ * (`editintro:<guildId>_<discordId>_<index>`) so no cross-interaction state is
+ * needed. `DefaultModalManager` routes on the prefix before `:`.
+ */
+@Component
+class EditIntroModal(
+    private val introHelper: IntroHelper,
+) : Modal {
+
+    override val name = MODAL_NAME
+
+    override fun handle(ctx: ModalContext, deleteDelay: Int) {
+        val event = ctx.event
+        logger.setGuildAndMemberContext(ctx.guild, ctx.member)
+
+        val introId = event.modalId.substringAfter(':', "").takeIf { it.isNotBlank() }
+            ?: return reply(ctx, "That edit form lost track of which intro it was for — run `/editintro` again.")
+
+        // The modal is only ever shown to the user who opened it, but the id
+        // travels through the client so re-derive ownership from it rather
+        // than trusting it. Mirrors IntroWebService.requireOwnedIntro.
+        val expectedPrefix = "${ctx.guild.idLong}_${event.user.idLong}_"
+        if (!introId.startsWith(expectedPrefix)) {
+            logger.warn { "Rejecting intro edit for '$introId' — not owned by user ${event.user.idLong}" }
+            return reply(ctx, "That intro isn't yours to edit.")
+        }
+
+        val intro = introHelper.findIntroById(introId)
+            ?: return reply(ctx, "Unable to find that intro — it may have been deleted.")
+
+        val name = event.getValue(FIELD_NAME)?.asString?.trim()
+        if (name != null && name.isEmpty()) return reply(ctx, "Name cannot be empty.")
+        if (name != null && name.length > MAX_NAME_LENGTH) {
+            return reply(ctx, "Name is too long (max $MAX_NAME_LENGTH characters).")
+        }
+
+        val rawVolume = event.getValue(FIELD_VOLUME)?.asString?.trim().orEmpty()
+        val volume = if (rawVolume.isEmpty()) intro.introVolume else rawVolume.toIntOrNull()
+        if (volume == null || volume !in 0..100) {
+            return reply(ctx, "Volume must be a whole number between 0 and 100.")
+        }
+
+        val start = IntroClip.parseTimestamp(event.getValue(FIELD_START)?.asString, "Clip start")
+        if (start is IntroClip.Parsed.Invalid) return reply(ctx, start.message)
+        val end = IntroClip.parseTimestamp(event.getValue(FIELD_END)?.asString, "Clip end")
+        if (end is IntroClip.Parsed.Invalid) return reply(ctx, end.message)
+
+        val startMs = (start as IntroClip.Parsed.Ok).ms
+        val endMs = (end as IntroClip.Parsed.Ok).ms
+
+        // Source duration is only knowable for URL intros; for uploads the
+        // callback validates span/ordering alone, exactly as the web form does.
+        val sourceUrl = intro.takeIf { IntroPresenter.isUrlIntro(it) }?.musicBlob?.let { String(it) }
+        introHelper.validateClipAgainstSource(sourceUrl, startMs, endMs) { error ->
+            if (error != null) {
+                reply(ctx, error)
+                return@validateClipAgainstSource
+            }
+            applyEdit(ctx, intro, name, volume, startMs, endMs)
+        }
+    }
+
+    private fun applyEdit(
+        ctx: ModalContext,
+        intro: MusicDto,
+        name: String?,
+        volume: Int,
+        startMs: Int?,
+        endMs: Int?,
+    ) {
+        name?.let { intro.fileName = it }
+        intro.introVolume = volume
+        intro.startMs = startMs
+        intro.endMs = endMs
+        introHelper.updateIntro(intro)
+
+        logger.info { "Updated intro '${intro.id}' — ${IntroPresenter.summary(intro)}" }
+        reply(
+            ctx,
+            "Updated **${IntroPresenter.displayName(intro)}** — ${IntroPresenter.summary(intro)}",
+        )
+    }
+
+    private fun reply(ctx: ModalContext, message: String) {
+        ctx.event.hook.sendMessage(message).setEphemeral(true).queue()
+    }
+
+    companion object {
+        const val MODAL_NAME = "editintro"
+        const val FIELD_NAME = "intro_name"
+        const val FIELD_VOLUME = "intro_volume"
+        const val FIELD_START = "intro_start"
+        const val FIELD_END = "intro_end"
+
+        /** Matches IntroWebService.updateIntroName so both surfaces agree. */
+        const val MAX_NAME_LENGTH = 200
+
+        /** Room for `mm:ss.s` and then some; nothing legitimate is longer. */
+        private const val TIMESTAMP_FIELD_LIMIT = 12
+
+        fun customId(introId: String) = "$MODAL_NAME:$introId"
+
+        /**
+         * Builds the editor pre-filled from [intro]. Every field is optional —
+         * an untouched form submits the values it was opened with, so
+         * "cancel by submitting" is a no-op rather than a wipe.
+         */
+        fun buildFor(intro: MusicDto): JdaModal {
+            val nameField = TextInput.create(FIELD_NAME, TextInputStyle.SHORT)
+                .setRequired(false)
+                .setRequiredRange(0, MAX_NAME_LENGTH)
+                .setValue(IntroPresenter.displayName(intro).take(MAX_NAME_LENGTH))
+                .build()
+            val volumeField = TextInput.create(FIELD_VOLUME, TextInputStyle.SHORT)
+                .setRequired(false)
+                .setRequiredRange(0, 3)
+                .setValue((intro.introVolume ?: 100).toString())
+                .build()
+            val startField = TextInput.create(FIELD_START, TextInputStyle.SHORT)
+                .setRequired(false)
+                .setRequiredRange(0, TIMESTAMP_FIELD_LIMIT)
+                .setPlaceholder("0:00")
+                .apply { IntroClip.format(intro.startMs).takeIf { it.isNotEmpty() }?.let { setValue(it) } }
+                .build()
+            val endField = TextInput.create(FIELD_END, TextInputStyle.SHORT)
+                .setRequired(false)
+                .setRequiredRange(0, TIMESTAMP_FIELD_LIMIT)
+                .setPlaceholder("0:${"%02d".format(IntroClip.MAX_DURATION_SECONDS)}")
+                .apply { IntroClip.format(intro.endMs).takeIf { it.isNotEmpty() }?.let { setValue(it) } }
+                .build()
+
+            return JdaModal.create(customId(intro.id.orEmpty()), "Edit intro")
+                .addComponents(
+                    Label.of("Name", nameField),
+                    Label.of("Volume (0-100)", volumeField),
+                    Label.of("Clip start — blank for none", startField),
+                    Label.of("Clip end — blank for none", endField),
+                )
+                .build()
+        }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/music/UndoDeleteIntroButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/music/UndoDeleteIntroButtonTest.kt
@@ -1,0 +1,141 @@
+package bot.toby.button.buttons.music
+
+import bot.toby.button.ButtonTest
+import bot.toby.button.ButtonTest.Companion.event
+import bot.toby.button.ButtonTest.Companion.introHelper
+import bot.toby.button.DefaultButtonContext
+import bot.toby.intro.IntroUndoStore
+import database.dto.music.MusicDto
+import database.dto.user.UserDto
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.verify
+import net.dv8tion.jda.api.requests.restaction.interactions.MessageEditCallbackAction
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class UndoDeleteIntroButtonTest : ButtonTest {
+
+    private lateinit var undoStore: IntroUndoStore
+    private lateinit var button: UndoDeleteIntroButton
+    private val edits = mutableListOf<String>()
+
+    /** The clicking user, matching ButtonTest's event.user. */
+    private val owner = UserDto(discordId = 1L, guildId = 1L)
+
+    @BeforeEach
+    override fun setup() {
+        super.setup()
+        undoStore = IntroUndoStore()
+        button = UndoDeleteIntroButton(introHelper, undoStore)
+
+        edits.clear()
+        val editAction = mockk<MessageEditCallbackAction>(relaxed = true)
+        every { event.editMessage(capture(edits)) } returns editAction
+        every { editAction.setComponents() } returns editAction
+
+        every { introHelper.findUserById(1L, 1L) } returns owner
+        every { introHelper.createIntro(any()) } answers { firstArg() }
+    }
+
+    @AfterEach
+    override fun tearDown() {
+        super.tearDown()
+        unmockkAll()
+    }
+
+    private fun deleted(index: Int = 2, name: String = "track") =
+        MusicDto(owner, index, name, 40, "https://example.com/a".toByteArray(), 3_000, 9_000)
+
+    @Test
+    fun `restores the snapshot into its original slot`() {
+        undoStore.remember(deleted())
+        owner.musicDtos = mutableListOf()
+
+        button.handle(DefaultButtonContext(event), owner, 0)
+
+        val restored = slot<MusicDto>()
+        verify { introHelper.createIntro(capture(restored)) }
+        assertEquals(2, restored.captured.index)
+        assertEquals("track", restored.captured.fileName)
+        assertEquals(40, restored.captured.introVolume)
+        assertEquals(3_000, restored.captured.startMs)
+        assertEquals(9_000, restored.captured.endMs)
+        assertTrue(edits.single().contains("Restored"))
+    }
+
+    @Test
+    fun `falls back to the lowest free slot when the original was reclaimed`() {
+        undoStore.remember(deleted(index = 2))
+        owner.musicDtos = mutableListOf(MusicDto(owner, 2, "something else", 90, byteArrayOf(1)))
+
+        button.handle(DefaultButtonContext(event), owner, 0)
+
+        val restored = slot<MusicDto>()
+        verify { introHelper.createIntro(capture(restored)) }
+        assertEquals(1, restored.captured.index)
+    }
+
+    @Test
+    fun `the restored slot stays inside the slot range when the remaining intros leave a gap`() {
+        undoStore.remember(deleted(index = 3))
+        owner.musicDtos = mutableListOf(MusicDto(owner, 3, "something else", 90, byteArrayOf(1)))
+
+        button.handle(DefaultButtonContext(event), owner, 0)
+
+        val restored = slot<MusicDto>()
+        verify { introHelper.createIntro(capture(restored)) }
+        assertEquals(1, restored.captured.index)
+    }
+
+    @Test
+    fun `an expired or already-used undo says so instead of restoring`() {
+        button.handle(DefaultButtonContext(event), owner, 0)
+
+        verify(exactly = 0) { introHelper.createIntro(any()) }
+        assertTrue(edits.single().contains("Nothing to undo"))
+    }
+
+    @Test
+    fun `undo is refused once the slots have filled back up`() {
+        undoStore.remember(deleted())
+        owner.musicDtos = mutableListOf(
+            MusicDto(owner, 1, "a", 90, byteArrayOf(1)),
+            MusicDto(owner, 2, "b", 90, byteArrayOf(2)),
+            MusicDto(owner, 3, "c", 90, byteArrayOf(3)),
+        )
+
+        button.handle(DefaultButtonContext(event), owner, 0)
+
+        verify(exactly = 0) { introHelper.createIntro(any()) }
+        assertTrue(edits.single().contains("Can't restore"))
+    }
+
+    @Test
+    fun `a rejected re-insert is reported rather than silently swallowed`() {
+        undoStore.remember(deleted())
+        owner.musicDtos = mutableListOf()
+        every { introHelper.createIntro(any()) } returns null
+
+        button.handle(DefaultButtonContext(event), owner, 0)
+
+        assertTrue(edits.single().contains("Couldn't restore"))
+    }
+
+    @Test
+    fun `undo is single use`() {
+        undoStore.remember(deleted())
+        owner.musicDtos = mutableListOf()
+
+        button.handle(DefaultButtonContext(event), owner, 0)
+        button.handle(DefaultButtonContext(event), owner, 0)
+
+        verify(exactly = 1) { introHelper.createIntro(any()) }
+        assertTrue(edits.last().contains("Nothing to undo"))
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/music/PlayCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/music/PlayCommandTest.kt
@@ -219,9 +219,9 @@ internal class PlayCommandTest : MusicCommandTest {
         mockkObject(MusicPlayerHelper)
         every {
             MusicPlayerHelper.playUserIntro(
-                any(), any(), any(), any(), any(), any()
+                any(), any(), any(), any(), any(), any(), any()
             )
-        } just Runs
+        } returns null
 
         // Act
         playCommand.handleMusicCommand(
@@ -239,7 +239,8 @@ internal class PlayCommandTest : MusicCommandTest {
                 CommandTest.event,
                 5,
                 0L,
-                CommandTest.member
+                CommandTest.member,
+                null
             )
         }
         verify(exactly = 0) { playerManager.loadAndPlay(any(), any(), any(), any(), any(), any(), any()) }

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/music/SetIntroCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/music/SetIntroCommandTest.kt
@@ -25,6 +25,7 @@ import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.Mentions
 import net.dv8tion.jda.api.interactions.commands.OptionMapping
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -283,6 +284,150 @@ internal class SetIntroCommandTest : MusicCommandTest {
                 event.hook.sendMessageEmbeds(match<MessageEmbed> { it.fields.size == 3 })
             }
         }
+
+
+    // --- clip options (`start` / `end`) -------------------------------------
+
+    private fun mockClipOptions(start: String?, end: String?) {
+        every { event.getOption("start") } returns start?.let { v -> mockk { every { asString } returns v } }
+        every { event.getOption("end") } returns end?.let { v -> mockk { every { asString } returns v } }
+    }
+
+    private fun newCommand(dispatcher: kotlinx.coroutines.CoroutineDispatcher): SetIntroCommand {
+        val introHelper =
+            IntroHelper(userDtoHelper, musicFileService, configService, httpHelper, eventWaiter, dispatcher)
+        return SetIntroCommand(introHelper)
+    }
+
+    @Test
+    fun `a clip inside a long source is accepted and persisted`() = runTest {
+        mockSub("link")
+        setIntroCommand = newCommand(StandardTestDispatcher(testScheduler))
+
+        every { event.getOption("attachment") } returns mockk(relaxed = true)
+        every { configService.getConfigByName("DEFAULT_VOLUME", "1") } returns ConfigDto("DEFAULT_VOLUME", "20", "1")
+        // A minute-long video: rejected outright before clips existed.
+        coEvery { httpHelper.getYouTubeVideoDuration(any()) } returns 60.seconds
+        mockClipOptions("0:10", "0:22")
+
+        setIntroCommand.handleMusicCommand(
+            DefaultCommandContext(event), MusicCommandTest.playerManager, requestingUserDto, 0
+        )
+        advanceUntilIdle()
+
+        val saved = slot<MusicDto>()
+        verify { musicFileService.createNewMusicFile(capture(saved)) }
+        assertEquals(10_000, saved.captured.startMs)
+        assertEquals(22_000, saved.captured.endMs)
+        verify {
+            event.hook.sendMessage(
+                match<String> { it.contains("(clip 0:10 – 0:22)") }
+            )
+        }
+    }
+
+    @Test
+    fun `raw seconds are accepted for the clip bounds`() = runTest {
+        mockSub("link")
+        setIntroCommand = newCommand(StandardTestDispatcher(testScheduler))
+
+        every { event.getOption("attachment") } returns mockk(relaxed = true)
+        every { configService.getConfigByName("DEFAULT_VOLUME", "1") } returns ConfigDto("DEFAULT_VOLUME", "20", "1")
+        coEvery { httpHelper.getYouTubeVideoDuration(any()) } returns 60.seconds
+        mockClipOptions("3", "9")
+
+        setIntroCommand.handleMusicCommand(
+            DefaultCommandContext(event), MusicCommandTest.playerManager, requestingUserDto, 0
+        )
+        advanceUntilIdle()
+
+        val saved = slot<MusicDto>()
+        verify { musicFileService.createNewMusicFile(capture(saved)) }
+        assertEquals(3_000, saved.captured.startMs)
+        assertEquals(9_000, saved.captured.endMs)
+    }
+
+    @Test
+    fun `a clip longer than the cap is rejected`() = runTest {
+        mockSub("link")
+        setIntroCommand = newCommand(StandardTestDispatcher(testScheduler))
+
+        every { event.getOption("attachment") } returns mockk(relaxed = true)
+        every { configService.getConfigByName("DEFAULT_VOLUME", "1") } returns ConfigDto("DEFAULT_VOLUME", "20", "1")
+        coEvery { httpHelper.getYouTubeVideoDuration(any()) } returns 300.seconds
+        mockClipOptions("0:10", "1:10")
+
+        setIntroCommand.handleMusicCommand(
+            DefaultCommandContext(event), MusicCommandTest.playerManager, requestingUserDto, 0
+        )
+        advanceUntilIdle()
+
+        verify(exactly = 0) { musicFileService.createNewMusicFile(any()) }
+        verify { event.hook.sendMessage(match<String> { it.contains("Clip is too long") }) }
+    }
+
+    @Test
+    fun `a clip that runs past the end of the source is rejected`() = runTest {
+        mockSub("link")
+        setIntroCommand = newCommand(StandardTestDispatcher(testScheduler))
+
+        every { event.getOption("attachment") } returns mockk(relaxed = true)
+        every { configService.getConfigByName("DEFAULT_VOLUME", "1") } returns ConfigDto("DEFAULT_VOLUME", "20", "1")
+        coEvery { httpHelper.getYouTubeVideoDuration(any()) } returns 20.seconds
+        mockClipOptions("0:15", "0:25")
+
+        setIntroCommand.handleMusicCommand(
+            DefaultCommandContext(event), MusicCommandTest.playerManager, requestingUserDto, 0
+        )
+        advanceUntilIdle()
+
+        verify(exactly = 0) { musicFileService.createNewMusicFile(any()) }
+        verify { event.hook.sendMessage("End time exceeds the source duration.") }
+    }
+
+    @Test
+    fun `an unparseable timestamp is reported without touching the source`() = runTest {
+        mockSub("link")
+        setIntroCommand = newCommand(StandardTestDispatcher(testScheduler))
+
+        every { event.getOption("attachment") } returns mockk(relaxed = true)
+        every { configService.getConfigByName("DEFAULT_VOLUME", "1") } returns ConfigDto("DEFAULT_VOLUME", "20", "1")
+        mockClipOptions("banana", null)
+
+        setIntroCommand.handleMusicCommand(
+            DefaultCommandContext(event), MusicCommandTest.playerManager, requestingUserDto, 0
+        )
+        advanceUntilIdle()
+
+        verify(exactly = 0) { musicFileService.createNewMusicFile(any()) }
+        coVerify(exactly = 0) { httpHelper.getYouTubeVideoDuration(any()) }
+        verify { event.hook.sendMessage(match<String> { it.startsWith("Clip start") }) }
+    }
+
+    @Test
+    fun `an uploaded file can be clipped even though its duration is unknown`() = runTest {
+        mockSub("attachment")
+        setIntroCommand = newCommand(StandardTestDispatcher(testScheduler))
+
+        val attachmentOptionMapping = mockk<OptionMapping>()
+        every { event.getOption("attachment") } returns attachmentOptionMapping
+        setupAttachments(attachmentOptionMapping)
+        every { event.getOption("link") } returns mockk { every { asString } returns "" }
+        every { configService.getConfigByName("DEFAULT_VOLUME", "1") } returns ConfigDto("DEFAULT_VOLUME", "20", "1")
+        mockClipOptions("0:01", "0:05")
+
+        setIntroCommand.handleMusicCommand(
+            DefaultCommandContext(event), MusicCommandTest.playerManager, requestingUserDto, 0
+        )
+        advanceUntilIdle()
+
+        val saved = slot<MusicDto>()
+        verify { musicFileService.createNewMusicFile(capture(saved)) }
+        assertEquals(1_000, saved.captured.startMs)
+        assertEquals(5_000, saved.captured.endMs)
+        // No YouTube lookup for an upload.
+        coVerify(exactly = 0) { httpHelper.getYouTubeVideoDuration(any()) }
+    }
 
     private fun setupMentions(userOptionMapping: OptionMapping) {
         val mentions = mockk<Mentions>()

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/music/SetIntroCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/music/SetIntroCommandTest.kt
@@ -13,6 +13,7 @@ import bot.toby.helpers.IntroHelper
 import bot.toby.helpers.UserDtoHelper
 import database.dto.guild.ConfigDto
 import database.dto.music.MusicDto
+import net.dv8tion.jda.api.entities.MessageEmbed
 import database.dto.user.UserDto
 import database.service.guild.ConfigService
 import io.mockk.*
@@ -105,7 +106,11 @@ internal class SetIntroCommandTest : MusicCommandTest {
         advanceUntilIdle()
 
         verify(exactly = 0) { musicFileService.createNewMusicFile(any()) }
-        verify { event.hook.sendMessage("Intro provided was over 15s long, out of courtesy please pick a shorter intro.") }
+        verify {
+            event.hook.sendMessage(
+                "Video is too long (21s). Max allowed is 15s — set a start/end clip to use a longer source."
+            )
+        }
     }
 
     @Test
@@ -275,9 +280,7 @@ internal class SetIntroCommandTest : MusicCommandTest {
 
             verify(exactly = 0) { musicFileService.createNewMusicFile(any()) }
             verify {
-                event.hook.sendMessage(
-                    match<String> { it.contains("Select the intro you'd like to replace with your new upload as we only allow 3 intros") }
-                )
+                event.hook.sendMessageEmbeds(match<MessageEmbed> { it.fields.size == 3 })
             }
         }
 

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/music/intro/DeleteIntroCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/music/intro/DeleteIntroCommandTest.kt
@@ -5,6 +5,7 @@ import bot.toby.command.CommandTest.Companion.requestingUserDto
 import bot.toby.command.commands.music.MusicCommandTest
 import core.command.CommandContext
 import database.dto.music.MusicDto
+import net.dv8tion.jda.api.entities.MessageEmbed
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.unmockkAll
@@ -53,6 +54,10 @@ class DeleteIntroCommandTest : MusicCommandTest {
 
         deleteIntroCommand.handle(ctx, requestingUserDto, 5)
 
-        verify { event.hook.sendMessage(match<String> { it.contains("Please select an intro to delete") }) }
+        verify {
+            event.hook.sendMessageEmbeds(
+                match<MessageEmbed> { embed -> embed.fields.size == 2 }
+            )
+        }
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/music/intro/EditIntroCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/music/intro/EditIntroCommandTest.kt
@@ -5,6 +5,7 @@ import bot.toby.command.CommandTest.Companion.requestingUserDto
 import bot.toby.command.commands.music.MusicCommandTest
 import core.command.CommandContext
 import database.dto.music.MusicDto
+import net.dv8tion.jda.api.entities.MessageEmbed
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.unmockkAll
@@ -40,7 +41,7 @@ class EditIntroCommandTest : MusicCommandTest {
         editIntroCommand.handle(mockCtx, requestingUserDto, 5)
 
         // Verify the reply indicating no intros
-        verify { event.hook.sendMessage("You have no intros to edit.") }
+        verify { event.hook.sendMessage("You have no intros to edit. Add one with `/setintro`.") }
     }
 
     @Test
@@ -54,6 +55,13 @@ class EditIntroCommandTest : MusicCommandTest {
 
         editIntroCommand.handle(ctx, requestingUserDto, 5)
 
-        verify { event.hook.sendMessage(match<String> { it.contains("Your intro songs are currently set as:") }) }
+        verify {
+            event.hook.sendMessageEmbeds(
+                match<MessageEmbed> { embed ->
+                    embed.fields.map { it.name }.any { it!!.startsWith("#1 · Intro1") } &&
+                        embed.fields.map { it.name }.any { it!!.startsWith("#2 · Intro2") }
+                }
+            )
+        }
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/music/intro/ListIntrosCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/music/intro/ListIntrosCommandTest.kt
@@ -1,0 +1,122 @@
+package bot.toby.command.commands.music.intro
+
+import bot.toby.command.CommandTest.Companion.event
+import bot.toby.command.CommandTest.Companion.guild
+import bot.toby.command.CommandTest.Companion.interactionHook
+import bot.toby.command.CommandTest.Companion.member
+import bot.toby.command.CommandTest.Companion.requestingUserDto
+import bot.toby.command.CommandTest.Companion.targetMember
+import bot.toby.command.commands.music.MusicCommandTest
+import bot.toby.helpers.IntroHelper
+import core.command.CommandContext
+import database.dto.music.MusicDto
+import database.dto.user.UserDto
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import io.mockk.verify
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.interactions.commands.OptionMapping
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class ListIntrosCommandTest : MusicCommandTest {
+
+    private lateinit var introHelper: IntroHelper
+    private lateinit var command: ListIntrosCommand
+    private lateinit var ctx: CommandContext
+
+    @BeforeEach
+    fun setup() {
+        setupCommonMusicMocks()
+        introHelper = mockk(relaxed = true)
+        command = ListIntrosCommand(introHelper)
+        ctx = mockk(relaxed = true)
+        every { ctx.event } returns event
+        every { event.getOption("user") } returns null
+        every { member.effectiveAvatarUrl } returns "https://cdn.example/avatar.png"
+    }
+
+    @AfterEach
+    fun tearDown() {
+        tearDownCommonMusicMocks()
+        unmockkAll()
+    }
+
+    @Test
+    fun `lists the caller's own intros`() {
+        val dto = UserDto(discordId = 1L, guildId = 1L)
+        every { requestingUserDto.musicDtos } returns mutableListOf(
+            MusicDto(dto, 2, "second", 40, "https://youtu.be/x".toByteArray(), 1_000, 5_000),
+            MusicDto(dto, 1, "first", 90, byteArrayOf(1, 2, 3)),
+        )
+
+        command.handle(ctx, requestingUserDto, 5)
+
+        val embeds = mutableListOf<MessageEmbed>()
+        verify { event.hook.sendMessageEmbeds(capture(embeds)) }
+        val fields = embeds.single().fields
+        assertEquals(2, fields.size)
+        assertTrue(fields[0].name!!.startsWith("#1 · first"))
+        assertTrue(fields[1].name!!.startsWith("#2 · second"))
+        assertTrue(fields[1].value!!.contains("0:01 – 0:05"))
+    }
+
+    @Test
+    fun `renders an empty state rather than an error when nothing is set`() {
+        every { requestingUserDto.musicDtos } returns mutableListOf()
+
+        command.handle(ctx, requestingUserDto, 5)
+
+        val embeds = mutableListOf<MessageEmbed>()
+        verify { event.hook.sendMessageEmbeds(capture(embeds)) }
+        assertTrue(embeds.single().description!!.contains("/setintro"))
+    }
+
+    @Test
+    fun `a super-user can inspect another member`() {
+        val other = UserDto(discordId = 99L, guildId = 1L).apply {
+            musicDtos = mutableListOf(MusicDto(this, 1, "theirs", 90, byteArrayOf(1)))
+        }
+        every { requestingUserDto.superUser } returns true
+        every { targetMember.idLong } returns 99L
+        every { targetMember.effectiveAvatarUrl } returns "https://cdn.example/other.png"
+        every { event.getOption("user") } returns mockk<OptionMapping> { every { asMember } returns targetMember }
+        every { introHelper.findUserById(99L, 1L) } returns other
+
+        command.handle(ctx, requestingUserDto, 5)
+
+        val embeds = mutableListOf<MessageEmbed>()
+        verify { event.hook.sendMessageEmbeds(capture(embeds)) }
+        assertTrue(embeds.single().fields.single().name!!.contains("theirs"))
+    }
+
+    @Test
+    fun `a non super-user cannot inspect another member`() {
+        every { requestingUserDto.superUser } returns false
+        every { targetMember.idLong } returns 99L
+        every { event.getOption("user") } returns mockk<OptionMapping> { every { asMember } returns targetMember }
+
+        command.handle(ctx, requestingUserDto, 5)
+
+        verify(exactly = 0) { interactionHook.sendMessageEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 0) { introHelper.findUserById(any(), any()) }
+        // `sendErrorMessage` names the server owner in its reply — reaching for
+        // it is the observable sign the permission branch ran.
+        verify { guild.owner }
+    }
+
+    @Test
+    fun `passing yourself explicitly is not treated as a super-user action`() {
+        every { requestingUserDto.superUser } returns false
+        every { requestingUserDto.musicDtos } returns mutableListOf()
+        every { event.getOption("user") } returns mockk<OptionMapping> { every { asMember } returns member }
+
+        command.handle(ctx, requestingUserDto, 5)
+
+        verify { event.hook.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/handler/VoiceEventHandlerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/handler/VoiceEventHandlerTest.kt
@@ -1,6 +1,7 @@
 import bot.toby.handler.VoiceEventHandler
 import bot.toby.helpers.IntroHelper
 import bot.toby.helpers.UserDtoHelper
+import bot.toby.intro.IntroPlaybackTracker
 import bot.toby.lavaplayer.PlayerManager
 import bot.toby.managers.NowPlayingManager
 import bot.toby.voice.LastConnectedChannelTracker
@@ -27,6 +28,8 @@ import net.dv8tion.jda.api.managers.AudioManager
 import net.dv8tion.jda.api.requests.restaction.CommandListUpdateAction
 import net.dv8tion.jda.api.utils.cache.SnowflakeCacheView
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -45,6 +48,10 @@ class VoiceEventHandlerTest {
     private val xpAwardService: XpAwardService = mockk(relaxed = true)
     private val nowPlayingManager: NowPlayingManager = mockk(relaxed = true)
 
+    // JUnit builds a fresh test instance per method, so this tracker (and the
+    // handler holding it) starts empty for every test.
+    private val introPlaybackTracker = IntroPlaybackTracker()
+
     private val handler = spyk(
         VoiceEventHandler(
             configService,
@@ -55,6 +62,7 @@ class VoiceEventHandlerTest {
             awardService,
             xpAwardService,
             nowPlayingManager,
+            introPlaybackTracker,
         )
     )
 
@@ -712,6 +720,99 @@ class VoiceEventHandlerTest {
         verify(exactly = 0) {
             awardService.award(any(), any(), VoiceEventHandler.INTRO_PLAY_CREDIT, "intro-play", any(), any())
         }
+
+        unmockkObject(PlayerManager)
+    }
+
+    /**
+     * Builds a "member joins the channel the bot is already in" event for
+     * guild [gid] with [intros] configured, runs the handler, and returns the
+     * PlayerManager mock so callers can assert on playback.
+     */
+    private fun joinWithIntros(gid: Long, intros: MutableList<MusicDto>): PlayerManager {
+        val guild = mockk<Guild>(relaxed = true)
+        val event = mockk<GuildVoiceUpdateEvent>(relaxed = true)
+        val audioManager = mockk<AudioManager>(relaxed = true)
+        val member = mockk<Member>(relaxed = true)
+        val channel = mockk<AudioChannelUnion>(relaxed = true)
+        val audioPlayerManager = mockk<PlayerManager>(relaxed = true)
+
+        every { event.guild } returns guild
+        every { event.jda.selfUser } returns selfUser
+        every { guild.audioManager } returns audioManager
+        every { event.member } returns member
+        every { event.channelJoined } returns channel
+        every { event.channelLeft } returns null
+        every { channel.members } returns listOf(member)
+        every { member.user.isBot } returns false
+        every { member.guild } returns guild
+        every { member.isOwner } returns false
+        every { member.idLong } returns 1L
+        every { member.user.idLong } returns 1L
+        every { guild.idLong } returns gid
+        every { guild.id } returns gid.toString()
+        every { audioManager.isConnected } returns false
+        every { audioManager.connectedChannel } returns channel
+
+        mockkObject(PlayerManager)
+        every { PlayerManager.instance } returns audioPlayerManager
+        every { configService.getConfigByName(ConfigDto.Configurations.DELETE_DELAY.configValue, gid.toString()) } returns
+            ConfigDto().apply { value = "30" }
+        every { configService.getConfigByName(ConfigDto.Configurations.VOLUME.configValue, gid.toString()) } returns null
+        every { userDtoHelper.calculateUserDto(1L, gid, false) } returns mockk(relaxed = true) {
+            every { discordId } returns 1L
+            every { guildId } returns gid
+            every { musicDtos } returns intros
+        }
+
+        handler.onGuildVoiceUpdate(event)
+        return audioPlayerManager
+    }
+
+    @Test
+    fun `rejoining inside the cooldown does not replay the intro or pay out again`() {
+        val musicDto = mockk<MusicDto>(relaxed = true) {
+            every { id } returns "11_1_1"
+            every { fileName } returns "https://example.com/intro.mp3"
+            every { musicBlob } returns null
+            every { introVolume } returns 75
+            every { startMs } returns null
+            every { endMs } returns null
+        }
+
+        // Channel hop: Discord delivers a join event each time.
+        joinWithIntros(11L, mutableListOf(musicDto))
+        val second = joinWithIntros(11L, mutableListOf(musicDto))
+
+        // Exactly one playback and one payout across both joins.
+        verify(exactly = 0) {
+            second.loadAndPlayIntro(any(), any(), any(), any(), any(), any(), any())
+        }
+        verify(exactly = 1) {
+            awardService.award(1L, 11L, VoiceEventHandler.INTRO_PLAY_CREDIT, "intro-play", any(), any())
+        }
+        verify(exactly = 1) {
+            xpAwardService.award(1L, 11L, VoiceEventHandler.INTRO_PLAY_XP, "intro-play", any(), any(), any())
+        }
+
+        unmockkObject(PlayerManager)
+    }
+
+    @Test
+    fun `the intro that played is remembered so the next pick can avoid it`() {
+        val musicDto = mockk<MusicDto>(relaxed = true) {
+            every { id } returns "12_1_1"
+            every { fileName } returns "https://example.com/intro.mp3"
+            every { musicBlob } returns null
+            every { introVolume } returns 75
+            every { startMs } returns null
+            every { endMs } returns null
+        }
+
+        joinWithIntros(12L, mutableListOf(musicDto))
+
+        assertEquals("12_1_1", introPlaybackTracker.lastPlayedIntroId(12L, 1L))
+        assertTrue(introPlaybackTracker.onCooldown(12L, 1L))
 
         unmockkObject(PlayerManager)
     }

--- a/discord-bot/src/test/kotlin/bot/toby/intro/IntroNotificationServiceCooldownTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/intro/IntroNotificationServiceCooldownTest.kt
@@ -1,0 +1,124 @@
+package bot.toby.intro
+
+import bot.toby.handler.EventWaiter
+import bot.toby.helpers.HttpHelper
+import bot.toby.helpers.UserDtoHelper
+import common.notification.NotificationChannelKind
+import common.notification.Surface
+import database.service.music.MusicFileService
+import database.service.user.UserNotificationPrefService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.User
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * `VoiceEventHandler` calls the prompt on *every* voice join while the user
+ * has no intro. Without a cooldown a channel-hopper collected a DM per hop —
+ * plus, five minutes later, a "you didn't respond in time" DM per hop, since
+ * each prompt armed its own [EventWaiter].
+ */
+class IntroNotificationServiceCooldownTest {
+
+    private val discordId = 100L
+    private val guildId = 42L
+
+    private lateinit var user: User
+    private lateinit var guild: Guild
+    private lateinit var prefService: UserNotificationPrefService
+    private lateinit var eventWaiter: EventWaiter
+    private lateinit var service: IntroNotificationService
+
+    private fun newService() = IntroNotificationService(
+        userDtoHelper = mockk<UserDtoHelper>(relaxed = true),
+        musicFileService = mockk<MusicFileService>(relaxed = true),
+        httpHelper = mockk<HttpHelper>(relaxed = true),
+        eventWaiter = eventWaiter,
+        validationService = mockk<IntroValidationService>(relaxed = true),
+        mediaLoader = mockk<IntroMediaLoader>(relaxed = true),
+        notificationPrefService = prefService,
+    )
+
+    private fun otherUser(id: Long): User = mockk(relaxed = true) { every { idLong } returns id }
+    private fun otherGuild(id: Long): Guild = mockk(relaxed = true) {
+        every { idLong } returns id
+        every { name } returns "Other Guild"
+    }
+
+    @BeforeEach
+    fun setup() {
+        user = mockk(relaxed = true)
+        guild = mockk(relaxed = true)
+        prefService = mockk(relaxed = true)
+        eventWaiter = mockk(relaxed = true)
+        every { user.idLong } returns discordId
+        every { guild.idLong } returns guildId
+        every { guild.name } returns "Test Guild"
+        every {
+            prefService.isOptedIn(any(), any(), NotificationChannelKind.INTRO_PROMPT, Surface.DM)
+        } returns true
+
+        service = newService()
+    }
+
+    @Test
+    fun `a second join within the cooldown does not re-prompt`() {
+        service.promptUserForMusicInfo(user, guild)
+        service.promptUserForMusicInfo(user, guild)
+        service.promptUserForMusicInfo(user, guild)
+
+        verify(exactly = 1) { user.openPrivateChannel() }
+    }
+
+    @Test
+    fun `the cooldown is per guild`() {
+        val second = otherGuild(999L)
+
+        service.promptUserForMusicInfo(user, guild)
+        service.promptUserForMusicInfo(user, second)
+
+        // Same user, different server — they genuinely have no intro there.
+        verify(exactly = 2) { user.openPrivateChannel() }
+    }
+
+    @Test
+    fun `the cooldown is per user`() {
+        val second = otherUser(999L)
+
+        service.promptUserForMusicInfo(user, guild)
+        service.promptUserForMusicInfo(second, guild)
+
+        verify(exactly = 1) { user.openPrivateChannel() }
+        verify(exactly = 1) { second.openPrivateChannel() }
+    }
+
+    @Test
+    fun `an opted-out user is never recorded, so opting back in still prompts`() {
+        every {
+            prefService.isOptedIn(discordId, guildId, NotificationChannelKind.INTRO_PROMPT, Surface.DM)
+        } returns false
+        service.promptUserForMusicInfo(user, guild)
+        verify(exactly = 0) { user.openPrivateChannel() }
+
+        every {
+            prefService.isOptedIn(discordId, guildId, NotificationChannelKind.INTRO_PROMPT, Surface.DM)
+        } returns true
+        service.promptUserForMusicInfo(user, guild)
+
+        verify(exactly = 1) { user.openPrivateChannel() }
+    }
+
+    @Test
+    fun `only one waiter is armed per prompt`() {
+        service.promptUserForMusicInfo(user, guild)
+        service.promptUserForMusicInfo(user, guild)
+
+        // openPrivateChannel is stubbed relaxed, so the waiter is set up in
+        // its callback and never actually runs here — the assertion that
+        // matters is that we didn't even open the channel a second time.
+        verify(exactly = 1) { user.openPrivateChannel() }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/intro/IntroPlaybackTrackerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/intro/IntroPlaybackTrackerTest.kt
@@ -1,0 +1,83 @@
+package bot.toby.intro
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class IntroPlaybackTrackerTest {
+
+    private lateinit var tracker: IntroPlaybackTracker
+
+    private val guildId = 1L
+    private val discordId = 2L
+    private val start: Instant = Instant.parse("2026-01-01T12:00:00Z")
+
+    @BeforeEach
+    fun setUp() {
+        tracker = IntroPlaybackTracker()
+    }
+
+    @Test
+    fun `a user who has never joined is not on cooldown`() {
+        assertFalse(tracker.onCooldown(guildId, discordId, start))
+        assertNull(tracker.lastPlayedIntroId(guildId, discordId))
+    }
+
+    @Test
+    fun `a rejoin inside the window is on cooldown`() {
+        tracker.record(guildId, discordId, "1_2_1", start)
+
+        assertTrue(tracker.onCooldown(guildId, discordId, start))
+        assertTrue(tracker.onCooldown(guildId, discordId, start.plusSeconds(1)))
+        assertTrue(
+            tracker.onCooldown(guildId, discordId, start.plusSeconds(IntroPlaybackTracker.COOLDOWN.seconds - 1))
+        )
+    }
+
+    @Test
+    fun `the cooldown lapses once the window passes`() {
+        tracker.record(guildId, discordId, "1_2_1", start)
+
+        assertFalse(tracker.onCooldown(guildId, discordId, start.plusSeconds(IntroPlaybackTracker.COOLDOWN.seconds)))
+        assertFalse(tracker.onCooldown(guildId, discordId, start.plusSeconds(3600)))
+    }
+
+    @Test
+    fun `the last played intro is remembered so the next pick can avoid it`() {
+        tracker.record(guildId, discordId, "1_2_2", start)
+        assertEquals("1_2_2", tracker.lastPlayedIntroId(guildId, discordId))
+    }
+
+    @Test
+    fun `a later play replaces the remembered one`() {
+        tracker.record(guildId, discordId, "1_2_1", start)
+        tracker.record(guildId, discordId, "1_2_3", start.plusSeconds(300))
+
+        assertEquals("1_2_3", tracker.lastPlayedIntroId(guildId, discordId))
+        assertFalse(tracker.onCooldown(guildId, discordId, start.plusSeconds(400)))
+        assertTrue(tracker.onCooldown(guildId, discordId, start.plusSeconds(301)))
+    }
+
+    @Test
+    fun `a failed play still starts the cooldown but remembers no intro`() {
+        // playUserIntro returning null shouldn't leave the user open to an
+        // immediate retrigger loop.
+        tracker.record(guildId, discordId, null, start)
+
+        assertTrue(tracker.onCooldown(guildId, discordId, start))
+        assertNull(tracker.lastPlayedIntroId(guildId, discordId))
+    }
+
+    @Test
+    fun `tracking is scoped per guild and per user`() {
+        tracker.record(guildId, discordId, "1_2_1", start)
+
+        assertFalse(tracker.onCooldown(99L, discordId, start))
+        assertFalse(tracker.onCooldown(guildId, 99L, start))
+        assertNull(tracker.lastPlayedIntroId(99L, discordId))
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/intro/IntroPresenterTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/intro/IntroPresenterTest.kt
@@ -1,0 +1,108 @@
+package bot.toby.intro
+
+import database.dto.music.MusicDto
+import database.dto.user.UserDto
+import io.mockk.every
+import io.mockk.mockk
+import net.dv8tion.jda.api.entities.Member
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class IntroPresenterTest {
+
+    private val userDto = UserDto(discordId = 1234L, guildId = 4567L)
+
+    private fun urlIntro(index: Int, name: String, volume: Int = 90, start: Int? = null, end: Int? = null) =
+        MusicDto(userDto, index, name, volume, "https://www.youtube.com/watch?v=abc".toByteArray(), start, end)
+
+    private fun fileIntro(index: Int, name: String) =
+        MusicDto(userDto, index, name, 90, byteArrayOf(1, 2, 3))
+
+    private fun member(name: String = "Someone", avatar: String = "https://cdn.example/avatar.png"): Member =
+        mockk(relaxed = true) {
+            every { effectiveName } returns name
+            every { effectiveAvatarUrl } returns avatar
+        }
+
+    @Test
+    fun `options are ordered by slot, not insertion order`() {
+        val options = IntroPresenter.selectOptions(listOf(urlIntro(3, "third"), urlIntro(1, "first"), urlIntro(2, "second")))
+        assertEquals(listOf("first", "second", "third"), options.map { it.label })
+    }
+
+    @Test
+    fun `option values are the intro ids so the menu handlers can look them up`() {
+        val intro = urlIntro(2, "second")
+        val option = IntroPresenter.selectOptions(listOf(intro)).single()
+        assertEquals(intro.id, option.value)
+    }
+
+    @Test
+    fun `long titles are truncated to Discord's select limit`() {
+        // A real YouTube title can comfortably exceed 100 characters; building
+        // the option unclamped used to throw and break the whole menu.
+        val longTitle = "y".repeat(250)
+        val option = IntroPresenter.selectOptions(listOf(urlIntro(1, longTitle))).single()
+        assertEquals(100, option.label.length)
+        assertTrue(option.label.endsWith("…"))
+    }
+
+    @Test
+    fun `option description summarises slot, volume and clip`() {
+        val option = IntroPresenter.selectOptions(listOf(urlIntro(2, "track", volume = 40, start = 3_000, end = 9_000)))
+            .single()
+        assertEquals("Slot #2 · Volume 40% · 0:03 – 0:09", option.description)
+    }
+
+    @Test
+    fun `unclipped intros are described as the full track`() {
+        assertEquals("Slot #1 · Volume 90% · full track", IntroPresenter.summary(urlIntro(1, "track")))
+    }
+
+    @Test
+    fun `url and file intros are distinguished by their blob`() {
+        assertTrue(IntroPresenter.isUrlIntro(urlIntro(1, "link")))
+        assertFalse(IntroPresenter.isUrlIntro(fileIntro(1, "upload.mp3")))
+        assertFalse(IntroPresenter.isUrlIntro(MusicDto(userDto, 1, "empty", 90, null)))
+    }
+
+    @Test
+    fun `blank names fall back to a placeholder`() {
+        assertEquals("Unknown", IntroPresenter.displayName(MusicDto(userDto, 1, "   ", 90, null)))
+        assertEquals("Unknown", IntroPresenter.displayName(MusicDto(userDto, 1, null, 90, null)))
+    }
+
+    @Test
+    fun `list embed has a field per intro in slot order`() {
+        val embed = IntroPresenter.listEmbed(member(), listOf(urlIntro(2, "second"), fileIntro(1, "first.mp3")), 3)
+
+        assertEquals(2, embed.fields.size)
+        assertTrue(embed.fields[0].name!!.startsWith("#1 · first.mp3"))
+        assertTrue(embed.fields[1].name!!.startsWith("#2 · second"))
+        assertTrue(embed.fields[0].value!!.contains("Uploaded file"))
+        assertTrue(embed.fields[1].value!!.contains("Link"))
+        assertEquals("2/3 slots used · edit with /editintro, remove with /deleteintro", embed.footer?.text)
+    }
+
+    @Test
+    fun `empty list embed points at setintro`() {
+        val embed = IntroPresenter.listEmbed(member(), emptyList(), 3)
+        assertTrue(embed.fields.isEmpty())
+        assertTrue(embed.description!!.contains("/setintro"))
+    }
+
+    @Test
+    fun `a member without a usable avatar url does not blow up the embed`() {
+        // EmbedBuilder rejects non-http thumbnails; relaxed/absent avatars are common in tests.
+        val embed = IntroPresenter.listEmbed(member(avatar = ""), listOf(urlIntro(1, "track")), 3)
+        assertEquals(1, embed.fields.size)
+    }
+
+    @Test
+    fun `dashboard button deep links to the guild intro page`() {
+        val button = IntroPresenter.webDashboardButton(4567L)
+        assertEquals("https://www.toby-bot.co.uk/intro/4567", button.url)
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/intro/IntroSelectionTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/intro/IntroSelectionTest.kt
@@ -1,0 +1,78 @@
+package bot.toby.intro
+
+import database.dto.music.MusicDto
+import database.dto.user.UserDto
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import kotlin.random.Random
+
+class IntroSelectionTest {
+
+    private val userDto = UserDto(discordId = 1234L, guildId = 4567L)
+
+    private fun intro(index: Int) = MusicDto(userDto, index, "intro$index", 90, byteArrayOf(index.toByte()))
+
+    @Test
+    fun `no intros means nothing to play`() {
+        assertNull(IntroSelection.pick(emptyList()))
+    }
+
+    @Test
+    fun `a single intro is always picked, even if it just played`() {
+        val only = intro(1)
+        assertEquals(only, IntroSelection.pick(listOf(only)))
+        assertEquals(only, IntroSelection.pick(listOf(only), lastPlayedId = only.id))
+    }
+
+    @Test
+    fun `the previous pick is never repeated back to back`() {
+        val intros = listOf(intro(1), intro(2), intro(3))
+        val last = intros[1]
+
+        // Every seed must avoid it — this is the whole point of the change.
+        repeat(200) { seed ->
+            val picked = IntroSelection.pick(intros, last.id, Random(seed))
+            assertNotEquals(last.id, picked?.id, "seed $seed repeated the previous intro")
+        }
+    }
+
+    @Test
+    fun `with no history any intro can come up`() {
+        val intros = listOf(intro(1), intro(2), intro(3))
+        val seen = (0 until 200).mapNotNull { IntroSelection.pick(intros, null, Random(it))?.id }.toSet()
+        assertEquals(intros.mapNotNull { it.id }.toSet(), seen)
+    }
+
+    @Test
+    fun `both remaining intros stay reachable after excluding the previous one`() {
+        val intros = listOf(intro(1), intro(2), intro(3))
+        val seen = (0 until 200).mapNotNull { IntroSelection.pick(intros, intros[0].id, Random(it))?.id }.toSet()
+        assertEquals(setOf(intros[1].id, intros[2].id), seen)
+    }
+
+    @Test
+    fun `two intros alternate`() {
+        val intros = listOf(intro(1), intro(2))
+        assertEquals(intros[1].id, IntroSelection.pick(intros, intros[0].id)?.id)
+        assertEquals(intros[0].id, IntroSelection.pick(intros, intros[1].id)?.id)
+    }
+
+    @Test
+    fun `an unknown last-played id excludes nothing`() {
+        val intros = listOf(intro(1), intro(2))
+        val seen = (0 until 100).mapNotNull { IntroSelection.pick(intros, "not-an-id", Random(it))?.id }.toSet()
+        assertEquals(intros.mapNotNull { it.id }.toSet(), seen)
+    }
+
+    @Test
+    fun `duplicate ids fall back to the full set rather than playing nothing`() {
+        // Defensive: shouldn't happen (ids are unique per slot), but excluding
+        // every candidate must not silence the intro.
+        val dup = intro(1)
+        val intros = listOf(dup, dup)
+        assertTrue(IntroSelection.pick(intros, dup.id) != null)
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/intro/IntroUndoStoreTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/intro/IntroUndoStoreTest.kt
@@ -1,0 +1,87 @@
+package bot.toby.intro
+
+import database.dto.music.MusicDto
+import database.dto.user.UserDto
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class IntroUndoStoreTest {
+
+    private lateinit var store: IntroUndoStore
+
+    private val userDto = UserDto(discordId = 1234L, guildId = 4567L)
+
+    @BeforeEach
+    fun setUp() {
+        store = IntroUndoStore()
+    }
+
+    private fun intro(index: Int = 2, name: String = "track") =
+        MusicDto(userDto, index, name, 40, "https://example.com/a".toByteArray(), 3_000, 9_000)
+
+    @Test
+    fun `a remembered intro can be taken back`() {
+        store.remember(intro())
+
+        val snapshot = store.take(4567L, 1234L)
+
+        assertNotNull(snapshot)
+        assertEquals(2, snapshot!!.index)
+        assertEquals("track", snapshot.fileName)
+        assertEquals(40, snapshot.introVolume)
+        assertEquals(3_000, snapshot.startMs)
+        assertEquals(9_000, snapshot.endMs)
+        assertTrue(snapshot.musicBlob.contentEquals("https://example.com/a".toByteArray()))
+    }
+
+    @Test
+    fun `undo is single use`() {
+        store.remember(intro())
+
+        assertNotNull(store.take(4567L, 1234L))
+        assertNull(store.take(4567L, 1234L))
+    }
+
+    @Test
+    fun `snapshots are scoped to guild and user`() {
+        store.remember(intro())
+
+        assertNull(store.take(9999L, 1234L))
+        assertNull(store.take(4567L, 9999L))
+        assertNotNull(store.take(4567L, 1234L))
+    }
+
+    @Test
+    fun `a later delete replaces the pending snapshot`() {
+        store.remember(intro(index = 1, name = "first"))
+        store.remember(intro(index = 2, name = "second"))
+
+        assertEquals("second", store.take(4567L, 1234L)?.fileName)
+    }
+
+    @Test
+    fun `an intro with no owner is ignored rather than throwing`() {
+        store.remember(MusicDto(id = "orphan", userDto = null))
+
+        assertNull(store.take(4567L, 1234L))
+    }
+
+    @Test
+    fun `the snapshot copies the blob so later mutation cannot corrupt it`() {
+        val original = intro()
+        store.remember(original)
+        original.musicBlob!![0] = 0
+
+        val snapshot = store.take(4567L, 1234L)!!
+        assertEquals('h'.code.toByte(), snapshot.musicBlob!![0])
+    }
+
+    @Test
+    fun `nothing to take when nothing was deleted`() {
+        assertNull(store.take(4567L, 1234L))
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/intro/IntroValidationServiceTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/intro/IntroValidationServiceTest.kt
@@ -1,0 +1,245 @@
+package bot.toby.intro
+
+import bot.toby.helpers.HttpHelper
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import net.dv8tion.jda.api.entities.Message.Attachment
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import kotlin.time.Duration.Companion.seconds
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class IntroValidationServiceTest {
+
+    private val httpHelper: HttpHelper = mockk()
+
+    private fun service(dispatcher: kotlinx.coroutines.CoroutineDispatcher) =
+        IntroValidationService(httpHelper, dispatcher)
+
+    private fun attachment(extension: String?, size: Int): Attachment = mockk {
+        io.mockk.every { fileExtension } returns extension
+        io.mockk.every { this@mockk.size } returns size
+    }
+
+    // --- parseVolume --------------------------------------------------------
+
+    @Test
+    fun `a trailing standalone number is the volume`() = runTest {
+        val svc = service(StandardTestDispatcher(testScheduler))
+        assertEquals(85, svc.parseVolume("https://www.youtube.com/watch?v=dQw4w9WgXcQ 85"))
+        assertEquals(0, svc.parseVolume("https://www.youtube.com/watch?v=dQw4w9WgXcQ 0"))
+        assertEquals(100, svc.parseVolume("https://www.youtube.com/watch?v=dQw4w9WgXcQ 100"))
+    }
+
+    @Test
+    fun `a leading standalone number is also accepted`() = runTest {
+        val svc = service(StandardTestDispatcher(testScheduler))
+        assertEquals(70, svc.parseVolume("70 https://www.youtube.com/watch?v=dQw4w9WgXcQ"))
+    }
+
+    @Test
+    fun `a bare number works for the attachment reply`() = runTest {
+        val svc = service(StandardTestDispatcher(testScheduler))
+        assertEquals(30, svc.parseVolume("30"))
+    }
+
+    @Test
+    fun `digits inside the url are not mistaken for a volume`() = runTest {
+        val svc = service(StandardTestDispatcher(testScheduler))
+        // Regression: the old \b(\d{1,3})\b scan matched these and silently
+        // set the intro to 42% / 7%.
+        assertNull(svc.parseVolume("https://youtu.be/dQw4w9WgXcQ?t=42"))
+        assertNull(svc.parseVolume("https://www.youtube.com/watch?v=abc&list=PL9&index=7"))
+        assertNull(svc.parseVolume("https://example.com/clips/12/intro.mp3"))
+    }
+
+    @Test
+    fun `no number at all means no volume`() = runTest {
+        val svc = service(StandardTestDispatcher(testScheduler))
+        assertNull(svc.parseVolume("https://www.youtube.com/watch?v=dQw4w9WgXcQ"))
+        assertNull(svc.parseVolume(""))
+        assertNull(svc.parseVolume("   "))
+    }
+
+    @Test
+    fun `an out-of-range number is not treated as a volume`() = runTest {
+        val svc = service(StandardTestDispatcher(testScheduler))
+        assertNull(svc.parseVolume("https://example.com/a.mp3 101"))
+        assertNull(svc.parseVolume("https://example.com/a.mp3 9999"))
+    }
+
+    // --- isValidAttachment --------------------------------------------------
+
+    @Test
+    fun `only mp3 files within the size limit are valid attachments`() = runTest {
+        val svc = service(StandardTestDispatcher(testScheduler))
+        assertTrue(svc.isValidAttachment(attachment("mp3", 1_000)))
+        assertTrue(svc.isValidAttachment(attachment("mp3", IntroValidationService.MAX_FILE_SIZE)))
+        assertFalse(svc.isValidAttachment(attachment("mp3", IntroValidationService.MAX_FILE_SIZE + 1)))
+        assertFalse(svc.isValidAttachment(attachment("wav", 1_000)))
+        assertFalse(svc.isValidAttachment(attachment(null, 1_000)))
+    }
+
+    // --- convertShortsUrls / isValidUrl ------------------------------------
+
+    @Test
+    fun `shorts urls are rewritten to the watch form`() = runTest {
+        val svc = service(StandardTestDispatcher(testScheduler))
+        assertEquals(
+            "https://www.youtube.com/watch?v=abc123",
+            svc.convertShortsUrls("https://www.youtube.com/shorts/abc123"),
+        )
+        assertEquals(
+            "https://www.youtube.com/watch?v=abc123",
+            svc.convertShortsUrls("https://www.youtube.com/watch?v=abc123"),
+        )
+    }
+
+    @Test
+    fun `isValidUrl accepts http urls and rejects junk`() = runTest {
+        val svc = service(StandardTestDispatcher(testScheduler))
+        assertTrue(svc.isValidUrl("https://www.youtube.com/watch?v=abc"))
+        assertFalse(svc.isValidUrl("not a url"))
+    }
+
+    // --- checkForOverlyLongIntroDuration -----------------------------------
+
+    @Test
+    fun `a source over the cap is over limit`() = runTest {
+        val svc = service(StandardTestDispatcher(testScheduler))
+        coEvery { httpHelper.getYouTubeVideoDuration(any()) } returns 21.seconds
+        assertTrue(svc.checkForOverlyLongIntroDuration("https://example.com/a"))
+    }
+
+    @Test
+    fun `a source within the cap is not over limit`() = runTest {
+        val svc = service(StandardTestDispatcher(testScheduler))
+        coEvery { httpHelper.getYouTubeVideoDuration(any()) } returns 10.seconds
+        assertFalse(svc.checkForOverlyLongIntroDuration("https://example.com/a"))
+    }
+
+    @Test
+    fun `an unknown duration is not treated as over limit`() = runTest {
+        val svc = service(StandardTestDispatcher(testScheduler))
+        coEvery { httpHelper.getYouTubeVideoDuration(any()) } returns null
+        assertFalse(svc.checkForOverlyLongIntroDuration("https://example.com/a"))
+    }
+
+    // --- validateIntroLength (legacy boolean gate) -------------------------
+
+    @Test
+    fun `validateIntroLength reports over-limit for a long source`() = runTest {
+        val svc = service(StandardTestDispatcher(testScheduler))
+        coEvery { httpHelper.getYouTubeVideoDuration(any()) } returns 60.seconds
+
+        var result: Boolean? = null
+        svc.validateIntroLength("https://example.com/a") { result = it }
+        advanceUntilIdle()
+
+        assertEquals(true, result)
+    }
+
+    @Test
+    fun `validateIntroLength fails closed when the lookup throws`() = runTest {
+        val svc = service(StandardTestDispatcher(testScheduler))
+        coEvery { httpHelper.getYouTubeVideoDuration(any()) } throws IllegalStateException("boom")
+
+        var result: Boolean? = null
+        svc.validateIntroLength("https://example.com/a") { result = it }
+        advanceUntilIdle()
+
+        assertEquals(true, result)
+    }
+
+    // --- sourceDurationMs ---------------------------------------------------
+
+    @Test
+    fun `sourceDurationMs converts the looked-up duration to milliseconds`() = runTest {
+        val svc = service(StandardTestDispatcher(testScheduler))
+        coEvery { httpHelper.getYouTubeVideoDuration(any()) } returns 12.seconds
+        assertEquals(12_000, svc.sourceDurationMs("https://example.com/a"))
+    }
+
+    @Test
+    fun `sourceDurationMs is null when the lookup fails`() = runTest {
+        val svc = service(StandardTestDispatcher(testScheduler))
+        coEvery { httpHelper.getYouTubeVideoDuration(any()) } throws IllegalStateException("boom")
+        assertNull(svc.sourceDurationMs("https://example.com/a"))
+    }
+
+    // --- validateClipAgainstSource -----------------------------------------
+
+    @Test
+    fun `an unclipped long source is rejected`() = runTest {
+        val svc = service(StandardTestDispatcher(testScheduler))
+        coEvery { httpHelper.getYouTubeVideoDuration(any()) } returns 60.seconds
+
+        var error: String? = null
+        var called = false
+        svc.validateClipAgainstSource("https://example.com/a", null, null) { error = it; called = true }
+        advanceUntilIdle()
+
+        assertTrue(called)
+        assertNotNull(error)
+        assertTrue(error!!.contains("set a start/end clip"), error!!)
+    }
+
+    @Test
+    fun `a clip inside a long source is accepted`() = runTest {
+        val svc = service(StandardTestDispatcher(testScheduler))
+        coEvery { httpHelper.getYouTubeVideoDuration(any()) } returns 60.seconds
+
+        var error: String? = "unset"
+        svc.validateClipAgainstSource("https://example.com/a", 10_000, 20_000) { error = it }
+        advanceUntilIdle()
+
+        assertNull(error)
+    }
+
+    @Test
+    fun `a clip past the end of the source is rejected`() = runTest {
+        val svc = service(StandardTestDispatcher(testScheduler))
+        coEvery { httpHelper.getYouTubeVideoDuration(any()) } returns 20.seconds
+
+        var error: String? = null
+        svc.validateClipAgainstSource("https://example.com/a", 15_000, 25_000) { error = it }
+        advanceUntilIdle()
+
+        assertEquals("End time exceeds the source duration.", error)
+    }
+
+    @Test
+    fun `an upload has no source to look up so only the span is checked`() = runTest {
+        val svc = service(StandardTestDispatcher(testScheduler))
+
+        var error: String? = "unset"
+        svc.validateClipAgainstSource(null, 1_000, 5_000) { error = it }
+        advanceUntilIdle()
+        assertNull(error)
+
+        var tooLong: String? = null
+        svc.validateClipAgainstSource(null, 0, 60_000) { tooLong = it }
+        advanceUntilIdle()
+        assertNotNull(tooLong)
+    }
+
+    @Test
+    fun `a lookup failure lets the intro through rather than blocking everyone`() = runTest {
+        val svc = service(StandardTestDispatcher(testScheduler))
+        coEvery { httpHelper.getYouTubeVideoDuration(any()) } throws IllegalStateException("api down")
+
+        var error: String? = "unset"
+        svc.validateClipAgainstSource("https://example.com/a", null, null) { error = it }
+        advanceUntilIdle()
+
+        assertNull(error)
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/menu/menus/DeleteIntroMenuTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/menu/menus/DeleteIntroMenuTest.kt
@@ -2,6 +2,7 @@ package bot.toby.menu.menus
 
 import bot.toby.handler.EventWaiter
 import bot.toby.helpers.IntroHelper
+import bot.toby.intro.IntroUndoStore
 import bot.toby.menu.DefaultMenuContext
 import bot.toby.menu.MenuTest
 import bot.toby.menu.MenuTest.Companion.menuEvent
@@ -19,6 +20,7 @@ class DeleteIntroMenuTest : MenuTest {
 
     private lateinit var introHelper: IntroHelper
     private lateinit var eventWaiter: EventWaiter
+    private lateinit var undoStore: IntroUndoStore
     private lateinit var deleteIntroMenu: DeleteIntroMenu
     private lateinit var menuContext: DefaultMenuContext
     private val userDto: UserDto = mockk {
@@ -33,9 +35,10 @@ class DeleteIntroMenuTest : MenuTest {
         // Mock the dependencies
         introHelper = mockk(relaxed = true)
         eventWaiter = mockk(relaxed = true)
+        undoStore = mockk(relaxed = true)
 
         // Initialize the class under test
-        deleteIntroMenu = DeleteIntroMenu(introHelper)
+        deleteIntroMenu = DeleteIntroMenu(introHelper, undoStore)
 
         // Mock the context
         menuContext = mockk(relaxed = true)
@@ -57,7 +60,8 @@ class DeleteIntroMenuTest : MenuTest {
         // Call handle
         deleteIntroMenu.handle(menuContext, 0)
 
-        // Verify that intro is deleted
+        // Verify the intro is snapshotted for undo, then deleted
+        verify { undoStore.remember(intro) }
         verify { introHelper.deleteIntro(intro) }
     }
 

--- a/discord-bot/src/test/kotlin/bot/toby/menu/menus/EditIntroMenuTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/menu/menus/EditIntroMenuTest.kt
@@ -1,6 +1,5 @@
 package bot.toby.menu.menus
 
-import bot.toby.handler.EventWaiter
 import bot.toby.helpers.IntroHelper
 import bot.toby.menu.DefaultMenuContext
 import bot.toby.menu.MenuTest
@@ -14,10 +13,16 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
+/**
+ * `EditIntroMenu` responds to the component interaction directly (a modal has
+ * to be the first response), and JDA's `reply`/`replyModal` are default
+ * interface methods that the shared event mock doesn't intercept — so these
+ * assert on the collaborator side. The modal's contents and submit behaviour
+ * are covered by `EditIntroModalTest`.
+ */
 class EditIntroMenuTest : MenuTest {
 
     private lateinit var introHelper: IntroHelper
-    private lateinit var eventWaiter: EventWaiter
     private lateinit var editIntroMenu: EditIntroMenu
     private lateinit var menuContext: DefaultMenuContext
     private val userDto: database.dto.user.UserDto = mockk {
@@ -29,49 +34,49 @@ class EditIntroMenuTest : MenuTest {
     fun setUp() {
         setUpMenuMocks()
 
-        // Mock the dependencies
         introHelper = mockk(relaxed = true)
-        eventWaiter = mockk(relaxed = true)
+        editIntroMenu = EditIntroMenu(introHelper)
 
-        // Initialize the class under test
-        editIntroMenu = EditIntroMenu(introHelper, eventWaiter)
-
-        // Mock the context
         menuContext = mockk(relaxed = true)
         every { menuContext.event } returns menuEvent
     }
 
     @AfterEach
-    fun tearDown(){
+    fun tearDown() {
         tearDownMenuMocks()
         unmockkAll()
     }
 
     @Test
-    fun `test valid intro selection`() {
+    fun `resolves the selected intro before opening the editor`() {
+        val intro = MusicDto(userDto, 1, "Intro1", 42, "https://example.com/a".toByteArray(), 3_000, 9_000)
+        every { introHelper.findIntroById("4567_1234_1") } returns intro
+        every { menuContext.event.values.firstOrNull() } returns "4567_1234_1"
 
-        val intro = MusicDto(userDto, 1, "Intro1")
-        every { introHelper.findIntroById("1") } returns intro
-        every { menuContext.event.values.firstOrNull() } returns "1"
-
-
-        // Call handle
         editIntroMenu.handle(menuContext, 0)
 
-        // Verify that the user is prompted for a new volume
-        verify { menuContext.event.hook.sendMessage("You've selected Intro1. Please reply with the new volume (0-100).") }
+        verify { introHelper.findIntroById("4567_1234_1") }
+        // The old flow mutated the intro straight from the menu; the modal is
+        // now the only thing that writes.
+        verify(exactly = 0) { introHelper.updateIntro(any()) }
     }
 
     @Test
-    fun `test invalid intro selection`() {
-        // Return null when trying to find the intro
+    fun `unknown intro does not update anything`() {
         every { introHelper.findIntroById("1") } returns null
         every { menuContext.event.values.firstOrNull() } returns "1"
 
-        // Call handle
         editIntroMenu.handle(menuContext, 0)
 
-        // Verify that the user is informed the intro wasn't found
-        verify { menuContext.event.hook.sendMessage("Unable to find the selected intro.") }
+        verify(exactly = 0) { introHelper.updateIntro(any()) }
+    }
+
+    @Test
+    fun `empty selection is ignored`() {
+        every { menuContext.event.values.firstOrNull() } returns null
+
+        editIntroMenu.handle(menuContext, 0)
+
+        verify(exactly = 0) { introHelper.findIntroById(any()) }
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/menu/menus/SetIntroMenuTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/menu/menus/SetIntroMenuTest.kt
@@ -2,6 +2,7 @@ package bot.toby.menu.menus
 
 import bot.toby.command.CommandTest.Companion.interactionHook
 import bot.toby.helpers.InputData
+import bot.toby.helpers.PendingIntro
 import bot.toby.helpers.IntroHelper
 import bot.toby.helpers.UserDtoHelper
 import bot.toby.menu.DefaultMenuContext
@@ -76,7 +77,7 @@ internal class SetIntroMenuTest : MenuTest {
 
         every { userDtoHelper.calculateUserDto(1234L, 1L, true) } returns userDto
         val musicDtoToReplace = userDto.musicDtos.first { it.id == "2" } // Match the selectedMusicDtoId
-        every { introHelper.pendingIntros[1234L] } returns Triple(mockk(), "url", 50)
+        every { introHelper.pendingIntros[1234L] } returns PendingIntro(mockk(), "url", 50)
 
         // Act
         setIntroMenu.handle(menuContext, 10)
@@ -92,7 +93,9 @@ internal class SetIntroMenuTest : MenuTest {
                 capture(inputData),
                 50,
                 musicDtoToReplace, // Ensure we are using the correct MusicDto
-                "Effective Name"
+                "Effective Name",
+                null,
+                null,
             )
         }
     }
@@ -153,7 +156,7 @@ internal class SetIntroMenuTest : MenuTest {
 
         // Assert
         verify(exactly = 0) {
-            introHelper.handleMedia(any(), any(), any(), any(), any(), any(), any())
+            introHelper.handleMedia(any(), any(), any(), any(), any(), any(), any(), any(), any())
         }
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/modal/modals/EditIntroModalTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/modal/modals/EditIntroModalTest.kt
@@ -1,0 +1,259 @@
+package bot.toby.modal.modals
+
+import bot.toby.helpers.IntroHelper
+import core.modal.ModalContext
+import database.dto.music.MusicDto
+import database.dto.user.UserDto
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.entities.User
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
+import net.dv8tion.jda.api.interactions.InteractionHook
+import net.dv8tion.jda.api.interactions.modals.ModalMapping
+import net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class EditIntroModalTest {
+
+    private lateinit var introHelper: IntroHelper
+    private lateinit var modal: EditIntroModal
+    private lateinit var ctx: ModalContext
+    private lateinit var event: ModalInteractionEvent
+    private lateinit var hook: InteractionHook
+    private val replies = mutableListOf<String>()
+
+    private val userDto = UserDto(discordId = 42L, guildId = 100L)
+
+    private fun intro(
+        index: Int = 1,
+        name: String = "Original",
+        volume: Int = 90,
+        blob: ByteArray? = "https://www.youtube.com/watch?v=abc".toByteArray(),
+        start: Int? = null,
+        end: Int? = null,
+    ) = MusicDto(userDto, index, name, volume, blob, start, end)
+
+    @BeforeEach
+    fun setUp() {
+        introHelper = mockk(relaxed = true)
+        modal = EditIntroModal(introHelper)
+        hook = mockk(relaxed = true)
+        event = mockk(relaxed = true)
+
+        val guild = mockk<Guild>(relaxed = true) { every { idLong } returns 100L }
+        val user = mockk<User> { every { idLong } returns 42L }
+        every { event.user } returns user
+        every { event.hook } returns hook
+        every { event.modalId } returns EditIntroModal.customId("100_42_1")
+
+        ctx = mockk(relaxed = true) {
+            every { this@mockk.event } returns this@EditIntroModalTest.event
+            every { this@mockk.guild } returns guild
+        }
+
+        replies.clear()
+        val send = mockk<WebhookMessageCreateAction<Message>>(relaxed = true)
+        every { hook.sendMessage(capture(replies)) } returns send
+        every { send.setEphemeral(true) } returns send
+        every { send.queue() } just Runs
+
+        // By default the clip passes validation; individual tests override.
+        every { introHelper.validateClipAgainstSource(any(), any(), any(), any()) } answers {
+            lastArg<(String?) -> Unit>().invoke(null)
+        }
+    }
+
+    private fun field(id: String, value: String?) {
+        every { event.getValue(id) } returns value?.let { v -> mockk<ModalMapping> { every { asString } returns v } }
+    }
+
+    private fun fields(name: String? = null, volume: String? = null, start: String? = null, end: String? = null) {
+        field(EditIntroModal.FIELD_NAME, name)
+        field(EditIntroModal.FIELD_VOLUME, volume)
+        field(EditIntroModal.FIELD_START, start)
+        field(EditIntroModal.FIELD_END, end)
+    }
+
+    // --- buildFor -----------------------------------------------------------
+
+    @Test
+    fun `the form is pre-filled from the intro`() {
+        val built = EditIntroModal.buildFor(intro(name = "My intro", volume = 55, start = 3_000, end = 9_000))
+
+        assertEquals(EditIntroModal.customId("100_42_1"), built.id)
+        assertEquals(4, built.components.size)
+    }
+
+    @Test
+    fun `an unclipped intro opens with empty clip fields`() {
+        // Nothing to assert beyond "it builds" — JDA rejects a null setValue,
+        // which is exactly the regression this guards.
+        val built = EditIntroModal.buildFor(intro())
+        assertEquals(4, built.components.size)
+    }
+
+    // --- handle -------------------------------------------------------------
+
+    @Test
+    fun `submitting new values updates the intro`() {
+        val existing = intro(name = "Original", volume = 90)
+        every { introHelper.findIntroById("100_42_1") } returns existing
+        fields(name = "Renamed", volume = "40", start = "0:03", end = "0:09")
+
+        modal.handle(ctx, 0)
+
+        val saved = slot<MusicDto>()
+        verify { introHelper.updateIntro(capture(saved)) }
+        assertEquals("Renamed", saved.captured.fileName)
+        assertEquals(40, saved.captured.introVolume)
+        assertEquals(3_000, saved.captured.startMs)
+        assertEquals(9_000, saved.captured.endMs)
+        assertTrue(replies.single().contains("Renamed"))
+    }
+
+    @Test
+    fun `blank clip fields clear an existing clip`() {
+        val existing = intro(start = 3_000, end = 9_000)
+        every { introHelper.findIntroById("100_42_1") } returns existing
+        fields(name = "Original", volume = "90", start = "", end = "")
+
+        modal.handle(ctx, 0)
+
+        val saved = slot<MusicDto>()
+        verify { introHelper.updateIntro(capture(saved)) }
+        assertNull(saved.captured.startMs)
+        assertNull(saved.captured.endMs)
+    }
+
+    @Test
+    fun `an untouched volume field keeps the current volume`() {
+        val existing = intro(volume = 33)
+        every { introHelper.findIntroById("100_42_1") } returns existing
+        fields(name = "Original", volume = "")
+
+        modal.handle(ctx, 0)
+
+        val saved = slot<MusicDto>()
+        verify { introHelper.updateIntro(capture(saved)) }
+        assertEquals(33, saved.captured.introVolume)
+    }
+
+    @Test
+    fun `out of range volume is rejected without saving`() {
+        every { introHelper.findIntroById("100_42_1") } returns intro()
+        fields(volume = "150")
+
+        modal.handle(ctx, 0)
+
+        verify(exactly = 0) { introHelper.updateIntro(any()) }
+        assertTrue(replies.single().contains("between 0 and 100"))
+    }
+
+    @Test
+    fun `unparseable timestamps are rejected without saving`() {
+        every { introHelper.findIntroById("100_42_1") } returns intro()
+        fields(start = "banana")
+
+        modal.handle(ctx, 0)
+
+        verify(exactly = 0) { introHelper.updateIntro(any()) }
+        assertTrue(replies.single().startsWith("Clip start"))
+    }
+
+    @Test
+    fun `an empty name is rejected without saving`() {
+        every { introHelper.findIntroById("100_42_1") } returns intro()
+        fields(name = "   ")
+
+        modal.handle(ctx, 0)
+
+        verify(exactly = 0) { introHelper.updateIntro(any()) }
+        assertEquals("Name cannot be empty.", replies.single())
+    }
+
+    @Test
+    fun `an over-long name is rejected without saving`() {
+        every { introHelper.findIntroById("100_42_1") } returns intro()
+        fields(name = "n".repeat(EditIntroModal.MAX_NAME_LENGTH + 1))
+
+        modal.handle(ctx, 0)
+
+        verify(exactly = 0) { introHelper.updateIntro(any()) }
+        assertTrue(replies.single().contains("too long"))
+    }
+
+    @Test
+    fun `a clip the shared rules reject is not saved`() {
+        every { introHelper.findIntroById("100_42_1") } returns intro()
+        fields(start = "0:00", end = "1:00")
+        every { introHelper.validateClipAgainstSource(any(), any(), any(), any()) } answers {
+            lastArg<(String?) -> Unit>().invoke("Clip is too long (60s). Max allowed is 15s.")
+        }
+
+        modal.handle(ctx, 0)
+
+        verify(exactly = 0) { introHelper.updateIntro(any()) }
+        assertEquals("Clip is too long (60s). Max allowed is 15s.", replies.single())
+    }
+
+    @Test
+    fun `an intro belonging to another user is refused`() {
+        every { event.modalId } returns EditIntroModal.customId("100_999_1")
+
+        modal.handle(ctx, 0)
+
+        verify(exactly = 0) { introHelper.updateIntro(any()) }
+        assertEquals("That intro isn't yours to edit.", replies.single())
+    }
+
+    @Test
+    fun `a modal id with no intro reference is refused`() {
+        every { event.modalId } returns EditIntroModal.MODAL_NAME
+
+        modal.handle(ctx, 0)
+
+        verify(exactly = 0) { introHelper.updateIntro(any()) }
+        assertTrue(replies.single().contains("run `/editintro` again"))
+    }
+
+    @Test
+    fun `an intro deleted between opening and submitting is reported`() {
+        every { introHelper.findIntroById("100_42_1") } returns null
+        fields()
+
+        modal.handle(ctx, 0)
+
+        verify(exactly = 0) { introHelper.updateIntro(any()) }
+        assertTrue(replies.single().contains("may have been deleted"))
+    }
+
+    @Test
+    fun `an uploaded file has no source duration to validate against`() {
+        every { introHelper.findIntroById("100_42_1") } returns intro(blob = byteArrayOf(1, 2, 3))
+        fields(start = "0:01", end = "0:05")
+
+        modal.handle(ctx, 0)
+
+        verify { introHelper.validateClipAgainstSource(null, 1_000, 5_000, any()) }
+    }
+
+    @Test
+    fun `a url intro validates against its source`() {
+        every { introHelper.findIntroById("100_42_1") } returns intro()
+        fields(start = "0:01", end = "0:05")
+
+        modal.handle(ctx, 0)
+
+        verify { introHelper.validateClipAgainstSource("https://www.youtube.com/watch?v=abc", 1_000, 5_000, any()) }
+    }
+}

--- a/web/src/main/kotlin/web/service/IntroWebService.kt
+++ b/web/src/main/kotlin/web/service/IntroWebService.kt
@@ -2,6 +2,8 @@ package web.service
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.github.benmanes.caffeine.cache.Caffeine
+import common.intro.IntroClip
+import common.intro.IntroSlots
 import common.logging.DiscordLogger
 import database.dto.music.MusicDto
 import database.dto.user.UserDto
@@ -25,9 +27,12 @@ class IntroWebService(
 ) {
     companion object {
         const val MAX_FILE_SIZE = 550 * 1024
-        const val MAX_INTRO_COUNT = 3
-        const val MAX_INTRO_DURATION_SECONDS = 15
-        const val MAX_CLIP_DURATION_MS = MAX_INTRO_DURATION_SECONDS * 1000
+
+        // Canonical values live in common.intro so the web form, the Discord
+        // slash commands and intros.js can't drift on the caps.
+        const val MAX_INTRO_COUNT = IntroSlots.MAX_INTRO_COUNT
+        const val MAX_INTRO_DURATION_SECONDS = IntroClip.MAX_DURATION_SECONDS
+        const val MAX_CLIP_DURATION_MS = IntroClip.MAX_CLIP_DURATION_MS
         private val objectMapper = ObjectMapper()
         private val logger = DiscordLogger(IntroWebService::class.java)
         // Real ids are 11 chars of this alphabet; the upper bound leaves
@@ -319,40 +324,13 @@ class IntroWebService(
     }
 
     /**
-     * Validates a clip range against the source duration.
-     *
-     * - Both null: no clipping. Only reject when source is known and longer than the 15s cap.
-     * - start/end present: start must be < end; clip span (end - start) must be <= MAX_CLIP_DURATION_MS.
-     * - When [sourceDurationMs] is known, end must be <= sourceDurationMs.
-     *
-     * Returns an error message or null if the clip is valid.
+     * Validates a clip range against the source duration. Delegates to
+     * [IntroClip.validate] — the same rules the Discord `/setintro` and
+     * `/editintro` flows apply — and is kept here so existing callers and
+     * tests keep the service-level entry point.
      */
-    fun validateClip(startMs: Int?, endMs: Int?, sourceDurationMs: Int?): String? {
-        if (startMs == null && endMs == null) {
-            if (sourceDurationMs != null && sourceDurationMs > MAX_CLIP_DURATION_MS) {
-                val seconds = sourceDurationMs / 1000
-                return "Video is too long (${seconds}s). Max allowed is ${MAX_INTRO_DURATION_SECONDS}s — set a start/end clip to use a longer source."
-            }
-            return null
-        }
-        val start = startMs ?: 0
-        if (start < 0) return "Start time cannot be negative."
-        if (endMs != null) {
-            if (endMs <= start) return "End time must be greater than start time."
-            if (sourceDurationMs != null && endMs > sourceDurationMs) {
-                return "End time exceeds the source duration."
-            }
-            if (endMs - start > MAX_CLIP_DURATION_MS) {
-                return "Clip is too long (${(endMs - start) / 1000}s). Max allowed is ${MAX_INTRO_DURATION_SECONDS}s."
-            }
-        } else if (sourceDurationMs != null) {
-            // Only start was provided; the clip runs from start to end of source.
-            if (sourceDurationMs - start > MAX_CLIP_DURATION_MS) {
-                return "Clip is too long (${(sourceDurationMs - start) / 1000}s). Max allowed is ${MAX_INTRO_DURATION_SECONDS}s."
-            }
-        }
-        return null
-    }
+    fun validateClip(startMs: Int?, endMs: Int?, sourceDurationMs: Int?): String? =
+        IntroClip.validate(startMs, endMs, sourceDurationMs)
 
     // Picks the smallest unused slot in 1..MAX_INTRO_COUNT. Walking the range
     // (rather than `size + 1`) is what lets "Add" work after a delete left a
@@ -600,7 +578,14 @@ data class IntroViewModel(
     val videoId: String? = null,
     val startMs: Int? = null,
     val endMs: Int? = null
-)
+) {
+    /**
+     * What the row's clip badge shows — the actual range (`0:03 – 0:12`)
+     * rather than a generic "clip set", so the list is scannable without
+     * opening each editor.
+     */
+    val clipLabel: String get() = IntroClip.describe(startMs, endMs)
+}
 
 data class GuildInfo(
     val id: String,

--- a/web/src/main/resources/static/css/intros.css
+++ b/web/src/main/resources/static/css/intros.css
@@ -277,6 +277,12 @@
 }
 .clip-badge:hover { border-color: var(--accent); color: var(--accent); }
 .clip-badge-label { font-size: 0.8rem; }
+/* The badge shows the real range ("0:03 – 0:12"), so keep it on one line
+   and line the digits up the way the trim readout above does. */
+.clip-badge-range {
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+}
 
 /* Row-level clip editor popover */
 .clip-editor-popover {

--- a/web/src/main/resources/static/js/intros.js
+++ b/web/src/main/resources/static/js/intros.js
@@ -45,6 +45,15 @@ function formatMs(ms) {
     return m + ':' + secStr;
 }
 
+// Mirrors IntroClip.describe (Kotlin) so the badge a row shows after an
+// inline save matches what a full page render would produce.
+function describeClip(startMs, endMs) {
+    if (startMs == null && endMs == null) return 'full track';
+    if (startMs != null && endMs != null) return formatMs(startMs) + ' – ' + formatMs(endMs);
+    if (startMs != null) return 'from ' + formatMs(startMs);
+    return 'up to ' + formatMs(endMs);
+}
+
 // Mirrors IntroWebService.validateClip. Returns an error string, or '' if valid.
 function validateClipMs(startMs, endMs, sourceDurationMs, maxClipMs) {
     const cap = maxClipMs || DEFAULT_MAX_CLIP_SECONDS * 1000;
@@ -1013,9 +1022,7 @@ function initIntroPage() {
                     tr.dataset.startMs = startMs == null ? '' : String(startMs);
                     tr.dataset.endMs = endMs == null ? '' : String(endMs);
                     const rangeLabel = badgeBtn.querySelector('.clip-badge-range');
-                    if (rangeLabel) {
-                        rangeLabel.textContent = (startMs == null && endMs == null) ? 'full track' : 'clip set';
-                    }
+                    if (rangeLabel) rangeLabel.textContent = describeClip(startMs, endMs);
                     window.TobyToasts.show('Clip updated.', { type: 'success', duration: 2000 });
                     closeOpenRowEditor();
                 },
@@ -1243,6 +1250,7 @@ if (typeof module !== 'undefined') {
         closeClipPreviewRow,
         parseTimeInput,
         formatMs,
+        describeClip,
         validateClipMs,
         ensureYtApi,
         createTrimBar,

--- a/web/src/main/resources/templates/intros.html
+++ b/web/src/main/resources/templates/intros.html
@@ -97,8 +97,7 @@
                                     th:aria-label="'Edit clip for ' + ${intro.fileName}"
                                     title="Edit clip timestamps">
                                 <span class="clip-badge-label">⏱</span>
-                                <span class="clip-badge-range"
-                                      th:text="${intro.startMs != null or intro.endMs != null} ? 'clip set' : 'full track'">clip</span>
+                                <span class="clip-badge-range" th:text="${intro.clipLabel}">full track</span>
                             </button>
                         </td>
                         <td data-label="Volume">

--- a/web/src/test/js/intros.test.js
+++ b/web/src/test/js/intros.test.js
@@ -20,6 +20,7 @@ const {
     closeClipPreviewRow,
     parseTimeInput,
     formatMs,
+    describeClip,
     validateClipMs,
     ensureYtApi,
     createTrimBar,
@@ -244,6 +245,28 @@ describe('formatMs', () => {
     test('returns empty string for invalid input', () => {
         expect(formatMs(null)).toBe('');
         expect(formatMs(-1)).toBe('');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// describeClip
+// ---------------------------------------------------------------------------
+
+// Mirrors IntroClipTest.`describe covers every combination of bounds` on the
+// Kotlin side — the row badge is rendered by Thymeleaf on load and by this
+// helper after an inline save, so the two must agree.
+describe('describeClip', () => {
+    test('an unclipped intro reads as the full track', () => {
+        expect(describeClip(null, null)).toBe('full track');
+    });
+
+    test('both bounds render as a range', () => {
+        expect(describeClip(3000, 12000)).toBe('0:03 – 0:12');
+    });
+
+    test('a single bound renders open-ended', () => {
+        expect(describeClip(3000, null)).toBe('from 0:03');
+        expect(describeClip(null, 12000)).toBe('up to 0:12');
     });
 });
 

--- a/web/src/test/kotlin/web/service/IntroWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/IntroWebServiceTest.kt
@@ -228,6 +228,25 @@ class IntroWebServiceTest {
         assertEquals("myclip.mp3", view.fileName)
     }
 
+    @Test
+    fun `clipLabel shows the actual range rather than a generic marker`() {
+        val dto = intro(1, blob = byteArrayOf(1, 2, 3), fileName = "myclip.mp3").apply {
+            startMs = 3_000
+            endMs = 12_000
+        }
+        every { userService.getUserById(discordId, guildId) } returns user(dto)
+
+        assertEquals("0:03 – 0:12", service.getUserIntros(discordId, guildId).first().clipLabel)
+    }
+
+    @Test
+    fun `clipLabel falls back to full track when unclipped`() {
+        val dto = intro(1, blob = byteArrayOf(1, 2, 3), fileName = "myclip.mp3")
+        every { userService.getUserById(discordId, guildId) } returns user(dto)
+
+        assertEquals("full track", service.getUserIntros(discordId, guildId).first().clipLabel)
+    }
+
     // --- setIntroByUrl ---------------------------------------------------
 
     @Test

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -1,5 +1,22 @@
 **Q**: How do I change the intro song?  
-**A**: Use the `/setintro [YouTube URL] [volume]` command.
+**A**: Use `/setintro link` with a YouTube URL, or `/setintro attachment` with an MP3. Both take an optional `volume`.
 
 **Q**: What if I forget to set a volume?  
 **A**: The bot will default to 90% volume if none is specified.
+
+**Q**: How do I see what I've already got set?  
+**A**: `/listintros` shows every slot with its volume, clip range and source, plus a link through to the web dashboard.
+
+**Q**: The video I want is longer than 15 seconds — can I still use it?  
+**A**: Yes. Pass `start` and `end` to `/setintro` (e.g. `start:1:04 end:1:16`) and the bot plays just that stretch.
+Both accept `mm:ss` or a raw number of seconds. The clip itself still has to fit inside the 15-second limit.
+
+**Q**: Can I rename an intro or trim it after the fact?  
+**A**: `/editintro`, then pick the intro — a form opens with its name, volume and clip bounds pre-filled.
+Clearing a clip field removes that bound, so blanking both restores the full track.
+
+**Q**: I deleted the wrong intro.  
+**A**: The `/deleteintro` confirmation has an **Undo** button, good for 10 minutes.
+
+**Q**: Where's the web version?  
+**A**: <https://www.toby-bot.co.uk/intro/guilds> — same intros, with drag-to-reorder and a draggable trim bar for picking clips.

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -18,5 +18,15 @@ Clearing a clip field removes that bound, so blanking both restores the full tra
 **Q**: I deleted the wrong intro.  
 **A**: The `/deleteintro` confirmation has an **Undo** button, good for 10 minutes.
 
+**Q**: Why didn't my intro play when I rejoined?  
+**A**: An intro won't replay within 60 seconds of the last one, so channel-hopping and reconnects don't
+retrigger it. Wait a minute, or play it on demand with `/play intro`.
+
+**Q**: With several intros set, why do I keep hearing the same one?  
+**A**: You shouldn't any more — the pick now skips whichever intro played last, so consecutive joins always differ.
+
+**Q**: TobyBot keeps DMing me to set an intro.  
+**A**: It'll only nudge you once a day per server now. To silence it entirely, run `/notify set INTRO_PROMPT off`.
+
 **Q**: Where's the web version?  
 **A**: <https://www.toby-bot.co.uk/intro/guilds> — same intros, with drag-to-reorder and a draggable trim bar for picking clips.

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -34,7 +34,10 @@
 - **Volume Control**: Optionally set a volume between 0 and 100 when configuring your intro.
 - **Clips**: `start`/`end` bounds (`mm:ss` or raw seconds) pick a stretch out of a longer source, so a 15-second
   limit doesn't mean a 15-second video. The same rules apply on Discord and on the web — see `common.intro.IntroClip`.
-- **Slots**: up to three intros per server; TobyBot picks one at random on join. `/listintros` shows them all.
+- **Slots**: up to three intros per server; TobyBot picks one at random on join, never repeating the one
+  it played last. `/listintros` shows them all.
+- **Replay cooldown**: an intro won't retrigger within 60 seconds, so channel-hopping and reconnects don't
+  replay it (or pay out the intro-play credit and XP again).
 - **Editing**: `/editintro` opens a form for the name, volume and clip bounds of a chosen intro;
   `/deleteintro` removes one and offers a 10-minute Undo.
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -32,6 +32,11 @@
 - **URL Support**: Provide a YouTube URL or another music link.
 - **File Upload**: Upload a music file directly into the Discord chat.
 - **Volume Control**: Optionally set a volume between 0 and 100 when configuring your intro.
+- **Clips**: `start`/`end` bounds (`mm:ss` or raw seconds) pick a stretch out of a longer source, so a 15-second
+  limit doesn't mean a 15-second video. The same rules apply on Discord and on the web — see `common.intro.IntroClip`.
+- **Slots**: up to three intros per server; TobyBot picks one at random on join. `/listintros` shows them all.
+- **Editing**: `/editintro` opens a form for the name, volume and clip bounds of a chosen intro;
+  `/deleteintro` removes one and offers a 10-minute Undo.
 
 #### **EventWaiter Pattern**
 


### PR DESCRIPTION
The intro page on the web can rename, re-volume, clip, reorder and undo-delete an intro. Discord could set one and change its volume — via a flow that asked you to type a bare number into the channel and raced a 10-second `EventWaiter` against you. This closes most of that gap, and moves the rules the two surfaces are meant to share into one place.

## Shared rules

New `common.intro` package, depended on by both `web` and `discord-bot`:

- **`IntroClip`** owns the 15-second cap, the `mm:ss` timestamp grammar and the validation messages. `IntroWebService.validateClip` delegates to it, `intros.js` mirrors it under matching tests, and the slash commands get clip support for the first time.
- **`IntroSlots`** owns the three-slot cap, previously declared independently in `SetIntroCommand.LIMIT` and `IntroWebService.MAX_INTRO_COUNT`.

## Discord

- **`/setintro link|attachment` take optional `start`/`end`.** A source longer than the cap used to be rejected outright; it can now be clipped instead. The player has always honoured `MusicDto.startMs`/`endMs` (`MusicPlayerHelper.playUserIntro`) and the web form has always been able to set them — the slash command was the only place that couldn't express it.
- **`/editintro` opens a modal** — name, volume, clip start and clip end, all pre-filled, no timer, nothing posted to the channel. Blank clip fields clear that bound, which is how a clipped intro goes back to the full track.
- **`/listintros` (new)** — read-only embed of every slot with its volume, clip range and source type, plus a link button through to the web page. Previously the only way to see your intros was to start `/editintro` or `/deleteintro` and read the prompt before backing out.
- **`/deleteintro` confirmations carry an Undo button**, backed by a 10-minute in-memory snapshot — the same window the web has had.
- **Select menus are built once in `IntroPresenter`**: ordered by slot, described with volume and clip range, and clamped to Discord's 100-character option limit. A YouTube title longer than that used to make `/editintro` and `/deleteintro` throw instead of opening.

## Fix

`IntroHelper.findUserById(discordId, guildId)` forwarded the pair reversed to `UserDtoHelper.calculateUserDto(discordId, guildId)`. Its one caller is the super-user branch of `/setintro users:@someone`, which therefore resolved — and lazily created — a user row keyed `(guildId, discordId)`, whose intros the normal lookup could never find again.

## Behaviour note

The clip check reads the source duration once and lets a lookup failure through, where the old `validateIntroLength` failed closed and rejected everything until the YouTube Data API recovered. That matches the web, which has always treated an unavailable preview as "duration unknown".

## Web

The row clip badge shows the real range (`0:03 – 0:12`) rather than a generic "clip set", both on first render and after an inline save.

## Testing

`:common:test`, `:web:test` and `:discord-bot:test` all pass locally, along with `npm test` in `web/` (795 JS tests). New coverage: `IntroClipTest`, `IntroPresenterTest`, `IntroUndoStoreTest`, `EditIntroModalTest`, `ListIntrosCommandTest`, `UndoDeleteIntroButtonTest`, plus `describeClip` cases in `intros.test.js` and `clipLabel` cases in `IntroWebServiceTest`.

`:application:test` couldn't run in this environment — its Spring contexts need a Postgres testcontainer and Docker isn't available here. The lists those integration tests assert against have been updated for the new command and button (`CommandManagerTest`, `ButtonManagerTest`), so CI should cover them.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UzSiANtbGDsaSbCRDkqQWc)_