### PR TITLE
Stop a new intro overwriting an existing one after a delete

### DIFF
--- a/common/src/main/kotlin/common/intro/IntroSlots.kt
+++ b/common/src/main/kotlin/common/intro/IntroSlots.kt
@@ -1,12 +1,29 @@
 package common.intro
 
 /**
- * How many intros a user may hold per guild.
+ * How many intros a user may hold per guild, and which slot a new one takes.
  *
- * The number was previously declared three times — `SetIntroCommand.LIMIT`,
+ * The count was previously declared three times — `SetIntroCommand.LIMIT`,
  * `IntroWebService.MAX_INTRO_COUNT` and the `maxIntros` model attribute — with
  * nothing tying them together, so raising the cap meant remembering all three.
  */
 object IntroSlots {
     const val MAX_INTRO_COUNT = 3
+
+    /**
+     * The lowest slot in `1..MAX_INTRO_COUNT` not already taken, or null when
+     * every slot is full.
+     *
+     * Walking the range matters: a `size + 1` count is wrong the moment a
+     * delete leaves a gap. With intros in slots `[1, 3]`, `size + 1` picks 3,
+     * whose id (`guildId_discordId_3`) already exists — and
+     * `DefaultMusicFilePersistence.createNewMusicFile` turns an id collision
+     * into an update, silently overwriting the intro in slot 3 with the new
+     * one. Both the web form and the slash commands allocate through here so
+     * neither can reintroduce that.
+     */
+    fun nextFreeIndex(usedIndexes: Collection<Int?>): Int? {
+        val used = usedIndexes.filterNotNull().toSet()
+        return (1..MAX_INTRO_COUNT).firstOrNull { it !in used }
+    }
 }

--- a/common/src/test/kotlin/common/intro/IntroSlotsTest.kt
+++ b/common/src/test/kotlin/common/intro/IntroSlotsTest.kt
@@ -1,0 +1,54 @@
+package common.intro
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+/**
+ * The gap case is the whole point: `size + 1` picked an already-taken slot,
+ * and because `createNewMusicFile` turns an id collision into an update, the
+ * intro sitting in that slot was silently overwritten.
+ */
+class IntroSlotsTest {
+
+    @Test
+    fun `an empty set starts at slot one`() {
+        assertEquals(1, IntroSlots.nextFreeIndex(emptyList()))
+    }
+
+    @Test
+    fun `slots fill in order`() {
+        assertEquals(2, IntroSlots.nextFreeIndex(listOf(1)))
+        assertEquals(3, IntroSlots.nextFreeIndex(listOf(1, 2)))
+    }
+
+    @Test
+    fun `a gap left by a delete is reused instead of colliding`() {
+        // Deleting slot 2 of [1, 2, 3] leaves [1, 3]: size + 1 would say 3,
+        // which already exists.
+        assertEquals(2, IntroSlots.nextFreeIndex(listOf(1, 3)))
+        assertEquals(1, IntroSlots.nextFreeIndex(listOf(2, 3)))
+        assertEquals(1, IntroSlots.nextFreeIndex(listOf(3)))
+        assertEquals(2, IntroSlots.nextFreeIndex(listOf(3, 1)))
+    }
+
+    @Test
+    fun `a full set has no free slot`() {
+        assertNull(IntroSlots.nextFreeIndex(listOf(1, 2, 3)))
+        assertNull(IntroSlots.nextFreeIndex(listOf(3, 2, 1)))
+    }
+
+    @Test
+    fun `null indexes are ignored rather than blocking a slot`() {
+        assertEquals(1, IntroSlots.nextFreeIndex(listOf(null)))
+        assertEquals(2, IntroSlots.nextFreeIndex(listOf(1, null)))
+    }
+
+    @Test
+    fun `indexes outside the range never consume a slot`() {
+        // Defensive: a stray index 4 (the old allocator could produce one)
+        // shouldn't make 1..3 look full.
+        assertEquals(1, IntroSlots.nextFreeIndex(listOf(4, 5)))
+        assertEquals(2, IntroSlots.nextFreeIndex(listOf(1, 4)))
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/music/intro/DeleteIntroCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/music/intro/DeleteIntroCommand.kt
@@ -1,10 +1,14 @@
 package bot.toby.command.commands.music.intro
 
 import bot.toby.command.commands.music.MusicCommand
+import bot.toby.helpers.IntroHelper
 import bot.toby.helpers.MenuHelper.DELETE_INTRO
 import bot.toby.lavaplayer.PlayerManager
 import core.command.CommandContext
 import database.dto.user.UserDto
+import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.interactions.commands.build.OptionData
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 /**
@@ -13,7 +17,9 @@ import org.springframework.stereotype.Component
  * mis-click on the menu is recoverable, matching the web dashboard.
  */
 @Component
-class DeleteIntroCommand : MusicCommand {
+class DeleteIntroCommand @Autowired constructor(
+    private val introHelper: IntroHelper,
+) : MusicCommand {
 
     override val ephemeral: Boolean = true
 
@@ -27,9 +33,10 @@ class DeleteIntroCommand : MusicCommand {
         requestingUserDto: UserDto,
         deleteDelay: Int
     ) {
+        val target = resolveIntroTarget(ctx.event, requestingUserDto, introHelper, deleteDelay) ?: return
         sendIntroSelection(
             event = ctx.event,
-            requestingUserDto = requestingUserDto,
+            target = target,
             menuId = DELETE_INTRO,
             placeholder = "Select an intro to delete",
             emptyMessage = "You have no intros to delete.",
@@ -41,4 +48,9 @@ class DeleteIntroCommand : MusicCommand {
 
     override val description: String
         get() = "Delete one of your intros."
+
+    override val optionData: List<OptionData>
+        get() = listOf(
+            OptionData(OptionType.USER, INTRO_USER_OPTION, "Whose intro to manage (super-users only)", false)
+        )
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/music/intro/EditIntroCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/music/intro/EditIntroCommand.kt
@@ -1,10 +1,14 @@
 package bot.toby.command.commands.music.intro
 
 import bot.toby.command.commands.music.MusicCommand
+import bot.toby.helpers.IntroHelper
 import bot.toby.helpers.MenuHelper.EDIT_INTRO
 import bot.toby.lavaplayer.PlayerManager
 import core.command.CommandContext
 import database.dto.user.UserDto
+import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.interactions.commands.build.OptionData
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 /**
@@ -14,7 +18,9 @@ import org.springframework.stereotype.Component
  * into the channel within ten seconds of selecting.
  */
 @Component
-class EditIntroCommand : MusicCommand {
+class EditIntroCommand @Autowired constructor(
+    private val introHelper: IntroHelper,
+) : MusicCommand {
 
     override val ephemeral: Boolean = true
 
@@ -28,9 +34,10 @@ class EditIntroCommand : MusicCommand {
         requestingUserDto: UserDto,
         deleteDelay: Int
     ) {
+        val target = resolveIntroTarget(ctx.event, requestingUserDto, introHelper, deleteDelay) ?: return
         sendIntroSelection(
             event = ctx.event,
-            requestingUserDto = requestingUserDto,
+            target = target,
             menuId = EDIT_INTRO,
             placeholder = "Select an intro to edit",
             emptyMessage = "You have no intros to edit. Add one with `/setintro`.",

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/music/intro/IntroSelectionSupport.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/music/intro/IntroSelectionSupport.kt
@@ -1,5 +1,7 @@
 package bot.toby.command.commands.music.intro
 
+import bot.toby.command.commands.music.MusicCommand
+import bot.toby.helpers.IntroHelper
 import bot.toby.helpers.MenuHelper.SET_INTRO
 import bot.toby.intro.IntroPresenter
 import common.intro.IntroSlots
@@ -21,18 +23,58 @@ import net.dv8tion.jda.api.interactions.InteractionHook
  */
 internal fun sendIntroSelection(
     event: SlashCommandInteractionEvent,
-    requestingUserDto: UserDto,
+    target: IntroTarget,
     menuId: String,
     placeholder: String,
     emptyMessage: String,
 ) {
-    val intros = requestingUserDto.musicDtos
+    val intros = target.userDto.musicDtos
     if (intros.isEmpty()) {
         event.hook.sendMessage(emptyMessage).setEphemeral(true).queue()
         return
     }
 
-    sendIntroMenu(event.hook, event.member, intros, menuId, placeholder, null)
+    sendIntroMenu(event.hook, target.member, intros, menuId, placeholder, null)
+}
+
+/** Whose intros a command is acting on. */
+internal data class IntroTarget(val member: Member, val userDto: UserDto)
+
+/** Option name shared by the intro commands that can act on someone else. */
+internal const val INTRO_USER_OPTION = "user"
+
+/**
+ * Resolves whose intros to act on. Defaults to the caller; a `user:` option
+ * targets someone else, which only super-users may do — the same rule
+ * `/setintro` applies to setting them.
+ *
+ * @return the target, or null when the caller was rejected (the refusal has
+ *         already been sent) or the command ran outside a guild.
+ */
+internal fun MusicCommand.resolveIntroTarget(
+    event: SlashCommandInteractionEvent,
+    requestingUserDto: UserDto,
+    introHelper: IntroHelper,
+    deleteDelay: Int,
+): IntroTarget? {
+    val requested = event.getOption(INTRO_USER_OPTION)?.asMember
+    if (requested != null && requested.idLong != event.user.idLong && !requestingUserDto.superUser) {
+        sendErrorMessage(event, deleteDelay)
+        return null
+    }
+
+    val member = requested ?: event.member ?: run {
+        event.hook.sendMessage("Intros are per-server — run this inside the server you want to manage.")
+            .setEphemeral(true).queue()
+        return null
+    }
+
+    val userDto = if (member.idLong == event.user.idLong) {
+        requestingUserDto
+    } else {
+        introHelper.findUserById(member.idLong, member.guild.idLong)
+    }
+    return IntroTarget(member, userDto)
 }
 
 /**

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/music/intro/ListIntrosCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/music/intro/ListIntrosCommand.kt
@@ -8,7 +8,6 @@ import common.intro.IntroSlots
 import core.command.CommandContext
 import database.dto.user.UserDto
 import net.dv8tion.jda.api.components.actionrow.ActionRow
-import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.interactions.commands.build.OptionData
 import org.springframework.beans.factory.annotation.Autowired
@@ -47,27 +46,11 @@ class ListIntrosCommand @Autowired constructor(
         val event = ctx.event
         logger.setGuildAndMemberContext(ctx.guild, ctx.member)
 
-        val requestedMember: Member? = event.getOption(USER)?.asMember
-        if (requestedMember != null && requestedMember.idLong != event.user.idLong && !requestingUserDto.superUser) {
-            sendErrorMessage(event, deleteDelay)
-            return
-        }
+        val target = resolveIntroTarget(event, requestingUserDto, introHelper, deleteDelay) ?: return
 
-        val targetMember = requestedMember ?: event.member ?: run {
-            event.hook.sendMessage("Intros are per-server — run this inside the server you want to see.")
-                .setEphemeral(true).queue()
-            return
-        }
-
-        val targetDto = if (targetMember.idLong == event.user.idLong) {
-            requestingUserDto
-        } else {
-            introHelper.findUserById(targetMember.idLong, targetMember.guild.idLong)
-        }
-
-        val embed = IntroPresenter.listEmbed(targetMember, targetDto.musicDtos, IntroSlots.MAX_INTRO_COUNT)
+        val embed = IntroPresenter.listEmbed(target.member, target.userDto.musicDtos, IntroSlots.MAX_INTRO_COUNT)
         event.hook.sendMessageEmbeds(embed)
-            .addComponents(ActionRow.of(IntroPresenter.webDashboardButton(targetMember.guild.idLong)))
+            .addComponents(ActionRow.of(IntroPresenter.webDashboardButton(target.member.guild.idLong)))
             .setEphemeral(true)
             .queue()
     }
@@ -78,10 +61,6 @@ class ListIntrosCommand @Autowired constructor(
 
     override val optionData: List<OptionData>
         get() = listOf(
-            OptionData(OptionType.USER, USER, "Whose intros to show (super-users only)", false)
+            OptionData(OptionType.USER, INTRO_USER_OPTION, "Whose intros to show (super-users only)", false)
         )
-
-    companion object {
-        private const val USER = "user"
-    }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/music/intro/SetIntroCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/music/intro/SetIntroCommand.kt
@@ -14,6 +14,7 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.interactions.InteractionHook
 import net.dv8tion.jda.api.interactions.commands.OptionMapping
 import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.interactions.commands.build.OptionData
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
@@ -195,7 +196,10 @@ class SetIntroCommand @Autowired constructor(
         get() = listOf(
             SubcommandData(LINK, "Set intro via YouTube link")
                 .addOption(OptionType.STRING, LINK, "Link to set as your discord intro", true)
-                .addOption(OptionType.INTEGER, VOLUME, "Volume to set your intro to")
+                .addOptions(
+                    OptionData(OptionType.INTEGER, VOLUME, "Volume to set your intro to")
+                        .setRequiredRange(MIN_VOLUME.toLong(), MAX_VOLUME.toLong())
+                )
                 .addOption(OptionType.STRING, START, "Clip start, e.g. 0:12 — lets you use a longer video")
                 .addOption(
                     OptionType.STRING, END,
@@ -204,7 +208,10 @@ class SetIntroCommand @Autowired constructor(
                 .addOption(OptionType.MENTIONABLE, USERS, "User whose intro to change"),
             SubcommandData(ATTACHMENT, "Set intro via file upload")
                 .addOption(OptionType.ATTACHMENT, ATTACHMENT, "Attachment (file) to set as your discord intro", true)
-                .addOption(OptionType.INTEGER, VOLUME, "Volume to set your intro to")
+                .addOptions(
+                    OptionData(OptionType.INTEGER, VOLUME, "Volume to set your intro to")
+                        .setRequiredRange(MIN_VOLUME.toLong(), MAX_VOLUME.toLong())
+                )
                 .addOption(OptionType.STRING, START, "Clip start, e.g. 0:12")
                 .addOption(
                     OptionType.STRING, END,
@@ -219,6 +226,11 @@ class SetIntroCommand @Autowired constructor(
         private const val LINK = "link"
         private const val ATTACHMENT = "attachment"
         private const val START = "start"
+
+        // Declared on the option so Discord rejects an out-of-range value in
+        // the client, rather than the bot silently coercing it after the fact.
+        private const val MIN_VOLUME = 1
+        private const val MAX_VOLUME = 100
         private const val END = "end"
         private val LIMIT = IntroSlots.MAX_INTRO_COUNT
     }

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/IntroHelper.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/IntroHelper.kt
@@ -3,8 +3,10 @@ package bot.toby.helpers
 import bot.toby.handler.EventWaiter
 import bot.toby.intro.IntroMediaLoader
 import bot.toby.intro.IntroNotificationService
+import bot.toby.intro.IntroOwnership
 import bot.toby.intro.IntroValidationService
 import common.intro.IntroClip
+import common.intro.IntroSlots
 import common.logging.DiscordLogger
 import core.command.Command.Companion.invokeDeleteOnMessageResponse
 import core.command.Command.Companion.replyAndDelete
@@ -195,6 +197,17 @@ class IntroHelper(
 
     fun findIntroById(musicFileId: String) = musicFileService.getMusicFileById(musicFileId)
 
+    /**
+     * Whether [actorDiscordId] may edit or delete the intro [introId] in this
+     * guild: their own always, anyone's if they're a super-user.
+     *
+     * The super-user lookup only runs when the intro isn't theirs, so the
+     * ordinary path stays a string comparison.
+     */
+    fun canManageIntro(introId: String?, guildId: Long, actorDiscordId: Long): Boolean =
+        IntroOwnership.ownedBy(introId, guildId, actorDiscordId) ||
+            findUserById(actorDiscordId, guildId).superUser
+
     fun createIntro(musicDto: MusicDto) = musicFileService.createNewMusicFile(musicDto)
 
     fun updateIntro(musicDto: MusicDto) = musicFileService.updateMusicFile(musicDto)
@@ -221,10 +234,8 @@ class IntroHelper(
         val fileContents = mediaLoader.readContents(inputStream)
             ?: return event.hook.replyEphemeralAndDelete("Unable to read file '$filename'", deleteDelay)
 
-        val index = selectedMusicDto?.index ?: userDtoHelper.calculateUserDto(
-            targetDto.discordId,
-            targetDto.guildId
-        ).musicDtos.size.plus(1)
+        val index = selectedMusicDto?.index ?: allocateSlot(targetDto)
+            ?: return rejectIntroForFullSlots(event, deleteDelay)
         val musicDto = selectedMusicDto?.apply {
             this.musicBlob = fileContents
             this.musicBlobHash = computeHash(fileContents)
@@ -238,7 +249,7 @@ class IntroHelper(
         if (selectedMusicDto == null) {
             musicFileService.createNewMusicFile(musicDto)
                 ?.let { sendSuccessMessage(event, userName, filename, introVolume, index, deleteDelay, startMs, endMs) }
-                ?: rejectIntroForDuplication(event, userName, filename, deleteDelay)
+                ?: rejectIntroForDuplication(event, userName, filename, deleteDelay, musicDto)
         } else {
             musicFileService.updateMusicFile(musicDto)
                 ?.let {
@@ -265,10 +276,8 @@ class IntroHelper(
         logger.setGuildAndMemberContext(event.guild, event.member)
         logger.info { "Persisting music URL for user '$memberName' on guild: ${event.guild?.idLong}" }
         val urlBytes = url.toByteArray()
-        val index = selectedMusicDto?.index ?: userDtoHelper.calculateUserDto(
-            targetDto.discordId,
-            targetDto.guildId
-        ).musicDtos.size.plus(1)
+        val index = selectedMusicDto?.index ?: allocateSlot(targetDto)
+            ?: return rejectIntroForFullSlots(event, deleteDelay)
         val musicDto = selectedMusicDto?.apply {
             this.id = "${targetDto.guildId}_${targetDto.discordId}_$index"
             this.userDto = targetDto
@@ -284,7 +293,7 @@ class IntroHelper(
             logger.info { "Creating new music file $musicDto" }
             musicFileService.createNewMusicFile(musicDto)
                 ?.let { sendSuccessMessage(event, memberName, filename, introVolume, index, deleteDelay, startMs, endMs) }
-                ?: rejectIntroForDuplication(event, memberName, filename, deleteDelay)
+                ?: rejectIntroForDuplication(event, memberName, filename, deleteDelay, musicDto)
         } else {
             logger.info { "Updating music file $musicDto" }
             musicFileService.updateMusicFile(musicDto)
@@ -295,6 +304,32 @@ class IntroHelper(
                 }
                 ?: rejectIntroForDuplication(event, memberName, filename, deleteDelay)
         }
+    }
+
+    /**
+     * The slot a brand-new intro should take, re-reading the user so the count
+     * reflects anything saved since the command started.
+     *
+     * This used to be `musicDtos.size + 1`, which is wrong whenever a delete
+     * has left a gap: with intros in slots [1, 3] it picks 3, and since
+     * `createNewMusicFile` turns an id collision into an update, the intro
+     * already in slot 3 was silently overwritten. `IntroSlots.nextFreeIndex`
+     * walks the range instead — the same allocator the web form uses.
+     *
+     * @return the free slot, or null when all [IntroSlots.MAX_INTRO_COUNT] are taken.
+     */
+    private fun allocateSlot(targetDto: database.dto.user.UserDto): Int? {
+        val existing = userDtoHelper.calculateUserDto(targetDto.discordId, targetDto.guildId).musicDtos
+        return IntroSlots.nextFreeIndex(existing.map { it.index })
+    }
+
+    private fun rejectIntroForFullSlots(event: IReplyCallback, deleteDelay: Int) {
+        logger.info { "All ${IntroSlots.MAX_INTRO_COUNT} intro slots are taken; nothing saved" }
+        event.hook.replyEphemeralAndDelete(
+            "You already have ${IntroSlots.MAX_INTRO_COUNT} intros — " +
+                "delete one with `/deleteintro`, or use `/setintro` to pick which to replace.",
+            deleteDelay,
+        )
     }
 
     /**
@@ -342,12 +377,18 @@ class IntroHelper(
         event: IReplyCallback,
         memberName: String,
         filename: String,
-        deleteDelay: Int
+        deleteDelay: Int,
+        attempted: MusicDto? = null
     ) {
         logger.setGuildAndMemberContext(event.guild, event.member)
         logger.info { "$memberName's intro song '$filename' was rejected for duplication" }
+        // Naming the slot turns "that's already there" into something the user
+        // can act on — it's the slot they'd pass to /setintro to replace.
+        val existingSlot = attempted?.let { musicFileService.isFileAlreadyUploaded(it)?.index }
+        val where = existingSlot?.let { " in slot #$it" }.orEmpty()
         event.hook.replyEphemeralAndDelete(
-            "$memberName's intro song '$filename' was rejected as it already exists as one of their intros for this server",
+            "$memberName's intro song '$filename' was rejected as it already exists$where " +
+                "as one of their intros for this server",
             deleteDelay,
         )
     }

--- a/discord-bot/src/main/kotlin/bot/toby/intro/IntroOwnership.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/intro/IntroOwnership.kt
@@ -1,0 +1,18 @@
+package bot.toby.intro
+
+/**
+ * Who is allowed to act on a given intro.
+ *
+ * Intro ids are `guildId_discordId_index`, so ownership is readable straight
+ * off the id — no lookup needed for the common case.
+ *
+ * This matters because the id arrives from the client. The select menus and
+ * the edit modal only ever *offer* intros the caller may touch, but a crafted
+ * component or modal submission can name any id at all, so the handler has to
+ * check rather than trust what came back.
+ */
+object IntroOwnership {
+
+    fun ownedBy(introId: String?, guildId: Long, discordId: Long): Boolean =
+        introId != null && introId.startsWith("${guildId}_${discordId}_")
+}

--- a/discord-bot/src/main/kotlin/bot/toby/intro/IntroUndoStore.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/intro/IntroUndoStore.kt
@@ -43,12 +43,17 @@ class IntroUndoStore {
         .maximumSize(1_000)
         .build<String, Snapshot>()
 
-    fun remember(intro: MusicDto) {
+    /**
+     * @param actorDiscordId who pressed delete — the undo button is theirs to
+     *        press, which for a super-user managing someone else's intros is
+     *        not the same person as [MusicDto.userDto].
+     */
+    fun remember(intro: MusicDto, actorDiscordId: Long? = null) {
         val user = intro.userDto ?: return
         val guildId = user.guildId
         val discordId = user.discordId
         snapshots.put(
-            key(guildId, discordId),
+            key(guildId, actorDiscordId ?: discordId),
             Snapshot(
                 guildId = guildId,
                 discordId = discordId,

--- a/discord-bot/src/main/kotlin/bot/toby/menu/menus/DeleteIntroMenu.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/menu/menus/DeleteIntroMenu.kt
@@ -21,10 +21,19 @@ class DeleteIntroMenu @Autowired constructor(
     override fun handle(ctx: MenuContext, deleteDelay: Int) {
         val selectedIntro = resolveSelectedIntroOrElse(ctx, introHelper, deleteDelay) ?: return
 
+        // The selected id comes back from the client, so re-check it rather
+        // than trusting that the menu only offered manageable intros.
+        val actorId = ctx.event.user.idLong
+        if (!introHelper.canManageIntro(selectedIntro.id, ctx.guild.idLong, actorId)) {
+            logger.warn { "Rejecting delete of '${selectedIntro.id}' — not manageable by $actorId" }
+            ctx.event.hook.sendMessage("That intro isn't yours to delete.").setEphemeral(true).queue()
+            return
+        }
+
         // Snapshot before deleting so the Undo button has something to put
-        // back. The confirmation isn't auto-deleted any more — it has to
-        // outlive the delete delay for the undo to be reachable.
-        undoStore.remember(selectedIntro)
+        // back. Keyed on whoever pressed delete — they're the one looking at
+        // the button — while the snapshot itself carries the owner's ids.
+        undoStore.remember(selectedIntro, actorId)
         introHelper.deleteIntro(selectedIntro)
 
         val confirmation = MessageCreateBuilder()

--- a/discord-bot/src/main/kotlin/bot/toby/modal/modals/EditIntroModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/modal/modals/EditIntroModal.kt
@@ -45,11 +45,10 @@ class EditIntroModal(
             ?: return reply(ctx, "That edit form lost track of which intro it was for — run `/editintro` again.")
 
         // The modal is only ever shown to the user who opened it, but the id
-        // travels through the client so re-derive ownership from it rather
-        // than trusting it. Mirrors IntroWebService.requireOwnedIntro.
-        val expectedPrefix = "${ctx.guild.idLong}_${event.user.idLong}_"
-        if (!introId.startsWith(expectedPrefix)) {
-            logger.warn { "Rejecting intro edit for '$introId' — not owned by user ${event.user.idLong}" }
+        // travels through the client so re-check rather than trusting it.
+        // Super-users may edit anyone's, matching `/editintro user:`.
+        if (!introHelper.canManageIntro(introId, ctx.guild.idLong, event.user.idLong)) {
+            logger.warn { "Rejecting intro edit for '$introId' — not manageable by ${event.user.idLong}" }
             return reply(ctx, "That intro isn't yours to edit.")
         }
 

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/music/intro/DeleteIntroCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/music/intro/DeleteIntroCommandTest.kt
@@ -1,10 +1,16 @@
 package bot.toby.command.commands.music.intro
 
 import bot.toby.command.CommandTest.Companion.event
+import bot.toby.command.CommandTest.Companion.guild
+import bot.toby.command.CommandTest.Companion.interactionHook
+import bot.toby.command.CommandTest.Companion.targetMember
 import bot.toby.command.CommandTest.Companion.requestingUserDto
 import bot.toby.command.commands.music.MusicCommandTest
+import bot.toby.helpers.IntroHelper
 import core.command.CommandContext
 import database.dto.music.MusicDto
+import database.dto.user.UserDto
+import net.dv8tion.jda.api.interactions.commands.OptionMapping
 import net.dv8tion.jda.api.entities.MessageEmbed
 import io.mockk.every
 import io.mockk.mockk
@@ -15,12 +21,16 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class DeleteIntroCommandTest : MusicCommandTest {
-    private var deleteIntroCommand = DeleteIntroCommand()
+    private val introHelper: IntroHelper = mockk(relaxed = true)
+    private var deleteIntroCommand = DeleteIntroCommand(introHelper)
     private lateinit var ctx: CommandContext
 
     @BeforeEach
     fun setup() {
         setupCommonMusicMocks()
+        // The relaxed event would otherwise hand back a phantom member for
+        // the user option and target it instead of the caller.
+        every { event.getOption("user") } returns null
         ctx = mockk(relaxed = true)
     }
 
@@ -59,5 +69,41 @@ class DeleteIntroCommandTest : MusicCommandTest {
                 match<MessageEmbed> { embed -> embed.fields.size == 2 }
             )
         }
+    }
+
+    // --- super-user targeting ------------------------------------------------
+
+    @Test
+    fun `a super-user can delete someone else's intro`() {
+        every { ctx.event } returns event
+        val theirs = UserDto(discordId = 99L, guildId = 1L).apply {
+            musicDtos = mutableListOf(MusicDto(this, 1, "theirs", 90, byteArrayOf(1)))
+        }
+        every { requestingUserDto.superUser } returns true
+        every { targetMember.idLong } returns 99L
+        every { targetMember.effectiveAvatarUrl } returns "https://cdn.example/other.png"
+        every { event.getOption("user") } returns mockk<OptionMapping> { every { asMember } returns targetMember }
+        every { introHelper.findUserById(99L, 1L) } returns theirs
+
+        deleteIntroCommand.handle(ctx, requestingUserDto, 5)
+
+        verify {
+            event.hook.sendMessageEmbeds(match<MessageEmbed> { e -> e.fields.single().name!!.contains("theirs") })
+        }
+    }
+
+    @Test
+    fun `a non super-user cannot delete someone else's intro`() {
+        every { ctx.event } returns event
+        every { requestingUserDto.superUser } returns false
+        every { targetMember.idLong } returns 99L
+        every { event.getOption("user") } returns mockk<OptionMapping> { every { asMember } returns targetMember }
+
+        deleteIntroCommand.handle(ctx, requestingUserDto, 5)
+
+        verify(exactly = 0) { introHelper.findUserById(any(), any()) }
+        verify(exactly = 0) { interactionHook.sendMessageEmbeds(any<MessageEmbed>()) }
+        // sendErrorMessage names the server owner in its refusal.
+        verify { guild.owner }
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/music/intro/EditIntroCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/music/intro/EditIntroCommandTest.kt
@@ -1,10 +1,16 @@
 package bot.toby.command.commands.music.intro
 
 import bot.toby.command.CommandTest.Companion.event
+import bot.toby.command.CommandTest.Companion.guild
+import bot.toby.command.CommandTest.Companion.interactionHook
+import bot.toby.command.CommandTest.Companion.targetMember
 import bot.toby.command.CommandTest.Companion.requestingUserDto
 import bot.toby.command.commands.music.MusicCommandTest
+import bot.toby.helpers.IntroHelper
 import core.command.CommandContext
 import database.dto.music.MusicDto
+import database.dto.user.UserDto
+import net.dv8tion.jda.api.interactions.commands.OptionMapping
 import net.dv8tion.jda.api.entities.MessageEmbed
 import io.mockk.every
 import io.mockk.mockk
@@ -16,12 +22,16 @@ import org.junit.jupiter.api.Test
 
 class EditIntroCommandTest : MusicCommandTest {
 
-    private val editIntroCommand = EditIntroCommand()
+    private val introHelper: IntroHelper = mockk(relaxed = true)
+    private val editIntroCommand = EditIntroCommand(introHelper)
     private lateinit var ctx: CommandContext
 
     @BeforeEach
     fun setup() {
         setupCommonMusicMocks()
+        // The relaxed event would otherwise hand back a phantom member for
+        // the user option and target it instead of the caller.
+        every { event.getOption("user") } returns null
         ctx = mockk(relaxed = true)
     }
 
@@ -63,5 +73,41 @@ class EditIntroCommandTest : MusicCommandTest {
                 }
             )
         }
+    }
+
+    // --- super-user targeting ------------------------------------------------
+
+    @Test
+    fun `a super-user can edit someone else's intro`() {
+        every { ctx.event } returns event
+        val theirs = UserDto(discordId = 99L, guildId = 1L).apply {
+            musicDtos = mutableListOf(MusicDto(this, 1, "theirs", 90, byteArrayOf(1)))
+        }
+        every { requestingUserDto.superUser } returns true
+        every { targetMember.idLong } returns 99L
+        every { targetMember.effectiveAvatarUrl } returns "https://cdn.example/other.png"
+        every { event.getOption("user") } returns mockk<OptionMapping> { every { asMember } returns targetMember }
+        every { introHelper.findUserById(99L, 1L) } returns theirs
+
+        editIntroCommand.handle(ctx, requestingUserDto, 5)
+
+        verify {
+            event.hook.sendMessageEmbeds(match<MessageEmbed> { e -> e.fields.single().name!!.contains("theirs") })
+        }
+    }
+
+    @Test
+    fun `a non super-user cannot edit someone else's intro`() {
+        every { ctx.event } returns event
+        every { requestingUserDto.superUser } returns false
+        every { targetMember.idLong } returns 99L
+        every { event.getOption("user") } returns mockk<OptionMapping> { every { asMember } returns targetMember }
+
+        editIntroCommand.handle(ctx, requestingUserDto, 5)
+
+        verify(exactly = 0) { introHelper.findUserById(any(), any()) }
+        verify(exactly = 0) { interactionHook.sendMessageEmbeds(any<MessageEmbed>()) }
+        // sendErrorMessage names the server owner in its refusal.
+        verify { guild.owner }
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/helpers/IntroHelperTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/helpers/IntroHelperTest.kt
@@ -281,6 +281,90 @@ class IntroHelperTest {
         }
     }
 
+    // --- slot allocation ---------------------------------------------------
+
+    /** A user whose intros sit in [indexes]. */
+    private fun userWithSlots(vararg indexes: Int): database.dto.user.UserDto {
+        val owner = database.dto.user.UserDto(discordId = 1234L, guildId = 1L)
+        owner.musicDtos = indexes.map { MusicDto(owner, it, "intro$it", 90, byteArrayOf(it.toByte())) }
+            .toMutableList()
+        return owner
+    }
+
+    @Test
+    fun `a new intro fills the gap a delete left rather than overwriting a slot`() {
+        // Regression: slots [1, 3] with the old `size + 1` allocator produced
+        // index 3, whose id already existed — and createNewMusicFile turns an
+        // id collision into an update, silently replacing the slot-3 intro.
+        val owner = userWithSlots(1, 3)
+        every { userDtoHelper.calculateUserDto(1234L, 1L) } returns owner
+
+        introHelper.persistMusicUrl(
+            event, owner, 10, "new", "http://valid.url", "TestUser", 70, null
+        )
+
+        val saved = slot<MusicDto>()
+        verify { musicFileService.createNewMusicFile(capture(saved)) }
+        assertEquals(2, saved.captured.index)
+        assertEquals("1_1234_2", saved.captured.id)
+    }
+
+    @Test
+    fun `a file intro also takes the lowest free slot`() {
+        val owner = userWithSlots(2)
+        every { userDtoHelper.calculateUserDto(1234L, 1L) } returns owner
+        val inputStream = mockk<InputStream>()
+        every { FileUtils.readInputStreamToByteArray(inputStream) } returns ByteArray(10)
+
+        introHelper.persistMusicFile(
+            event, owner, "TestUser", 10, "filename.mp3", 70, inputStream, null
+        )
+
+        val saved = slot<MusicDto>()
+        verify { musicFileService.createNewMusicFile(capture(saved)) }
+        assertEquals(1, saved.captured.index)
+    }
+
+    @Test
+    fun `slots fill in order when there is no gap`() {
+        val owner = userWithSlots(1, 2)
+        every { userDtoHelper.calculateUserDto(1234L, 1L) } returns owner
+
+        introHelper.persistMusicUrl(
+            event, owner, 10, "new", "http://valid.url", "TestUser", 70, null
+        )
+
+        val saved = slot<MusicDto>()
+        verify { musicFileService.createNewMusicFile(capture(saved)) }
+        assertEquals(3, saved.captured.index)
+    }
+
+    @Test
+    fun `a full set saves nothing and says so`() {
+        val owner = userWithSlots(1, 2, 3)
+        every { userDtoHelper.calculateUserDto(1234L, 1L) } returns owner
+
+        introHelper.persistMusicUrl(
+            event, owner, 10, "new", "http://valid.url", "TestUser", 70, null
+        )
+
+        verify(exactly = 0) { musicFileService.createNewMusicFile(any()) }
+        verify { hook.sendMessage(match<String> { it.contains("already have 3 intros") }) }
+    }
+
+    @Test
+    fun `replacing a chosen intro keeps its slot`() {
+        val owner = userWithSlots(1, 2, 3)
+        every { userDtoHelper.calculateUserDto(1234L, 1L) } returns owner
+        val chosen = owner.musicDtos[1]
+
+        introHelper.persistMusicUrl(
+            event, owner, 10, "new", "http://valid.url", "TestUser", 70, chosen
+        )
+
+        verify { musicFileService.updateMusicFile(match<MusicDto> { it.index == 2 }) }
+    }
+
     @Test
     fun `persistMusicUrl should persist a valid URL`() {
         introHelper.persistMusicUrl(

--- a/discord-bot/src/test/kotlin/bot/toby/menu/menus/DeleteIntroMenuTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/menu/menus/DeleteIntroMenuTest.kt
@@ -36,6 +36,7 @@ class DeleteIntroMenuTest : MenuTest {
         introHelper = mockk(relaxed = true)
         eventWaiter = mockk(relaxed = true)
         undoStore = mockk(relaxed = true)
+        every { introHelper.canManageIntro(any(), any(), any()) } returns true
 
         // Initialize the class under test
         deleteIntroMenu = DeleteIntroMenu(introHelper, undoStore)
@@ -61,7 +62,7 @@ class DeleteIntroMenuTest : MenuTest {
         deleteIntroMenu.handle(menuContext, 0)
 
         // Verify the intro is snapshotted for undo, then deleted
-        verify { undoStore.remember(intro) }
+        verify { undoStore.remember(intro, any()) }
         verify { introHelper.deleteIntro(intro) }
     }
 
@@ -76,5 +77,20 @@ class DeleteIntroMenuTest : MenuTest {
 
         // Verify that the user is informed the intro wasn't found
         verify { menuContext.event.hook.sendMessage("Unable to find the selected intro.") }
+    }
+
+    @Test
+    fun `an intro the caller cannot manage is not deleted`() {
+        // The selected id comes back from the client, so a forged value must
+        // not be able to delete someone else's intro.
+        val intro = MusicDto(userDto, 1, "Someone else's")
+        every { introHelper.findIntroById("1") } returns intro
+        every { menuContext.event.values.firstOrNull() } returns "1"
+        every { introHelper.canManageIntro(any(), any(), any()) } returns false
+
+        deleteIntroMenu.handle(menuContext, 0)
+
+        verify(exactly = 0) { introHelper.deleteIntro(any()) }
+        verify(exactly = 0) { undoStore.remember(any(), any()) }
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/modal/modals/EditIntroModalTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/modal/modals/EditIntroModalTest.kt
@@ -68,6 +68,9 @@ class EditIntroModalTest {
         every { send.setEphemeral(true) } returns send
         every { send.queue() } just Runs
 
+        // Callers manage their own intros unless a test says otherwise.
+        every { introHelper.canManageIntro(any(), any(), any()) } returns true
+
         // By default the clip passes validation; individual tests override.
         every { introHelper.validateClipAgainstSource(any(), any(), any(), any()) } answers {
             lastArg<(String?) -> Unit>().invoke(null)
@@ -217,11 +220,25 @@ class EditIntroModalTest {
     @Test
     fun `an intro belonging to another user is refused`() {
         every { event.modalId } returns EditIntroModal.customId("100_999_1")
+        every { introHelper.canManageIntro("100_999_1", 100L, 42L) } returns false
 
         modal.handle(ctx, 0)
 
         verify(exactly = 0) { introHelper.updateIntro(any()) }
         assertEquals("That intro isn't yours to edit.", replies.single())
+    }
+
+    @Test
+    fun `a super-user may edit someone else's intro`() {
+        val theirs = MusicDto(UserDto(discordId = 999L, guildId = 100L), 1, "Theirs", 90, byteArrayOf(1))
+        every { event.modalId } returns EditIntroModal.customId("100_999_1")
+        every { introHelper.canManageIntro("100_999_1", 100L, 42L) } returns true
+        every { introHelper.findIntroById("100_999_1") } returns theirs
+        fields(volume = "10")
+
+        modal.handle(ctx, 0)
+
+        verify { introHelper.updateIntro(match<MusicDto> { it.introVolume == 10 }) }
     }
 
     @Test

--- a/web/src/main/kotlin/web/service/IntroWebService.kt
+++ b/web/src/main/kotlin/web/service/IntroWebService.kt
@@ -333,14 +333,10 @@ class IntroWebService(
     fun validateClip(startMs: Int?, endMs: Int?, sourceDurationMs: Int?): String? =
         IntroClip.validate(startMs, endMs, sourceDurationMs)
 
-    // Picks the smallest unused slot in 1..MAX_INTRO_COUNT. Walking the range
-    // (rather than `size + 1`) is what lets "Add" work after a delete left a
-    // gap like [1, 3] — otherwise the new id collides with an existing row's
-    // id and the JPA layer silently turns the insert into an update.
-    private fun nextFreeIndex(existingIntros: List<MusicDto>): Int? {
-        val used = existingIntros.mapNotNull { it.index }.toSet()
-        return (1..MAX_INTRO_COUNT).firstOrNull { it !in used }
-    }
+    // Shared with the slash-command path via IntroSlots — see there for why
+    // walking the range beats `size + 1`.
+    private fun nextFreeIndex(existingIntros: List<MusicDto>): Int? =
+        IntroSlots.nextFreeIndex(existingIntros.map { it.index })
 
     private fun requireOwnedIntro(discordId: Long, guildId: Long, introId: String): String? =
         if (introId.startsWith("${guildId}_${discordId}_")) null

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -20,6 +20,9 @@ TobyBot picks one. Switch every intro off and nothing plays at all.
 **A**: Yes. Pass `start` and `end` to `/setintro` (e.g. `start:1:04 end:1:16`) and the bot plays just that stretch.
 Both accept `mm:ss` or a raw number of seconds. The clip itself still has to fit inside the 15-second limit.
 
+**Q**: I'm an admin — can I fix someone else's intro?  
+**A**: Yes. `/setintro`, `/listintros`, `/editintro` and `/deleteintro` all take a user option for super-users.
+
 **Q**: Can I rename an intro or trim it after the fact?  
 **A**: `/editintro`, then pick the intro — a form opens with its name, volume and clip bounds pre-filled.
 Clearing a clip field removes that bound, so blanking both restores the full track.


### PR DESCRIPTION
## The bug

Adding an intro on Discord could **silently destroy another one**.

`IntroHelper` allocated the slot for a new intro with `musicDtos.size + 1`, and `DefaultMusicFilePersistence.createNewMusicFile` turns an id collision into an update:

```kotlin
val databaseMusicFile = entityManager.find(MusicDto::class.java, musicDto.id)
return if (databaseMusicFile == null) persistMusicDto(musicDto) else updateMusicFile(musicDto)
```

So:

1. Hold three intros
2. `/deleteintro` slot 2 → remaining slots are `[1, 3]`, size 2
3. `/setintro` → allocated slot `2 + 1` = **3**, whose id already exists

The intro in slot 3 is overwritten, the new one lands in 3 instead of the free 2, and nothing reports a problem.

The web form already walks the range rather than counting, with a comment describing this exact failure — the slash-command path never got the fix. That allocator now lives in `IntroSlots.nextFreeIndex` and both surfaces call it. When every slot really is full, the Discord path now says so instead of picking an index that overwrites something.

## Super-user targeting on `/editintro` and `/deleteintro`

Super-users could already set and list someone else's intros, but not fix or remove one — the more useful half. Both now take a `user:` option.

That required tightening the two handlers, because the intro id arrives from the client and the menus only *offer* what you may touch. **`DeleteIntroMenu` had no check at all** — a forged select value would have deleted any intro in the guild. Both it and `EditIntroModal` now go through `IntroHelper.canManageIntro` ("yours, or you're a super-user"), which only hits the database in the second case. `IntroUndoStore` keys on whoever pressed delete rather than the owner, so Undo works for a super-user acting on someone else's intro.

## Smaller fixes

- **`/setintro volume` declares its 1-100 range** on the option, so Discord rejects an out-of-range value client-side instead of the bot quietly coercing it.
- **The duplicate refusal names the slot** the existing copy is in, like the web's does. "already exists in slot #2" is actionable; "already exists" isn't.

## Testing

`:common`, `:web` and `:discord-bot` suites pass. New `IntroSlotsTest` covers the allocator directly — the gap case, a full set, and stray out-of-range indexes. `IntroHelperTest` gains the end-to-end regression (slots `[1, 3]` must allocate 2, not 3), plus the full-set refusal and replace-keeps-its-slot. `EditIntroModalTest` and `DeleteIntroMenuTest` cover both sides of the permission check, including that a forged id can't delete someone else's intro; `EditIntroCommandTest` and `DeleteIntroCommandTest` cover the targeting both ways.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UzSiANtbGDsaSbCRDkqQWc)_