### PR TITLE
Intro health, guild controls, loudness matching and play stats

### DIFF
--- a/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
@@ -39,6 +39,7 @@ import bot.toby.command.commands.music.channel.JoinCommand
 import bot.toby.command.commands.music.channel.LeaveCommand
 import bot.toby.command.commands.music.intro.DeleteIntroCommand
 import bot.toby.command.commands.music.intro.EditIntroCommand
+import bot.toby.command.commands.music.intro.IntroStatsCommand
 import bot.toby.command.commands.music.intro.ListIntrosCommand
 import bot.toby.command.commands.music.intro.SetIntroCommand
 import bot.toby.command.commands.music.player.*
@@ -141,6 +142,7 @@ class CommandManagerTest {
             EditIntroCommand::class.java,
             DeleteIntroCommand::class.java,
             ListIntrosCommand::class.java,
+            IntroStatsCommand::class.java,
             UserInfoCommand::class.java,
             LevelCommand::class.java,
             RandomCommand::class.java,

--- a/application/src/test/kotlin/integration/database/GuildIntroStatsIntegrationTest.kt
+++ b/application/src/test/kotlin/integration/database/GuildIntroStatsIntegrationTest.kt
@@ -1,0 +1,133 @@
+package integration.database
+
+import app.Application
+import bot.configuration.TestAppConfig
+import bot.configuration.TestBotConfig
+import bot.configuration.TestManagerConfig
+import common.configuration.TestCachingConfig
+import common.intro.IntroHealth
+import database.configuration.TestDatabaseConfig
+import database.dto.music.MusicDto
+import database.dto.user.UserDto
+import database.persistence.music.MusicFilePersistence
+import jakarta.persistence.EntityManager
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.annotation.Rollback
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * Covers the one piece of this feature that only a real Postgres can answer
+ * for: `getGuildIntroStats` is native SQL (`octet_length`, `COUNT(*) FILTER`)
+ * because the whole point is to total the size of the stored audio without
+ * loading it. A unit test with a mocked EntityManager would assert the string
+ * we wrote, not that the database accepts it.
+ */
+@SpringBootTest(
+    classes = [
+        Application::class,
+        TestCachingConfig::class,
+        TestDatabaseConfig::class,
+        TestManagerConfig::class,
+        TestAppConfig::class,
+        TestBotConfig::class,
+    ]
+)
+@ActiveProfiles("test")
+@Transactional
+class GuildIntroStatsIntegrationTest {
+
+    @Autowired
+    lateinit var entityManager: EntityManager
+
+    @Autowired
+    lateinit var persistence: MusicFilePersistence
+
+    private val guildId = 5150L
+    private val otherGuildId = 6160L
+
+    private fun persistUser(discordId: Long, guildId: Long): UserDto =
+        UserDto(discordId = discordId, guildId = guildId).also {
+            entityManager.persist(it)
+            entityManager.flush()
+        }
+
+    private fun persistIntro(
+        user: UserDto,
+        index: Int,
+        blob: ByteArray,
+        enabled: Boolean = true,
+        failures: Int = 0,
+        plays: Int = 0,
+    ) {
+        val dto = MusicDto(user, index, "intro$index", 90, blob).apply {
+            this.enabled = enabled
+            this.failureCount = failures
+            this.playCount = plays
+        }
+        entityManager.persist(dto)
+        entityManager.flush()
+    }
+
+    @Test
+    @Rollback
+    fun `a guild with no intros reports zeroes rather than failing`() {
+        val stats = persistence.getGuildIntroStats(guildId, IntroHealth.UNHEALTHY_AFTER_FAILURES)
+
+        assertEquals(0L, stats.introCount)
+        assertEquals(0L, stats.storedBytes)
+        assertEquals(0L, stats.totalPlays)
+    }
+
+    @Test
+    @Rollback
+    fun `the report totals only the guild it was asked about`() {
+        val alice = persistUser(1L, guildId)
+        val bob = persistUser(2L, guildId)
+        val elsewhere = persistUser(3L, otherGuildId)
+
+        persistIntro(alice, 1, ByteArray(100), plays = 5)
+        persistIntro(alice, 2, ByteArray(200), plays = 3, enabled = false)
+        persistIntro(bob, 1, ByteArray(300), plays = 1, failures = IntroHealth.UNHEALTHY_AFTER_FAILURES)
+        // Must not leak into the totals.
+        persistIntro(elsewhere, 1, ByteArray(9999), plays = 99)
+
+        val stats = persistence.getGuildIntroStats(guildId, IntroHealth.UNHEALTHY_AFTER_FAILURES)
+
+        assertEquals(3L, stats.introCount)
+        assertEquals(2L, stats.userCount)
+        // octet_length over the three blobs, not the fourth.
+        assertEquals(600L, stats.storedBytes)
+        assertEquals(9L, stats.totalPlays)
+        assertEquals(1L, stats.disabledCount)
+        assertEquals(1L, stats.brokenCount)
+    }
+
+    @Test
+    @Rollback
+    fun `an intro one failure short of the threshold is not counted as broken`() {
+        val alice = persistUser(4L, guildId)
+        persistIntro(alice, 1, ByteArray(10), failures = IntroHealth.UNHEALTHY_AFTER_FAILURES - 1)
+
+        val stats = persistence.getGuildIntroStats(guildId, IntroHealth.UNHEALTHY_AFTER_FAILURES)
+
+        assertEquals(0L, stats.brokenCount)
+    }
+
+    @Test
+    @Rollback
+    fun `a link intro contributes only its url to the storage total`() {
+        // The distinction the report's footer draws: uploads are what grow the
+        // table, links are a couple of dozen bytes.
+        val alice = persistUser(5L, guildId)
+        val url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ".toByteArray()
+        persistIntro(alice, 1, url)
+
+        val stats = persistence.getGuildIntroStats(guildId, IntroHealth.UNHEALTHY_AFTER_FAILURES)
+
+        assertEquals(url.size.toLong(), stats.storedBytes)
+    }
+}

--- a/common/src/main/kotlin/common/intro/IntroGuildPolicy.kt
+++ b/common/src/main/kotlin/common/intro/IntroGuildPolicy.kt
@@ -1,0 +1,48 @@
+package common.intro
+
+/**
+ * Server-wide rules about when intros are allowed to play at all.
+ *
+ * `DEFAULT_INTRO_VOLUME` used to be the only intro config key, which meant a
+ * server could make intros quieter but never turn them off, and could never
+ * exempt a channel. A "study", "meeting" or on-call voice channel got
+ * everyone's intro at full blast and the only remedy was asking each member
+ * individually to unset theirs.
+ *
+ * Both knobs read as opt-out so an existing guild with no rows behaves
+ * exactly as it does today.
+ */
+object IntroGuildPolicy {
+
+    /** Intros play unless the guild has explicitly stored "false". */
+    fun introsEnabled(raw: String?): Boolean = !raw.orEmpty().trim().equals("false", ignoreCase = true)
+
+    /**
+     * Channel ids the guild has exempted, parsed from the stored CSV.
+     *
+     * Anything unparseable is dropped rather than failing the whole set: the
+     * value is hand-editable from `/setconfig`, and one fat-fingered id should
+     * not silently re-enable intros in every other exempted channel.
+     */
+    fun excludedChannelIds(raw: String?): Set<Long> = raw.orEmpty()
+        .split(',', ' ', '\n')
+        .mapNotNull { it.trim().removePrefix("<#").removeSuffix(">").toLongOrNull() }
+        .toSet()
+
+    fun formatExcludedChannelIds(ids: Collection<Long>): String = ids.joinToString(",")
+
+    /**
+     * Whether an intro may play for someone joining [channelId].
+     *
+     * A null channel means we couldn't resolve one; that's not a reason to
+     * suppress, so it only fails the server-wide gate.
+     */
+    fun playsIn(enabledRaw: String?, excludedRaw: String?, channelId: Long?): Boolean {
+        if (!introsEnabled(enabledRaw)) return false
+        if (channelId == null) return true
+        return channelId !in excludedChannelIds(excludedRaw)
+    }
+
+    /** Loudness normalisation is on unless the guild stores "false". */
+    fun normaliseVolume(raw: String?): Boolean = !raw.orEmpty().trim().equals("false", ignoreCase = true)
+}

--- a/common/src/main/kotlin/common/intro/IntroHealth.kt
+++ b/common/src/main/kotlin/common/intro/IntroHealth.kt
@@ -1,0 +1,45 @@
+package common.intro
+
+/**
+ * When a stored intro should be treated as broken.
+ *
+ * Intros play through the voice-join path, which has no interaction to reply
+ * to, so until now a track that failed to load produced silence and a server
+ * log line — nothing the owner could see. A dead YouTube link (video deleted,
+ * region-locked, age-gated, or the uploader's channel pulled) therefore stayed
+ * in the rotation forever, looking healthy in `/listintros` and on the web.
+ *
+ * The counter this thresholds is *consecutive* failures: a successful load
+ * resets it to zero. Lavaplayer already retries transient severities twice
+ * before reporting a failure at all, so reaching [UNHEALTHY_AFTER_FAILURES]
+ * means the source has failed outright on separate joins, minutes or days
+ * apart. That's deliberately conservative — the cost of a false positive is
+ * telling someone their intro is broken when it isn't.
+ */
+object IntroHealth {
+
+    /**
+     * Consecutive failed loads before an intro is considered broken: shown as
+     * such in Discord and on the web, and skipped by [IntroSelection] when the
+     * user has a working alternative.
+     */
+    const val UNHEALTHY_AFTER_FAILURES = 2
+
+    /** Truncation bound for the stored failure reason (matches the column). */
+    const val MAX_REASON_LENGTH = 500
+
+    fun isUnhealthy(failureCount: Int): Boolean = failureCount >= UNHEALTHY_AFTER_FAILURES
+
+    /**
+     * Lavaplayer's `FriendlyException` messages are written for a human
+     * ("This video is not available in your country"), so they're worth
+     * showing verbatim — just bounded, and never blank, since an empty reason
+     * reads as "we don't know why" when we do.
+     */
+    fun normaliseReason(raw: String?): String {
+        val trimmed = raw?.trim().orEmpty()
+        if (trimmed.isEmpty()) return "Source could not be loaded"
+        return if (trimmed.length <= MAX_REASON_LENGTH) trimmed
+        else trimmed.take(MAX_REASON_LENGTH - 1).trimEnd() + "…"
+    }
+}

--- a/common/src/main/kotlin/common/intro/IntroLoudness.kt
+++ b/common/src/main/kotlin/common/intro/IntroLoudness.kt
@@ -1,0 +1,96 @@
+package common.intro
+
+import kotlin.math.sqrt
+
+/**
+ * Levelling intros against each other so the per-intro volume slider stops
+ * being a trial-and-error control.
+ *
+ * Two people set an intro at the default volume: one picked a mastered-loud
+ * pop track, the other a quiet live recording. The first is painful and the
+ * second is inaudible, and the only fix on offer is "join a channel, listen,
+ * run `/editintro`, guess a new number, repeat". The slider was never really
+ * expressing a preference — it was compensating for the source.
+ *
+ * So the bot measures each intro's actual level the first time it plays (see
+ * `IntroLoudnessMeter`) and applies a correcting gain on subsequent plays.
+ * The user's number stays a *relative* preference — 50% is still half as loud
+ * as 100% — but equal numbers on different tracks now sound equally loud.
+ *
+ * RMS rather than EBU R128 loudness: R128 needs K-weighting and gated
+ * windowing over the whole programme, which is a lot of machinery for clips
+ * capped at fifteen seconds. Plain RMS over the audio actually played gets
+ * the two tracks above within a few dB of each other, which is the entire
+ * complaint.
+ */
+object IntroLoudness {
+
+    /**
+     * Target RMS in the -1..1 float PCM lavaplayer hands the filter chain.
+     * 0.09 is about -21 dBFS: comfortably below clipping with peaks intact,
+     * and close to where the existing default volumes land for a typical
+     * YouTube music upload, so guilds that never touch this barely move.
+     */
+    const val TARGET_RMS = 0.09
+
+    /**
+     * Correction bounds. Normalisation should fix "one of these is three
+     * times louder than the other", not rescue a recording that's 30 dB down
+     * — pushing that up just amplifies its noise floor. Clamping also means a
+     * bad measurement (a clip that happens to start in silence) can't produce
+     * a jarring result.
+     */
+    const val MIN_GAIN = 0.5
+    const val MAX_GAIN = 2.0
+
+    /**
+     * Below this the measurement is treated as unusable rather than as "very
+     * quiet" — a clip whose measured window was pure silence would otherwise
+     * demand the maximum boost on the strength of no signal at all.
+     */
+    const val MIN_MEASURABLE_RMS = 0.001
+
+    /** RMS from accumulated sum-of-squares, or null when nothing was sampled. */
+    fun rmsOf(sumOfSquares: Double, sampleCount: Long): Double? {
+        if (sampleCount <= 0L) return null
+        val mean = sumOfSquares / sampleCount
+        if (mean.isNaN() || mean < 0.0) return null
+        return sqrt(mean)
+    }
+
+    /**
+     * Multiplier to bring [measuredRms] to [TARGET_RMS], clamped to
+     * [MIN_GAIN]..[MAX_GAIN]. Returns 1.0 (no change) when there's no usable
+     * measurement — an unmeasured intro must sound exactly as it does today.
+     */
+    fun gainFor(measuredRms: Double?): Double {
+        if (measuredRms == null || measuredRms.isNaN() || measuredRms < MIN_MEASURABLE_RMS) return 1.0
+        return (TARGET_RMS / measuredRms).coerceIn(MIN_GAIN, MAX_GAIN)
+    }
+
+    /**
+     * The volume to actually play [nominalVolume] at.
+     *
+     * Clamped to 0..200 to match the range `/setconfig` and the web form
+     * accept for volumes, so a boosted loud intro can't hand lavaplayer a
+     * value the rest of the bot would reject.
+     */
+    fun normalisedVolume(nominalVolume: Int, measuredRms: Double?): Int =
+        (nominalVolume * gainFor(measuredRms)).toInt().coerceIn(0, MAX_VOLUME)
+
+    /**
+     * How the measurement reads to a human, for `/listintros` and the web row.
+     * Phrased about the source, not the correction, because that's the part
+     * the user can act on by picking a different track.
+     */
+    fun describe(measuredRms: Double?): String? {
+        if (measuredRms == null || measuredRms.isNaN() || measuredRms < MIN_MEASURABLE_RMS) return null
+        return when {
+            measuredRms >= TARGET_RMS * 1.6 -> "loud source"
+            measuredRms <= TARGET_RMS / 1.6 -> "quiet source"
+            else -> "level"
+        }
+    }
+
+    private const val MAX_VOLUME = 200
+}

--- a/common/src/main/kotlin/common/notification/NotificationChannelKind.kt
+++ b/common/src/main/kotlin/common/notification/NotificationChannelKind.kt
@@ -77,6 +77,15 @@ enum class NotificationChannelKind(
         // DM-only: the prompt is a direct message with a setup link,
         // which doesn't translate to a one-shot push notification.
         perSurfaceDefaults = mapOf(Surface.DM to true),
+    ),
+    INTRO_BROKEN(
+        displayName = "Broken intro",
+        description = "DM when one of your intros stops loading — a deleted, private, " +
+            "age-gated or region-blocked link plays as silence otherwise.",
+        // DM-only and on by default. This one reports a fault in something
+        // the user set up, which they cannot otherwise discover: the intro
+        // simply stops playing, and every surface keeps listing it as fine.
+        perSurfaceDefaults = mapOf(Surface.DM to true),
     );
 
     /** Surfaces this kind ships on. Derived from [perSurfaceDefaults]. */

--- a/common/src/test/kotlin/common/intro/IntroGuildPolicyTest.kt
+++ b/common/src/test/kotlin/common/intro/IntroGuildPolicyTest.kt
@@ -1,0 +1,92 @@
+package common.intro
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class IntroGuildPolicyTest {
+
+    // --- the server-wide switch ---------------------------------------------
+
+    @Test
+    fun `a guild that has never set the key keeps playing intros`() {
+        // Opt-out is the whole point: shipping this must not silently disable
+        // the feature for every existing server.
+        assertTrue(IntroGuildPolicy.introsEnabled(null))
+        assertTrue(IntroGuildPolicy.introsEnabled(""))
+    }
+
+    @Test
+    fun `only an explicit false turns intros off`() {
+        assertFalse(IntroGuildPolicy.introsEnabled("false"))
+        assertFalse(IntroGuildPolicy.introsEnabled("  FALSE  "))
+        assertTrue(IntroGuildPolicy.introsEnabled("true"))
+        // Junk is not "off" — a typo shouldn't quietly disable the feature.
+        assertTrue(IntroGuildPolicy.introsEnabled("maybe"))
+    }
+
+    // --- per-channel exemptions ---------------------------------------------
+
+    @Test
+    fun `channel ids parse from csv, spaces and mentions alike`() {
+        assertEquals(setOf(1L, 2L, 3L), IntroGuildPolicy.excludedChannelIds("1,2,3"))
+        assertEquals(setOf(1L, 2L), IntroGuildPolicy.excludedChannelIds("1, 2"))
+        assertEquals(setOf(42L), IntroGuildPolicy.excludedChannelIds("<#42>"))
+    }
+
+    @Test
+    fun `one unparseable id does not discard the rest`() {
+        // The value is hand-editable from /setconfig. Failing the whole set on
+        // one bad entry would re-enable intros in channels an admin had
+        // deliberately silenced.
+        assertEquals(setOf(1L, 3L), IntroGuildPolicy.excludedChannelIds("1,oops,3"))
+    }
+
+    @Test
+    fun `an empty or absent list excludes nothing`() {
+        assertTrue(IntroGuildPolicy.excludedChannelIds(null).isEmpty())
+        assertTrue(IntroGuildPolicy.excludedChannelIds("").isEmpty())
+        assertTrue(IntroGuildPolicy.excludedChannelIds(" , , ").isEmpty())
+    }
+
+    @Test
+    fun `formatting round-trips back through the parser`() {
+        val ids = setOf(10L, 20L, 30L)
+        assertEquals(ids, IntroGuildPolicy.excludedChannelIds(IntroGuildPolicy.formatExcludedChannelIds(ids)))
+    }
+
+    // --- the combined decision ----------------------------------------------
+
+    @Test
+    fun `intros play in a channel that is not exempt`() {
+        assertTrue(IntroGuildPolicy.playsIn(enabledRaw = null, excludedRaw = "99", channelId = 1L))
+    }
+
+    @Test
+    fun `intros do not play in an exempt channel`() {
+        assertFalse(IntroGuildPolicy.playsIn(enabledRaw = null, excludedRaw = "1,99", channelId = 99L))
+    }
+
+    @Test
+    fun `the server-wide switch beats the exemption list`() {
+        assertFalse(IntroGuildPolicy.playsIn(enabledRaw = "false", excludedRaw = "", channelId = 1L))
+    }
+
+    @Test
+    fun `an unresolved channel is not treated as exempt`() {
+        // Not knowing which channel someone joined is not a reason to suppress
+        // their intro; only the server-wide switch does that.
+        assertTrue(IntroGuildPolicy.playsIn(enabledRaw = null, excludedRaw = "1,2", channelId = null))
+        assertFalse(IntroGuildPolicy.playsIn(enabledRaw = "false", excludedRaw = "1,2", channelId = null))
+    }
+
+    // --- normalisation switch -----------------------------------------------
+
+    @Test
+    fun `loudness matching is on unless explicitly disabled`() {
+        assertTrue(IntroGuildPolicy.normaliseVolume(null))
+        assertTrue(IntroGuildPolicy.normaliseVolume("true"))
+        assertFalse(IntroGuildPolicy.normaliseVolume("false"))
+    }
+}

--- a/common/src/test/kotlin/common/intro/IntroHealthTest.kt
+++ b/common/src/test/kotlin/common/intro/IntroHealthTest.kt
@@ -1,0 +1,46 @@
+package common.intro
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class IntroHealthTest {
+
+    @Test
+    fun `a single failure is not enough to call an intro broken`() {
+        // Lavaplayer already retries transient severities before reporting a
+        // failure at all, but one bad night for YouTube shouldn't tell someone
+        // their intro is dead.
+        assertFalse(IntroHealth.isUnhealthy(0))
+        assertFalse(IntroHealth.isUnhealthy(1))
+    }
+
+    @Test
+    fun `repeated failures cross the threshold`() {
+        assertTrue(IntroHealth.isUnhealthy(IntroHealth.UNHEALTHY_AFTER_FAILURES))
+        assertTrue(IntroHealth.isUnhealthy(IntroHealth.UNHEALTHY_AFTER_FAILURES + 5))
+    }
+
+    @Test
+    fun `a blank reason becomes something a user can read`() {
+        // "" in the embed reads as "we have no idea", which is worse than a
+        // generic sentence and untrue — we know the load failed.
+        assertEquals("Source could not be loaded", IntroHealth.normaliseReason(null))
+        assertEquals("Source could not be loaded", IntroHealth.normaliseReason("   "))
+    }
+
+    @Test
+    fun `a real reason is kept verbatim`() {
+        val reason = "This video is not available in your country"
+        assertEquals(reason, IntroHealth.normaliseReason("  $reason  "))
+    }
+
+    @Test
+    fun `an overlong reason is truncated to fit the column`() {
+        val truncated = IntroHealth.normaliseReason("x".repeat(IntroHealth.MAX_REASON_LENGTH + 200))
+
+        assertEquals(IntroHealth.MAX_REASON_LENGTH, truncated.length)
+        assertTrue(truncated.endsWith("…"), truncated.takeLast(5))
+    }
+}

--- a/common/src/test/kotlin/common/intro/IntroLoudnessTest.kt
+++ b/common/src/test/kotlin/common/intro/IntroLoudnessTest.kt
@@ -1,0 +1,101 @@
+package common.intro
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import kotlin.math.abs
+
+class IntroLoudnessTest {
+
+    private fun assertClose(expected: Double, actual: Double, tolerance: Double = 1e-9) {
+        assertTrue(abs(expected - actual) <= tolerance, "expected ~$expected but was $actual")
+    }
+
+    // --- measurement --------------------------------------------------------
+
+    @Test
+    fun `rms of a constant signal is its amplitude`() {
+        // 100 samples of 0.5 → mean square 0.25 → rms 0.5.
+        assertClose(0.5, IntroLoudness.rmsOf(sumOfSquares = 0.25 * 100, sampleCount = 100)!!)
+    }
+
+    @Test
+    fun `no samples means no measurement`() {
+        // A track that failed before producing audio must not be recorded as
+        // silent — silent would demand the maximum boost next time.
+        assertNull(IntroLoudness.rmsOf(sumOfSquares = 0.0, sampleCount = 0))
+        assertNull(IntroLoudness.rmsOf(sumOfSquares = 5.0, sampleCount = -1))
+    }
+
+    // --- gain ---------------------------------------------------------------
+
+    @Test
+    fun `an unmeasured intro is left exactly as it is`() {
+        // Every existing row starts null. The first play of anything must
+        // sound identical to today or this ships as a surprise volume change.
+        assertEquals(1.0, IntroLoudness.gainFor(null))
+        assertEquals(90, IntroLoudness.normalisedVolume(90, null))
+    }
+
+    @Test
+    fun `a track already at target is left alone`() {
+        assertClose(1.0, IntroLoudness.gainFor(IntroLoudness.TARGET_RMS))
+    }
+
+    @Test
+    fun `a quiet track is boosted and a loud one cut`() {
+        assertTrue(IntroLoudness.gainFor(IntroLoudness.TARGET_RMS / 1.5) > 1.0)
+        assertTrue(IntroLoudness.gainFor(IntroLoudness.TARGET_RMS * 1.5) < 1.0)
+    }
+
+    @Test
+    fun `correction is clamped in both directions`() {
+        // Rescuing a recording 30 dB down just amplifies its noise floor, and
+        // an unclamped cut could mute an intro entirely.
+        assertEquals(IntroLoudness.MAX_GAIN, IntroLoudness.gainFor(0.0001 + IntroLoudness.MIN_MEASURABLE_RMS))
+        assertEquals(IntroLoudness.MIN_GAIN, IntroLoudness.gainFor(0.9))
+    }
+
+    @Test
+    fun `a measurement below the noise floor is treated as unusable, not as silence`() {
+        assertEquals(1.0, IntroLoudness.gainFor(IntroLoudness.MIN_MEASURABLE_RMS / 2))
+        assertEquals(1.0, IntroLoudness.gainFor(Double.NaN))
+    }
+
+    // --- applied volume -----------------------------------------------------
+
+    @Test
+    fun `two tracks at the same nominal volume end up at comparable levels`() {
+        // The actual complaint: same number, wildly different loudness.
+        val quiet = IntroLoudness.TARGET_RMS / 1.8
+        val loud = IntroLoudness.TARGET_RMS * 1.8
+
+        val quietPlayback = IntroLoudness.normalisedVolume(50, quiet)
+        val loudPlayback = IntroLoudness.normalisedVolume(50, loud)
+
+        assertTrue(quietPlayback > 50, "quiet source should be boosted, got $quietPlayback")
+        assertTrue(loudPlayback < 50, "loud source should be cut, got $loudPlayback")
+        // Perceived level = volume x source rms. After correction the two
+        // should land far closer together than the 3.24x they started apart.
+        val ratio = (quietPlayback * quiet) / (loudPlayback * loud)
+        assertTrue(ratio in 0.7..1.4, "levels should be close after correction, ratio was $ratio")
+    }
+
+    @Test
+    fun `the volume handed to the player stays inside the accepted range`() {
+        assertTrue(IntroLoudness.normalisedVolume(200, IntroLoudness.TARGET_RMS / 4) <= 200)
+        assertTrue(IntroLoudness.normalisedVolume(0, IntroLoudness.TARGET_RMS / 4) >= 0)
+    }
+
+    // --- description --------------------------------------------------------
+
+    @Test
+    fun `loudness is described only when it was actually measured`() {
+        assertNull(IntroLoudness.describe(null))
+        assertNull(IntroLoudness.describe(IntroLoudness.MIN_MEASURABLE_RMS / 2))
+        assertEquals("level", IntroLoudness.describe(IntroLoudness.TARGET_RMS))
+        assertEquals("loud source", IntroLoudness.describe(IntroLoudness.TARGET_RMS * 2))
+        assertEquals("quiet source", IntroLoudness.describe(IntroLoudness.TARGET_RMS / 2))
+    }
+}

--- a/database/src/main/kotlin/database/dto/guild/ConfigDto.kt
+++ b/database/src/main/kotlin/database/dto/guild/ConfigDto.kt
@@ -30,6 +30,27 @@ class ConfigDto(
 
     enum class Configurations(val configValue: String) {
         INTRO_VOLUME("DEFAULT_INTRO_VOLUME"),
+
+        // Server-wide intro switch. Boolean ("true"/"false"); opt-out, so a
+        // guild with no row keeps playing intros exactly as before. "false"
+        // suppresses both playback on join and the "you don't have an intro
+        // yet" nudge — a server that doesn't want the feature shouldn't be
+        // recruiting people into it.
+        INTROS_ENABLED("INTROS_ENABLED"),
+
+        // Voice channels exempt from intros, as a CSV of channel ids. For the
+        // "study" / "meeting" / on-call channel where an intro is an
+        // interruption rather than a greeting. Unparseable entries are
+        // ignored rather than failing the whole list.
+        INTRO_EXCLUDED_CHANNELS("INTRO_EXCLUDED_CHANNELS"),
+
+        // Loudness normalisation. Boolean ("true"/"false"); opt-out. When on,
+        // each intro's measured level (music_files.measured_rms, sampled on
+        // first play) corrects its volume so two intros set to the same
+        // number sound equally loud. Correction is clamped to 0.5x-2x, so
+        // turning this off changes at most a factor of two either way.
+        INTRO_NORMALISE_VOLUME("INTRO_NORMALISE_VOLUME"),
+
         VOLUME("DEFAULT_VOLUME"),
         MOVE("DEFAULT_MOVE_CHANNEL"),
         DELETE_DELAY("DELETE_MESSAGE_DELAY"),

--- a/database/src/main/kotlin/database/dto/music/MusicDto.kt
+++ b/database/src/main/kotlin/database/dto/music/MusicDto.kt
@@ -5,6 +5,7 @@ import jakarta.persistence.*
 import org.springframework.transaction.annotation.Transactional
 import java.io.Serializable
 import java.security.MessageDigest
+import java.time.Instant
 import database.dto.user.UserDto
 
 @NamedQueries(
@@ -58,7 +59,36 @@ class MusicDto(
      * user can mute an intro without losing the upload.
      */
     @Column(name = "enabled", nullable = false)
-    var enabled: Boolean = true
+    var enabled: Boolean = true,
+
+    /** Times this intro has been loaded for playback. */
+    @Column(name = "play_count", nullable = false)
+    var playCount: Int = 0,
+
+    @Column(name = "last_played_at")
+    var lastPlayedAt: Instant? = null,
+
+    /**
+     * *Consecutive* failed loads — reset to zero by the next success. See
+     * [common.intro.IntroHealth] for what the count means and when an intro
+     * crosses into "broken".
+     */
+    @Column(name = "failure_count", nullable = false)
+    var failureCount: Int = 0,
+
+    @Column(name = "last_failure_at")
+    var lastFailureAt: Instant? = null,
+
+    @Column(name = "last_failure_reason")
+    var lastFailureReason: String? = null,
+
+    /**
+     * The intro's own RMS level, sampled during playback, used to correct the
+     * volume so equal numbers on different tracks sound equally loud. Null
+     * until it has played once with normalisation enabled.
+     */
+    @Column(name = "measured_rms")
+    var measuredRms: Double? = null,
 ) : Serializable {
 
     constructor(

--- a/database/src/main/kotlin/database/persistence/music/MusicFilePersistence.kt
+++ b/database/src/main/kotlin/database/persistence/music/MusicFilePersistence.kt
@@ -9,4 +9,34 @@ interface MusicFilePersistence {
     fun deleteMusicFile(musicDto: MusicDto)
     fun deleteMusicFileById(id: String?)
     fun isFileAlreadyUploaded(musicDto: MusicDto): MusicDto?
+
+    /**
+     * Aggregate report for one guild's intros.
+     *
+     * Deliberately a projection rather than `List<MusicDto>`: the interesting
+     * total is how many bytes of audio the guild is storing, and loading every
+     * row to add up `musicBlob.size` would pull those bytes into heap to
+     * measure them — on a 512 MB dyno, for the one query whose whole purpose
+     * is to warn that they're adding up.
+     */
+    fun getGuildIntroStats(guildId: Long, unhealthyThreshold: Int): GuildIntroStats
 }
+
+/**
+ * @param introCount rows stored for the guild.
+ * @param userCount distinct members holding at least one.
+ * @param storedBytes total size of the stored audio blobs. URL intros hold
+ *        only the URL, so this is effectively "how much uploaded audio".
+ * @param totalPlays lifetime plays summed across the guild's intros.
+ * @param disabledCount intros switched out of the rotation by their owner.
+ * @param brokenCount intros whose consecutive-failure count has crossed the
+ *        unhealthy threshold — the number an admin would actually act on.
+ */
+data class GuildIntroStats(
+    val introCount: Long = 0,
+    val userCount: Long = 0,
+    val storedBytes: Long = 0,
+    val totalPlays: Long = 0,
+    val disabledCount: Long = 0,
+    val brokenCount: Long = 0,
+)

--- a/database/src/main/kotlin/database/persistence/music/impl/DefaultMusicFilePersistence.kt
+++ b/database/src/main/kotlin/database/persistence/music/impl/DefaultMusicFilePersistence.kt
@@ -2,6 +2,7 @@ package database.persistence.music.impl
 
 import common.logging.DiscordLogger
 import database.dto.music.MusicDto
+import database.persistence.music.GuildIntroStats
 import database.persistence.music.MusicFilePersistence
 import jakarta.persistence.EntityManager
 import jakarta.persistence.PersistenceContext
@@ -93,4 +94,44 @@ class DefaultMusicFilePersistence : MusicFilePersistence {
         q.setParameter("id", id)
         q.executeUpdate()
     }
+
+    @Transactional(readOnly = true)
+    override fun getGuildIntroStats(guildId: Long, unhealthyThreshold: Int): GuildIntroStats {
+        return runCatching {
+            // Native because the point is octet_length(music_blob) — the size
+            // of the stored audio without reading the audio. There is no JPQL
+            // spelling for that, and pulling the rows to measure them in Kotlin
+            // would allocate exactly the bytes we're trying to report on.
+            val sql = """
+                SELECT COUNT(*),
+                       COUNT(DISTINCT discord_id),
+                       COALESCE(SUM(octet_length(music_blob)), 0),
+                       COALESCE(SUM(play_count), 0),
+                       COUNT(*) FILTER (WHERE NOT enabled),
+                       COUNT(*) FILTER (WHERE failure_count >= :threshold)
+                FROM music_files
+                WHERE guild_id = :guildId
+            """.trimIndent()
+            val query = entityManager.createNativeQuery(sql)
+            query.setParameter("guildId", guildId)
+            query.setParameter("threshold", unhealthyThreshold)
+
+            val row = query.singleResult as Array<*>
+            GuildIntroStats(
+                introCount = row.longAt(0),
+                userCount = row.longAt(1),
+                storedBytes = row.longAt(2),
+                totalPlays = row.longAt(3),
+                disabledCount = row.longAt(4),
+                brokenCount = row.longAt(5),
+            )
+        }.onFailure {
+            logger.error("Failed to compute intro stats for guild $guildId: ${it.message}")
+        }.getOrDefault(GuildIntroStats())
+    }
+
+    // COUNT and SUM come back as Long on Postgres, but the JDBC driver is free
+    // to widen SUM to BigInteger/BigDecimal, and an all-NULL SUM would be null
+    // were it not for the COALESCE. Normalise rather than cast.
+    private fun Array<*>.longAt(index: Int): Long = (getOrNull(index) as? Number)?.toLong() ?: 0L
 }

--- a/database/src/main/kotlin/database/service/music/MusicFileService.kt
+++ b/database/src/main/kotlin/database/service/music/MusicFileService.kt
@@ -1,6 +1,7 @@
 package database.service.music
 
 import database.dto.music.MusicDto
+import database.persistence.music.GuildIntroStats
 
 interface MusicFileService {
     fun createNewMusicFile(musicDto: MusicDto): MusicDto?
@@ -10,4 +11,7 @@ interface MusicFileService {
     fun deleteMusicFileById(id: String?)
     fun clearCache()
     fun isFileAlreadyUploaded(musicDto: MusicDto): MusicDto?
+
+    /** Aggregate intro report for one guild — see the persistence contract. */
+    fun getGuildIntroStats(guildId: Long, unhealthyThreshold: Int): GuildIntroStats
 }

--- a/database/src/main/kotlin/database/service/music/impl/DefaultMusicFileService.kt
+++ b/database/src/main/kotlin/database/service/music/impl/DefaultMusicFileService.kt
@@ -2,6 +2,7 @@ package database.service.music.impl
 
 import common.events.user.IntroSetEvent
 import database.dto.music.MusicDto
+import database.persistence.music.GuildIntroStats
 import database.persistence.music.MusicFilePersistence
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.cache.annotation.CacheEvict
@@ -58,4 +59,9 @@ class DefaultMusicFileService(
     override fun isFileAlreadyUploaded(musicDto: MusicDto): MusicDto? {
         return musicFileService.isFileAlreadyUploaded(musicDto)
     }
+
+    // Uncached: the report is an admin command run occasionally, and caching it
+    // would show stale counts right after someone fixed a broken intro.
+    override fun getGuildIntroStats(guildId: Long, unhealthyThreshold: Int): GuildIntroStats =
+        musicFileService.getGuildIntroStats(guildId, unhealthyThreshold)
 }

--- a/database/src/main/resources/db/migration/V53__intro_health_and_stats.sql
+++ b/database/src/main/resources/db/migration/V53__intro_health_and_stats.sql
@@ -1,0 +1,30 @@
+-- Intro health, play stats and measured loudness.
+--
+-- Intros play through the voice-join path, which has no interaction to reply
+-- to, so a track that failed to load produced silence and a log line and
+-- nothing else: the owner was never told, and both /listintros and the web
+-- page kept listing a dead link as healthy. failure_count/last_failure_* give
+-- that failure somewhere to live so it can be surfaced and acted on; a
+-- successful load resets the counter, so it always reads as "consecutive
+-- failures".
+--
+-- play_count/last_played_at answer "is this feature used, and by whom" —
+-- previously unanswerable, since nothing recorded that an intro ever played.
+--
+-- measured_rms is the intro's own level, sampled by the playback filter the
+-- first time it plays, and used to correct the volume on later plays so two
+-- intros set to the same number sound equally loud.
+ALTER TABLE public.music_files
+    ADD COLUMN IF NOT EXISTS play_count          INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS last_played_at      TIMESTAMP WITH TIME ZONE NULL,
+    ADD COLUMN IF NOT EXISTS failure_count       INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS last_failure_at     TIMESTAMP WITH TIME ZONE NULL,
+    ADD COLUMN IF NOT EXISTS last_failure_reason VARCHAR(500) NULL,
+    ADD COLUMN IF NOT EXISTS measured_rms        DOUBLE PRECISION NULL;
+
+-- The guild intro report (/introstats) aggregates every row for one guild.
+-- music_files is keyed by (discord_id, guild_id) with no index on guild_id
+-- alone, so without this the report is a sequential scan over every intro in
+-- every server — including their audio blobs.
+CREATE INDEX IF NOT EXISTS idx_music_files_guild_id
+    ON public.music_files (guild_id);

--- a/database/src/test/kotlin/database/persistence/impl/DefaultMusicFilePersistenceStatsTest.kt
+++ b/database/src/test/kotlin/database/persistence/impl/DefaultMusicFilePersistenceStatsTest.kt
@@ -1,0 +1,136 @@
+package database.persistence.impl
+
+import database.persistence.music.impl.DefaultMusicFilePersistence
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import jakarta.persistence.EntityManager
+import jakarta.persistence.Query
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.math.BigInteger
+
+/**
+ * The mapping half of the guild intro report.
+ *
+ * That the SQL is valid is proven against a real Postgres in
+ * `GuildIntroStatsIntegrationTest` — `octet_length` and `COUNT(*) FILTER`
+ * have no JPQL spelling, and the whole point of the query is to total the
+ * size of the stored audio without loading it. What's asserted here is the
+ * part that has bitten before: JDBC is free to hand back `COUNT` as Long,
+ * `SUM` as BigInteger or BigDecimal, and an empty table as nulls, and a
+ * straight cast would throw on a report nobody would then be able to read.
+ */
+class DefaultMusicFilePersistenceStatsTest {
+
+    private lateinit var em: EntityManager
+    private lateinit var query: Query
+    private lateinit var persistence: DefaultMusicFilePersistence
+
+    private val guildId = 4567L
+
+    @BeforeEach
+    fun setUp() {
+        em = mockk(relaxed = true)
+        query = mockk(relaxed = true)
+        every { em.createNativeQuery(any<String>()) } returns query
+        every { query.setParameter(any<String>(), any()) } returns query
+        persistence = DefaultMusicFilePersistence().apply {
+            DefaultMusicFilePersistence::class.java
+                .getDeclaredField("entityManager")
+                .apply { isAccessible = true }
+                .set(this, em)
+        }
+    }
+
+    private fun resultRow(vararg values: Any?) {
+        every { query.singleResult } returns arrayOf(*values)
+    }
+
+    @Test
+    fun `each column lands in the field it belongs to`() {
+        resultRow(3L, 2L, 600L, 9L, 1L, 1L)
+
+        val stats = persistence.getGuildIntroStats(guildId, 2)
+
+        assertEquals(3L, stats.introCount)
+        assertEquals(2L, stats.userCount)
+        assertEquals(600L, stats.storedBytes)
+        assertEquals(9L, stats.totalPlays)
+        assertEquals(1L, stats.disabledCount)
+        assertEquals(1L, stats.brokenCount)
+    }
+
+    @Test
+    fun `sums returned as BigInteger or BigDecimal are still read as numbers`() {
+        resultRow(BigInteger.valueOf(3), 2L, BigDecimal("600"), BigInteger.valueOf(9), 0L, 0L)
+
+        val stats = persistence.getGuildIntroStats(guildId, 2)
+
+        assertEquals(3L, stats.introCount)
+        assertEquals(600L, stats.storedBytes)
+        assertEquals(9L, stats.totalPlays)
+    }
+
+    @Test
+    fun `a null column reads as zero rather than blowing up the report`() {
+        resultRow(0L, 0L, null, null, null, null)
+
+        val stats = persistence.getGuildIntroStats(guildId, 2)
+
+        assertEquals(0L, stats.storedBytes)
+        assertEquals(0L, stats.totalPlays)
+    }
+
+    @Test
+    fun `a short row does not throw`() {
+        resultRow(1L)
+
+        val stats = persistence.getGuildIntroStats(guildId, 2)
+
+        assertEquals(1L, stats.introCount)
+        assertEquals(0L, stats.brokenCount)
+    }
+
+    @Test
+    fun `the guild and threshold are bound as parameters, not interpolated`() {
+        resultRow(0L, 0L, 0L, 0L, 0L, 0L)
+        val names = mutableListOf<String>()
+        val values = mutableListOf<Any>()
+        every { query.setParameter(capture(names), capture(values)) } returns query
+
+        persistence.getGuildIntroStats(guildId, 2)
+
+        assertEquals(listOf("guildId", "threshold"), names)
+        assertEquals(listOf<Any>(guildId, 2), values)
+    }
+
+    @Test
+    fun `the query filters on guild_id rather than scanning every server`() {
+        // music_files is keyed by (discord_id, guild_id); the report must use
+        // the indexed column, not a LIKE over the composite row id.
+        resultRow(0L, 0L, 0L, 0L, 0L, 0L)
+        val sql = slot<String>()
+        every { em.createNativeQuery(capture(sql)) } returns query
+
+        persistence.getGuildIntroStats(guildId, 2)
+
+        assertTrue(sql.captured.contains("WHERE guild_id = :guildId"), sql.captured)
+        assertTrue(sql.captured.contains("octet_length(music_blob)"), sql.captured)
+    }
+
+    @Test
+    fun `a database failure degrades to an empty report`() {
+        // /introstats is a diagnostic; failing it with a stack trace when the
+        // database hiccups helps nobody.
+        every { query.singleResult } throws IllegalStateException("connection reset")
+
+        val stats = persistence.getGuildIntroStats(guildId, 2)
+
+        assertEquals(0L, stats.introCount)
+        assertEquals(0L, stats.storedBytes)
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
@@ -5,6 +5,7 @@ import bot.toby.modal.modals.setconfig.SetConfigBlackjackRulesModal
 import bot.toby.modal.modals.setconfig.SetConfigBlackjackTableModal
 import bot.toby.modal.modals.setconfig.SetConfigFeesModal
 import bot.toby.modal.modals.setconfig.SetConfigGeneralModal
+import bot.toby.modal.modals.setconfig.SetConfigIntroModal
 import bot.toby.modal.modals.setconfig.SetConfigJackpotActivityModal
 import bot.toby.modal.modals.setconfig.SetConfigJackpotModal
 import bot.toby.modal.modals.setconfig.SetConfigLotteryBasicsModal
@@ -47,6 +48,7 @@ import common.casino.blackjack.Blackjack
 class SetConfigCommand @Autowired constructor(
     private val configService: ConfigService,
     private val general: SetConfigGeneralModal,
+    private val intro: SetConfigIntroModal,
     private val activity: SetConfigActivityModal,
     private val fees: SetConfigFeesModal,
     private val jackpot: SetConfigJackpotModal,
@@ -68,6 +70,7 @@ class SetConfigCommand @Autowired constructor(
 
     override val subCommands: List<SubcommandData> = listOf(
         SubcommandData(SUB_GENERAL, "Audio + auto-delete + move/leaderboard channels"),
+        SubcommandData(SUB_INTRO, "Intros on/off, default volume, loudness matching, silent channels"),
         SubcommandData(SUB_ACTIVITY, "Game-activity tracking + UBI + daily credit cap"),
         SubcommandData(SUB_FEES, "Loss tribute, jackpot win %, Toby Coin trade fees"),
         SubcommandData(SUB_JACKPOT, "Jackpot stake anchor, cooldown, RTP gate, modlog channel"),
@@ -112,6 +115,7 @@ class SetConfigCommand @Autowired constructor(
 
         val modal = when (sub) {
             SUB_GENERAL -> general.buildModal(SetConfigGeneralModal.MODAL_NAME, guild, reader)
+            SUB_INTRO -> intro.buildModal(SetConfigIntroModal.MODAL_NAME, guild, reader)
             SUB_ACTIVITY -> activity.buildModal(SetConfigActivityModal.MODAL_NAME, guild, reader)
             SUB_FEES -> fees.buildModal(SetConfigFeesModal.MODAL_NAME, guild, reader)
             SUB_JACKPOT -> jackpot.buildModal(SetConfigJackpotModal.MODAL_NAME, guild, reader)
@@ -143,6 +147,7 @@ class SetConfigCommand @Autowired constructor(
 
     companion object {
         const val SUB_GENERAL = "general"
+        const val SUB_INTRO = "intro"
         const val SUB_ACTIVITY = "activity"
         const val SUB_FEES = "fees"
         const val SUB_JACKPOT = "jackpot"

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/music/intro/IntroStatsCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/music/intro/IntroStatsCommand.kt
@@ -1,0 +1,140 @@
+package bot.toby.command.commands.music.intro
+
+import bot.toby.command.commands.music.MusicCommand
+import bot.toby.intro.IntroPresenter
+import bot.toby.lavaplayer.PlayerManager
+import common.discord.embed
+import common.discord.field
+import common.intro.IntroGuildPolicy
+import common.intro.IntroHealth
+import core.command.CommandContext
+import database.dto.guild.ConfigDto.Configurations.INTROS_ENABLED
+import database.dto.guild.ConfigDto.Configurations.INTRO_EXCLUDED_CHANNELS
+import database.dto.user.UserDto
+import database.persistence.music.GuildIntroStats
+import database.service.guild.ConfigService
+import database.service.music.MusicFileService
+import net.dv8tion.jda.api.components.actionrow.ActionRow
+import net.dv8tion.jda.api.entities.Guild
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import java.awt.Color
+
+/**
+ * `/introstats` — the server-wide view of the intro feature.
+ *
+ * Three things had no home before this. How many intros are broken, which
+ * nobody could see at all. How much audio the server is storing, which grows
+ * quietly at up to 550KB × 3 per member and is only interesting shortly before
+ * it becomes a problem. And whether the feature is used at all, which nothing
+ * recorded.
+ *
+ * Super-user only: it reports across every member, so it's a moderation view
+ * rather than a personal one. Members get their own numbers from `/listintros`.
+ */
+@Component
+class IntroStatsCommand @Autowired constructor(
+    private val musicFileService: MusicFileService,
+    private val configService: ConfigService,
+) : MusicCommand {
+
+    override val ephemeral: Boolean = true
+
+    override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        handleMusicCommand(ctx, PlayerManager.instance, requestingUserDto, deleteDelay)
+    }
+
+    override fun handleMusicCommand(
+        ctx: CommandContext,
+        instance: PlayerManager,
+        requestingUserDto: UserDto,
+        deleteDelay: Int
+    ) {
+        val event = ctx.event
+        logger.setGuildAndMemberContext(ctx.guild, ctx.member)
+
+        if (!requestingUserDto.superUser) {
+            sendErrorMessage(event, deleteDelay)
+            return
+        }
+        val guild = ctx.guild ?: run {
+            event.hook.sendMessage("Intros are per-server — run this inside the server you want to inspect.")
+                .setEphemeral(true).queue()
+            return
+        }
+
+        val stats = musicFileService.getGuildIntroStats(guild.idLong, IntroHealth.UNHEALTHY_AFTER_FAILURES)
+        event.hook.sendMessageEmbeds(statsEmbed(guild, stats))
+            .addComponents(ActionRow.of(IntroPresenter.webDashboardButton(guild.idLong)))
+            .setEphemeral(true)
+            .queue()
+    }
+
+    private fun statsEmbed(guild: Guild, stats: GuildIntroStats) = embed(
+        title = "Intro report — ${guild.name}",
+        color = INTRO_COLOR,
+        description = if (stats.introCount == 0L) {
+            "Nobody on this server has set an intro yet."
+        } else {
+            "${stats.introCount} intro${plural(stats.introCount)} across " +
+                "${stats.userCount} member${plural(stats.userCount)}."
+        },
+    ) {
+        field(name = "Plays", value = "**${stats.totalPlays}** since play counts were added", inline = true)
+        field(name = "Stored audio", value = "**${formatBytes(stats.storedBytes)}**", inline = true)
+        field(
+            name = "Switched off",
+            value = "**${stats.disabledCount}** by their owner",
+            inline = true,
+        )
+        field(
+            name = "Not playing",
+            value = if (stats.brokenCount == 0L) {
+                "**0** — every intro is loading fine"
+            } else {
+                // Owners are DM'd when theirs breaks, but that DM can be
+                // missed or muted, so the count is repeated where an admin
+                // will see it.
+                "**${stats.brokenCount}** failing to load. Owners have been " +
+                    "DM'd; they can replace the link with `/setintro`."
+            },
+        )
+        field(name = "Server settings", value = describeSettings(guild))
+        setFooter("Storage is the audio uploaded to TobyBot; link intros store only the link.")
+    }
+
+    private fun describeSettings(guild: Guild): String {
+        val enabledRaw = configService.getConfigByName(INTROS_ENABLED.configValue, guild.id)?.value
+        val excludedRaw = configService.getConfigByName(INTRO_EXCLUDED_CHANNELS.configValue, guild.id)?.value
+        if (!IntroGuildPolicy.introsEnabled(enabledRaw)) {
+            return "Intros are **off** server-wide (`/setconfig intro`)."
+        }
+        val excluded = IntroGuildPolicy.excludedChannelIds(excludedRaw)
+        if (excluded.isEmpty()) return "Intros are **on** in every voice channel."
+        val named = excluded.joinToString(", ") { id ->
+            guild.getVoiceChannelById(id)?.let { "#${it.name}" } ?: "`$id`"
+        }
+        return "Intros are **on**, except in: $named"
+    }
+
+    private fun plural(count: Long) = if (count == 1L) "" else "s"
+
+    /**
+     * Binary units, because the thing being sized is a Postgres column and the
+     * limit an admin will eventually hit is quoted the same way.
+     */
+    internal fun formatBytes(bytes: Long): String = when {
+        bytes < 1024 -> "$bytes B"
+        bytes < 1024 * 1024 -> "${bytes / 1024} KB"
+        bytes < 1024L * 1024 * 1024 -> String.format("%.1f MB", bytes / (1024.0 * 1024.0))
+        else -> String.format("%.2f GB", bytes / (1024.0 * 1024.0 * 1024.0))
+    }
+
+    override val name: String get() = "introstats"
+
+    override val description: String get() = "Server-wide intro report: usage, broken intros and storage (super-users)."
+
+    companion object {
+        private val INTRO_COLOR: Color = Color(88, 101, 242) // Discord blurple
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/handler/VoiceEventHandler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/handler/VoiceEventHandler.kt
@@ -10,8 +10,12 @@ import bot.toby.lavaplayer.PlayerManager
 import bot.toby.managers.NowPlayingManager
 import bot.toby.voice.LastConnectedChannelTracker
 import bot.toby.voice.VoiceSessionLifecycle
+import common.intro.IntroGuildPolicy
 import common.logging.DiscordLogger
 import database.dto.guild.ConfigDto.Configurations.DELETE_DELAY
+import database.dto.guild.ConfigDto.Configurations.INTROS_ENABLED
+import database.dto.guild.ConfigDto.Configurations.INTRO_EXCLUDED_CHANNELS
+import database.dto.guild.ConfigDto.Configurations.INTRO_NORMALISE_VOLUME
 import database.dto.guild.ConfigDto.Configurations.VOLUME
 import database.service.guild.ConfigService
 import database.service.social.SocialCreditAwardService
@@ -183,15 +187,36 @@ class VoiceEventHandler(
             event.channelJoined?.let { voiceSessionLifecycle.openSession(event.member.idLong, guild.idLong, it, now) }
         }
 
+        // Server-wide switch and per-channel exemptions. Checked once here so
+        // both playback and the "you don't have an intro yet" nudge respect
+        // them — a server that has turned intros off shouldn't be recruiting
+        // people into setting one.
+        val introsAllowedHere = introsAllowedIn(guild, event.channelJoined?.idLong)
+
         val requestingUserDto = event.member.getRequestingUserDto(userDtoHelper)
-        if (audioManager.connectedChannel == event.channelJoined) {
+        if (audioManager.connectedChannel == event.channelJoined && introsAllowedHere) {
             logger.info { "AudioManager channel and event joined channel are the same" }
             setupAndPlayUserIntro(event, guild, deleteDelay, requestingUserDto)
         }
-        if (requestingUserDto.musicDtos.isEmpty() && event.member.user.idLong != event.jda.selfUser.idLong) {
+        if (introsAllowedHere &&
+            requestingUserDto.musicDtos.isEmpty() &&
+            event.member.user.idLong != event.jda.selfUser.idLong
+        ) {
             logger.info { "Prompting user to set an intro ..." }
             introHelper.promptUserForMusicInfo(event.member.user, guild)
         }
+    }
+
+    private fun introsAllowedIn(guild: Guild, channelId: Long?): Boolean {
+        val allowed = IntroGuildPolicy.playsIn(
+            enabledRaw = getConfigString(INTROS_ENABLED.configValue, guild.id),
+            excludedRaw = getConfigString(INTRO_EXCLUDED_CHANNELS.configValue, guild.id),
+            channelId = channelId,
+        )
+        if (!allowed) {
+            logger.info { "Intros are switched off for guild ${guild.idLong} or channel $channelId; skipping." }
+        }
+        return allowed
     }
 
     private fun checkStateAndConnectToVoiceChannel(
@@ -239,6 +264,9 @@ class VoiceEventHandler(
                 member = member,
                 lastPlayedIntroId = introPlaybackTracker.lastPlayedIntroId(
                     guild.idLong, requestingUserDto.discordId
+                ),
+                normaliseVolume = IntroGuildPolicy.normaliseVolume(
+                    getConfigString(INTRO_NORMALISE_VOLUME.configValue, guild.id)
                 ),
             )
             introPlaybackTracker.record(guild.idLong, requestingUserDto.discordId, played?.id)
@@ -310,6 +338,10 @@ class VoiceEventHandler(
         val config = configService.getConfigByName(configName, guildId)
         return config?.value?.toInt() ?: defaultValue
     }
+
+    /** Raw config value, or null when the guild has never set the key. */
+    private fun getConfigString(configName: String, guildId: String): String? =
+        configService.getConfigByName(configName, guildId)?.value
 
     companion object {
         // Small, daily-capped reward so joining a channel with an intro set

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/MusicPlayerHelper.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/MusicPlayerHelper.kt
@@ -10,6 +10,7 @@ import bot.toby.util.isUrl as utilIsUrl
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayer
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack
 import common.discord.embed
+import common.intro.IntroLoudness
 import common.logging.DiscordLogger
 import core.command.Command.Companion.replyEmbedAndDelete
 import core.command.Command.Companion.replyEphemeralEmbedAndDelete
@@ -32,6 +33,10 @@ object MusicPlayerHelper {
     /**
      * @param lastPlayedIntroId the intro played for this user last time, so
      *        [IntroSelection] can avoid repeating it back to back.
+     * @param normaliseVolume apply the intro's measured-loudness correction so
+     *        it lands at the same perceived level as everyone else's. Inert
+     *        until the intro has played once and been measured, so an existing
+     *        install hears no change on the first play of anything.
      * @return the intro that was played, or null when the user has none (or
      *         playback failed) — callers record it as the new "last played".
      */
@@ -42,7 +47,8 @@ object MusicPlayerHelper {
         deleteDelay: Int,
         startPosition: Long = 0,
         member: Member? = null,
-        lastPlayedIntroId: String? = null
+        lastPlayedIntroId: String? = null,
+        normaliseVolume: Boolean = true,
     ): MusicDto? {
         logger.setGuildAndMemberContext(guild, member)
         logger.info { "Finding intro to play ..." }
@@ -57,7 +63,18 @@ object MusicPlayerHelper {
 
         return runCatching {
             logger.info { "User has a musicDto. Preparing to play intro." }
-            val introVolume = selected.introVolume
+            val nominalVolume = selected.introVolume ?: currentVolume
+            val playbackVolume = if (normaliseVolume) {
+                IntroLoudness.normalisedVolume(nominalVolume, selected.measuredRms)
+            } else {
+                nominalVolume
+            }
+            if (playbackVolume != nominalVolume) {
+                logger.info {
+                    "Normalising intro '${selected.id}' from $nominalVolume to $playbackVolume " +
+                        "(measured rms ${selected.measuredRms})"
+                }
+            }
             instance.setPreviousVolume(currentVolume)
             val url = determineUrlFromMusicDto(selected)
             val clipStart = selected.startMs?.toLong() ?: startPosition
@@ -65,7 +82,7 @@ object MusicPlayerHelper {
             logger.info { "Url to play is: '$url' (clip ${clipStart}ms -> ${clipEnd ?: "end"})" }
             instance.loadAndPlayIntro(
                 guild, event, url, deleteDelay, clipStart,
-                introVolume ?: currentVolume, clipEnd
+                playbackVolume, clipEnd, selected.id,
             )
             selected
         }.onFailure {

--- a/discord-bot/src/main/kotlin/bot/toby/intro/IntroHealthService.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/intro/IntroHealthService.kt
@@ -1,0 +1,119 @@
+package bot.toby.intro
+
+import bot.toby.notify.NotificationRouter
+import common.discord.embed
+import common.intro.IntroHealth
+import common.logging.DiscordLogger
+import common.notification.NotificationChannelKind
+import database.dto.music.MusicDto
+import database.service.music.MusicFileService
+import net.dv8tion.jda.api.components.actionrow.ActionRow
+import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Service
+import java.awt.Color
+import java.time.Instant
+
+/**
+ * Keeps each intro row's health and play history up to date, and tells the
+ * owner when one of theirs has stopped working.
+ *
+ * The gap this closes: intros play from the voice-join path, which has no
+ * interaction to reply to, so `PlayerManager`'s failure branches were writing
+ * to a null hook. A YouTube link that had been deleted, region-locked or
+ * age-gated produced silence on every join, indefinitely, while `/listintros`
+ * and the web page both still described it as fine. The only evidence was a
+ * server log nobody reads.
+ */
+@Service
+class IntroHealthService(
+    private val musicFileService: MusicFileService,
+    private val notificationRouter: NotificationRouter? = null,
+) {
+    private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
+
+    @EventListener
+    fun onIntroPlayed(event: IntroPlayedEvent) {
+        update(event.introId) { dto ->
+            dto.playCount += 1
+            dto.lastPlayedAt = Instant.now()
+            // A success is what makes the failure count "consecutive". Without
+            // this reset a link that broke for a week in 2024 would still be
+            // flagged today.
+            dto.failureCount = 0
+            dto.lastFailureReason = null
+        }
+    }
+
+    @EventListener
+    fun onIntroLoadFailed(event: IntroLoadFailedEvent) {
+        val reason = IntroHealth.normaliseReason(event.reason)
+        val updated = update(event.introId) { dto ->
+            dto.failureCount += 1
+            dto.lastFailureAt = Instant.now()
+            dto.lastFailureReason = reason
+        } ?: return
+
+        // Notify on the crossing only. Nagging every join would make the
+        // notification worthless faster than the broken intro does.
+        if (updated.failureCount == IntroHealth.UNHEALTHY_AFTER_FAILURES) {
+            notifyOwner(updated, reason)
+        }
+    }
+
+    @EventListener
+    fun onIntroLoudnessMeasured(event: IntroLoudnessMeasuredEvent) {
+        update(event.introId) { dto -> dto.measuredRms = event.rms }
+    }
+
+    private fun update(introId: String, mutate: (MusicDto) -> Unit): MusicDto? =
+        runCatching {
+            val dto = musicFileService.getMusicFileById(introId)
+            if (dto == null) {
+                // Normal, not alarming: the owner can delete an intro between
+                // it being queued and its outcome arriving.
+                logger.info { "Intro $introId no longer exists; dropping its playback outcome." }
+                return@runCatching null
+            }
+            mutate(dto)
+            musicFileService.updateMusicFile(dto)
+            dto
+        }.onFailure {
+            // Called from event handlers on the audio and load paths — a throw
+            // here must not take playback with it.
+            logger.error("Failed to record playback outcome for intro $introId: ${it.message}")
+        }.getOrNull()
+
+    private fun notifyOwner(dto: MusicDto, reason: String) {
+        val owner = dto.userDto ?: return
+        val router = notificationRouter ?: return
+        val name = IntroPresenter.displayName(dto)
+        logger.info { "Intro ${dto.id} ('$name') has failed ${dto.failureCount} times; notifying owner." }
+        runCatching {
+            router.sendDm(owner.discordId, owner.guildId, NotificationChannelKind.INTRO_BROKEN) {
+                MessageCreateBuilder()
+                    .setEmbeds(brokenEmbed(name, dto, reason))
+                    .setComponents(ActionRow.of(IntroPresenter.webDashboardButton(owner.guildId, "Fix my intro")))
+                    .build()
+            }
+        }.onFailure {
+            logger.error("Failed to DM owner about broken intro ${dto.id}: ${it.message}")
+        }
+    }
+
+    private fun brokenEmbed(name: String, dto: MusicDto, reason: String) = embed(
+        title = "Your intro isn't playing",
+        color = BROKEN_COLOR,
+        description = "**$name** (slot #${dto.index ?: '?'}) has failed to load " +
+            "${dto.failureCount} times in a row, so nothing plays when you join voice.\n\n" +
+            "> $reason\n\n" +
+            "This usually means the video was deleted, made private, age-gated or " +
+            "blocked in the bot's region. Replacing the link fixes it.",
+    ) {
+        setFooter("Don't want these? Run /notify set INTRO_BROKEN off")
+    }
+
+    companion object {
+        private val BROKEN_COLOR: Color = Color(237, 66, 69) // Discord red
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/intro/IntroPlaybackEvents.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/intro/IntroPlaybackEvents.kt
@@ -1,0 +1,46 @@
+package bot.toby.intro
+
+/**
+ * Facts about an intro's playback that originate below Spring.
+ *
+ * `PlayerManager` / `GuildMusicManager` / `TrackScheduler` are constructed by
+ * the `PlayerManager` singleton rather than the container, so they reach the
+ * bean that persists these through [bot.toby.lavaplayer.SchedulerEvents] —
+ * the same static bridge the track events already use. Publishing rather than
+ * calling a service keeps the audio path free of a Spring dependency, and a
+ * missing publisher (unit tests) degrades to a no-op instead of an NPE.
+ */
+sealed interface IntroPlaybackEvent {
+    val introId: String
+}
+
+/**
+ * An intro's audio was sampled during playback. [rms] is its own level, in
+ * the -1..1 float PCM domain, before any volume was applied.
+ */
+data class IntroLoudnessMeasuredEvent(
+    override val introId: String,
+    val rms: Double,
+) : IntroPlaybackEvent
+
+/**
+ * An intro's source loaded and started. This is the closest thing to "it
+ * played" that the load path can honestly report — a source that starts and
+ * then dies mid-stream is a different failure, and one nobody has complained
+ * about.
+ */
+data class IntroPlayedEvent(
+    override val introId: String,
+) : IntroPlaybackEvent
+
+/**
+ * An intro's source could not be loaded, after lavaplayer exhausted its
+ * retries. [reason] is the human-readable message shown back to the owner.
+ *
+ * No guild/user on the event: the handler loads the row to bump its failure
+ * count anyway, and that row already knows whose it is.
+ */
+data class IntroLoadFailedEvent(
+    override val introId: String,
+    val reason: String,
+) : IntroPlaybackEvent

--- a/discord-bot/src/main/kotlin/bot/toby/intro/IntroPresenter.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/intro/IntroPresenter.kt
@@ -4,12 +4,15 @@ import bot.toby.BOT_WEB_URL
 import common.discord.embed
 import common.discord.field
 import common.intro.IntroClip
+import common.intro.IntroHealth
 import database.dto.music.MusicDto
 import net.dv8tion.jda.api.components.buttons.Button
 import net.dv8tion.jda.api.components.selections.SelectOption
 import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.MessageEmbed
 import java.awt.Color
+import java.time.Duration
+import java.time.Instant
 
 /**
  * Rendering for everything intro-shaped that Discord shows: the select-menu
@@ -47,10 +50,42 @@ object IntroPresenter {
      * notice when wondering why it never plays.
      */
     fun summary(intro: MusicDto): String = buildString {
+        // Broken first, then off: both explain "why doesn't this play", and a
+        // broken intro is the one the user didn't choose and can't see.
+        if (isBroken(intro)) append("BROKEN · ")
         if (!intro.enabled) append("OFF · ")
         append("Slot #${intro.index ?: '?'}")
         append(" · Volume ${intro.introVolume ?: 100}%")
         append(" · ${IntroClip.describe(intro.startMs, intro.endMs)}")
+    }
+
+    /** Whether this intro's source has failed enough times to be called dead. */
+    fun isBroken(intro: MusicDto): Boolean = IntroHealth.isUnhealthy(intro.failureCount)
+
+    /**
+     * `Played 12× · last 3 days ago` — or null for an intro that has never
+     * played, where "Played 0×" is noise rather than information.
+     *
+     * Play counts only start from the deploy that introduced them, so an
+     * old intro reading as never-played is expected for a while.
+     */
+    fun playSummary(intro: MusicDto, now: Instant = Instant.now()): String? {
+        if (intro.playCount <= 0) return null
+        val last = intro.lastPlayedAt?.let { " · last ${relativeTime(it, now)}" }.orEmpty()
+        return "Played ${intro.playCount}×$last"
+    }
+
+    /** Coarse "3 days ago" phrasing — exact timestamps aren't the point here. */
+    internal fun relativeTime(then: Instant, now: Instant): String {
+        val seconds = Duration.between(then, now).seconds
+        return when {
+            seconds < 0 -> "just now"
+            seconds < 60 -> "just now"
+            seconds < 3_600 -> "${seconds / 60}m ago"
+            seconds < 86_400 -> "${seconds / 3_600}h ago"
+            seconds < 86_400 * 30 -> "${seconds / 86_400}d ago"
+            else -> "${seconds / (86_400 * 30)}mo ago"
+        }
     }
 
     /**
@@ -73,6 +108,9 @@ object IntroPresenter {
                 ordered.none { it.enabled } ->
                     "Every intro is switched off, so nothing plays on join. " +
                         "Turn one back on with `/editintro`."
+                ordered.filter { it.enabled }.all { isBroken(it) } ->
+                    "Every intro that's switched on has stopped loading, so nothing plays on join. " +
+                        "Replacing the link with `/setintro` fixes it."
                 else ->
                     "TobyBot plays one of these at random when you join a voice channel."
             },
@@ -83,7 +121,11 @@ object IntroPresenter {
                 .takeIf { it.startsWith("http://") || it.startsWith("https://") }
                 ?.let { setThumbnail(it) }
             ordered.forEach { intro ->
-                val marker = if (intro.enabled) "" else " (off)"
+                val marker = when {
+                    isBroken(intro) -> " ⚠️"
+                    !intro.enabled -> " (off)"
+                    else -> ""
+                }
                 field(
                     name = "#${intro.index ?: '?'} · ${truncate(displayName(intro), FIELD_NAME_LIMIT)}$marker",
                     value = buildString {
@@ -91,6 +133,14 @@ object IntroPresenter {
                         append(" · Clip **${IntroClip.describe(intro.startMs, intro.endMs)}**")
                         append(" · ${if (isUrlIntro(intro)) "Link" else "Uploaded file"}")
                         if (!intro.enabled) append(" · **skipped on join**")
+                        playSummary(intro)?.let { append("\n$it") }
+                        if (isBroken(intro)) {
+                            // The reason is the actionable half — "video
+                            // unavailable" and "region blocked" call for
+                            // different fixes.
+                            append("\n**Not playing** — ")
+                            append(truncate(intro.lastFailureReason ?: "source could not be loaded", REASON_LIMIT))
+                        }
                     },
                 )
             }
@@ -103,6 +153,9 @@ object IntroPresenter {
         Button.link("$BOT_WEB_URL/intro/$guildId", label)
 
     private const val FIELD_NAME_LIMIT = 200
+
+    /** Failure reasons come from the audio source and can be paragraphs. */
+    private const val REASON_LIMIT = 200
 
     private fun truncate(text: String, limit: Int = SELECT_TEXT_LIMIT): String =
         if (text.length <= limit) text else text.take(limit - 1).trimEnd() + "…"

--- a/discord-bot/src/main/kotlin/bot/toby/intro/IntroSelection.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/intro/IntroSelection.kt
@@ -1,5 +1,6 @@
 package bot.toby.intro
 
+import common.intro.IntroHealth
 import database.dto.music.MusicDto
 import kotlin.random.Random
 
@@ -12,7 +13,9 @@ import kotlin.random.Random
  * didn't feel random. Excluding the previous pick keeps every join a change
  * while staying uniform across the rest.
  *
- * Disabled intros ([MusicDto.enabled]) are skipped entirely.
+ * Disabled intros ([MusicDto.enabled]) are skipped entirely, and intros whose
+ * source has repeatedly failed to load are skipped in favour of one that
+ * works — see [common.intro.IntroHealth].
  */
 object IntroSelection {
 
@@ -28,7 +31,16 @@ object IntroSelection {
     ): MusicDto? {
         // A disabled intro keeps its slot but sits out the rotation; with all
         // of them off the user has effectively muted themselves, so play none.
-        val candidates = intros.filter { it.enabled }
+        val enabled = intros.filter { it.enabled }
+
+        // Prefer intros that actually load. Someone with a working intro and a
+        // dead one shouldn't get silence half the time while they wait to
+        // notice. This is a preference, not a filter: if every intro looks
+        // broken we still try one, because the alternative is guaranteeing the
+        // silence we're trying to avoid — and the source may well have come
+        // back (a region block lifting, YouTube unthrottling the bot's IP).
+        val healthy = enabled.filterNot { IntroHealth.isUnhealthy(it.failureCount) }
+        val candidates = healthy.ifEmpty { enabled }
         if (candidates.size <= 1) return candidates.firstOrNull()
 
         // With only one intro left after excluding the previous pick there is

--- a/discord-bot/src/main/kotlin/bot/toby/lavaplayer/GuildMusicManager.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/lavaplayer/GuildMusicManager.kt
@@ -1,5 +1,6 @@
 package bot.toby.lavaplayer
 
+import bot.toby.intro.IntroLoudnessMeasuredEvent
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayer
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager
 
@@ -11,6 +12,16 @@ class GuildMusicManager(manager: AudioPlayerManager, idLong: Long = 0) {
 
     init {
         audioPlayer.addListener(this.scheduler)
+        // Measures how loud each intro actually is so its volume can be
+        // corrected on later plays. The factory builds an empty chain for
+        // everything that isn't an intro, so regular music playback is
+        // untouched.
+        audioPlayer.setFilterFactory(
+            IntroLoudnessFilterFactory(
+                introIdOf = { track -> scheduler.introIdFor(track) },
+                onMeasured = { introId, rms -> SchedulerEvents.publish(IntroLoudnessMeasuredEvent(introId, rms)) },
+            ),
+        )
         this.sendHandler = AudioPlayerSendHandler(this.audioPlayer)
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/lavaplayer/IntroLoudnessFilterFactory.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/lavaplayer/IntroLoudnessFilterFactory.kt
@@ -1,0 +1,49 @@
+package bot.toby.lavaplayer
+
+import com.sedmelluq.discord.lavaplayer.filter.AudioFilter
+import com.sedmelluq.discord.lavaplayer.filter.PcmFilterFactory
+import com.sedmelluq.discord.lavaplayer.filter.UniversalPcmAudioFilter
+import com.sedmelluq.discord.lavaplayer.format.AudioDataFormat
+import com.sedmelluq.discord.lavaplayer.track.AudioTrack
+import common.logging.DiscordLogger
+
+/**
+ * Installs [IntroLoudnessMeter] on intro tracks, and only on intro tracks.
+ *
+ * The factory is set once per guild player, so it sees every track the guild
+ * plays — hour-long queued music included. Measuring those would be pointless
+ * work on the audio thread for a number nothing reads, so [introIdOf] gates
+ * it: no intro id, no filter, and the chain stays empty exactly as it is
+ * today for regular playback.
+ *
+ * @param introIdOf resolves the intro row id for a track, or null if the
+ *        track isn't an intro. Backed by [TrackScheduler]'s intro bookkeeping.
+ * @param onMeasured receives `(introId, rms)` once the track's chain closes.
+ */
+class IntroLoudnessFilterFactory(
+    private val introIdOf: (AudioTrack) -> String?,
+    private val onMeasured: (String, Double) -> Unit,
+) : PcmFilterFactory {
+
+    private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
+
+    override fun buildChain(
+        track: AudioTrack,
+        format: AudioDataFormat,
+        output: UniversalPcmAudioFilter,
+    ): List<AudioFilter> {
+        val introId = runCatching { introIdOf(track) }.getOrNull() ?: return emptyList()
+        // The returned list runs in signal order and its last element feeds
+        // `output`; with a single filter the meter is both head and tail.
+        return listOf(
+            IntroLoudnessMeter(output) { rms ->
+                runCatching { onMeasured(introId, rms) }.onFailure {
+                    // This runs on lavaplayer's audio thread. A throw here
+                    // would surface as a broken pipeline mid-playback, which
+                    // is a spectacularly bad trade for a statistic.
+                    logger.warn { "Failed to record measured loudness for intro $introId: ${it.message}" }
+                }
+            },
+        )
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/lavaplayer/IntroLoudnessMeter.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/lavaplayer/IntroLoudnessMeter.kt
@@ -1,0 +1,72 @@
+package bot.toby.lavaplayer
+
+import com.sedmelluq.discord.lavaplayer.filter.FloatPcmAudioFilter
+import common.intro.IntroLoudness
+
+/**
+ * A pass-through PCM filter that measures how loud an intro actually is.
+ *
+ * It sits in lavaplayer's user filter chain, ahead of `FinalPcmAudioFilter`
+ * and therefore ahead of `VolumePostProcessor` — so the samples it sees are
+ * the track's own level, not the level the listener hears. That's the whole
+ * point: measuring post-volume would just tell us the number the user already
+ * chose.
+ *
+ * Every sample is forwarded to [downstream] unmodified. This filter never
+ * changes what anyone hears; the correction it enables is applied later, as
+ * an ordinary player volume on the *next* play.
+ */
+class IntroLoudnessMeter(
+    private val downstream: FloatPcmAudioFilter,
+    private val onMeasured: (Double) -> Unit,
+) : FloatPcmAudioFilter {
+
+    private var sumOfSquares = 0.0
+    private var sampleCount = 0L
+    private var reported = false
+
+    override fun process(input: Array<FloatArray>, offset: Int, length: Int) {
+        accumulate(input, offset, length)
+        downstream.process(input, offset, length)
+    }
+
+    private fun accumulate(input: Array<FloatArray>, offset: Int, length: Int) {
+        if (length <= 0) return
+        for (channel in input) {
+            // Defensive: lavaplayer sizes these to the negotiated channel
+            // count, but a short buffer here would be an
+            // ArrayIndexOutOfBounds thrown from inside the audio thread —
+            // which would take the track down, not just the measurement.
+            val end = minOf(offset + length, channel.size)
+            var i = offset
+            while (i < end) {
+                val sample = channel[i].toDouble()
+                sumOfSquares += sample * sample
+                i++
+            }
+            sampleCount += (end - offset).coerceAtLeast(0)
+        }
+    }
+
+    /**
+     * A seek invalidates everything sampled so far — the clip's start offset
+     * is applied as a seek, so without this the measurement would include
+     * whatever the decoder emitted before jumping to the clip.
+     */
+    override fun seekPerformed(requestedTime: Long, providedTime: Long) {
+        sumOfSquares = 0.0
+        sampleCount = 0L
+    }
+
+    override fun flush() {
+        // Nothing buffered here — samples are forwarded as they arrive.
+    }
+
+    override fun close() {
+        // close() can fire more than once as the pipeline tears down; the
+        // measurement is only meaningful the first time.
+        if (reported) return
+        reported = true
+        IntroLoudness.rmsOf(sumOfSquares, sampleCount)?.let(onMeasured)
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/lavaplayer/PlayerManager.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/lavaplayer/PlayerManager.kt
@@ -1,5 +1,7 @@
 package bot.toby.lavaplayer
 
+import bot.toby.intro.IntroLoadFailedEvent
+import bot.toby.intro.IntroPlayedEvent
 import com.github.topi314.lavasrc.applemusic.AppleMusicSourceManager
 import com.github.topi314.lavasrc.deezer.DeezerAudioSourceManager
 import com.github.topi314.lavasrc.mirror.DefaultMirroringAudioTrackResolver
@@ -19,6 +21,7 @@ import com.sedmelluq.discord.lavaplayer.source.vimeo.VimeoAudioSourceManager
 import com.sedmelluq.discord.lavaplayer.tools.FriendlyException
 import com.sedmelluq.discord.lavaplayer.track.AudioPlaylist
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack
+import common.intro.IntroHealth
 import common.logging.DiscordLogger
 import core.command.Command.Companion.replyAndDelete
 import dev.lavalink.youtube.YoutubeAudioSourceManager
@@ -220,6 +223,12 @@ class PlayerManager(
      * Load an intro track and preempt whatever is currently playing. The
      * preempted track is restored automatically once the intro ends.
      */
+    /**
+     * @param introId the stored intro row this playback is for. Threaded down
+     *        so the outcome — played, or failed and why — can be recorded
+     *        against it. Without it a broken intro is silent in both senses:
+     *        nothing plays, and nothing anywhere records that nothing played.
+     */
     @Synchronized
     fun loadAndPlayIntro(
         guild: Guild,
@@ -229,13 +238,17 @@ class PlayerManager(
         startPosition: Long,
         volume: Int,
         endPosition: Long?,
+        introId: String? = null,
     ) {
         val musicManager = this.getMusicManager(guild)
         this.isCurrentlyStoppable = true
         audioPlayerManager.loadItemOrdered(
             musicManager,
             trackUrl,
-            getResultHandler(event, musicManager, trackUrl, startPosition, endPosition, volume, deleteDelay, isIntro = true)
+            getResultHandler(
+                event, musicManager, trackUrl, startPosition, endPosition, volume, deleteDelay,
+                isIntro = true, introId = introId,
+            )
         )
     }
 
@@ -249,6 +262,7 @@ class PlayerManager(
         deleteDelay: Int,
         isIntro: Boolean = false,
         attempt: Int = 1,
+        introId: String? = null,
     ): AudioLoadResultHandler {
         return object : AudioLoadResultHandler {
             private val scheduler: TrackScheduler = musicManager.scheduler
@@ -258,7 +272,8 @@ class PlayerManager(
                 scheduler.event = event
                 scheduler.deleteDelay = deleteDelay
                 if (isIntro) {
-                    scheduler.queueIntro(track, startPosition, endPosition, volume, requesterId)
+                    scheduler.queueIntro(track, startPosition, endPosition, volume, requesterId, introId)
+                    introId?.let { SchedulerEvents.publish(IntroPlayedEvent(it)) }
                 } else {
                     scheduler.queue(track, startPosition, endPosition, volume, requesterId)
                 }
@@ -273,6 +288,13 @@ class PlayerManager(
 
             override fun noMatches() {
                 event?.hook?.replyAndDelete("Nothing found for the link '$trackUrl'", deleteDelay)
+                // On the intro path `event` is always null, so before this the
+                // branch was a no-op and a deleted or private video simply
+                // produced silence forever.
+                introId?.let {
+                    logger.warn { "Intro $it resolved nothing for url=$trackUrl" }
+                    SchedulerEvents.publish(IntroLoadFailedEvent(it, "Nothing found at this link"))
+                }
             }
 
             override fun loadFailed(exception: FriendlyException) {
@@ -295,7 +317,7 @@ class PlayerManager(
                                 trackUrl,
                                 getResultHandler(
                                     event, musicManager, trackUrl, startPosition, endPosition,
-                                    volume, deleteDelay, isIntro, attempt + 1,
+                                    volume, deleteDelay, isIntro, attempt + 1, introId,
                                 ),
                             )
                         },
@@ -309,6 +331,11 @@ class PlayerManager(
                             exception.stackTraceToString()
                 }
                 event?.hook?.replyAndDelete("Could not play: ${exception.message}", deleteDelay)
+                // Retries are exhausted by this point, so this is a real
+                // failure of the source rather than a blip worth hiding.
+                introId?.let {
+                    SchedulerEvents.publish(IntroLoadFailedEvent(it, IntroHealth.normaliseReason(exception.message)))
+                }
             }
         }
     }

--- a/discord-bot/src/main/kotlin/bot/toby/lavaplayer/TrackScheduler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/lavaplayer/TrackScheduler.kt
@@ -31,6 +31,16 @@ class TrackScheduler(val player: AudioPlayer, val guildId: Long, var deleteDelay
     private val trackClipBounds = ConcurrentHashMap<AudioTrack, Pair<Long, Long>>()
     private val trackRequesters = ConcurrentHashMap<AudioTrack, Long>()
     private val introTracks: MutableSet<AudioTrack> = ConcurrentHashMap.newKeySet()
+
+    /**
+     * Which stored intro row each in-flight intro track came from.
+     *
+     * Kept alongside [introTracks] rather than folded into it because the id
+     * has to outlive the track by exactly one step: the loudness filter
+     * reports its measurement as the pipeline closes, and it needs to know
+     * which row to write the number to.
+     */
+    private val introTrackIds = ConcurrentHashMap<AudioTrack, String>()
     private var resumeAfterIntro: AudioTrack? = null
 
     fun getRequesterId(track: AudioTrack): Long? = trackRequesters[track]
@@ -38,6 +48,9 @@ class TrackScheduler(val player: AudioPlayer, val guildId: Long, var deleteDelay
     internal fun hasResumeAfterIntro(): Boolean = resumeAfterIntro != null
 
     internal fun isIntroTrack(track: AudioTrack): Boolean = introTracks.contains(track)
+
+    /** The intro row id behind [track], or null when it isn't an intro. */
+    internal fun introIdFor(track: AudioTrack): String? = introTrackIds[track]
 
     fun queue(track: AudioTrack, startPosition: Long, endPosition: Long?, volume: Int, requesterId: Long? = null) {
         logger.info("Adding ${track.info.title} by ${track.info.author} to the queue for guild $guildId")
@@ -68,9 +81,11 @@ class TrackScheduler(val player: AudioPlayer, val guildId: Long, var deleteDelay
         endPosition: Long?,
         volume: Int,
         requesterId: Long? = null,
+        introId: String? = null,
     ) {
         logger.info("Preparing intro ${introTrack.info.title} for guild $guildId")
         prepareTrack(introTrack, startPosition, endPosition, volume, requesterId)
+        introId?.let { introTrackIds[introTrack] = it }
         val currentlyPlaying = player.playingTrack
         if (currentlyPlaying == null || resumeAfterIntro != null) {
             // No track to preempt, or a resume slot is already occupied by an
@@ -163,6 +178,10 @@ class TrackScheduler(val player: AudioPlayer, val guildId: Long, var deleteDelay
     override fun onTrackEnd(player: AudioPlayer, track: AudioTrack, endReason: AudioTrackEndReason) {
         trackClipBounds.remove(track)
         trackRequesters.remove(track)
+        // Safe to drop here even though the loudness filter reports later: the
+        // factory resolved the id when the chain was built and holds it in its
+        // callback closure.
+        introTrackIds.remove(track)
         val wasIntro = introTracks.remove(track)
         logger.info("${track.info.title} by ${track.info.author} ended")
         SchedulerEvents.publish(TrackEndedEvent(guildId, endReason.name))
@@ -295,6 +314,7 @@ class TrackScheduler(val player: AudioPlayer, val guildId: Long, var deleteDelay
         // the in-flight intro ends.
         resumeAfterIntro = null
         introTracks.clear()
+        introTrackIds.clear()
         player.stopTrack()
         player.setVolumeToPrevious()
         return true

--- a/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigCategoryModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigCategoryModal.kt
@@ -162,6 +162,7 @@ abstract class SetConfigCategoryModal(
         is FieldSpec.EnumChoice -> spec.allowed.joinToString(" / ")
         is FieldSpec.ChannelByIdStoreName -> "channel id"
         is FieldSpec.ChannelByIdStoreId -> if (spec.allowClear) "channel id (0 to clear)" else "channel id"
+        is FieldSpec.VoiceChannelIdList -> "voice channel ids, comma-separated (0 to clear)"
     }
 
     private fun truncateLabel(label: String): String =

--- a/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigFieldValidator.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigFieldValidator.kt
@@ -59,6 +59,18 @@ object SetConfigFieldValidator {
          * `"0"` clears the override to empty string when [allowClear].
          */
         data class ChannelByIdStoreId(override val label: String, val allowClear: Boolean = true) : FieldSpec
+
+        /**
+         * Comma-separated voice channel references (ids or `<#id>` mentions),
+         * every one resolved against the guild; stored as a CSV of ids. Used
+         * for INTRO_EXCLUDED_CHANNELS. `"0"` or `"none"` clears the list.
+         *
+         * Unlike the join-time reader, which drops junk so one bad id can't
+         * disable every other exemption, this rejects the whole submission:
+         * an admin typing a channel id deserves to be told it didn't take,
+         * rather than discovering months later that intros still play there.
+         */
+        data class VoiceChannelIdList(override val label: String) : FieldSpec
     }
 
     sealed interface FieldResult {
@@ -80,6 +92,7 @@ object SetConfigFieldValidator {
             is FieldSpec.EnumChoice -> parseEnum(raw, spec)
             is FieldSpec.ChannelByIdStoreName -> resolveChannelName(raw, spec, guild)
             is FieldSpec.ChannelByIdStoreId -> resolveChannelId(raw, spec, guild)
+            is FieldSpec.VoiceChannelIdList -> resolveVoiceChannelIds(raw, spec, guild)
         }
     }
 
@@ -176,6 +189,20 @@ object SetConfigFieldValidator {
         guild.getTextChannelById(id)
             ?: return FieldResult.Error("${spec.label}: no text channel with id $id in this server")
         return FieldResult.Write(id.toString())
+    }
+
+    private fun resolveVoiceChannelIds(raw: String, spec: FieldSpec.VoiceChannelIdList, guild: Guild?): FieldResult {
+        if (raw == "0" || raw.equals("none", ignoreCase = true)) return FieldResult.Write("")
+        if (guild == null) return FieldResult.Error("${spec.label}: no guild context to resolve channels")
+        val ids = LinkedHashSet<Long>()
+        for (token in raw.split(',', ' ', '\n').map { it.trim() }.filter { it.isNotEmpty() }) {
+            val id = extractChannelId(token)
+                ?: return FieldResult.Error("${spec.label}: '$token' is not a channel id or #mention")
+            guild.getVoiceChannelById(id)
+                ?: return FieldResult.Error("${spec.label}: no voice channel with id $id in this server")
+            ids += id
+        }
+        return FieldResult.Write(ids.joinToString(","))
     }
 
     private fun extractChannelId(raw: String): Long? =

--- a/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigGeneralModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigGeneralModal.kt
@@ -9,6 +9,11 @@ import org.springframework.stereotype.Component
  * `/setconfig general` — audio defaults + auto-delete delay + the two
  * channel knobs every guild cares about (default move target +
  * monthly leaderboard post location).
+ *
+ * The default intro volume used to sit here too; it moved to
+ * [SetConfigIntroModal] when intros grew settings of their own, so all four
+ * are edited together rather than one being stranded among unrelated audio
+ * options.
  */
 @Component
 class SetConfigGeneralModal(
@@ -20,7 +25,6 @@ class SetConfigGeneralModal(
 
     override val specs: LinkedHashMap<Configurations, FieldSpec> = linkedMapOf(
         Configurations.VOLUME to FieldSpec.IntRange("Default volume", 0..200),
-        Configurations.INTRO_VOLUME to FieldSpec.IntRange("Default intro volume", 0..200),
         Configurations.DELETE_DELAY to FieldSpec.IntRange("Delete delay (seconds)", 0..600),
         Configurations.MOVE to FieldSpec.ChannelByIdStoreName("Default move channel"),
         Configurations.LEADERBOARD_CHANNEL to FieldSpec.ChannelByIdStoreId("Leaderboard channel"),
@@ -28,7 +32,6 @@ class SetConfigGeneralModal(
 
     override val fieldIds: Map<Configurations, String> = mapOf(
         Configurations.VOLUME to FIELD_VOLUME,
-        Configurations.INTRO_VOLUME to FIELD_INTRO_VOLUME,
         Configurations.DELETE_DELAY to FIELD_DELETE_DELAY,
         Configurations.MOVE to FIELD_MOVE,
         Configurations.LEADERBOARD_CHANNEL to FIELD_LEADERBOARD_CHANNEL,
@@ -37,7 +40,6 @@ class SetConfigGeneralModal(
     companion object {
         const val MODAL_NAME = "setconfig_general"
         const val FIELD_VOLUME = "volume"
-        const val FIELD_INTRO_VOLUME = "intro_volume"
         const val FIELD_DELETE_DELAY = "delete_delay"
         const val FIELD_MOVE = "move"
         const val FIELD_LEADERBOARD_CHANNEL = "leaderboard_channel"

--- a/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigIntroModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigIntroModal.kt
@@ -1,0 +1,49 @@
+package bot.toby.modal.modals.setconfig
+
+import bot.toby.modal.modals.setconfig.SetConfigFieldValidator.FieldSpec
+import database.dto.guild.ConfigDto.Configurations
+import database.service.guild.ConfigService
+import org.springframework.stereotype.Component
+
+/**
+ * `/setconfig intro` — everything a server can decide about intros.
+ *
+ * `DEFAULT_INTRO_VOLUME` used to be the only intro key, and it lived under
+ * `general` alongside the unrelated audio and channel settings. That left a
+ * server able to make intros quieter but never to turn them off, and never to
+ * exempt a channel — so the "study" or "meeting" voice channel got everyone's
+ * intro at full volume and the only remedy was asking members one by one to
+ * unset theirs. The volume key moves here so the intro settings are in one
+ * place, which also frees a slot in the general modal (Discord caps modals at
+ * five fields).
+ */
+@Component
+class SetConfigIntroModal(
+    configService: ConfigService,
+) : SimpleSetConfigCategoryModal(configService) {
+
+    override val name = MODAL_NAME
+    override val title = "Intro settings"
+
+    override val specs: LinkedHashMap<Configurations, FieldSpec> = linkedMapOf(
+        Configurations.INTROS_ENABLED to FieldSpec.BoolStrict("Intros enabled"),
+        Configurations.INTRO_VOLUME to FieldSpec.IntRange("Default intro volume", 0..200),
+        Configurations.INTRO_NORMALISE_VOLUME to FieldSpec.BoolStrict("Match intro loudness"),
+        Configurations.INTRO_EXCLUDED_CHANNELS to FieldSpec.VoiceChannelIdList("Silent channels (ids)"),
+    )
+
+    override val fieldIds: Map<Configurations, String> = mapOf(
+        Configurations.INTROS_ENABLED to FIELD_INTROS_ENABLED,
+        Configurations.INTRO_VOLUME to FIELD_INTRO_VOLUME,
+        Configurations.INTRO_NORMALISE_VOLUME to FIELD_NORMALISE,
+        Configurations.INTRO_EXCLUDED_CHANNELS to FIELD_EXCLUDED_CHANNELS,
+    )
+
+    companion object {
+        const val MODAL_NAME = "setconfig_intro"
+        const val FIELD_INTROS_ENABLED = "intros_enabled"
+        const val FIELD_INTRO_VOLUME = "intro_volume"
+        const val FIELD_NORMALISE = "intro_normalise"
+        const val FIELD_EXCLUDED_CHANNELS = "intro_excluded_channels"
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/music/PausePlayButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/music/PausePlayButtonTest.kt
@@ -48,6 +48,8 @@ class PausePlayButtonTest : ButtonTest {
         val mockAudioPlayerManager = mockk<AudioPlayerManager>()
         val mockAudioPlayer = mockk<AudioPlayer>()
         every { mockAudioPlayer.addListener(any()) } just Runs
+        // GuildMusicManager now installs the intro loudness meter.
+        every { mockAudioPlayer.setFilterFactory(any()) } just Runs
 
         every { mockAudioPlayerManager.createPlayer() } returns mockAudioPlayer
 

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/moderation/SetConfigCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/moderation/SetConfigCommandTest.kt
@@ -13,6 +13,7 @@ import bot.toby.modal.modals.setconfig.SetConfigBlackjackTableModal
 import bot.toby.modal.modals.setconfig.SetConfigFeesModal
 import bot.toby.modal.modals.setconfig.SetConfigGeneralModal
 import bot.toby.modal.modals.setconfig.SetConfigJackpotActivityModal
+import bot.toby.modal.modals.setconfig.SetConfigIntroModal
 import bot.toby.modal.modals.setconfig.SetConfigJackpotModal
 import bot.toby.modal.modals.setconfig.SetConfigLotteryBasicsModal
 import bot.toby.modal.modals.setconfig.SetConfigLotteryEngagementModal
@@ -57,6 +58,7 @@ internal class SetConfigCommandTest : CommandTest {
     private lateinit var general: SetConfigGeneralModal
     private lateinit var activity: SetConfigActivityModal
     private lateinit var fees: SetConfigFeesModal
+    private lateinit var intro: SetConfigIntroModal
     private lateinit var jackpot: SetConfigJackpotModal
     private lateinit var jackpotActivity: SetConfigJackpotActivityModal
     private lateinit var pokerStakes: SetConfigPokerStakesModal
@@ -78,6 +80,7 @@ internal class SetConfigCommandTest : CommandTest {
         general = mockk(relaxed = true)
         activity = mockk(relaxed = true)
         fees = mockk(relaxed = true)
+        intro = mockk(relaxed = true)
         jackpot = mockk(relaxed = true)
         jackpotActivity = mockk(relaxed = true)
         pokerStakes = mockk(relaxed = true)
@@ -90,7 +93,7 @@ internal class SetConfigCommandTest : CommandTest {
         stakes = mockk(relaxed = true)
         command = SetConfigCommand(
             configService,
-            general, activity, fees, jackpot, jackpotActivity,
+            general, intro, activity, fees, jackpot, jackpotActivity,
             pokerStakes, pokerTable, blackjackRules, blackjackTable,
             lotteryBasics, lotteryPools, lotteryEngagement, stakes,
         )

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/music/intro/IntroStatsCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/music/intro/IntroStatsCommandTest.kt
@@ -1,0 +1,166 @@
+package bot.toby.command.commands.music.intro
+
+import bot.toby.command.CommandTest.Companion.event
+import bot.toby.command.CommandTest.Companion.guild
+import bot.toby.command.CommandTest.Companion.requestingUserDto
+import bot.toby.command.commands.music.MusicCommandTest
+import common.intro.IntroHealth
+import core.command.CommandContext
+import database.dto.guild.ConfigDto
+import database.persistence.music.GuildIntroStats
+import database.service.guild.ConfigService
+import database.service.music.MusicFileService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import io.mockk.verify
+import net.dv8tion.jda.api.entities.MessageEmbed
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class IntroStatsCommandTest : MusicCommandTest {
+
+    private lateinit var musicFileService: MusicFileService
+    private lateinit var configService: ConfigService
+    private lateinit var command: IntroStatsCommand
+    private lateinit var ctx: CommandContext
+
+    @BeforeEach
+    fun setup() {
+        setupCommonMusicMocks()
+        musicFileService = mockk(relaxed = true)
+        configService = mockk(relaxed = true)
+        command = IntroStatsCommand(musicFileService, configService)
+        ctx = mockk(relaxed = true)
+        every { ctx.event } returns event
+        every { ctx.guild } returns guild
+        every { requestingUserDto.superUser } returns true
+        every { configService.getConfigByName(any(), any()) } returns null
+        every { musicFileService.getGuildIntroStats(any(), any()) } returns GuildIntroStats()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        tearDownCommonMusicMocks()
+        unmockkAll()
+    }
+
+    private fun runAndCaptureEmbed(): MessageEmbed {
+        command.handle(ctx, requestingUserDto, 5)
+        val embeds = mutableListOf<MessageEmbed>()
+        verify { event.hook.sendMessageEmbeds(capture(embeds)) }
+        return embeds.single()
+    }
+
+    private fun config(value: String) = ConfigDto().apply { this.value = value }
+
+    @Test
+    fun `a non-super-user is refused`() {
+        // The report spans every member's intros, so it's a moderation view
+        // rather than a personal one.
+        every { requestingUserDto.superUser } returns false
+
+        command.handle(ctx, requestingUserDto, 5)
+
+        verify(exactly = 0) { musicFileService.getGuildIntroStats(any(), any()) }
+    }
+
+    @Test
+    fun `broken intros are counted using the shared threshold`() {
+        // Drifting from IntroSelection's definition would have the report
+        // disagree with which intros actually get skipped.
+        command.handle(ctx, requestingUserDto, 5)
+
+        verify { musicFileService.getGuildIntroStats(any(), IntroHealth.UNHEALTHY_AFTER_FAILURES) }
+    }
+
+    @Test
+    fun `an empty server says so rather than showing a wall of zeroes`() {
+        val embed = runAndCaptureEmbed()
+
+        assertTrue(embed.description!!.contains("Nobody"), embed.description!!)
+    }
+
+    @Test
+    fun `the report totals usage, storage and faults`() {
+        every { musicFileService.getGuildIntroStats(any(), any()) } returns GuildIntroStats(
+            introCount = 7, userCount = 4, storedBytes = 3L * 1024 * 1024,
+            totalPlays = 128, disabledCount = 1, brokenCount = 2,
+        )
+
+        val embed = runAndCaptureEmbed()
+        val values = embed.fields.associate { it.name to it.value }
+
+        assertTrue(embed.description!!.contains("7 intros across 4 members"), embed.description!!)
+        assertTrue(values["Plays"]!!.contains("128"), values["Plays"]!!)
+        assertTrue(values["Stored audio"]!!.contains("3.0 MB"), values["Stored audio"]!!)
+        assertTrue(values["Not playing"]!!.contains("2"), values["Not playing"]!!)
+    }
+
+    @Test
+    fun `a single intro and member are not described in the plural`() {
+        every { musicFileService.getGuildIntroStats(any(), any()) } returns GuildIntroStats(
+            introCount = 1, userCount = 1,
+        )
+
+        val embed = runAndCaptureEmbed()
+
+        assertTrue(embed.description!!.contains("1 intro across 1 member"), embed.description!!)
+    }
+
+    @Test
+    fun `a healthy server is told nothing is broken rather than left to infer it`() {
+        every { musicFileService.getGuildIntroStats(any(), any()) } returns GuildIntroStats(introCount = 3)
+
+        val embed = runAndCaptureEmbed()
+
+        assertTrue(embed.fields.single { it.name == "Not playing" }.value!!.contains("loading fine"))
+    }
+
+    @Test
+    fun `the report repeats the server settings so a silent server is explicable`() {
+        // "Why is nobody's intro playing" has a config answer as often as a
+        // broken-link one, and the admin asking is already looking at this.
+        every { configService.getConfigByName(ConfigDto.Configurations.INTROS_ENABLED.configValue, any()) } returns
+            config("false")
+
+        val embed = runAndCaptureEmbed()
+
+        assertTrue(embed.fields.single { it.name == "Server settings" }.value!!.contains("**off**"))
+    }
+
+    @Test
+    fun `exempt channels are named where the bot can still see them`() {
+        every {
+            configService.getConfigByName(ConfigDto.Configurations.INTRO_EXCLUDED_CHANNELS.configValue, any())
+        } returns config("500,600")
+        every { guild.getVoiceChannelById(500L) } returns mockk(relaxed = true) { every { name } returns "study" }
+        every { guild.getVoiceChannelById(600L) } returns null
+
+        val embed = runAndCaptureEmbed()
+        val settings = embed.fields.single { it.name == "Server settings" }.value!!
+
+        assertTrue(settings.contains("#study"), settings)
+        // A channel that has since been deleted still shows its id rather than
+        // disappearing from the list.
+        assertTrue(settings.contains("600"), settings)
+    }
+
+    @Test
+    fun `a server with no exemptions says intros play everywhere`() {
+        val embed = runAndCaptureEmbed()
+
+        assertTrue(embed.fields.single { it.name == "Server settings" }.value!!.contains("every voice channel"))
+    }
+
+    @Test
+    fun `storage is reported in units an admin can act on`() {
+        assertEquals("512 B", command.formatBytes(512))
+        assertEquals("2 KB", command.formatBytes(2048))
+        assertEquals("1.5 MB", command.formatBytes(1024 * 1024 * 3 / 2))
+        assertEquals("2.00 GB", command.formatBytes(2L * 1024 * 1024 * 1024))
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/handler/VoiceEventHandlerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/handler/VoiceEventHandlerTest.kt
@@ -1,5 +1,6 @@
 import bot.toby.handler.VoiceEventHandler
 import bot.toby.helpers.IntroHelper
+import common.intro.IntroLoudness
 import bot.toby.helpers.UserDtoHelper
 import bot.toby.intro.IntroPlaybackTracker
 import bot.toby.lavaplayer.PlayerManager
@@ -71,6 +72,21 @@ class VoiceEventHandlerTest {
         every { jda.selfUser } returns selfUser
         every { selfUser.name } returns "TestBot"
         every { selfUser.idLong } returns 12345L
+        // The guild-level intro switches are opt-out, so "no row stored" is
+        // the default every existing test wants. Stubbed for any guild here
+        // rather than per-test; the tests that exercise the switches override.
+        introConfigDefaults()
+    }
+
+    /** No stored value for any of the intro guild-config keys. */
+    private fun introConfigDefaults() {
+        listOf(
+            ConfigDto.Configurations.INTROS_ENABLED,
+            ConfigDto.Configurations.INTRO_EXCLUDED_CHANNELS,
+            ConfigDto.Configurations.INTRO_NORMALISE_VOLUME,
+        ).forEach { key ->
+            every { configService.getConfigByName(key.configValue, any()) } returns null
+        }
     }
 
     @AfterEach
@@ -646,6 +662,7 @@ class VoiceEventHandlerTest {
         every { configService.getConfigByName(ConfigDto.Configurations.VOLUME.configValue, "9") } returns null
 
         val musicDto = mockk<MusicDto>(relaxed = true) {
+            every { id } returns "9_1_1"
             every { fileName } returns "https://example.com/intro.mp3"
             every { musicBlob } returns null
             every { introVolume } returns 75
@@ -654,6 +671,7 @@ class VoiceEventHandlerTest {
             // Relaxed Boolean mocks default to false, which would take the
             // intro out of the rotation entirely.
             every { enabled } returns true
+            every { measuredRms } returns null
         }
         every { userDtoHelper.calculateUserDto(1L, 9L, false) } returns mockk(relaxed = true) {
             every { discordId } returns 1L
@@ -665,7 +683,7 @@ class VoiceEventHandlerTest {
 
         verify(atLeast = 1) {
             audioPlayerManager.loadAndPlayIntro(
-                guild, null, "https://example.com/intro.mp3", 30, 0L, 75, null,
+                guild, null, "https://example.com/intro.mp3", 30, 0L, 75, null, "9_1_1",
             )
         }
         // Intros must never go through the regular loadAndPlay path now.
@@ -732,7 +750,14 @@ class VoiceEventHandlerTest {
      * guild [gid] with [intros] configured, runs the handler, and returns the
      * PlayerManager mock so callers can assert on playback.
      */
-    private fun joinWithIntros(gid: Long, intros: MutableList<MusicDto>): PlayerManager {
+    private fun joinWithIntros(
+        gid: Long,
+        intros: MutableList<MusicDto>,
+        introsEnabled: String? = null,
+        excludedChannels: String? = null,
+        normalise: String? = null,
+        channelId: Long = 500L,
+    ): PlayerManager {
         val guild = mockk<Guild>(relaxed = true)
         val event = mockk<GuildVoiceUpdateEvent>(relaxed = true)
         val audioManager = mockk<AudioManager>(relaxed = true)
@@ -757,11 +782,21 @@ class VoiceEventHandlerTest {
         every { audioManager.isConnected } returns false
         every { audioManager.connectedChannel } returns channel
 
+        every { channel.idLong } returns channelId
+
         mockkObject(PlayerManager)
         every { PlayerManager.instance } returns audioPlayerManager
         every { configService.getConfigByName(ConfigDto.Configurations.DELETE_DELAY.configValue, gid.toString()) } returns
             ConfigDto().apply { value = "30" }
         every { configService.getConfigByName(ConfigDto.Configurations.VOLUME.configValue, gid.toString()) } returns null
+        mapOf(
+            ConfigDto.Configurations.INTROS_ENABLED to introsEnabled,
+            ConfigDto.Configurations.INTRO_EXCLUDED_CHANNELS to excludedChannels,
+            ConfigDto.Configurations.INTRO_NORMALISE_VOLUME to normalise,
+        ).forEach { (key, value) ->
+            every { configService.getConfigByName(key.configValue, gid.toString()) } returns
+                value?.let { ConfigDto().apply { this.value = it } }
+        }
         every { userDtoHelper.calculateUserDto(1L, gid, false) } returns mockk(relaxed = true) {
             every { discordId } returns 1L
             every { guildId } returns gid
@@ -792,7 +827,7 @@ class VoiceEventHandlerTest {
 
         // Exactly one playback and one payout across both joins.
         verify(exactly = 0) {
-            second.loadAndPlayIntro(any(), any(), any(), any(), any(), any(), any())
+            second.loadAndPlayIntro(any(), any(), any(), any(), any(), any(), any(), any())
         }
         verify(exactly = 1) {
             awardService.award(1L, 11L, VoiceEventHandler.INTRO_PLAY_CREDIT, "intro-play", any(), any())
@@ -822,6 +857,132 @@ class VoiceEventHandlerTest {
 
         assertEquals("12_1_1", introPlaybackTracker.lastPlayedIntroId(12L, 1L))
         assertTrue(introPlaybackTracker.onCooldown(12L, 1L))
+
+        unmockkObject(PlayerManager)
+    }
+
+    // --- guild-level intro controls ----------------------------------------
+
+    /** An intro the handler will happily play, at volume 75. */
+    private fun playableIntro(id: String, measured: Double? = null) = mockk<MusicDto>(relaxed = true) {
+        every { this@mockk.id } returns id
+        every { fileName } returns "https://example.com/intro.mp3"
+        every { musicBlob } returns null
+        every { introVolume } returns 75
+        every { startMs } returns null
+        every { endMs } returns null
+        every { enabled } returns true
+        every { failureCount } returns 0
+        every { measuredRms } returns measured
+    }
+
+    @Test
+    fun `a server that has switched intros off plays nothing on join`() {
+        val manager = joinWithIntros(21L, mutableListOf(playableIntro("21_1_1")), introsEnabled = "false")
+
+        verify(exactly = 0) {
+            manager.loadAndPlayIntro(any(), any(), any(), any(), any(), any(), any(), any())
+        }
+
+        unmockkObject(PlayerManager)
+    }
+
+    @Test
+    fun `switching intros off also stops the set-up nudge`() {
+        // A server that doesn't want the feature shouldn't be recruiting
+        // people into it.
+        joinWithIntros(22L, mutableListOf(), introsEnabled = "false")
+
+        verify(exactly = 0) { introHelper.promptUserForMusicInfo(any(), any()) }
+
+        unmockkObject(PlayerManager)
+    }
+
+    @Test
+    fun `an exempt voice channel stays silent`() {
+        val manager = joinWithIntros(
+            23L,
+            mutableListOf(playableIntro("23_1_1")),
+            excludedChannels = "500",
+            channelId = 500L,
+        )
+
+        verify(exactly = 0) {
+            manager.loadAndPlayIntro(any(), any(), any(), any(), any(), any(), any(), any())
+        }
+
+        unmockkObject(PlayerManager)
+    }
+
+    @Test
+    fun `exempting one channel does not silence the others`() {
+        val manager = joinWithIntros(
+            24L,
+            mutableListOf(playableIntro("24_1_1")),
+            excludedChannels = "999",
+            channelId = 500L,
+        )
+
+        verify(exactly = 1) {
+            manager.loadAndPlayIntro(any(), any(), any(), any(), any(), any(), any(), any())
+        }
+
+        unmockkObject(PlayerManager)
+    }
+
+    @Test
+    fun `a guild with no intro config behaves exactly as before`() {
+        val manager = joinWithIntros(25L, mutableListOf(playableIntro("25_1_1")))
+
+        verify(exactly = 1) {
+            manager.loadAndPlayIntro(any(), any(), any(), any(), any(), any(), any(), any())
+        }
+
+        unmockkObject(PlayerManager)
+    }
+
+    // --- loudness normalisation --------------------------------------------
+
+    @Test
+    fun `a loud intro is turned down when loudness matching is on`() {
+        val manager = joinWithIntros(
+            26L,
+            mutableListOf(playableIntro("26_1_1", measured = IntroLoudness.TARGET_RMS * 2)),
+        )
+
+        val volume = slot<Int>()
+        verify {
+            manager.loadAndPlayIntro(any(), any(), any(), any(), any(), capture(volume), any(), any())
+        }
+        assertTrue(volume.captured < 75, "expected the loud intro to be cut, got ${volume.captured}")
+
+        unmockkObject(PlayerManager)
+    }
+
+    @Test
+    fun `the chosen volume is used verbatim when loudness matching is off`() {
+        val manager = joinWithIntros(
+            27L,
+            mutableListOf(playableIntro("27_1_1", measured = IntroLoudness.TARGET_RMS * 2)),
+            normalise = "false",
+        )
+
+        verify {
+            manager.loadAndPlayIntro(any(), any(), any(), any(), any(), 75, any(), any())
+        }
+
+        unmockkObject(PlayerManager)
+    }
+
+    @Test
+    fun `an intro that has never been measured plays at exactly its set volume`() {
+        // Every existing row starts unmeasured, so shipping normalisation must
+        // not change what anyone hears until their intro has played once.
+        val manager = joinWithIntros(28L, mutableListOf(playableIntro("28_1_1", measured = null)))
+
+        verify {
+            manager.loadAndPlayIntro(any(), any(), any(), any(), any(), 75, any(), any())
+        }
 
         unmockkObject(PlayerManager)
     }

--- a/discord-bot/src/test/kotlin/bot/toby/intro/IntroHealthServiceTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/intro/IntroHealthServiceTest.kt
@@ -1,0 +1,222 @@
+package bot.toby.intro
+
+import bot.toby.notify.NotificationRouter
+import common.intro.IntroHealth
+import common.notification.NotificationChannelKind
+import database.dto.music.MusicDto
+import database.dto.user.UserDto
+import database.service.music.MusicFileService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.verify
+import net.dv8tion.jda.api.utils.messages.MessageCreateData
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+/**
+ * The behaviour under test is the one that didn't exist at all: intros play
+ * from the voice-join path, which has no interaction to reply to, so a load
+ * failure wrote to a null hook and vanished. These assert that the outcome now
+ * lands on the row, and that the owner hears about it exactly once.
+ */
+class IntroHealthServiceTest {
+
+    private val introId = "1_2_1"
+
+    private lateinit var musicFileService: MusicFileService
+    private lateinit var router: NotificationRouter
+    private lateinit var service: IntroHealthService
+    private lateinit var dto: MusicDto
+
+    @BeforeEach
+    fun setUp() {
+        musicFileService = mockk(relaxed = true)
+        router = mockk(relaxed = true)
+        dto = MusicDto(
+            id = introId,
+            userDto = UserDto(discordId = 2L, guildId = 1L),
+            fileName = "Sandstorm",
+            index = 1,
+        )
+        every { musicFileService.getMusicFileById(introId) } returns dto
+        service = IntroHealthService(musicFileService, router)
+    }
+
+    @AfterEach
+    fun tearDown() = unmockkAll()
+
+    // --- plays --------------------------------------------------------------
+
+    @Test
+    fun `a play is counted and stamped`() {
+        service.onIntroPlayed(IntroPlayedEvent(introId))
+
+        assertEquals(1, dto.playCount)
+        assertNotNull(dto.lastPlayedAt)
+        verify { musicFileService.updateMusicFile(dto) }
+    }
+
+    @Test
+    fun `a play clears an earlier failure, keeping the count consecutive`() {
+        // Otherwise a link that broke once in 2024 stays flagged forever, and
+        // IntroSelection keeps deprioritising a perfectly good intro.
+        dto.failureCount = 1
+        dto.lastFailureReason = "Video unavailable"
+
+        service.onIntroPlayed(IntroPlayedEvent(introId))
+
+        assertEquals(0, dto.failureCount)
+        assertNull(dto.lastFailureReason)
+    }
+
+    // --- failures -----------------------------------------------------------
+
+    @Test
+    fun `a failure is recorded against the row with its reason`() {
+        service.onIntroLoadFailed(IntroLoadFailedEvent(introId, "This video is not available in your country"))
+
+        assertEquals(1, dto.failureCount)
+        assertEquals("This video is not available in your country", dto.lastFailureReason)
+        assertNotNull(dto.lastFailureAt)
+        verify { musicFileService.updateMusicFile(dto) }
+    }
+
+    @Test
+    fun `a blank reason is still readable when it reaches the owner`() {
+        service.onIntroLoadFailed(IntroLoadFailedEvent(introId, "   "))
+
+        assertEquals("Source could not be loaded", dto.lastFailureReason)
+    }
+
+    @Test
+    fun `the owner is not told about the first failure`() {
+        service.onIntroLoadFailed(IntroLoadFailedEvent(introId, "boom"))
+
+        verify(exactly = 0) { router.sendDm(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `the owner is told when the intro crosses into broken`() {
+        repeat(IntroHealth.UNHEALTHY_AFTER_FAILURES) {
+            service.onIntroLoadFailed(IntroLoadFailedEvent(introId, "Video unavailable"))
+        }
+
+        verify(exactly = 1) {
+            router.sendDm(2L, 1L, NotificationChannelKind.INTRO_BROKEN, any())
+        }
+    }
+
+    @Test
+    fun `the owner is told once, not on every join after that`() {
+        // A broken intro fires on every single voice join. Nagging turns the
+        // notification into noise faster than the fault turns into a problem.
+        repeat(IntroHealth.UNHEALTHY_AFTER_FAILURES + 6) {
+            service.onIntroLoadFailed(IntroLoadFailedEvent(introId, "Video unavailable"))
+        }
+
+        verify(exactly = 1) { router.sendDm(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `the DM names the intro, its slot and why it stopped`() {
+        val message = slot<() -> MessageCreateData>()
+        every { router.sendDm(any(), any(), any(), capture(message)) } returns Unit
+
+        repeat(IntroHealth.UNHEALTHY_AFTER_FAILURES) {
+            service.onIntroLoadFailed(IntroLoadFailedEvent(introId, "Video unavailable"))
+        }
+
+        val embed = message.captured().embeds.single()
+        val description = embed.description.orEmpty()
+        assertTrue(description.contains("Sandstorm"), description)
+        assertTrue(description.contains("#1"), description)
+        assertTrue(description.contains("Video unavailable"), description)
+    }
+
+    @Test
+    fun `an intro with no owner does not blow up the failure path`() {
+        dto.userDto = null
+
+        repeat(IntroHealth.UNHEALTHY_AFTER_FAILURES) {
+            service.onIntroLoadFailed(IntroLoadFailedEvent(introId, "boom"))
+        }
+
+        assertEquals(IntroHealth.UNHEALTHY_AFTER_FAILURES, dto.failureCount)
+        verify(exactly = 0) { router.sendDm(any(), any(), any(), any()) }
+    }
+
+    // --- loudness -----------------------------------------------------------
+
+    @Test
+    fun `a measurement is stored so later plays can be corrected`() {
+        service.onIntroLoudnessMeasured(IntroLoudnessMeasuredEvent(introId, 0.13))
+
+        assertEquals(0.13, dto.measuredRms)
+        verify { musicFileService.updateMusicFile(dto) }
+    }
+
+    // --- resilience ---------------------------------------------------------
+
+    @Test
+    fun `an intro deleted between playing and reporting is ignored`() {
+        every { musicFileService.getMusicFileById(introId) } returns null
+
+        service.onIntroPlayed(IntroPlayedEvent(introId))
+        service.onIntroLoadFailed(IntroLoadFailedEvent(introId, "boom"))
+        service.onIntroLoudnessMeasured(IntroLoudnessMeasuredEvent(introId, 0.1))
+
+        verify(exactly = 0) { musicFileService.updateMusicFile(any()) }
+        verify(exactly = 0) { router.sendDm(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `a database failure never propagates into the playback path`() {
+        every { musicFileService.getMusicFileById(introId) } throws IllegalStateException("connection reset")
+
+        // No throw: these run from event handlers on the load and audio paths.
+        service.onIntroPlayed(IntroPlayedEvent(introId))
+        service.onIntroLoadFailed(IntroLoadFailedEvent(introId, "boom"))
+        service.onIntroLoudnessMeasured(IntroLoudnessMeasuredEvent(introId, 0.1))
+    }
+
+    @Test
+    fun `a router failure does not lose the recorded failure`() {
+        every { router.sendDm(any(), any(), any(), any()) } throws IllegalStateException("discord down")
+
+        repeat(IntroHealth.UNHEALTHY_AFTER_FAILURES) {
+            service.onIntroLoadFailed(IntroLoadFailedEvent(introId, "boom"))
+        }
+
+        assertEquals(IntroHealth.UNHEALTHY_AFTER_FAILURES, dto.failureCount)
+    }
+
+    @Test
+    fun `without a router the counters still work`() {
+        val unrouted = IntroHealthService(musicFileService, null)
+
+        repeat(IntroHealth.UNHEALTHY_AFTER_FAILURES) {
+            unrouted.onIntroLoadFailed(IntroLoadFailedEvent(introId, "boom"))
+        }
+
+        assertEquals(IntroHealth.UNHEALTHY_AFTER_FAILURES, dto.failureCount)
+    }
+
+    @Test
+    fun `timestamps move forward across separate outcomes`() {
+        val before = Instant.now().minusSeconds(1)
+
+        service.onIntroPlayed(IntroPlayedEvent(introId))
+        service.onIntroLoadFailed(IntroLoadFailedEvent(introId, "boom"))
+
+        assertTrue(dto.lastPlayedAt!!.isAfter(before))
+        assertTrue(dto.lastFailureAt!!.isAfter(before))
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/intro/IntroPresenterTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/intro/IntroPresenterTest.kt
@@ -1,5 +1,6 @@
 package bot.toby.intro
 
+import common.intro.IntroHealth
 import database.dto.music.MusicDto
 import database.dto.user.UserDto
 import io.mockk.every
@@ -7,8 +8,10 @@ import io.mockk.mockk
 import net.dv8tion.jda.api.entities.Member
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import java.time.Instant
 
 class IntroPresenterTest {
 
@@ -104,5 +107,126 @@ class IntroPresenterTest {
     fun `dashboard button deep links to the guild intro page`() {
         val button = IntroPresenter.webDashboardButton(4567L)
         assertEquals("https://www.toby-bot.co.uk/intro/4567", button.url)
+    }
+
+    // --- broken intros ------------------------------------------------------
+
+    @Test
+    fun `a broken intro says so first in its summary`() {
+        // Whatever else is true of the intro, "it isn't playing" is the thing
+        // the reader is trying to find out.
+        val broken = urlIntro(1, "Dead link").apply { failureCount = IntroHealth.UNHEALTHY_AFTER_FAILURES }
+
+        assertTrue(IntroPresenter.summary(broken).startsWith("BROKEN · "), IntroPresenter.summary(broken))
+    }
+
+    @Test
+    fun `an intro with one failure is not called broken`() {
+        val flaky = urlIntro(1, "Occasionally slow").apply { failureCount = 1 }
+
+        assertFalse(IntroPresenter.isBroken(flaky))
+        assertFalse(IntroPresenter.summary(flaky).contains("BROKEN"))
+    }
+
+    @Test
+    fun `the list embed shows why a broken intro stopped working`() {
+        val broken = urlIntro(1, "Dead link").apply {
+            failureCount = IntroHealth.UNHEALTHY_AFTER_FAILURES
+            lastFailureReason = "This video is not available in your country"
+        }
+
+        val field = IntroPresenter.listEmbed(member(), listOf(broken), 3).fields.single()
+
+        assertTrue(field.name!!.contains("⚠️"), field.name!!)
+        assertTrue(field.value!!.contains("Not playing"), field.value!!)
+        assertTrue(field.value!!.contains("not available in your country"), field.value!!)
+    }
+
+    @Test
+    fun `a broken intro with no recorded reason still explains itself`() {
+        val broken = urlIntro(1, "Dead link").apply { failureCount = IntroHealth.UNHEALTHY_AFTER_FAILURES }
+
+        val field = IntroPresenter.listEmbed(member(), listOf(broken), 3).fields.single()
+
+        assertTrue(field.value!!.contains("source could not be loaded"), field.value!!)
+    }
+
+    @Test
+    fun `an overlong failure reason cannot burst the embed field`() {
+        val broken = urlIntro(1, "Dead link").apply {
+            failureCount = IntroHealth.UNHEALTHY_AFTER_FAILURES
+            lastFailureReason = "x".repeat(2000)
+        }
+
+        val field = IntroPresenter.listEmbed(member(), listOf(broken), 3).fields.single()
+
+        // Discord's field-value cap is 1024; the reason is bounded well below it.
+        assertTrue(field.value!!.length < 1024, "field value was ${field.value!!.length} chars")
+    }
+
+    @Test
+    fun `every intro being broken is called out at the top of the embed`() {
+        val broken = urlIntro(1, "a").apply { failureCount = IntroHealth.UNHEALTHY_AFTER_FAILURES }
+        val alsoBroken = urlIntro(2, "b").apply { failureCount = IntroHealth.UNHEALTHY_AFTER_FAILURES }
+
+        val embed = IntroPresenter.listEmbed(member(), listOf(broken, alsoBroken), 3)
+
+        assertTrue(embed.description!!.contains("stopped loading"), embed.description!!)
+    }
+
+    @Test
+    fun `switched-off intros are not reported as broken`() {
+        // "Every intro is switched off" is the owner's own doing and already
+        // has its own message; don't blame the sources for it.
+        val off = urlIntro(1, "a").apply { enabled = false }
+
+        val embed = IntroPresenter.listEmbed(member(), listOf(off), 3)
+
+        assertTrue(embed.description!!.contains("switched off"), embed.description!!)
+    }
+
+    // --- play stats ---------------------------------------------------------
+
+    @Test
+    fun `an intro that has never played reports nothing rather than zero`() {
+        assertNull(IntroPresenter.playSummary(urlIntro(1, "track")))
+    }
+
+    @Test
+    fun `play counts appear once there is something to count`() {
+        val played = urlIntro(1, "track").apply {
+            playCount = 12
+            lastPlayedAt = Instant.parse("2026-01-01T00:00:00Z")
+        }
+
+        val summary = IntroPresenter.playSummary(played, now = Instant.parse("2026-01-04T00:00:00Z"))!!
+
+        assertTrue(summary.contains("Played 12×"), summary)
+        assertTrue(summary.contains("3d ago"), summary)
+    }
+
+    @Test
+    fun `a play count with no timestamp still reports the count`() {
+        val played = urlIntro(1, "track").apply { playCount = 3 }
+
+        assertEquals("Played 3×", IntroPresenter.playSummary(played))
+    }
+
+    @Test
+    fun `relative times read the way a person would say them`() {
+        val now = Instant.parse("2026-06-01T12:00:00Z")
+
+        assertEquals("just now", IntroPresenter.relativeTime(now.minusSeconds(5), now))
+        assertEquals("30m ago", IntroPresenter.relativeTime(now.minusSeconds(1800), now))
+        assertEquals("5h ago", IntroPresenter.relativeTime(now.minusSeconds(5 * 3600), now))
+        assertEquals("2d ago", IntroPresenter.relativeTime(now.minusSeconds(2 * 86400), now))
+        assertEquals("3mo ago", IntroPresenter.relativeTime(now.minusSeconds(95L * 86400), now))
+    }
+
+    @Test
+    fun `a clock skew into the future does not produce a negative age`() {
+        val now = Instant.parse("2026-06-01T12:00:00Z")
+
+        assertEquals("just now", IntroPresenter.relativeTime(now.plusSeconds(60), now))
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/intro/IntroSelectionTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/intro/IntroSelectionTest.kt
@@ -1,9 +1,11 @@
 package bot.toby.intro
 
+import common.intro.IntroHealth
 import database.dto.music.MusicDto
 import database.dto.user.UserDto
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -112,5 +114,59 @@ class IntroSelectionTest {
         val off = intro(2).apply { enabled = false }
 
         assertEquals(on.id, IntroSelection.pick(listOf(on, off), on.id)?.id)
+    }
+
+    // --- broken intros ------------------------------------------------------
+
+    @Test
+    fun `a working intro is preferred over one whose source keeps failing`() {
+        // Someone with one dead link and one good one used to get silence
+        // half the time, with nothing anywhere saying why.
+        val working = intro(1)
+        val broken = intro(2).apply { failureCount = IntroHealth.UNHEALTHY_AFTER_FAILURES }
+
+        repeat(50) { seed ->
+            assertEquals(working.id, IntroSelection.pick(listOf(working, broken), null, Random(seed))?.id)
+        }
+    }
+
+    @Test
+    fun `a single failure does not take an intro out of rotation`() {
+        val flaky = intro(1).apply { failureCount = 1 }
+        val other = intro(2)
+
+        val picks = (0 until 100).mapNotNull { IntroSelection.pick(listOf(flaky, other), null, Random(it))?.id }
+
+        assertTrue(picks.contains(flaky.id), "one bad night should not sideline an intro")
+    }
+
+    @Test
+    fun `when every intro looks broken one is still tried`() {
+        // Guaranteeing silence is worse than trying: the source may have come
+        // back (a region block lifting, YouTube unthrottling the bot's IP).
+        val a = intro(1).apply { failureCount = IntroHealth.UNHEALTHY_AFTER_FAILURES }
+        val b = intro(2).apply { failureCount = IntroHealth.UNHEALTHY_AFTER_FAILURES + 3 }
+
+        assertNotNull(IntroSelection.pick(listOf(a, b)))
+    }
+
+    @Test
+    fun `a broken intro that is also switched off stays off`() {
+        // Disabled is the owner's decision and outranks our guess about health.
+        val off = intro(1).apply { enabled = false }
+        val broken = intro(2).apply { failureCount = IntroHealth.UNHEALTHY_AFTER_FAILURES }
+
+        assertEquals(broken.id, IntroSelection.pick(listOf(off, broken))?.id)
+    }
+
+    @Test
+    fun `the no-repeat rule still applies among healthy intros`() {
+        val first = intro(1)
+        val second = intro(2)
+        val broken = intro(3).apply { failureCount = IntroHealth.UNHEALTHY_AFTER_FAILURES }
+        val intros = listOf(first, second, broken)
+
+        assertEquals(second.id, IntroSelection.pick(intros, first.id)?.id)
+        assertEquals(first.id, IntroSelection.pick(intros, second.id)?.id)
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/lavaplayer/GuildMusicManagerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/lavaplayer/GuildMusicManagerTest.kt
@@ -22,6 +22,8 @@ class GuildMusicManagerTest {
         // Stub AudioPlayerManager's createPlayer() to return mock AudioPlayer
         every { mockAudioPlayerManager.createPlayer() } returns mockAudioPlayer
         every { mockAudioPlayer.addListener(any()) } just Runs
+        // GuildMusicManager now installs the intro loudness meter.
+        every { mockAudioPlayer.setFilterFactory(any()) } just Runs
 
 
         // Create GuildMusicManager instance using mocked AudioPlayerManager

--- a/discord-bot/src/test/kotlin/bot/toby/lavaplayer/IntroLoudnessFilterFactoryTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/lavaplayer/IntroLoudnessFilterFactoryTest.kt
@@ -1,0 +1,82 @@
+package bot.toby.lavaplayer
+
+import com.sedmelluq.discord.lavaplayer.filter.UniversalPcmAudioFilter
+import com.sedmelluq.discord.lavaplayer.format.AudioDataFormat
+import com.sedmelluq.discord.lavaplayer.track.AudioTrack
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class IntroLoudnessFilterFactoryTest {
+
+    private val format: AudioDataFormat = mockk(relaxed = true)
+    private val output: UniversalPcmAudioFilter = mockk(relaxed = true)
+
+    @Test
+    fun `regular music playback gets no filter at all`() {
+        // The factory is installed on the guild player, so it sees every
+        // queued track. Measuring an hour of music would be work on the audio
+        // thread for a number nothing reads.
+        val factory = IntroLoudnessFilterFactory(introIdOf = { null }, onMeasured = { _, _ -> })
+
+        val chain = factory.buildChain(mockk(relaxed = true), format, output)
+
+        assertTrue(chain.isEmpty(), "expected an empty chain for a non-intro track")
+    }
+
+    @Test
+    fun `an intro track gets a single meter that feeds the rest of the pipeline`() {
+        val factory = IntroLoudnessFilterFactory(introIdOf = { "1_2_1" }, onMeasured = { _, _ -> })
+
+        val chain = factory.buildChain(mockk(relaxed = true), format, output)
+
+        // One filter: with a single element there is no ambiguity about which
+        // end of lavaplayer's chain forwards to `output`.
+        assertEquals(1, chain.size)
+        assertInstanceOf(IntroLoudnessMeter::class.java, chain.single())
+    }
+
+    @Test
+    fun `the measurement is reported against the intro that was playing`() {
+        val reported = mutableListOf<Pair<String, Double>>()
+        val factory = IntroLoudnessFilterFactory(
+            introIdOf = { "42_7_2" },
+            onMeasured = { id, rms -> reported += id to rms },
+        )
+        val meter = factory.buildChain(mockk(relaxed = true), format, output).single() as IntroLoudnessMeter
+
+        meter.process(Array(1) { FloatArray(50) { 0.4f } }, 0, 50)
+        meter.close()
+
+        assertEquals(1, reported.size)
+        assertEquals("42_7_2", reported.single().first)
+    }
+
+    @Test
+    fun `a failure recording the measurement never reaches the audio thread`() {
+        // close() runs inside lavaplayer's pipeline teardown. A throw here
+        // would surface as broken playback in exchange for a statistic.
+        val factory = IntroLoudnessFilterFactory(
+            introIdOf = { "1_1_1" },
+            onMeasured = { _, _ -> error("database is on fire") },
+        )
+        val meter = factory.buildChain(mockk(relaxed = true), format, output).single() as IntroLoudnessMeter
+
+        meter.process(Array(1) { FloatArray(10) { 0.5f } }, 0, 10)
+        meter.close() // must not throw
+    }
+
+    @Test
+    fun `a failure resolving the intro id degrades to no filter`() {
+        val factory = IntroLoudnessFilterFactory(
+            introIdOf = { throw IllegalStateException("scheduler state gone") },
+            onMeasured = { _, _ -> },
+        )
+
+        val chain: List<Any> = factory.buildChain(mockk<AudioTrack>(relaxed = true), format, output)
+
+        assertTrue(chain.isEmpty())
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/lavaplayer/IntroLoudnessMeterTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/lavaplayer/IntroLoudnessMeterTest.kt
@@ -1,0 +1,137 @@
+package bot.toby.lavaplayer
+
+import com.sedmelluq.discord.lavaplayer.filter.FloatPcmAudioFilter
+import common.intro.IntroLoudness
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import kotlin.math.abs
+
+class IntroLoudnessMeterTest {
+
+    /** Records what reached the rest of the pipeline. */
+    private class RecordingFilter : FloatPcmAudioFilter {
+        val received = mutableListOf<Triple<Array<FloatArray>, Int, Int>>()
+        var flushed = 0
+        var closed = 0
+        override fun process(input: Array<FloatArray>, offset: Int, length: Int) {
+            received += Triple(input, offset, length)
+        }
+        override fun seekPerformed(requestedTime: Long, providedTime: Long) = Unit
+        override fun flush() { flushed++ }
+        override fun close() { closed++ }
+    }
+
+    private fun constantFrame(amplitude: Float, samples: Int, channels: Int = 2) =
+        Array(channels) { FloatArray(samples) { amplitude } }
+
+    @Test
+    fun `every sample is forwarded downstream unchanged`() {
+        // The meter must be acoustically invisible. If it ever swallowed or
+        // altered audio, every intro in every guild would be affected.
+        val downstream = RecordingFilter()
+        val meter = IntroLoudnessMeter(downstream) {}
+        val frame = constantFrame(0.25f, 8)
+
+        meter.process(frame, 0, 8)
+
+        assertEquals(1, downstream.received.size)
+        val (forwarded, offset, length) = downstream.received.single()
+        assertTrue(forwarded === frame, "the same buffer should be passed on, not a copy")
+        assertEquals(0, offset)
+        assertEquals(8, length)
+        assertTrue(forwarded.all { channel -> channel.all { it == 0.25f } })
+    }
+
+    @Test
+    fun `the measured level is the rms of what played`() {
+        var measured: Double? = null
+        val meter = IntroLoudnessMeter(RecordingFilter()) { measured = it }
+
+        meter.process(constantFrame(0.5f, 100), 0, 100)
+        meter.close()
+
+        assertNotNull(measured)
+        assertTrue(abs(0.5 - measured!!) < 1e-6, "expected ~0.5, got $measured")
+    }
+
+    @Test
+    fun `a track that produced no audio reports nothing`() {
+        // Reporting 0.0 would look like "extremely quiet" and earn the maximum
+        // boost next play; the honest answer is that we never measured it.
+        var measured: Double? = null
+        val meter = IntroLoudnessMeter(RecordingFilter()) { measured = it }
+
+        meter.close()
+
+        assertNull(measured)
+    }
+
+    @Test
+    fun `a seek discards everything sampled before the clip started`() {
+        // Clip start offsets are applied as a seek. Without the reset, audio
+        // the decoder emitted before jumping to the clip would be averaged in.
+        var measured: Double? = null
+        val meter = IntroLoudnessMeter(RecordingFilter()) { measured = it }
+
+        meter.process(constantFrame(0.9f, 200), 0, 200)
+        meter.seekPerformed(0L, 0L)
+        meter.process(constantFrame(0.1f, 200), 0, 200)
+        meter.close()
+
+        assertTrue(abs(0.1 - measured!!) < 1e-6, "expected only the post-seek audio, got $measured")
+    }
+
+    @Test
+    fun `only the requested window of the buffer is measured`() {
+        var measured: Double? = null
+        val meter = IntroLoudnessMeter(RecordingFilter()) { measured = it }
+        // Loud padding either side of a quiet window; only the window counts.
+        val frame = Array(1) { FloatArray(30) { i -> if (i in 10..19) 0.2f else 1.0f } }
+
+        meter.process(frame, 10, 10)
+        meter.close()
+
+        assertTrue(abs(0.2 - measured!!) < 1e-6, "expected ~0.2, got $measured")
+    }
+
+    @Test
+    fun `a short buffer does not throw on the audio thread`() {
+        // An ArrayIndexOutOfBounds raised here would kill the track, not just
+        // the measurement, so the accumulator clamps rather than trusting the
+        // declared length.
+        val downstream = RecordingFilter()
+        val meter = IntroLoudnessMeter(downstream) {}
+
+        meter.process(Array(1) { FloatArray(4) { 0.5f } }, 0, 999)
+
+        assertEquals(1, downstream.received.size)
+    }
+
+    @Test
+    fun `closing twice reports once`() {
+        var reports = 0
+        val meter = IntroLoudnessMeter(RecordingFilter()) { reports++ }
+
+        meter.process(constantFrame(0.3f, 10), 0, 10)
+        meter.close()
+        meter.close()
+
+        assertEquals(1, reports)
+    }
+
+    @Test
+    fun `the measurement is the number the gain calculation consumes`() {
+        // Ties the meter to the correction: a track measured well above target
+        // must come out asking to be turned down.
+        var measured: Double? = null
+        val meter = IntroLoudnessMeter(RecordingFilter()) { measured = it }
+
+        meter.process(constantFrame((IntroLoudness.TARGET_RMS * 2).toFloat(), 64), 0, 64)
+        meter.close()
+
+        assertTrue(IntroLoudness.gainFor(measured) < 1.0, "gain was ${IntroLoudness.gainFor(measured)}")
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/lavaplayer/PlayerManagerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/lavaplayer/PlayerManagerTest.kt
@@ -1,17 +1,23 @@
 package bot.toby.lavaplayer
 
+import bot.toby.intro.IntroLoadFailedEvent
+import bot.toby.intro.IntroPlayedEvent
 import com.sedmelluq.discord.lavaplayer.player.AudioLoadResultHandler
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager
 import com.sedmelluq.discord.lavaplayer.tools.FriendlyException
+import com.sedmelluq.discord.lavaplayer.track.AudioTrackInfo
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
 import java.util.concurrent.ScheduledExecutorService
 
 class PlayerManagerTest {
@@ -72,5 +78,136 @@ class PlayerManagerTest {
 
         assertEquals(1, handlers.size)
         verify(exactly = 1) { apm.loadItemOrdered(any<Any>(), any<String>(), any<AudioLoadResultHandler>()) }
+    }
+
+    // --- intro outcomes -----------------------------------------------------
+    //
+    // Both failure branches below used to write to `event?.hook`, and `event`
+    // is always null on the intro path (voice joins have no interaction). A
+    // dead link therefore produced silence, forever, with nothing recorded.
+
+    /** Captures what the audio layer published to the Spring bus. */
+    private fun captureEvents(): MutableList<Any> {
+        val published = mutableListOf<Any>()
+        SchedulerEvents.publisher = ApplicationEventPublisher { event -> published.add(event) }
+        return published
+    }
+
+    @AfterEach
+    fun clearPublisher() {
+        SchedulerEvents.publisher = null
+    }
+
+    @Test
+    fun `a loaded intro is reported as played, against its row`() {
+        val published = captureEvents()
+
+        pm.loadAndPlayIntro(guild, null, "url", 5, 0L, 50, null, "1_2_1")
+        handlers.last().trackLoaded(mockk(relaxed = true))
+
+        assertEquals(listOf(IntroPlayedEvent("1_2_1")), published.filterIsInstance<IntroPlayedEvent>())
+    }
+
+    @Test
+    fun `a link that resolves to nothing is reported as a failure`() {
+        val published = captureEvents()
+
+        pm.loadAndPlayIntro(guild, null, "url", 5, 0L, 50, null, "1_2_1")
+        handlers.last().noMatches()
+
+        val failure = published.filterIsInstance<IntroLoadFailedEvent>().single()
+        assertEquals("1_2_1", failure.introId)
+        assertEquals("Nothing found at this link", failure.reason)
+    }
+
+    @Test
+    fun `a permanent load failure is reported with the reason the source gave`() {
+        val published = captureEvents()
+
+        pm.loadAndPlayIntro(guild, null, "url", 5, 0L, 50, null, "1_2_1")
+        handlers.last().loadFailed(
+            FriendlyException(
+                "This video is not available in your country",
+                FriendlyException.Severity.COMMON,
+                RuntimeException("x"),
+            ),
+        )
+
+        val failure = published.filterIsInstance<IntroLoadFailedEvent>().single()
+        assertEquals("This video is not available in your country", failure.reason)
+    }
+
+    @Test
+    fun `a failure with no message still carries something readable`() {
+        val published = captureEvents()
+
+        pm.loadAndPlayIntro(guild, null, "url", 5, 0L, 50, null, "1_2_1")
+        handlers.last().loadFailed(FriendlyException(null, FriendlyException.Severity.COMMON, RuntimeException("x")))
+
+        assertEquals("Source could not be loaded", published.filterIsInstance<IntroLoadFailedEvent>().single().reason)
+    }
+
+    @Test
+    fun `a retried failure is only reported once the retries are exhausted`() {
+        // Otherwise every rate-limited night would mark healthy intros broken.
+        val published = captureEvents()
+
+        pm.loadAndPlayIntro(guild, null, "url", 5, 0L, 50, null, "1_2_1")
+
+        repeat(PlayerManager.MAX_LOAD_ATTEMPTS - 1) {
+            handlers.last().loadFailed(transientFailure())
+            assertTrue(published.filterIsInstance<IntroLoadFailedEvent>().isEmpty(), "reported mid-retry")
+        }
+        handlers.last().loadFailed(transientFailure())
+
+        assertEquals(1, published.filterIsInstance<IntroLoadFailedEvent>().size)
+    }
+
+    /** TrackInfoMapper reads AudioTrackInfo's fields, which mockk can't stub. */
+    private fun realTrack() = mockk<com.sedmelluq.discord.lavaplayer.track.AudioTrack>(relaxed = true) {
+        every { info } returns AudioTrackInfo("t", "a", 60_000L, "identifier", false, "http://example.com")
+        every { userData } returns 50
+    }
+
+    @Test
+    fun `regular playback reports no intro outcome at all`() {
+        val published = captureEvents()
+
+        pm.loadAndPlay(guild, event, "url", true, 5, 0L, 50, null)
+        handlers.last().trackLoaded(realTrack())
+        handlers.last().noMatches()
+
+        assertTrue(published.none { it is IntroPlayedEvent || it is IntroLoadFailedEvent }, published.toString())
+    }
+
+    @Test
+    fun `an intro played without a known row reports nothing rather than guessing`() {
+        val published = captureEvents()
+
+        pm.loadAndPlayIntro(guild, null, "url", 5, 0L, 50, null, null)
+        handlers.last().trackLoaded(mockk(relaxed = true))
+        handlers.last().noMatches()
+
+        assertTrue(published.none { it is IntroPlayedEvent || it is IntroLoadFailedEvent })
+    }
+
+    @Test
+    fun `the intro row id reaches the scheduler so the loudness meter can find it`() {
+        val musicManager = pm.getMusicManager(guild)
+        val track = mockk<com.sedmelluq.discord.lavaplayer.track.AudioTrack>(relaxed = true)
+
+        pm.loadAndPlayIntro(guild, null, "url", 5, 0L, 50, null, "1_2_3")
+        handlers.last().trackLoaded(track)
+
+        assertEquals("1_2_3", musicManager.scheduler.introIdFor(track))
+    }
+
+    @Test
+    fun `no publisher wired means the outcome is dropped, not thrown`() {
+        // Unit tests and early startup run without the Spring bridge.
+        SchedulerEvents.publisher = null
+
+        pm.loadAndPlayIntro(guild, null, "url", 5, 0L, 50, null, "1_2_1")
+        handlers.last().noMatches()
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/lavaplayer/TrackSchedulerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/lavaplayer/TrackSchedulerTest.kt
@@ -609,4 +609,73 @@ class TrackSchedulerTest {
         scheduler.onPlayerPause(player)
         scheduler.onPlayerResume(player)
     }
+
+    // --- intro row bookkeeping ---------------------------------------------
+    //
+    // The loudness meter is built when the audio pipeline opens and needs to
+    // know which stored intro it is measuring; the scheduler is the only place
+    // that knows a given track is an intro at all.
+
+    @Test
+    fun `queueing an intro records which row it came from`() {
+        val intro = mockTrack("Intro")
+
+        scheduler.queueIntro(intro, 0L, null, 60, requesterId = null, introId = "1_2_1")
+
+        assertEquals("1_2_1", scheduler.introIdFor(intro))
+    }
+
+    @Test
+    fun `the row is recorded on the preempting path too`() {
+        // queueIntro takes one of two routes depending on whether something is
+        // already playing; a measurement that only worked on the idle path
+        // would silently never happen for anyone listening to music.
+        val playing = mockTrack("Playing")
+        every { player.playingTrack } returns playing
+        val intro = mockTrack("Intro")
+
+        scheduler.queueIntro(intro, 0L, null, 60, requesterId = null, introId = "1_2_2")
+
+        assertEquals("1_2_2", scheduler.introIdFor(intro))
+    }
+
+    @Test
+    fun `a regular queued track has no intro row`() {
+        val track = mockTrack("Music")
+
+        scheduler.queue(track, 0L, null, 50)
+
+        assertNull(scheduler.introIdFor(track))
+    }
+
+    @Test
+    fun `an intro queued without a row id records nothing`() {
+        val intro = mockTrack("Intro")
+
+        scheduler.queueIntro(intro, 0L, null, 60)
+
+        assertNull(scheduler.introIdFor(intro))
+    }
+
+    @Test
+    fun `the row mapping is released when the intro ends`() {
+        // Tracks are map keys; holding them past the end of playback would
+        // pin every intro ever played for the lifetime of the guild player.
+        val intro = mockTrack("Intro")
+        scheduler.queueIntro(intro, 0L, null, 60, requesterId = null, introId = "1_2_1")
+
+        scheduler.onTrackEnd(player, intro, AudioTrackEndReason.FINISHED)
+
+        assertNull(scheduler.introIdFor(intro))
+    }
+
+    @Test
+    fun `stopping the player releases the row mapping`() {
+        val intro = mockTrack("Intro")
+        scheduler.queueIntro(intro, 0L, null, 60, requesterId = null, introId = "1_2_1")
+
+        scheduler.stopTrack(true)
+
+        assertNull(scheduler.introIdFor(intro))
+    }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/modal/modals/setconfig/SetConfigCategoryModalRenderingTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/modal/modals/setconfig/SetConfigCategoryModalRenderingTest.kt
@@ -50,13 +50,14 @@ class SetConfigCategoryModalRenderingTest {
     }
 
     @Test
-    fun `General modal renders 5 TextInputs and zero EntitySelectMenus`() {
+    fun `General modal renders 4 TextInputs and zero EntitySelectMenus`() {
         val modal = SetConfigGeneralModal(configService)
         val built = modal.buildModal(SetConfigGeneralModal.MODAL_NAME, guild) { null }
 
         val textInputs = built.allComponents().filterIsInstance<TextInput>()
         val selectMenus = built.allComponents().filterIsInstance<EntitySelectMenu>()
-        assertEquals(5, textInputs.size, "General modal has 5 TextInputs")
+        // Four since the default intro volume moved to /setconfig intro.
+        assertEquals(4, textInputs.size, "General modal has 4 TextInputs")
         assertTrue(
             selectMenus.isEmpty(),
             "General modal must not embed EntitySelectMenu — Discord rejects mixed modals (got ${selectMenus.size})",
@@ -150,6 +151,7 @@ class SetConfigCategoryModalRenderingTest {
         // embed an EntitySelectMenu.
         val concretes = listOf<SetConfigCategoryModal>(
             SetConfigGeneralModal(configService),
+            SetConfigIntroModal(configService),
             SetConfigActivityModal(configService, mockk(relaxed = true)),
             SetConfigFeesModal(configService),
             SetConfigJackpotModal(configService),

--- a/discord-bot/src/test/kotlin/bot/toby/modal/modals/setconfig/SetConfigFieldValidatorTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/modal/modals/setconfig/SetConfigFieldValidatorTest.kt
@@ -15,6 +15,9 @@ import org.junit.jupiter.api.Test
 
 internal class SetConfigFieldValidatorTest {
 
+    /** Guild for the channel-resolving specs; individual tests stub lookups. */
+    private val guild = mockk<Guild>()
+
     // ----- per-type validate() coverage -----
 
     @Test
@@ -230,5 +233,73 @@ internal class SetConfigFieldValidatorTest {
         assertEquals(2, errors.messages.size)
         assertTrue(errors.messages[0].startsWith("Volume:"))
         assertTrue(errors.messages[1].startsWith("Intro volume:"))
+    }
+
+    // --- VoiceChannelIdList (INTRO_EXCLUDED_CHANNELS) -----------------------
+
+    @Test
+    fun `a list of voice channel ids is stored as a normalised csv`() {
+        every { guild.getVoiceChannelById(100L) } returns mockk(relaxed = true)
+        every { guild.getVoiceChannelById(200L) } returns mockk(relaxed = true)
+
+        val result = SetConfigFieldValidator.validate(
+            "100, <#200>", FieldSpec.VoiceChannelIdList("Silent channels"), guild,
+        )
+
+        assertEquals(FieldResult.Write("100,200"), result)
+    }
+
+    @Test
+    fun `duplicate ids collapse rather than being stored twice`() {
+        every { guild.getVoiceChannelById(100L) } returns mockk(relaxed = true)
+
+        val result = SetConfigFieldValidator.validate(
+            "100,100", FieldSpec.VoiceChannelIdList("Silent channels"), guild,
+        )
+
+        assertEquals(FieldResult.Write("100"), result)
+    }
+
+    @Test
+    fun `an id that is not a voice channel in this server is rejected`() {
+        // An exemption that silently does nothing is worse than no exemption:
+        // the admin walks away believing that channel is quiet.
+        every { guild.getVoiceChannelById(any<Long>()) } returns null
+
+        val result = SetConfigFieldValidator.validate(
+            "100", FieldSpec.VoiceChannelIdList("Silent channels"), guild,
+        )
+
+        assertInstanceOf(FieldResult.Error::class.java, result)
+    }
+
+    @Test
+    fun `junk in the list fails the whole submission`() {
+        every { guild.getVoiceChannelById(100L) } returns mockk(relaxed = true)
+
+        val result = SetConfigFieldValidator.validate(
+            "100,notanid", FieldSpec.VoiceChannelIdList("Silent channels"), guild,
+        )
+
+        assertInstanceOf(FieldResult.Error::class.java, result)
+    }
+
+    @Test
+    fun `zero clears the exemption list`() {
+        val result = SetConfigFieldValidator.validate(
+            "0", FieldSpec.VoiceChannelIdList("Silent channels"), guild,
+        )
+
+        assertEquals(FieldResult.Write(""), result)
+    }
+
+    @Test
+    fun `a blank field leaves the existing list alone`() {
+        // Shared rule across every setconfig field: blank means "don't
+        // overwrite", which is how the pre-filled modal stays safe to submit.
+        assertEquals(
+            FieldResult.Skip,
+            SetConfigFieldValidator.validate("  ", FieldSpec.VoiceChannelIdList("Silent channels"), guild),
+        )
     }
 }

--- a/web/src/main/kotlin/web/service/IntroWebService.kt
+++ b/web/src/main/kotlin/web/service/IntroWebService.kt
@@ -3,6 +3,8 @@ package web.service
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.github.benmanes.caffeine.cache.Caffeine
 import common.intro.IntroClip
+import common.intro.IntroHealth
+import common.intro.IntroLoudness
 import common.intro.IntroSlots
 import common.logging.DiscordLogger
 import database.dto.music.MusicDto
@@ -17,6 +19,7 @@ import org.springframework.web.multipart.MultipartFile
 import java.net.HttpURLConnection
 import java.net.URI
 import java.net.URL
+import java.time.Instant
 import java.util.concurrent.TimeUnit
 
 @Service
@@ -203,7 +206,12 @@ class IntroWebService(
                 videoId = videoId,
                 startMs = dto.startMs,
                 endMs = dto.endMs,
-                enabled = dto.enabled
+                enabled = dto.enabled,
+                playCount = dto.playCount,
+                lastPlayedAt = dto.lastPlayedAt,
+                failureCount = dto.failureCount,
+                lastFailureReason = dto.lastFailureReason,
+                measuredRms = dto.measuredRms
             )
         }
     }
@@ -588,7 +596,12 @@ data class IntroViewModel(
     val videoId: String? = null,
     val startMs: Int? = null,
     val endMs: Int? = null,
-    val enabled: Boolean = true
+    val enabled: Boolean = true,
+    val playCount: Int = 0,
+    val lastPlayedAt: Instant? = null,
+    val failureCount: Int = 0,
+    val lastFailureReason: String? = null,
+    val measuredRms: Double? = null
 ) {
     /**
      * What the row's clip badge shows — the actual range (`0:03 – 0:12`)
@@ -596,6 +609,22 @@ data class IntroViewModel(
      * opening each editor.
      */
     val clipLabel: String get() = IntroClip.describe(startMs, endMs)
+
+    /**
+     * Whether this intro's source has failed enough times running to be
+     * called dead. Until this existed the page happily listed a link that
+     * had been deleted months ago as though it still worked.
+     */
+    val broken: Boolean get() = IntroHealth.isUnhealthy(failureCount)
+
+    /** Why it stopped loading, in the words of whatever refused to serve it. */
+    val brokenReason: String get() = lastFailureReason ?: "Source could not be loaded"
+
+    /** `Played 12×`, or null when it has never played and the zero is noise. */
+    val playLabel: String? get() = if (playCount > 0) "Played $playCount×" else null
+
+    /** "quiet source" / "loud source" — context for the volume slider. */
+    val loudnessLabel: String? get() = IntroLoudness.describe(measuredRms)
 }
 
 data class GuildInfo(

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -818,10 +818,27 @@ class ModerationWebService(
                 id
             }
             ConfigDto.Configurations.ACTIVITY_TRACKING,
-            ConfigDto.Configurations.CARD_MENTIONS -> {
+            ConfigDto.Configurations.CARD_MENTIONS,
+            ConfigDto.Configurations.INTROS_ENABLED,
+            ConfigDto.Configurations.INTRO_NORMALISE_VOLUME -> {
                 val v = rawValue.trim().lowercase()
                 if (v != "true" && v != "false") return "Value must be true or false."
                 v
+            }
+            ConfigDto.Configurations.INTRO_EXCLUDED_CHANNELS -> {
+                // Stored as CSV. Blank clears the exemption list.
+                val ids = common.intro.IntroGuildPolicy.excludedChannelIds(rawValue)
+                if (rawValue.isNotBlank() && ids.isEmpty()) {
+                    return "Enter one or more voice channel ids, separated by commas."
+                }
+                // Reject ids that aren't voice channels here rather than
+                // silently ignoring them at join time — an exemption that
+                // quietly does nothing is worse than no exemption.
+                val unknown = ids.filter { guild.getVoiceChannelById(it) == null }
+                if (unknown.isNotEmpty()) {
+                    return "No voice channel in this server with id ${unknown.joinToString(", ")}."
+                }
+                common.intro.IntroGuildPolicy.formatExcludedChannelIds(ids)
             }
             ConfigDto.Configurations.CUBE_CURRENCY -> {
                 // The /mtgcube preview's "cube value" currency. Normalise to the

--- a/web/src/main/resources/static/css/intros.css
+++ b/web/src/main/resources/static/css/intros.css
@@ -304,6 +304,22 @@ tr.intro-disabled .slot-index,
 tr.intro-disabled .volume-inline { opacity: 0.45; }
 tr.intro-disabled .name-label { text-decoration: line-through; }
 
+/* A broken intro is the opposite case: the owner did not switch it off and
+   has no way to tell it stopped working, so it gets emphasis rather than
+   dimming. The left border makes it findable when scanning a full table. */
+tr.intro-broken { border-left: 3px solid var(--danger); }
+.intro-broken-note {
+    margin: 4px 0 0;
+    font-size: 0.8rem;
+    line-height: 1.4;
+    color: var(--danger);
+}
+.intro-meta {
+    margin: 4px 0 0;
+    font-size: 0.78rem;
+    color: var(--text-muted);
+}
+
 @media (prefers-reduced-motion: reduce) {
     .intro-toggle-track,
     .intro-toggle-track::after { transition: none; }

--- a/web/src/main/resources/templates/intros.html
+++ b/web/src/main/resources/templates/intros.html
@@ -79,7 +79,8 @@
                 </thead>
                 <tbody id="introsTbody">
                     <tr th:each="intro : ${intros}"
-                        th:classappend="${intro.enabled} ? '' : ' intro-disabled'"
+                        th:classappend="(${intro.enabled} ? '' : ' intro-disabled')
+                                        + (${intro.broken} ? ' intro-broken' : '')"
                         th:attr="data-intro-id=${intro.id},
                                  data-start-ms=${intro.startMs != null ? intro.startMs : ''},
                                  data-end-ms=${intro.endMs != null ? intro.endMs : ''},
@@ -111,6 +112,24 @@
                                 <span class="clip-badge-label">⏱</span>
                                 <span class="clip-badge-range" th:text="${intro.clipLabel}">full track</span>
                             </button>
+                            <!--
+                                An intro that has stopped loading is silence on
+                                join with no other symptom, so the reason the
+                                source gave is shown inline rather than left in
+                                a server log.
+                            -->
+                            <p th:if="${intro.broken}" class="intro-broken-note">
+                                <span aria-hidden="true">⚠️</span>
+                                <strong>Not playing.</strong>
+                                <span th:text="${intro.brokenReason}">Video unavailable</span>
+                                Replace the link to fix it.
+                            </p>
+                            <p class="intro-meta"
+                               th:if="${intro.playLabel != null or intro.loudnessLabel != null}">
+                                <span th:if="${intro.playLabel != null}" th:text="${intro.playLabel}">Played 3×</span>
+                                <span th:if="${intro.playLabel != null and intro.loudnessLabel != null}"> · </span>
+                                <span th:if="${intro.loudnessLabel != null}" th:text="${intro.loudnessLabel}">level</span>
+                            </p>
                         </td>
                         <td data-label="Volume">
                             <div class="volume-inline">

--- a/web/src/main/resources/templates/moderation/settings.html
+++ b/web/src/main/resources/templates/moderation/settings.html
@@ -36,6 +36,7 @@
                 <div class="settings-nav-group">
                     <p class="settings-nav-heading">Server</p>
                     <a href="#settings-section-server-features" class="settings-nav-link">Server features</a>
+                    <a href="#settings-section-intros" class="settings-nav-link">Intros</a>
                     <a href="#settings-section-messages" class="settings-nav-link">Messages &amp; leaderboards</a>
                     <a href="#settings-section-magic" class="settings-nav-link">Magic: The Gathering</a>
                 </div>
@@ -77,13 +78,6 @@
                                    th:disabled="${!isOwner}">
                             <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                         </div>
-                        <div class="config-row" data-key="INTRO_VOLUME">
-                            <label>Default intro volume</label>
-                            <input type="number" min="0" max="200"
-                                   th:value="${overview.config['INTRO_VOLUME']}"
-                                   th:disabled="${!isOwner}">
-                            <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                        </div>
                         <div class="config-row" data-key="MOVE">
                             <label>Default move channel</label>
                             <div th:replace="~{fragments/channelPicker :: channelPicker(
@@ -118,6 +112,87 @@
                             <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                         </div>
                     </div>
+                </details>
+
+                <details id="settings-section-intros" class="config-section">
+                    <summary>Intros</summary>
+                    <div class="config-grid">
+                        <!--
+                            Until these existed the default volume was the only
+                            intro setting a server had, so a server could make
+                            intros quieter but never turn them off and never
+                            exempt a channel. Both new switches are opt-out:
+                            no row stored means intros behave as they always have.
+                        -->
+                        <div class="config-row" data-key="INTROS_ENABLED">
+                            <label>
+                                Intros on join
+                                <span class="config-hint">
+                                    Off suppresses both the intro and the
+                                    &quot;you don&rsquo;t have an intro yet&quot; DM.
+                                </span>
+                            </label>
+                            <select th:disabled="${!isOwner}">
+                                <option value="true"
+                                        th:selected="${overview.config['INTROS_ENABLED'] == null or overview.config['INTROS_ENABLED'] != 'false'}">
+                                    Enabled
+                                </option>
+                                <option value="false"
+                                        th:selected="${overview.config['INTROS_ENABLED'] == 'false'}">
+                                    Disabled
+                                </option>
+                            </select>
+                            <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                        </div>
+                        <div class="config-row" data-key="INTRO_VOLUME">
+                            <label>Default intro volume</label>
+                            <input type="number" min="0" max="200"
+                                   th:value="${overview.config['INTRO_VOLUME']}"
+                                   th:disabled="${!isOwner}">
+                            <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                        </div>
+                        <div class="config-row" data-key="INTRO_NORMALISE_VOLUME">
+                            <label>
+                                Match intro loudness
+                                <span class="config-hint">
+                                    Corrects each intro towards the same perceived
+                                    level, so a loud track and a quiet one set to
+                                    the same volume sound alike. Correction is
+                                    capped at half to double.
+                                </span>
+                            </label>
+                            <select th:disabled="${!isOwner}">
+                                <option value="true"
+                                        th:selected="${overview.config['INTRO_NORMALISE_VOLUME'] == null or overview.config['INTRO_NORMALISE_VOLUME'] != 'false'}">
+                                    Enabled
+                                </option>
+                                <option value="false"
+                                        th:selected="${overview.config['INTRO_NORMALISE_VOLUME'] == 'false'}">
+                                    Disabled
+                                </option>
+                            </select>
+                            <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                        </div>
+                        <div class="config-row" data-key="INTRO_EXCLUDED_CHANNELS">
+                            <label>
+                                Silent voice channels
+                                <span class="config-hint">
+                                    Comma-separated voice channel ids where intros
+                                    never play &mdash; for a study, meeting or
+                                    on-call channel. Blank means every channel.
+                                </span>
+                            </label>
+                            <input type="text"
+                                   th:value="${overview.config['INTRO_EXCLUDED_CHANNELS']}"
+                                   placeholder="e.g. 123456789012345678, 987654321098765432"
+                                   th:disabled="${!isOwner}">
+                            <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                        </div>
+                    </div>
+                    <p class="muted" style="margin: 8px 0 0;">
+                        Voice channel ids: enable Developer Mode in Discord, then
+                        right-click a channel &rarr; Copy Channel ID.
+                    </p>
                 </details>
 
                 <details id="settings-section-messages" class="config-section">

--- a/web/src/test/kotlin/web/service/IntroViewModelTest.kt
+++ b/web/src/test/kotlin/web/service/IntroViewModelTest.kt
@@ -1,0 +1,73 @@
+package web.service
+
+import common.intro.IntroHealth
+import common.intro.IntroLoudness
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * The row's derived labels. These are what turned the intros page from
+ * "everything here looks fine" into something that can say an intro stopped
+ * working — the page previously rendered a link deleted months ago exactly
+ * like a healthy one.
+ */
+class IntroViewModelTest {
+
+    private fun row(
+        failureCount: Int = 0,
+        lastFailureReason: String? = null,
+        playCount: Int = 0,
+        measuredRms: Double? = null,
+    ) = IntroViewModel(
+        id = "1_2_1",
+        index = 1,
+        fileName = "track",
+        introVolume = 90,
+        url = "https://youtu.be/x",
+        failureCount = failureCount,
+        lastFailureReason = lastFailureReason,
+        playCount = playCount,
+        measuredRms = measuredRms,
+    )
+
+    @Test
+    fun `a healthy row is not flagged`() {
+        assertFalse(row().broken)
+        assertFalse(row(failureCount = 1).broken)
+    }
+
+    @Test
+    fun `repeated failures flag the row, on the same rule Discord uses`() {
+        assertTrue(row(failureCount = IntroHealth.UNHEALTHY_AFTER_FAILURES).broken)
+    }
+
+    @Test
+    fun `the failure reason falls back to something readable`() {
+        assertEquals("Source could not be loaded", row(failureCount = 2).brokenReason)
+        assertEquals("Video unavailable", row(failureCount = 2, lastFailureReason = "Video unavailable").brokenReason)
+    }
+
+    @Test
+    fun `a never-played intro shows no play count`() {
+        // "Played 0×" is noise, and every pre-existing row starts at zero
+        // because counting only began with this change.
+        assertNull(row().playLabel)
+        assertEquals("Played 4×", row(playCount = 4).playLabel)
+    }
+
+    @Test
+    fun `loudness is only described once it has been measured`() {
+        assertNull(row().loudnessLabel)
+        assertEquals("loud source", row(measuredRms = IntroLoudness.TARGET_RMS * 2).loudnessLabel)
+    }
+
+    @Test
+    fun `the clip badge still reads as a range`() {
+        val clipped = row().copy(startMs = 1_000, endMs = 5_000)
+
+        assertEquals("0:01 – 0:05", clipped.clipLabel)
+    }
+}

--- a/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
@@ -255,6 +255,81 @@ class ModerationWebServiceTest {
     }
 
     @Test
+    fun `updateConfig accepts only true or false for the intro switches`() {
+        mockMember(ownerId, isOwner = true)
+
+        listOf(
+            ConfigDto.Configurations.INTROS_ENABLED,
+            ConfigDto.Configurations.INTRO_NORMALISE_VOLUME,
+        ).forEach { key ->
+            assertNull(service.updateConfig(ownerId, guildId, key, "true"))
+            assertNull(service.updateConfig(ownerId, guildId, key, "FALSE"))
+            verify { configService.upsertConfig(key.configValue, "false", guildId.toString()) }
+            assertNotNull(service.updateConfig(ownerId, guildId, key, "sometimes"))
+        }
+    }
+
+    @Test
+    fun `updateConfig stores excluded intro channels as a normalised csv`() {
+        mockMember(ownerId, isOwner = true)
+        every { guild.getVoiceChannelById(100L) } returns mockk(relaxed = true)
+        every { guild.getVoiceChannelById(200L) } returns mockk(relaxed = true)
+        val key = ConfigDto.Configurations.INTRO_EXCLUDED_CHANNELS
+
+        assertNull(service.updateConfig(ownerId, guildId, key, "100, <#200>"))
+
+        verify { configService.upsertConfig(key.configValue, "100,200", guildId.toString()) }
+    }
+
+    @Test
+    fun `updateConfig rejects an intro exclusion that is not a voice channel here`() {
+        // An exemption that silently does nothing is worse than none at all —
+        // the admin walks away believing that channel is quiet.
+        mockMember(ownerId, isOwner = true)
+        every { guild.getVoiceChannelById(any<Long>()) } returns null
+
+        val err = service.updateConfig(
+            ownerId, guildId, ConfigDto.Configurations.INTRO_EXCLUDED_CHANNELS, "100",
+        )
+
+        assertNotNull(err)
+        verify(exactly = 0) {
+            configService.upsertConfig(
+                ConfigDto.Configurations.INTRO_EXCLUDED_CHANNELS.configValue, any(), any(),
+            )
+        }
+    }
+
+    @Test
+    fun `updateConfig rejects an intro exclusion list that parses to nothing`() {
+        // "abc" isn't blank, so it isn't a clear — but it names no channel
+        // either. Storing it would read back as "no exemptions" and quietly
+        // lose whatever the admin meant.
+        mockMember(ownerId, isOwner = true)
+
+        val err = service.updateConfig(
+            ownerId, guildId, ConfigDto.Configurations.INTRO_EXCLUDED_CHANNELS, "abc",
+        )
+
+        assertNotNull(err)
+        verify(exactly = 0) {
+            configService.upsertConfig(
+                ConfigDto.Configurations.INTRO_EXCLUDED_CHANNELS.configValue, any(), any(),
+            )
+        }
+    }
+
+    @Test
+    fun `updateConfig clears the intro exclusion list when blank`() {
+        mockMember(ownerId, isOwner = true)
+        val key = ConfigDto.Configurations.INTRO_EXCLUDED_CHANNELS
+
+        assertNull(service.updateConfig(ownerId, guildId, key, "   "))
+
+        verify { configService.upsertConfig(key.configValue, "", guildId.toString()) }
+    }
+
+    @Test
     fun `updateConfig rejects MOVE when channel name does not exist`() {
         mockMember(ownerId, isOwner = true)
         every { guild.getVoiceChannelsByName("nope", true) } returns emptyList()


### PR DESCRIPTION
Four intro improvements, one commit each. The first is a live defect; the rest are features that were missing rather than broken.

## 1. Broken intros were completely silent — `c4b51ec`

Intros play from the voice-join path, which has no interaction to reply to, so `playUserIntro` passes `event = null` down into `PlayerManager.getResultHandler`. Both failure branches there are `event?.hook?.replyAndDelete(...)` — no-ops on the intro path.

A deleted, private, age-gated or region-blocked link therefore produced **silence on every join, indefinitely**: the owner was never told, `/listintros` still called it healthy, the web page rendered it like any other intro, and the only trace was a server log. The README already flags YouTube IP-blocking as a live concern for this deployment, so this is very likely already happening.

Failures now land on the row (`failure_count`, `last_failure_at`, `last_failure_reason`), published from the load path through `SchedulerEvents` — the static bridge the track events already use, since `PlayerManager` isn't a Spring bean. The count is *consecutive*; a successful load resets it.

Threshold is two, in `common.intro.IntroHealth` so Discord, the web page and the report can't drift. Lavaplayer already retries transient severities twice before reporting anything, so two means the source failed outright on separate joins.

Consequences:
- `IntroSelection` prefers intros that load — a preference, not a filter, so an all-broken user still gets an attempt rather than guaranteed silence.
- `/listintros` and the web row mark the intro and quote the reason ("video unavailable" and "not available in your country" call for different fixes).
- One DM to the owner on the crossing, as a new `INTRO_BROKEN` notification kind. On the crossing only — a broken intro fires every join.

Every recording path is failure-tolerant: these run off the audio and load threads, where a throw costs playback rather than a statistic.

## 2. Servers had no say in whether intros play — `759f383`

`DEFAULT_INTRO_VOLUME` was the only intro config key. A server could make intros quieter and nothing else — no off switch, no per-channel exemption, so a "study" or on-call channel got everyone's intro at full volume with no remedy short of asking members individually.

Three opt-out keys (`INTROS_ENABLED`, `INTRO_EXCLUDED_CHANNELS`, `INTRO_NORMALISE_VOLUME`); a guild with no rows behaves exactly as today. Turning intros off also suppresses the "you don't have an intro yet" nudge.

Parsing lives in `common.intro.IntroGuildPolicy`. The join-time reader drops unparseable ids so one bad entry can't re-enable intros everywhere else; both write paths reject outright, because an exemption that silently does nothing is worse than none.

New `/setconfig intro` modal. The default intro volume moves there from `general`, grouping the intro settings and freeing a slot in a modal that was at Discord's five-field cap. Matching section on the moderation page.

## 3. Volume was manual trial and error — `dd8fef7`

Two people set an intro at the default volume; one picked a mastered-loud track, the other a quiet recording. The slider was never a preference — it was hand-compensating for the source.

The bot now measures each intro's own level during playback and corrects the volume on later plays. The user's number stays relative; equal numbers now sound comparably loud.

Measurement is a pass-through PCM filter in lavaplayer's user chain. It sits ahead of `FinalPcmAudioFilter` and therefore ahead of `VolumePostProcessor`, so it sees the track's own level rather than the number the user chose, and it covers link and file intros alike. It forwards every sample untouched — nothing about what plays changes; the correction lands as an ordinary player volume next time.

Plain RMS, not EBU R128: K-weighting and gated windowing is a lot of machinery for fifteen-second clips. Gain is clamped to 0.5x–2x, and a sub-noise-floor measurement is treated as unusable rather than as "very quiet".

On by default, which is safe because every existing row starts unmeasured and an unmeasured intro gets a gain of exactly 1.0 — nothing changes for anyone until their intro has played once.

## 4. No play counts, no storage visibility — `c6c0161`

Nothing recorded that an intro ever played, and the audio grows quietly in a BYTEA column at up to 550KB × 3 per member with no way to see the total.

`play_count` / `last_played_at` are written by the same outcome that records failures, and surface per-intro in `/listintros` and on the web row (omitted at zero — every existing row starts there).

New `/introstats`, super-user only since it spans every member: usage, broken count, stored bytes, plus the guild's intro settings, because "why is nobody hearing intros" has a config answer at least as often as a broken-link one.

The aggregate is native SQL — `octet_length(music_blob)` has no JPQL spelling, and loading the rows to measure them would allocate exactly the bytes the report exists to warn about. The migration adds an index on `guild_id`, without which the report is a sequential scan over every intro in every server, blobs included.

## Testing

`:common`, `:core-api`, `:database`, `:web` and `:discord-bot` all pass on a forced full rerun. Roughly 120 new tests, including the two failure branches that were previously unreachable, the filter's pass-through and seek-reset behaviour, the guild gate, and the result-mapping in the stats query.

`:application:test` could not run in this environment — it needs Docker for the Testcontainers Postgres. It fails identically on unmodified `main` here, so this is environmental rather than a regression; CI is the arbiter. `GuildIntroStatsIntegrationTest` is written for that suite specifically, since a real Postgres is the only thing that can confirm the native SQL is accepted rather than merely well-formed.

Kover, comparing like-for-like clean reruns with `:application:test` excluded:

| | main | this branch |
|---|---|---|
| instructions | 79.45% | 79.68% |
| lines | 81.72% | 81.92% |
| branches | passing | passing |

Both fall below the configured floors locally for the same reason (`:application` excluded); the branch improves on every metric.

## Note on defaults

Two behaviour changes ship on by default: loudness matching, and skipping intros that look broken. Both are inert until an intro has actually played or actually failed, and both have a config switch. Flagging in case you'd rather either were opt-in.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzSiANtbGDsaSbCRDkqQWc)_