### PR TITLE
Fix the stuck-intro resume leak, and close four unauthenticated reads

### DIFF
--- a/application/src/test/kotlin/integration/web/PageRenderSmokeIT.kt
+++ b/application/src/test/kotlin/integration/web/PageRenderSmokeIT.kt
@@ -89,7 +89,10 @@ class PageRenderSmokeIT {
             "/commands",
             "/commands/wiki",
             "/changelog",
-            // Bot info pages (public)
+            // Legacy JSON endpoints from BotController. /brother, /config and
+            // /user now require authentication (this suite is authenticated);
+            // /music stays anonymous for lavaplayer but needs a signed token,
+            // so an unsigned hit here is a 404 rather than a render.
             "/brother",
             "/config",
             "/music",

--- a/application/src/test/kotlin/web/controller/BotControllerTest.kt
+++ b/application/src/test/kotlin/web/controller/BotControllerTest.kt
@@ -1,5 +1,6 @@
 package web.controller
 
+import common.media.MediaToken
 import database.dto.social.BrotherDto
 import database.dto.guild.ConfigDto
 import database.dto.music.MusicDto
@@ -10,6 +11,7 @@ import database.service.music.MusicFileService
 import database.service.user.UserService
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
@@ -17,6 +19,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
+import java.time.Instant
 
 class BotControllerTest {
 
@@ -84,14 +87,25 @@ class BotControllerTest {
     }
 
     // getMusicBlob
+    //
+    // The endpoint is anonymous — lavaplayer fetches stored intro audio with
+    // no session — so a signed token is the only thing standing between an id
+    // of the form `guildId_discordId_index` and every uploaded MP3 on the bot.
+
+    /** Signs [id] the way the player and the intros page both do. */
+    private fun signed(id: String): Pair<Long, String> {
+        val expiry = MediaToken.expiryFor(Instant.now())
+        return expiry to MediaToken.sign(id, expiry)
+    }
 
     @Test
-    fun `getMusicBlob returns 200 with audio content when blob found`() {
+    fun `getMusicBlob returns 200 with audio content for a signed request`() {
         val audioBytes = byteArrayOf(1, 2, 3)
         val musicFileDto = mockk<MusicDto> { every { musicBlob } returns audioBytes }
         every { musicFileService.getMusicFileById("abc") } returns musicFileDto
+        val (expiry, signature) = signed("abc")
 
-        val response = controller.getMusicBlob("abc")
+        val response = controller.getMusicBlob("abc", expiry, signature)
 
         assertEquals(HttpStatus.OK, response.statusCode)
         assertEquals(MediaType.parseMediaType("audio/mpeg"), response.headers.contentType)
@@ -99,10 +113,53 @@ class BotControllerTest {
     }
 
     @Test
+    fun `getMusicBlob refuses an unsigned request`() {
+        val musicFileDto = mockk<MusicDto> { every { musicBlob } returns byteArrayOf(1, 2, 3) }
+        every { musicFileService.getMusicFileById("abc") } returns musicFileDto
+
+        val response = controller.getMusicBlob("abc")
+
+        assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
+        assertNull(response.body)
+    }
+
+    @Test
+    fun `getMusicBlob refuses a token minted for a different intro`() {
+        val musicFileDto = mockk<MusicDto> { every { musicBlob } returns byteArrayOf(1, 2, 3) }
+        every { musicFileService.getMusicFileById(any()) } returns musicFileDto
+        val (expiry, signature) = signed("1_2_1")
+
+        val response = controller.getMusicBlob("1_2_2", expiry, signature)
+
+        assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
+    }
+
+    @Test
+    fun `getMusicBlob refuses an expired token`() {
+        val musicFileDto = mockk<MusicDto> { every { musicBlob } returns byteArrayOf(1, 2, 3) }
+        every { musicFileService.getMusicFileById("abc") } returns musicFileDto
+        val expired = Instant.now().epochSecond - 1
+
+        val response = controller.getMusicBlob("abc", expired, MediaToken.sign("abc", expired))
+
+        assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
+    }
+
+    @Test
+    fun `getMusicBlob does not hit the database for an unsigned request`() {
+        // The refusal is cheap on purpose: an unauthenticated scraper walking
+        // ids shouldn't be able to make the bot read blobs out of Postgres.
+        controller.getMusicBlob("abc")
+
+        verify(exactly = 0) { musicFileService.getMusicFileById(any()) }
+    }
+
+    @Test
     fun `getMusicBlob returns 404 when file not found`() {
         every { musicFileService.getMusicFileById(any()) } returns null
+        val (expiry, signature) = signed("missing-id")
 
-        val response = controller.getMusicBlob("missing-id")
+        val response = controller.getMusicBlob("missing-id", expiry, signature)
 
         assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
     }
@@ -111,8 +168,9 @@ class BotControllerTest {
     fun `getMusicBlob returns 404 when music blob is null`() {
         val musicFileDto = mockk<MusicDto> { every { musicBlob } returns null }
         every { musicFileService.getMusicFileById("abc") } returns musicFileDto
+        val (expiry, signature) = signed("abc")
 
-        val response = controller.getMusicBlob("abc")
+        val response = controller.getMusicBlob("abc", expiry, signature)
 
         assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
     }

--- a/common/src/main/kotlin/common/media/MediaToken.kt
+++ b/common/src/main/kotlin/common/media/MediaToken.kt
@@ -1,0 +1,97 @@
+package common.media
+
+import common.logging.DiscordLogger
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.time.Instant
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * Signs the `/music` URLs that serve stored intro audio.
+ *
+ * That endpoint has to stay anonymous: lavaplayer fetches it over plain HTTP
+ * with no session when it plays a file intro, so a cookie check would break
+ * playback outright. Anonymous plus a guessable key is the problem — intro ids
+ * are `guildId_discordId_index` and both halves are public Discord snowflakes,
+ * so anyone could walk the table and pull down every uploaded MP3 in every
+ * server, unauthenticated and unmetered.
+ *
+ * A signature closes that without needing a session. The two callers that
+ * legitimately build these URLs — the player and the intros page — both know
+ * the id already, so both can mint a token; nobody else can forge one.
+ *
+ * ## Key
+ *
+ * Taken from `MEDIA_TOKEN_SECRET` when set. Without it the process generates a
+ * random key at startup, which is correct and requires no configuration for a
+ * single-instance deployment (the same process both mints and verifies), but
+ * would reject tokens across a multi-instance one. That case logs a warning
+ * rather than failing, since the current deployment is a single dyno.
+ */
+object MediaToken {
+
+    const val SECRET_ENV = "MEDIA_TOKEN_SECRET"
+
+    /**
+     * How long a minted URL stays usable. Matches the endpoint's cache
+     * lifetime, so a token never outlives the response it authorises. The
+     * player consumes one within seconds; the intros page mints fresh ones on
+     * every render, so an hour only matters to a tab left open that long.
+     */
+    const val TTL_SECONDS = 3_600L
+
+    const val EXPIRY_PARAM = "exp"
+    const val SIGNATURE_PARAM = "sig"
+
+    private const val ALGORITHM = "HmacSHA256"
+
+    private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
+
+    private val key: ByteArray by lazy {
+        System.getenv(SECRET_ENV)?.takeIf { it.isNotBlank() }?.toByteArray()
+            ?: ByteArray(32).also {
+                SecureRandom().nextBytes(it)
+                logger.warn {
+                    "$SECRET_ENV is not set; signing intro media URLs with a per-process key. " +
+                        "Fine for a single instance — set $SECRET_ENV before running more than one, " +
+                        "or URLs minted by one instance will be rejected by the others."
+                }
+            }
+    }
+
+    /** Epoch-second deadline for a token minted at [now]. */
+    fun expiryFor(now: Instant): Long = now.epochSecond + TTL_SECONDS
+
+    fun sign(id: String, expiresAt: Long): String {
+        val mac = Mac.getInstance(ALGORITHM)
+        mac.init(SecretKeySpec(key, ALGORITHM))
+        // The separator keeps ("ab", 1) from colliding with ("a", 11).
+        return mac.doFinal("$id|$expiresAt".toByteArray()).joinToString("") { "%02x".format(it) }
+    }
+
+    /** `exp=…&sig=…`, ready to append to a `/music?id=…` URL. */
+    fun queryFor(id: String, now: Instant = Instant.now()): String {
+        val expiry = expiryFor(now)
+        return "$EXPIRY_PARAM=$expiry&$SIGNATURE_PARAM=${sign(id, expiry)}"
+    }
+
+    /** The full relative URL the intros page and the player both request. */
+    fun urlFor(id: String, now: Instant = Instant.now()): String = "/music?id=$id&${queryFor(id, now)}"
+
+    /**
+     * Whether [signature] authorises [id] at [now]. False for a missing,
+     * malformed, expired or forged token — the caller shouldn't need to tell
+     * those apart, and neither should the response.
+     */
+    fun isValid(id: String, expiresAt: Long?, signature: String?, now: Instant = Instant.now()): Boolean {
+        if (expiresAt == null || signature.isNullOrBlank()) return false
+        if (now.epochSecond > expiresAt) return false
+        // Constant-time: a byte-at-a-time comparison would let an attacker
+        // recover a valid signature one byte per round of guesses.
+        return MessageDigest.isEqual(
+            sign(id, expiresAt).toByteArray(),
+            signature.toByteArray(),
+        )
+    }
+}

--- a/common/src/test/kotlin/common/media/MediaTokenTest.kt
+++ b/common/src/test/kotlin/common/media/MediaTokenTest.kt
@@ -1,0 +1,105 @@
+package common.media
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class MediaTokenTest {
+
+    private val id = "1_2_1"
+    private val now: Instant = Instant.parse("2026-08-04T12:00:00Z")
+
+    private fun tokenFor(id: String, at: Instant = now): Pair<Long, String> {
+        val expiry = MediaToken.expiryFor(at)
+        return expiry to MediaToken.sign(id, expiry)
+    }
+
+    @Test
+    fun `a freshly minted token authorises its own id`() {
+        val (expiry, signature) = tokenFor(id)
+
+        assertTrue(MediaToken.isValid(id, expiry, signature, now))
+    }
+
+    @Test
+    fun `an unsigned request is refused`() {
+        // The whole point: `/music?id=…` on its own used to be enough, and the
+        // id is two public Discord snowflakes.
+        assertFalse(MediaToken.isValid(id, null, null, now))
+        assertFalse(MediaToken.isValid(id, MediaToken.expiryFor(now), null, now))
+        assertFalse(MediaToken.isValid(id, null, "deadbeef", now))
+        assertFalse(MediaToken.isValid(id, MediaToken.expiryFor(now), "   ", now))
+    }
+
+    @Test
+    fun `a token does not carry over to another intro`() {
+        // Otherwise one legitimately obtained URL would unlock the whole table.
+        val (expiry, signature) = tokenFor(id)
+
+        assertFalse(MediaToken.isValid("1_2_2", expiry, signature, now))
+        assertFalse(MediaToken.isValid("9_9_1", expiry, signature, now))
+    }
+
+    @Test
+    fun `a token stops working once it expires`() {
+        val (expiry, signature) = tokenFor(id)
+
+        assertTrue(MediaToken.isValid(id, expiry, signature, now.plusSeconds(MediaToken.TTL_SECONDS)))
+        assertFalse(MediaToken.isValid(id, expiry, signature, now.plusSeconds(MediaToken.TTL_SECONDS + 1)))
+    }
+
+    @Test
+    fun `extending the deadline invalidates the signature`() {
+        // The expiry is signed, so it can't be edited in the query string.
+        val (expiry, signature) = tokenFor(id)
+
+        assertFalse(MediaToken.isValid(id, expiry + 86_400, signature, now))
+    }
+
+    @Test
+    fun `a forged signature is refused`() {
+        val (expiry, signature) = tokenFor(id)
+        val tampered = signature.replaceRange(0, 1, if (signature.startsWith("a")) "b" else "a")
+
+        assertFalse(MediaToken.isValid(id, expiry, tampered, now))
+        assertFalse(MediaToken.isValid(id, expiry, "", now))
+        assertFalse(MediaToken.isValid(id, expiry, signature.dropLast(1), now))
+    }
+
+    @Test
+    fun `the id and expiry cannot be shuffled between each other`() {
+        // Without a separator, ("ab", 1) and ("a", 11) would hash identically
+        // and a token for one intro would authorise another.
+        assertFalse(MediaToken.sign("ab", 1) == MediaToken.sign("a", 11))
+    }
+
+    @Test
+    fun `signing is deterministic within a process`() {
+        // The player mints and the same process verifies; drifting per call
+        // would reject every legitimate request.
+        assertEquals(MediaToken.sign(id, 123), MediaToken.sign(id, 123))
+    }
+
+    @Test
+    fun `the minted url carries the id and both token parameters`() {
+        val url = MediaToken.urlFor(id, now)
+
+        assertTrue(url.startsWith("/music?id=$id&"), url)
+        assertTrue(url.contains("${MediaToken.EXPIRY_PARAM}="), url)
+        assertTrue(url.contains("${MediaToken.SIGNATURE_PARAM}="), url)
+
+        // And what it carries is accepted by the verifier.
+        val expiry = Regex("${MediaToken.EXPIRY_PARAM}=(\\d+)").find(url)!!.groupValues[1].toLong()
+        val signature = Regex("${MediaToken.SIGNATURE_PARAM}=([0-9a-f]+)").find(url)!!.groupValues[1]
+        assertTrue(MediaToken.isValid(id, expiry, signature, now))
+    }
+
+    @Test
+    fun `signatures are hex so they survive a query string unescaped`() {
+        val (_, signature) = tokenFor(id)
+
+        assertTrue(signature.matches(Regex("[0-9a-f]{64}")), signature)
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/MusicPlayerHelper.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/MusicPlayerHelper.kt
@@ -12,6 +12,7 @@ import com.sedmelluq.discord.lavaplayer.track.AudioTrack
 import common.discord.embed
 import common.intro.IntroLoudness
 import common.logging.DiscordLogger
+import common.media.MediaToken
 import core.command.Command.Companion.replyEmbedAndDelete
 import core.command.Command.Companion.replyEphemeralEmbedAndDelete
 import database.dto.music.MusicDto
@@ -289,8 +290,11 @@ object MusicPlayerHelper {
         // If musicBlob contains a URL (e.g. fileName stores the video title), use that
         val blobString = it.musicBlob?.let { bytes -> String(bytes) } ?: ""
         if (utilIsUrl(blobString).isNotEmpty()) return blobString
-        // Otherwise, serve the binary data via the web endpoint
-        return "$BOT_WEB_URL/music?id=${it.id}"
+        // Otherwise, serve the binary data via the web endpoint. Signed: that
+        // endpoint has to stay anonymous for lavaplayer to fetch it, and intro
+        // ids are guessable, so the signature is what stops it being an open
+        // read of every uploaded MP3 in every server.
+        return "$BOT_WEB_URL${MediaToken.urlFor(it.id.orEmpty())}"
     }
 
     fun resetMessages(guildId: Long) = nowPlayingManager.resetNowPlayingMessage(guildId)

--- a/discord-bot/src/main/kotlin/bot/toby/lavaplayer/TrackScheduler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/lavaplayer/TrackScheduler.kt
@@ -207,6 +207,7 @@ class TrackScheduler(val player: AudioPlayer, val guildId: Long, var deleteDelay
             player.startTrack(resume, false)
             return
         }
+        if (wasIntro) releaseStaleResumeSlot(endReason)
         if (endReason.mayStartNext) {
             handleNextTrack(player, track)
         } else if (endReason != AudioTrackEndReason.REPLACED) {
@@ -249,6 +250,38 @@ class TrackScheduler(val player: AudioPlayer, val guildId: Long, var deleteDelay
         }
     }
 
+    /**
+     * An intro ended without handing the player back to the track it preempted.
+     *
+     * Two ways that happens: something else took the player over (REPLACED —
+     * a skip landing mid-intro, or the stuck-track recovery below), or the
+     * player is being torn down (CLEANUP). Either way the resume slot is now
+     * stale, and leaving it set is the expensive part: [queueIntro] treats a
+     * non-null slot as "an intro is already in flight" and falls back to
+     * queueing, so one stranded slot quietly disables intro preemption for the
+     * rest of this player's life.
+     *
+     * On a takeover the preempted track goes back to the front of the queue
+     * rather than being dropped — the listener skipped the intro, not the music
+     * they were already playing. On CLEANUP there's nothing left to play it.
+     */
+    private fun releaseStaleResumeSlot(endReason: AudioTrackEndReason) {
+        val stranded = resumeAfterIntro ?: return
+        resumeAfterIntro = null
+        if (endReason != AudioTrackEndReason.REPLACED) {
+            logger.info("Dropping preempted track ${stranded.info.title}: player is going away ($endReason)")
+            return
+        }
+        logger.info("Intro was taken over; requeueing preempted track ${stranded.info.title} at the front")
+        synchronized(queue) {
+            val rest = queue.toMutableList()
+            queue.clear()
+            queue.offer(stranded)
+            rest.forEach { queue.offer(it) }
+        }
+        publishQueueChanged()
+    }
+
     private fun AudioPlayer.setVolumeToPrevious() {
         previousVolume?.let { previousVol ->
             if (player.volume != previousVol) {
@@ -260,13 +293,36 @@ class TrackScheduler(val player: AudioPlayer, val guildId: Long, var deleteDelay
         }
     }
 
+    /**
+     * Lavaplayer reports a track as stuck once it has gone [thresholdMs]
+     * (10 seconds by default) without producing a frame. That is a dead track,
+     * not a hiccup, so it is always recovered from — the old `position == 0L`
+     * guard meant a stall that started after playback began was never skipped
+     * and simply hung the queue with nothing to unstick it.
+     */
     override fun onTrackStuck(player: AudioPlayer, track: AudioTrack, thresholdMs: Long) {
-        if (track.position == 0L) {
-            event?.channel
-                ?.sendMessage("Track ${track.info.title} got stuck, skipping.")
-                ?.queue(invokeDeleteOnMessageResponse(deleteDelay))
-            nextTrack()
-        }
+        logger.warn(
+            "'${track.info.title}' produced no audio for ${thresholdMs}ms at position " +
+                "${track.position}ms on guild $guildId; recovering."
+        )
+        event?.channel
+            ?.sendMessage("Track ${track.info.title} got stuck, skipping.")
+            ?.queue(invokeDeleteOnMessageResponse(deleteDelay))
+
+        // Read before stopping: stopping is what consumes the resume slot.
+        val resumesPreemptedTrack = introTracks.contains(track) && resumeAfterIntro != null
+
+        // Stop through the player rather than jumping straight to nextTrack().
+        // onTrackEnd is the only place that restores a preempted track, drops
+        // the intro bookkeeping and tears down the now-playing message; going
+        // around it was how a single stuck intro lost the music it interrupted
+        // and left the resume slot set forever.
+        player.stopTrack()
+
+        // STOPPED has mayStartNext = false, so onTrackEnd deliberately doesn't
+        // advance the queue. Correct when the preempted track has just been
+        // put back on the player; wrong for everything else.
+        if (!resumesPreemptedTrack) nextTrack()
     }
 
     fun moveQueueItem(fromIndex: Int, toIndex: Int): Boolean {

--- a/discord-bot/src/test/kotlin/bot/toby/lavaplayer/TrackSchedulerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/lavaplayer/TrackSchedulerTest.kt
@@ -678,4 +678,117 @@ class TrackSchedulerTest {
 
         assertNull(scheduler.introIdFor(intro))
     }
+
+    // --- stuck tracks and the intro resume slot -----------------------------
+    //
+    // queueIntro parks the preempted track in resumeAfterIntro and treats a
+    // non-null slot as "an intro is already in flight". Anything that ended an
+    // intro without going through the resume branch therefore stranded the
+    // slot, which lost the music *and* silently downgraded every later intro
+    // on that guild from preempting to queueing.
+
+    @Test
+    fun `a stuck intro hands the player back to the music it interrupted`() {
+        val playing = mockTrack("Playing")
+        every { player.playingTrack } returns playing
+        val intro = mockTrack("Intro")
+        scheduler.queueIntro(intro, 0L, null, 60, requesterId = null, introId = "1_2_1")
+        // player.stopTrack() is what drives onTrackEnd in production.
+        every { player.stopTrack() } answers { scheduler.onTrackEnd(player, intro, AudioTrackEndReason.STOPPED) }
+
+        scheduler.onTrackStuck(player, intro, 10_000L)
+
+        // mockTrack stubs makeClone() to return the same mock, so the resume
+        // slot holds `playing` itself.
+        verify { player.startTrack(playing, false) }
+        assertFalse(scheduler.hasResumeAfterIntro())
+    }
+
+    @Test
+    fun `a stuck intro does not leave later intros unable to preempt`() {
+        val playing = mockTrack("Playing")
+        every { player.playingTrack } returns playing
+        val first = mockTrack("Intro one")
+        scheduler.queueIntro(first, 0L, null, 60, requesterId = null, introId = "1_2_1")
+        every { player.stopTrack() } answers { scheduler.onTrackEnd(player, first, AudioTrackEndReason.STOPPED) }
+
+        scheduler.onTrackStuck(player, first, 10_000L)
+
+        // The slot is free again, so the next intro preempts rather than
+        // queueing behind the music for the rest of the player's life.
+        assertFalse(scheduler.hasResumeAfterIntro())
+        val second = mockTrack("Intro two")
+        scheduler.queueIntro(second, 0L, null, 60, requesterId = null, introId = "1_2_2")
+        assertTrue(scheduler.hasResumeAfterIntro())
+    }
+
+    @Test
+    fun `a stuck regular track advances the queue`() {
+        val stuck = mockTrack("Stuck")
+        val next = mockTrack("Next")
+        scheduler.queue(next, 0L, null, 50)
+        every { player.stopTrack() } answers { scheduler.onTrackEnd(player, stuck, AudioTrackEndReason.STOPPED) }
+
+        scheduler.onTrackStuck(player, stuck, 10_000L)
+
+        verify { player.startTrack(next, false) }
+    }
+
+    @Test
+    fun `a track that stalls after it started playing is still recovered`() {
+        // The old guard only fired at position 0, so a mid-track stall hung
+        // the queue with nothing able to unstick it.
+        val stuck = mockTrack("Stuck")
+        every { stuck.position } returns 42_000L
+        val next = mockTrack("Next")
+        scheduler.queue(next, 0L, null, 50)
+        every { player.stopTrack() } answers { scheduler.onTrackEnd(player, stuck, AudioTrackEndReason.STOPPED) }
+
+        scheduler.onTrackStuck(player, stuck, 10_000L)
+
+        verify { player.stopTrack() }
+        verify { player.startTrack(next, false) }
+    }
+
+    @Test
+    fun `a skip landing mid-intro puts the preempted music back at the front`() {
+        // The listener skipped the intro, not the track they were listening to.
+        val playing = mockTrack("Playing")
+        every { player.playingTrack } returns playing
+        val queued = mockTrack("Queued")
+        scheduler.queue(queued, 0L, null, 50)
+        val intro = mockTrack("Intro")
+        scheduler.queueIntro(intro, 0L, null, 60, requesterId = null, introId = "1_2_1")
+
+        scheduler.onTrackEnd(player, intro, AudioTrackEndReason.REPLACED)
+
+        assertFalse(scheduler.hasResumeAfterIntro())
+        assertEquals(listOf("Playing", "Queued"), scheduler.queue.map { it.info.title })
+    }
+
+    @Test
+    fun `the resume slot is released when the player is torn down`() {
+        val playing = mockTrack("Playing")
+        every { player.playingTrack } returns playing
+        val intro = mockTrack("Intro")
+        scheduler.queueIntro(intro, 0L, null, 60, requesterId = null, introId = "1_2_1")
+
+        scheduler.onTrackEnd(player, intro, AudioTrackEndReason.CLEANUP)
+
+        assertFalse(scheduler.hasResumeAfterIntro())
+        // Nothing to play it on, so it is not requeued either.
+        assertTrue(scheduler.queue.isEmpty())
+    }
+
+    @Test
+    fun `a regular track ending normally never touches the resume slot`() {
+        val playing = mockTrack("Playing")
+        every { player.playingTrack } returns playing
+        val intro = mockTrack("Intro")
+        scheduler.queueIntro(intro, 0L, null, 60, requesterId = null, introId = "1_2_1")
+
+        scheduler.onTrackEnd(player, mockTrack("Unrelated"), AudioTrackEndReason.REPLACED)
+
+        assertTrue(scheduler.hasResumeAfterIntro())
+    }
 }

--- a/web/src/main/kotlin/web/configuration/WebSecurityConfig.kt
+++ b/web/src/main/kotlin/web/configuration/WebSecurityConfig.kt
@@ -21,7 +21,19 @@ class WebSecurityConfig {
             .authorizeHttpRequests { auth ->
                 auth.requestMatchers(
                     "/", "/terms", "/privacy", "/changelog",
-                    "/brother", "/config", "/music", "/user",
+                    // `/music` is anonymous by necessity — lavaplayer fetches
+                    // stored intro audio over plain HTTP with no session — so
+                    // it authorises on a signed token instead of a cookie.
+                    // See common.media.MediaToken and BotController.
+                    //
+                    // `/brother`, `/config` and `/user` used to sit here too.
+                    // They are unauthenticated reads of arbitrary rows keyed
+                    // on a Discord id: a whole UserDto (social credit,
+                    // superuser flag), any guild's config value, any brother
+                    // row. Nothing in the codebase calls them — they predate
+                    // the web app having authentication at all — so they now
+                    // fall through to anyRequest().authenticated() below.
+                    "/music",
                     "/commands", "/commands/**",
                     // Health probe only — the rest of /actuator/* (env,
                     // heapdump, …) must never be anonymously reachable even

--- a/web/src/main/kotlin/web/controller/BotController.kt
+++ b/web/src/main/kotlin/web/controller/BotController.kt
@@ -1,5 +1,6 @@
 package web.controller
 
+import common.media.MediaToken
 import database.dto.guild.ConfigDto
 import database.service.social.BrotherService
 import database.service.guild.ConfigService
@@ -30,11 +31,26 @@ class BotController(
     fun getConfig(@RequestParam("name") name: String?, @RequestParam("guildId") guildId: String): ConfigDto? = configService.getConfigByName(name, guildId)
 
 
+    /**
+     * Serves an intro's stored audio.
+     *
+     * Anonymous by necessity — lavaplayer fetches this with no session when it
+     * plays a file intro — so access is gated on a signature instead. Without
+     * it, ids of the form `guildId_discordId_index` made every uploaded MP3 in
+     * every server an unauthenticated, unmetered read for anyone who could
+     * read a Discord snowflake. See [MediaToken].
+     */
     @GetMapping("/music")
     fun getMusicBlob(
         @RequestParam("id") id: String,
+        @RequestParam(value = MediaToken.EXPIRY_PARAM, required = false) expiresAt: Long? = null,
+        @RequestParam(value = MediaToken.SIGNATURE_PARAM, required = false) signature: String? = null,
         @RequestHeader(value = HttpHeaders.IF_NONE_MATCH, required = false) ifNoneMatch: String? = null
     ): ResponseEntity<ByteArray> {
+        // 404 rather than 403: an unsigned request shouldn't be able to tell
+        // an id that exists from one that doesn't.
+        if (!MediaToken.isValid(id, expiresAt, signature)) return ResponseEntity.notFound().build()
+
         val dto = musicFileService.getMusicFileById(id) ?: return ResponseEntity.notFound().build()
         val blob = dto.musicBlob ?: return ResponseEntity.notFound().build()
 

--- a/web/src/main/kotlin/web/service/IntroWebService.kt
+++ b/web/src/main/kotlin/web/service/IntroWebService.kt
@@ -7,6 +7,7 @@ import common.intro.IntroHealth
 import common.intro.IntroLoudness
 import common.intro.IntroSlots
 import common.logging.DiscordLogger
+import common.media.MediaToken
 import database.dto.music.MusicDto
 import database.dto.user.UserDto
 import database.service.music.MusicFileService
@@ -625,6 +626,16 @@ data class IntroViewModel(
 
     /** "quiet source" / "loud source" — context for the volume slider. */
     val loudnessLabel: String? get() = IntroLoudness.describe(measuredRms)
+
+    /**
+     * Signed URL for this intro's stored audio, for the row's `<audio>` tag.
+     *
+     * `/music` can't require a session — lavaplayer fetches it too — so the
+     * page mints a token the same way the player does rather than relying on
+     * the id alone, which is public. Minted per render, so a tab left open
+     * past the token's hour needs a reload before the preview plays.
+     */
+    val mediaUrl: String get() = MediaToken.urlFor(id)
 }
 
 data class GuildInfo(

--- a/web/src/main/resources/templates/intros.html
+++ b/web/src/main/resources/templates/intros.html
@@ -157,8 +157,15 @@
                                title="Open link">↗</a>
                             <!-- Direct play for file intros -->
                             <span th:unless="${intro.url != null}">
+                                <!--
+                                    Signed rather than `/music?id=…`: that
+                                    endpoint stays anonymous so lavaplayer can
+                                    fetch it, and intro ids are public, so the
+                                    signature is what keeps it from being an
+                                    open read of everyone's uploads.
+                                -->
                                 <audio th:id="'audio-' + ${intro.id}"
-                                       th:src="@{/music(id=${intro.id})}"
+                                       th:src="${intro.mediaUrl}"
                                        preload="none"></audio>
                                 <button type="button" class="btn-play"
                                         th:attr="data-audio-id='audio-' + ${intro.id},

--- a/web/src/test/kotlin/web/service/IntroViewModelTest.kt
+++ b/web/src/test/kotlin/web/service/IntroViewModelTest.kt
@@ -2,6 +2,7 @@ package web.service
 
 import common.intro.IntroHealth
 import common.intro.IntroLoudness
+import common.media.MediaToken
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
@@ -69,5 +70,26 @@ class IntroViewModelTest {
         val clipped = row().copy(startMs = 1_000, endMs = 5_000)
 
         assertEquals("0:01 – 0:05", clipped.clipLabel)
+    }
+
+    @Test
+    fun `the row's audio url is signed rather than just carrying the id`() {
+        // `/music` stays anonymous so lavaplayer can fetch it, and intro ids
+        // are two public Discord snowflakes — the signature is the only thing
+        // between them and every uploaded MP3 on the bot.
+        val url = row().mediaUrl
+
+        assertTrue(url.startsWith("/music?id=1_2_1&"), url)
+        assertTrue(url.contains("${MediaToken.EXPIRY_PARAM}="), url)
+        assertTrue(url.contains("${MediaToken.SIGNATURE_PARAM}="), url)
+    }
+
+    @Test
+    fun `the minted url is one the endpoint will actually accept`() {
+        val url = row().mediaUrl
+        val expiry = Regex("${MediaToken.EXPIRY_PARAM}=(\\d+)").find(url)!!.groupValues[1].toLong()
+        val signature = Regex("${MediaToken.SIGNATURE_PARAM}=([0-9a-f]+)").find(url)!!.groupValues[1]
+
+        assertTrue(MediaToken.isValid("1_2_1", expiry, signature))
     }
 }


### PR DESCRIPTION
Two defects, one commit each. Both are silent — nothing surfaces either to a user or an admin.

## 1. A stuck intro ate the music and disabled preemption — `ce36c03`

`queueIntro` parks the currently-playing track in `resumeAfterIntro` so `onTrackEnd` can hand the player back after the intro. That slot doubles as a flag: `queueIntro` reads a non-null slot as "an intro is already in flight" and falls back to queueing rather than preempting.

`onTrackStuck` went straight to `nextTrack()` and never touched it. When an intro stalled — ten seconds without a frame, which the YouTube throttling already flagged in the README makes a live possibility — the preempted song was dropped and **the slot stayed set for the life of the process**. From then on every intro in that guild queued behind the music instead of preempting it, until someone happened to run `/stop`.

The same leak was reachable without a stall: hit skip during an intro, the intro ends `REPLACED`, and `shouldResumeAfterIntro` deliberately excludes `REPLACED` — slot stranded identically.

Fixed on every path that ends an intro without resuming:
- **`REPLACED`** — the preempted track goes back to the *front* of the queue. The listener skipped the intro, not the track they were already playing.
- **`CLEANUP`** — cleared and dropped; the player is going away.

`onTrackStuck` now routes through `player.stopTrack()` instead of jumping to `nextTrack()`, since `onTrackEnd` is the only place that restores a preempted track, clears the intro bookkeeping and tears down the now-playing message. `STOPPED` has `mayStartNext = false`, so the non-resume case advances the queue explicitly afterwards.

It also drops the `position == 0L` guard: a stall that began *after* playback started was never skipped, so the queue just hung with nothing able to unstick it.

**Deliberate non-change:** stalls don't feed the intro-health counters from #736. A load failure is the source refusing to serve; a stall is often the bot's own network. Folding them together would mean one throttling episode marking every intro on the bot broken and DMing all their owners.

## 2. Four unauthenticated reads — `0479648`

`WebSecurityConfig` had `/brother`, `/config`, `/music` and `/user` in the permitAll list. None checked anything, and all four key on identifiers that are public by construction:

| endpoint | returned |
|---|---|
| `/user?discordId=&guildId=` | a whole `UserDto` — social credit, superuser flag — for any member of any guild |
| `/config?name=&guildId=` | any guild's stored config value |
| `/brother?discordId=` | any brother row |
| `/music?id=` | any intro's stored audio |

`/music` is the widest: ids are `guildId_discordId_index`, both halves Discord snowflakes, so the table was walkable — every uploaded MP3 on the bot, unauthenticated and unmetered, at up to 550KB a row.

These are the `BotController` endpoints and they predate the web app having authentication at all. **Nothing in the codebase calls them**, so the first three come off the permitAll list and fall through to `anyRequest().authenticated()`.

`/music` can't do that — lavaplayer fetches it with no session, so a cookie check breaks playback. It authorises on a signed token instead: HMAC-SHA256 over `id|expiry`, hex, constant-time compare. Both legitimate callers already know the id, so both mint their own — `MusicPlayerHelper` when handing a URL to the player, and the intros page for the row's `<audio>` tag.

An unsigned or expired request 404s rather than 403s, **before touching the database** — a scraper walking ids shouldn't be able to make the bot read blobs out of Postgres, or learn which ids exist.

Key comes from `MEDIA_TOKEN_SECRET` if set; otherwise the process generates one at startup. That needs no configuration and is correct for a single instance, since the same process mints and verifies. Running more than one instance without the variable would have them reject each other's URLs, so that logs a warning at first use rather than failing quietly. **Worth setting on Heroku if you ever scale past one dyno.**

Token TTL is an hour, matching the endpoint's existing cache lifetime, so a token never outlives the response it authorises.

## Testing

`:common`, `:core-api`, `:database`, `:web`, `:discord-bot` all pass on a forced full rerun; Jest 797/797. New coverage for the resume-slot release on each end reason, the stuck-track recovery (including mid-playback), skip-during-intro requeueing, and the token — forged, expired, cross-id, unsigned, and that the unsigned path never reaches the database.

`:application:test` can't run here (needs Docker for Testcontainers) and fails identically on unmodified `main`; CI is the arbiter, as with #736.

Kover on like-for-like clean reruns with `:application:test` excluded: instructions 79.680% → **79.688%**, lines 81.925% → **81.936%**, branches passing. Same two floors blocked locally by the excluded module.

## One thing to sanity-check

I couldn't find any caller of `/brother`, `/config` or `/user` — in this repo or its templates and JS. If you have an external script or dashboard hitting them, this will break it and they'd need to move to an authenticated session or get their own token scheme. Easy to revert that one file if so.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzSiANtbGDsaSbCRDkqQWc)_