### PR TITLE
Fix intros overwriting each other, and add a clip form to the context menu

### DIFF
--- a/common/src/main/kotlin/common/intro/IntroSlots.kt
+++ b/common/src/main/kotlin/common/intro/IntroSlots.kt
@@ -6,24 +6,43 @@ package common.intro
  * The count was previously declared three times — `SetIntroCommand.LIMIT`,
  * `IntroWebService.MAX_INTRO_COUNT` and the `maxIntros` model attribute — with
  * nothing tying them together, so raising the cap meant remembering all three.
+ *
+ * ## Slots are identity, not ordering
+ *
+ * An intro's primary key is `guildId_discordId_slot`, so the slot is baked
+ * into the row's identity: two rows in the same slot are the same row. Every
+ * write path therefore has to agree on which slot is free, and has to agree
+ * with the *id*, not with anything stored alongside it.
  */
 object IntroSlots {
     const val MAX_INTRO_COUNT = 3
 
+    /** The slot encoded in an intro id, or null if it isn't one of ours. */
+    fun slotFromId(introId: String?): Int? = introId
+        ?.substringAfterLast('_')
+        ?.toIntOrNull()
+        ?.takeIf { it in 1..MAX_INTRO_COUNT }
+
     /**
-     * The lowest slot in `1..MAX_INTRO_COUNT` not already taken, or null when
-     * every slot is full.
+     * The lowest slot in `1..MAX_INTRO_COUNT` a new intro can take without
+     * landing on an existing row, or null when every slot is full.
      *
-     * Walking the range matters: a `size + 1` count is wrong the moment a
-     * delete leaves a gap. With intros in slots `[1, 3]`, `size + 1` picks 3,
-     * whose id (`guildId_discordId_3`) already exists — and
-     * `DefaultMusicFilePersistence.createNewMusicFile` turns an id collision
-     * into an update, silently overwriting the intro in slot 3 with the new
-     * one. Both the web form and the slash commands allocate through here so
-     * neither can reintroduce that.
+     * Occupancy is read from the **ids**, because the id is what collides:
+     * `DefaultMusicFilePersistence.createNewMusicFile` looks the id up and,
+     * before this, turned a hit into an update — a silent overwrite of the
+     * intro already living there.
+     *
+     * Reading the `index` column instead was wrong twice over. `size + 1` was
+     * wrong the moment a delete left a gap (intros in `[1, 3]` picks 3, which
+     * exists). Walking the range fixed that but still trusted `index`, which
+     * the web drag-reorder rewrites *without* rewriting the id — so a user who
+     * had reordered could hold ids `[_1, _3]` with indexes `[2, 1]`, and the
+     * allocator would hand out 3 for a row that was already there. That is the
+     * shape of the report this replaced: "it said it succeeded, but it
+     * overwrote my second intro and set itself into slot 3."
      */
-    fun nextFreeIndex(usedIndexes: Collection<Int?>): Int? {
-        val used = usedIndexes.filterNotNull().toSet()
+    fun nextFreeSlot(existingIntroIds: Collection<String?>): Int? {
+        val used = existingIntroIds.mapNotNull { slotFromId(it) }.toSet()
         return (1..MAX_INTRO_COUNT).firstOrNull { it !in used }
     }
 }

--- a/common/src/test/kotlin/common/intro/IntroSlotsTest.kt
+++ b/common/src/test/kotlin/common/intro/IntroSlotsTest.kt
@@ -1,54 +1,93 @@
 package common.intro
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 
 /**
- * The gap case is the whole point: `size + 1` picked an already-taken slot,
- * and because `createNewMusicFile` turns an id collision into an update, the
- * intro sitting in that slot was silently overwritten.
+ * Allocation reads the **ids**, because the id is what a new row collides
+ * with — `createNewMusicFile` looks it up, and before this it turned a hit
+ * into an update that destroyed whatever was already there.
+ *
+ * Two things fooled the old allocators. `size + 1` picked an occupied slot the
+ * moment a delete left a gap. Walking the range fixed that but still read the
+ * `index` column, which the web drag-reorder rewrote without rewriting the id —
+ * so index and id disagreed and the allocator handed out a slot that was
+ * already in use.
  */
 class IntroSlotsTest {
 
+    /** Ids as the database stores them: `guildId_discordId_slot`. */
+    private fun ids(vararg slots: Int) = slots.map { "42_7_$it" }
+
+    // --- slotFromId ---------------------------------------------------------
+
+    @Test
+    fun `the slot is read off the end of the id`() {
+        assertEquals(1, IntroSlots.slotFromId("42_7_1"))
+        assertEquals(3, IntroSlots.slotFromId("999999999999_888888888888_3"))
+    }
+
+    @Test
+    fun `anything that isn't one of our ids has no slot`() {
+        assertNull(IntroSlots.slotFromId(null))
+        assertNull(IntroSlots.slotFromId(""))
+        assertNull(IntroSlots.slotFromId("42_7_nope"))
+        assertNull(IntroSlots.slotFromId("42_7_0"))
+        assertNull(IntroSlots.slotFromId("42_7_${IntroSlots.MAX_INTRO_COUNT + 1}"))
+    }
+
+    // --- nextFreeSlot -------------------------------------------------------
+
     @Test
     fun `an empty set starts at slot one`() {
-        assertEquals(1, IntroSlots.nextFreeIndex(emptyList()))
+        assertEquals(1, IntroSlots.nextFreeSlot(emptyList()))
     }
 
     @Test
     fun `slots fill in order`() {
-        assertEquals(2, IntroSlots.nextFreeIndex(listOf(1)))
-        assertEquals(3, IntroSlots.nextFreeIndex(listOf(1, 2)))
+        assertEquals(2, IntroSlots.nextFreeSlot(ids(1)))
+        assertEquals(3, IntroSlots.nextFreeSlot(ids(1, 2)))
     }
 
     @Test
     fun `a gap left by a delete is reused instead of colliding`() {
-        // Deleting slot 2 of [1, 2, 3] leaves [1, 3]: size + 1 would say 3,
-        // which already exists.
-        assertEquals(2, IntroSlots.nextFreeIndex(listOf(1, 3)))
-        assertEquals(1, IntroSlots.nextFreeIndex(listOf(2, 3)))
-        assertEquals(1, IntroSlots.nextFreeIndex(listOf(3)))
-        assertEquals(2, IntroSlots.nextFreeIndex(listOf(3, 1)))
+        assertEquals(2, IntroSlots.nextFreeSlot(ids(1, 3)))
+        assertEquals(1, IntroSlots.nextFreeSlot(ids(2, 3)))
+        assertEquals(1, IntroSlots.nextFreeSlot(ids(3)))
+        assertEquals(2, IntroSlots.nextFreeSlot(ids(3, 1)))
     }
 
     @Test
     fun `a full set has no free slot`() {
-        assertNull(IntroSlots.nextFreeIndex(listOf(1, 2, 3)))
-        assertNull(IntroSlots.nextFreeIndex(listOf(3, 2, 1)))
+        assertNull(IntroSlots.nextFreeSlot(ids(1, 2, 3)))
+        assertNull(IntroSlots.nextFreeSlot(ids(3, 2, 1)))
     }
 
     @Test
-    fun `null indexes are ignored rather than blocking a slot`() {
-        assertEquals(1, IntroSlots.nextFreeIndex(listOf(null)))
-        assertEquals(2, IntroSlots.nextFreeIndex(listOf(1, null)))
+    fun `an unreadable id is ignored rather than blocking a slot`() {
+        assertEquals(1, IntroSlots.nextFreeSlot(listOf(null)))
+        assertEquals(2, IntroSlots.nextFreeSlot(listOf("42_7_1", null, "garbage")))
     }
 
     @Test
-    fun `indexes outside the range never consume a slot`() {
-        // Defensive: a stray index 4 (the old allocator could produce one)
-        // shouldn't make 1..3 look full.
-        assertEquals(1, IntroSlots.nextFreeIndex(listOf(4, 5)))
-        assertEquals(2, IntroSlots.nextFreeIndex(listOf(1, 4)))
+    fun `a reordered user is allocated a slot that is genuinely free`() {
+        // The reported bug. After a drag-reorder the rows held ids [_1, _3]
+        // with indexes [2, 1]; reading the index column said slot 3 was free,
+        // and the save landed on the row already living at `_3`. Reading the
+        // ids says 2, which is the empty one.
+        assertEquals(2, IntroSlots.nextFreeSlot(listOf("42_7_1", "42_7_3")))
+    }
+
+    @Test
+    fun `a user holding fewer than the cap always has somewhere to put one`() {
+        // The corollary of allocating on ids: occupancy can never exceed the
+        // number of rows, so nobody is told they're full while holding two.
+        // Reading indexes *could* overstate it — ids [_1, _3] carrying indexes
+        // [2, 1] made all three slots look taken by two rows.
+        listOf(ids(1, 2), ids(1, 3), ids(2, 3), ids(1), ids(2), ids(3)).forEach { held ->
+            assertNotNull(IntroSlots.nextFreeSlot(held), "no free slot for $held")
+        }
     }
 }

--- a/core-api/src/main/kotlin/core/command/MessageContextCommand.kt
+++ b/core-api/src/main/kotlin/core/command/MessageContextCommand.kt
@@ -21,6 +21,17 @@ interface MessageContextCommand : Loggable, Named {
     /** Whether the manager should defer with an ephemeral ack before dispatch. */
     val ephemeral: Boolean get() = true
 
+    /**
+     * Whether the manager should acknowledge the interaction before dispatch.
+     *
+     * Deferring is right for anything that replies with a message, and wrong
+     * for anything that opens a modal: a modal has to be the *first* response
+     * to an interaction, so a deferred command can never show one. Commands
+     * that call `replyModal` set this false and take on the 3-second ack
+     * budget themselves.
+     */
+    val defersReply: Boolean get() = true
+
     val commandData: CommandData get() = Commands.message(name)
 
     fun handle(event: MessageContextInteractionEvent, requestingUserDto: UserDto, deleteDelay: Int)

--- a/database/src/main/kotlin/database/dto/music/MusicDto.kt
+++ b/database/src/main/kotlin/database/dto/music/MusicDto.kt
@@ -117,6 +117,35 @@ class MusicDto(
         START
     }
 
+    /**
+     * Copy everything about [other] except which row this is.
+     *
+     * `id` encodes the slot and is the primary key, so reordering intros can't
+     * move rows — it moves their contents between fixed slots instead. `id`,
+     * `userDto` and `index` are the row's identity and stay put; everything
+     * else, playback history included, travels with the track it describes.
+     *
+     * Adding a column to this entity means adding it here too.
+     */
+    fun copyContentFrom(other: MusicDto) {
+        fileName = other.fileName
+        introVolume = other.introVolume
+        musicBlob = other.musicBlob
+        musicBlobHash = other.musicBlobHash
+        startMs = other.startMs
+        endMs = other.endMs
+        enabled = other.enabled
+        playCount = other.playCount
+        lastPlayedAt = other.lastPlayedAt
+        failureCount = other.failureCount
+        lastFailureAt = other.lastFailureAt
+        lastFailureReason = other.lastFailureReason
+        measuredRms = other.measuredRms
+    }
+
+    /** Detached copy used to stage a reorder before any row is written. */
+    fun contentSnapshot(): MusicDto = MusicDto().also { it.copyContentFrom(this) }
+
     override fun toString(): String {
         val blobPreview = musicBlob?.take(10)?.joinToString(", ") { it.toString() } // First 10 bytes
         return "MusicDto(id=$id, fileName=$fileName, introVolume=$introVolume, musicBlobPreview=[$blobPreview])"

--- a/database/src/main/kotlin/database/persistence/music/impl/DefaultMusicFilePersistence.kt
+++ b/database/src/main/kotlin/database/persistence/music/impl/DefaultMusicFilePersistence.kt
@@ -47,8 +47,20 @@ class DefaultMusicFilePersistence : MusicFilePersistence {
             logger.info { "Duplicate detected, not persisting file" }
             return null
         }
-        val databaseMusicFile = entityManager.find(MusicDto::class.java, musicDto.id)
-        return if (databaseMusicFile == null) persistMusicDto(musicDto) else updateMusicFile(musicDto)
+        // A row already at this id means the caller allocated an occupied slot.
+        // This used to fall through to updateMusicFile, which merged the new
+        // track over the existing one — the user was told their intro saved
+        // while the one it landed on was destroyed, with no trace anywhere.
+        // Refusing is the only safe answer: callers surface the null, and the
+        // worst case becomes "couldn't save" rather than silent data loss.
+        entityManager.find(MusicDto::class.java, musicDto.id)?.let {
+            logger.error(
+                "Refusing to create music file '${musicDto.id}': that slot is already taken. " +
+                    "Something allocated an occupied slot — this would have overwritten an existing intro."
+            )
+            return null
+        }
+        return persistMusicDto(musicDto)
     }
 
     override fun getMusicFileById(id: String): MusicDto? {

--- a/database/src/test/kotlin/database/persistence/impl/DefaultMusicFilePersistenceCreateTest.kt
+++ b/database/src/test/kotlin/database/persistence/impl/DefaultMusicFilePersistenceCreateTest.kt
@@ -1,0 +1,98 @@
+package database.persistence.impl
+
+import database.dto.music.MusicDto
+import database.dto.user.UserDto
+import database.persistence.music.impl.DefaultMusicFilePersistence
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import jakarta.persistence.EntityManager
+import jakarta.persistence.TypedQuery
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * The last line of defence against the overwrite that prompted this.
+ *
+ * An intro's id is `guildId_discordId_slot`, so a row already at that id is the
+ * intro living in that slot. `createNewMusicFile` used to fall through to
+ * `updateMusicFile` on a hit, merging the new track over the old one: the user
+ * was told their intro saved, and the one it landed on was gone, with nothing
+ * logged and nothing to recover from.
+ */
+class DefaultMusicFilePersistenceCreateTest {
+
+    private lateinit var em: EntityManager
+    private lateinit var persistence: DefaultMusicFilePersistence
+
+    private val user = UserDto(discordId = 7L, guildId = 42L)
+
+    @BeforeEach
+    fun setUp() {
+        em = mockk(relaxed = true)
+        // No prior upload with this content hash unless a test says otherwise.
+        val dedupeQuery = mockk<TypedQuery<MusicDto>>(relaxed = true)
+        every { em.createQuery(any<String>(), MusicDto::class.java) } returns dedupeQuery
+        every { dedupeQuery.setParameter(any<String>(), any()) } returns dedupeQuery
+        every { dedupeQuery.resultList } returns emptyList()
+
+        persistence = DefaultMusicFilePersistence().apply {
+            DefaultMusicFilePersistence::class.java
+                .getDeclaredField("entityManager")
+                .apply { isAccessible = true }
+                .set(this, em)
+        }
+    }
+
+    private fun intro(slot: Int) = MusicDto(user, slot, "track$slot", 90, byteArrayOf(slot.toByte()))
+
+    @Test
+    fun `a free slot is persisted`() {
+        every { em.find(MusicDto::class.java, any()) } returns null
+        val fresh = intro(2)
+
+        val saved = persistence.createNewMusicFile(fresh)
+
+        assertSame(fresh, saved)
+        verify { em.persist(fresh) }
+    }
+
+    @Test
+    fun `an occupied slot is refused rather than overwritten`() {
+        val existing = intro(3)
+        every { em.find(MusicDto::class.java, existing.id) } returns existing
+        val replacement = MusicDto(user, 3, "someone else's track", 90, byteArrayOf(9))
+
+        val saved = persistence.createNewMusicFile(replacement)
+
+        assertNull(saved, "a collision must not report success")
+        verify(exactly = 0) { em.persist(any()) }
+        verify(exactly = 0) { em.merge(any()) }
+    }
+
+    @Test
+    fun `the intro already in the slot is left exactly as it was`() {
+        val existing = intro(1).apply { fileName = "mine"; playCount = 12 }
+        every { em.find(MusicDto::class.java, existing.id) } returns existing
+
+        persistence.createNewMusicFile(MusicDto(user, 1, "theirs", 50, byteArrayOf(9)))
+
+        assertNotNull(existing.fileName)
+        assertSame("mine", existing.fileName)
+        assertSame(12, existing.playCount)
+    }
+
+    @Test
+    fun `a duplicate upload is still refused before the slot is even looked at`() {
+        val dedupeQuery = mockk<TypedQuery<MusicDto>>(relaxed = true)
+        every { em.createQuery(any<String>(), MusicDto::class.java) } returns dedupeQuery
+        every { dedupeQuery.setParameter(any<String>(), any()) } returns dedupeQuery
+        every { dedupeQuery.resultList } returns listOf(intro(1))
+
+        assertNull(persistence.createNewMusicFile(intro(2)))
+        verify(exactly = 0) { em.persist(any()) }
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/music/intro/SetIntroFromMessageCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/music/intro/SetIntroFromMessageCommand.kt
@@ -2,8 +2,7 @@ package bot.toby.command.commands.music.intro
 
 import bot.toby.helpers.IntroHelper
 import bot.toby.helpers.PendingIntro
-import bot.toby.helpers.URLHelper
-import common.intro.IntroSlots
+import bot.toby.modal.modals.SetIntroFromMessageModal
 import core.command.MessageContextCommand
 import database.dto.user.UserDto
 import net.dv8tion.jda.api.entities.Message
@@ -24,7 +23,12 @@ import org.springframework.stereotype.Component
  * super-user targeting on `/setintro` has no equivalent here, and silently
  * changing someone else's intro from their own message would be a trap.
  *
- * Clip bounds aren't part of this flow; `/editintro` trims afterwards.
+ * Picking the source is all this does. It opens [SetIntroFromMessageModal] for
+ * the volume and clip bounds, which is also where the intro is validated and
+ * saved. Going straight to the save skipped the clip form entirely, so this
+ * entry point was the one that couldn't trim — and, because the duration check
+ * lives with the clip rules, the one that would happily set a ten-minute video
+ * as somebody's intro.
  */
 @Component
 class SetIntroFromMessageCommand @Autowired constructor(
@@ -33,11 +37,15 @@ class SetIntroFromMessageCommand @Autowired constructor(
 
     override val name: String get() = COMMAND_NAME
 
+    /** Opens a modal, which has to be the interaction's first response. */
+    override val defersReply: Boolean = false
+
     override fun handle(event: MessageContextInteractionEvent, requestingUserDto: UserDto, deleteDelay: Int) {
         logger.setGuildAndMemberContext(event.guild, event.member)
 
         val source = extractSource(event.target) ?: run {
-            event.hook.sendMessage(
+            // Not deferred, so this replies directly rather than via the hook.
+            event.reply(
                 "That message has no MP3 attachment or link to use. Attach an MP3 (or post a YouTube link) " +
                     "and try again, or use `/setintro`."
             ).setEphemeral(true).queue()
@@ -46,28 +54,23 @@ class SetIntroFromMessageCommand @Autowired constructor(
 
         val volume = introHelper.defaultIntroVolume(event.guild?.id)
 
-        // At the slot limit the user has to choose what to replace, exactly as
-        // `/setintro` does — stash the pick and hand them the same menu.
-        val intros = requestingUserDto.musicDtos
-        if (intros.size >= IntroSlots.MAX_INTRO_COUNT) {
-            introHelper.pendingIntros[requestingUserDto.discordId] = PendingIntro(
-                attachment = (source as? Source.File)?.attachment,
-                url = (source as? Source.Link)?.url,
+        // Stashed for the modal to pick up: an attachment URL is far too long
+        // for a modal custom id, and the id travels through the client anyway.
+        introHelper.pendingIntros[requestingUserDto.discordId] = PendingIntro(
+            attachment = (source as? Source.File)?.attachment,
+            url = (source as? Source.Link)?.url,
+            volume = volume,
+        )
+
+        event.replyModal(
+            SetIntroFromMessageModal.buildFor(
+                sourceLabel = when (source) {
+                    is Source.File -> source.attachment.fileName
+                    is Source.Link -> source.url
+                },
                 volume = volume,
             )
-            sendReplacePrompt(event.hook, event.member, intros)
-            return
-        }
-
-        val userName = event.member?.effectiveName ?: event.user.effectiveName
-        when (source) {
-            is Source.File -> introHelper.handleAttachment(
-                event, requestingUserDto, userName, deleteDelay, source.attachment, volume
-            )
-            is Source.Link -> introHelper.handleUrl(
-                event, requestingUserDto, userName, deleteDelay, URLHelper.fromUrlString(source.url), volume
-            )
-        }
+        ).queue()
     }
 
     /**

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/IntroHelper.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/IntroHelper.kt
@@ -230,9 +230,10 @@ class IntroHelper(
         val fileContents = mediaLoader.readContents(inputStream)
             ?: return event.hook.replyEphemeralAndDelete("Unable to read file '$filename'", deleteDelay)
 
-        val index = selectedMusicDto?.index ?: allocateSlot(targetDto)
+        val index = selectedMusicDto?.let { slotOf(it) } ?: allocateSlot(targetDto)
             ?: return rejectIntroForFullSlots(event, deleteDelay)
         val musicDto = selectedMusicDto?.apply {
+            this.index = index
             this.musicBlob = fileContents
             this.musicBlobHash = computeHash(fileContents)
             this.fileName = filename
@@ -272,10 +273,14 @@ class IntroHelper(
         logger.setGuildAndMemberContext(event.guild, event.member)
         logger.info { "Persisting music URL for user '$memberName' on guild: ${event.guild?.idLong}" }
         val urlBytes = url.toByteArray()
-        val index = selectedMusicDto?.index ?: allocateSlot(targetDto)
+        val index = selectedMusicDto?.let { slotOf(it) } ?: allocateSlot(targetDto)
             ?: return rejectIntroForFullSlots(event, deleteDelay)
         val musicDto = selectedMusicDto?.apply {
-            this.id = "${targetDto.guildId}_${targetDto.discordId}_$index"
+            // Deliberately *not* reassigning `id`. It is the primary key, and
+            // rewriting it made `merge` insert a second row and orphan the
+            // original whenever `index` had drifted from the id — which the
+            // web drag-reorder causes, since it rewrites index only.
+            this.index = index
             this.userDto = targetDto
             this.musicBlob = urlBytes
             this.musicBlobHash = computeHash(urlBytes)
@@ -306,17 +311,23 @@ class IntroHelper(
      * The slot a brand-new intro should take, re-reading the user so the count
      * reflects anything saved since the command started.
      *
-     * This used to be `musicDtos.size + 1`, which is wrong whenever a delete
-     * has left a gap: with intros in slots [1, 3] it picks 3, and since
-     * `createNewMusicFile` turns an id collision into an update, the intro
-     * already in slot 3 was silently overwritten. `IntroSlots.nextFreeIndex`
-     * walks the range instead — the same allocator the web form uses.
+     * Allocates against the existing **ids**, which is what a new row can
+     * collide with — see [IntroSlots.nextFreeSlot] for why reading the `index`
+     * column silently overwrote people's intros.
      *
      * @return the free slot, or null when all [IntroSlots.MAX_INTRO_COUNT] are taken.
      */
+    /**
+     * The slot an existing intro occupies, read from its id rather than its
+     * `index` column. The two can disagree — the web drag-reorder rewrites
+     * `index` and can't rewrite the id — and the id is the one that decides
+     * which row a write lands on, so it wins.
+     */
+    private fun slotOf(intro: MusicDto): Int? = IntroSlots.slotFromId(intro.id) ?: intro.index
+
     private fun allocateSlot(targetDto: database.dto.user.UserDto): Int? {
         val existing = userDtoHelper.calculateUserDto(targetDto.discordId, targetDto.guildId).musicDtos
-        return IntroSlots.nextFreeIndex(existing.map { it.index })
+        return IntroSlots.nextFreeSlot(existing.map { it.id })
     }
 
     private fun rejectIntroForFullSlots(event: IReplyCallback, deleteDelay: Int) {

--- a/discord-bot/src/main/kotlin/bot/toby/managers/DefaultMessageContextManager.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/managers/DefaultMessageContextManager.kt
@@ -30,7 +30,9 @@ class DefaultMessageContextManager @Autowired constructor(
 
         // Defer before the DB lookups below so a slow query can't eat the
         // 3-second ack window — same reasoning as DefaultCommandManager.
-        event.deferReply(command.ephemeral).queue()
+        // Commands that open a modal opt out: a modal must be the first
+        // response, so deferring would make `replyModal` impossible.
+        if (command.defersReply) event.deferReply(command.ephemeral).queue()
 
         val deleteDelay = configService.getConfigByName(
             ConfigDto.Configurations.DELETE_DELAY.configValue,

--- a/discord-bot/src/main/kotlin/bot/toby/modal/modals/SetIntroFromMessageModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/modal/modals/SetIntroFromMessageModal.kt
@@ -1,0 +1,158 @@
+package bot.toby.modal.modals
+
+import bot.toby.command.commands.music.intro.sendReplacePrompt
+import bot.toby.helpers.IntroHelper
+import bot.toby.helpers.URLHelper
+import common.intro.IntroClip
+import common.intro.IntroSlots
+import core.modal.Modal
+import core.modal.ModalContext
+import database.dto.user.UserDto
+import net.dv8tion.jda.api.components.label.Label
+import net.dv8tion.jda.api.components.textinput.TextInput
+import net.dv8tion.jda.api.components.textinput.TextInputStyle
+import net.dv8tion.jda.api.modals.Modal as JdaModal
+import org.springframework.stereotype.Component
+
+/**
+ * Volume and clip bounds for **Apps → Set as my intro**.
+ *
+ * The context menu used to save straight from the message, which made it the
+ * one entry point with no way to trim — and, since the length rule lives with
+ * the clip rules, the one that never checked how long the source was. A
+ * ten-minute video became a ten-minute intro, reported as a success.
+ *
+ * The form is pre-filled with the guild's default volume and no clip, so
+ * submitting it untouched does exactly what the old one-click flow did, minus
+ * the missing validation. The source itself is carried in
+ * [IntroHelper.pendingIntros] rather than the modal id — a Discord attachment
+ * URL is far longer than the 100 characters a custom id allows.
+ */
+@Component
+class SetIntroFromMessageModal(
+    private val introHelper: IntroHelper,
+) : Modal {
+
+    override val name = MODAL_NAME
+
+    override fun handle(ctx: ModalContext, deleteDelay: Int) {
+        val event = ctx.event
+        logger.setGuildAndMemberContext(ctx.guild, ctx.member)
+
+        val pending = introHelper.pendingIntros[event.user.idLong] ?: return reply(
+            ctx,
+            "That form lost track of which track it was for — right-click the message and try again.",
+        )
+
+        val rawVolume = event.getValue(FIELD_VOLUME)?.asString?.trim().orEmpty()
+        val volume = if (rawVolume.isEmpty()) pending.volume else rawVolume.toIntOrNull()
+        if (volume == null || volume !in 0..100) {
+            return reply(ctx, "Volume must be a whole number between 0 and 100.")
+        }
+
+        val start = IntroClip.parseTimestamp(event.getValue(FIELD_START)?.asString, "Clip start")
+        if (start is IntroClip.Parsed.Invalid) return reply(ctx, start.message)
+        val end = IntroClip.parseTimestamp(event.getValue(FIELD_END)?.asString, "Clip end")
+        if (end is IntroClip.Parsed.Invalid) return reply(ctx, end.message)
+
+        val startMs = (start as IntroClip.Parsed.Ok).ms
+        val endMs = (end as IntroClip.Parsed.Ok).ms
+
+        // The same gate `/setintro` runs: one duration lookup, then the shared
+        // clip rules decide. A long source is fine *if* it has been clipped,
+        // which is exactly why the clip fields above are on this form.
+        introHelper.validateClipAgainstSource(pending.url, startMs, endMs) { error ->
+            if (error != null) {
+                logger.info { "Intro from message rejected: $error" }
+                reply(ctx, error)
+                return@validateClipAgainstSource
+            }
+            save(ctx, deleteDelay, pending.copy(volume = volume, startMs = startMs, endMs = endMs))
+        }
+    }
+
+    private fun save(ctx: ModalContext, deleteDelay: Int, pending: bot.toby.helpers.PendingIntro) {
+        val event = ctx.event
+        val requestingUserDto: UserDto = introHelper.findUserById(event.user.idLong, ctx.guild.idLong)
+        introHelper.pendingIntros[event.user.idLong] = pending
+
+        // At the slot limit the user still has to choose what to replace. The
+        // pending intro now carries their volume and clip, so the menu picks up
+        // where this left off.
+        val intros = requestingUserDto.musicDtos
+        if (intros.size >= IntroSlots.MAX_INTRO_COUNT) {
+            sendReplacePrompt(event.hook, ctx.member, intros)
+            return
+        }
+
+        val userName = ctx.member?.effectiveName ?: event.user.effectiveName
+        pending.attachment?.let {
+            introHelper.handleAttachment(
+                event, requestingUserDto, userName, deleteDelay, it,
+                pending.volume, null, pending.startMs, pending.endMs,
+            )
+            return
+        }
+        pending.url?.let {
+            introHelper.handleUrl(
+                event, requestingUserDto, userName, deleteDelay, URLHelper.fromUrlString(it),
+                pending.volume, null, pending.startMs, pending.endMs,
+            )
+        }
+    }
+
+    private fun reply(ctx: ModalContext, message: String) {
+        ctx.event.hook.sendMessage(message).setEphemeral(true).queue()
+    }
+
+    companion object {
+        const val MODAL_NAME = "setintrofrommessage"
+        const val FIELD_VOLUME = "intro_volume"
+        const val FIELD_START = "intro_start"
+        const val FIELD_END = "intro_end"
+
+        /** Room for `mm:ss.s` and then some. */
+        private const val TIMESTAMP_FIELD_LIMIT = 12
+
+        /** Discord modal titles are capped at 45 characters. */
+        private const val TITLE_LIMIT = 45
+
+        /**
+         * @param sourceLabel the file name or link taken off the message, shown
+         *        as the form's title so the user can see they right-clicked the
+         *        message they meant to.
+         */
+        fun buildFor(sourceLabel: String, volume: Int): JdaModal {
+            val volumeField = TextInput.create(FIELD_VOLUME, TextInputStyle.SHORT)
+                .setRequired(false)
+                .setRequiredRange(0, 3)
+                .setValue(volume.toString())
+                .build()
+            val startField = TextInput.create(FIELD_START, TextInputStyle.SHORT)
+                .setRequired(false)
+                .setRequiredRange(0, TIMESTAMP_FIELD_LIMIT)
+                .setPlaceholder("0:00")
+                .build()
+            val endField = TextInput.create(FIELD_END, TextInputStyle.SHORT)
+                .setRequired(false)
+                .setRequiredRange(0, TIMESTAMP_FIELD_LIMIT)
+                .setPlaceholder("0:${"%02d".format(IntroClip.MAX_DURATION_SECONDS)}")
+                .build()
+
+            return JdaModal.create(MODAL_NAME, title(sourceLabel))
+                .addComponents(
+                    Label.of("Volume (0-100)", volumeField),
+                    Label.of("Clip start — blank for none", startField),
+                    Label.of("Clip end — blank for none", endField),
+                )
+                .build()
+        }
+
+        internal fun title(sourceLabel: String): String {
+            val prefix = "Intro: "
+            val room = TITLE_LIMIT - prefix.length
+            val trimmed = sourceLabel.trim().ifEmpty { return "Set as my intro" }
+            return prefix + if (trimmed.length <= room) trimmed else trimmed.take(room - 1) + "…"
+        }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/music/intro/SetIntroFromMessageCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/music/intro/SetIntroFromMessageCommandTest.kt
@@ -2,6 +2,7 @@ package bot.toby.command.commands.music.intro
 
 import bot.toby.helpers.IntroHelper
 import bot.toby.helpers.PendingIntro
+import bot.toby.modal.modals.SetIntroFromMessageModal
 import database.dto.music.MusicDto
 import database.dto.user.UserDto
 import io.mockk.every
@@ -9,7 +10,8 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.unmockkAll
 import io.mockk.verify
-import net.dv8tion.jda.api.components.actionrow.ActionRow
+import net.dv8tion.jda.api.components.label.Label
+import net.dv8tion.jda.api.components.textinput.TextInput
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.Message
@@ -21,11 +23,12 @@ import net.dv8tion.jda.api.interactions.InteractionHook
 import net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import java.net.URI
+import net.dv8tion.jda.api.modals.Modal as JdaModal
 
 class SetIntroFromMessageCommandTest {
 
@@ -88,24 +91,31 @@ class SetIntroFromMessageCommandTest {
     }
 
     @Test
-    fun `an mp3 attachment becomes the intro`() {
+    fun `an mp3 attachment opens the clip form with the file parked for it`() {
         val file = mp3()
         withMessage(attachments = listOf(file))
 
         command.handle(event, userDto, 5)
 
-        verify { introHelper.handleAttachment(event, userDto, "Joiner", 5, file, 80) }
+        // Nothing is saved from the command any more — the modal validates and
+        // persists, which is how this entry point finally gets clip bounds and
+        // the duration check that lives with them.
+        verify(exactly = 0) { introHelper.handleAttachment(any(), any(), any(), any(), any(), any()) }
+        verify { event.replyModal(any()) }
+        assertEquals(file, pending[1L]?.attachment)
+        assertNull(pending[1L]?.url)
+        assertEquals(80, pending[1L]?.volume)
     }
 
     @Test
-    fun `a link in the message body becomes the intro`() {
+    fun `a link in the message body is parked for the clip form`() {
         withMessage(content = "this one https://www.youtube.com/watch?v=abc is unreal")
 
         command.handle(event, userDto, 5)
 
-        val uri = slot<URI>()
-        verify { introHelper.handleUrl(event, userDto, "Joiner", 5, capture(uri), 80) }
-        assertEquals("https://www.youtube.com/watch?v=abc", uri.captured.toString())
+        verify { event.replyModal(any()) }
+        assertEquals("https://www.youtube.com/watch?v=abc", pending[1L]?.url)
+        assertNull(pending[1L]?.attachment)
     }
 
     @Test
@@ -115,8 +125,8 @@ class SetIntroFromMessageCommandTest {
 
         command.handle(event, userDto, 5)
 
-        verify { introHelper.handleAttachment(event, userDto, "Joiner", 5, file, 80) }
-        verify(exactly = 0) { introHelper.handleUrl(any(), any(), any(), any(), any(), any()) }
+        assertEquals(file, pending[1L]?.attachment)
+        assertNull(pending[1L]?.url)
     }
 
     @Test
@@ -125,45 +135,60 @@ class SetIntroFromMessageCommandTest {
 
         command.handle(event, userDto, 5)
 
-        verify { introHelper.handleUrl(any(), any(), any(), any(), any(), any()) }
+        assertEquals("https://youtu.be/abc", pending[1L]?.url)
+        assertNull(pending[1L]?.attachment)
     }
 
     @Test
-    fun `a message with nothing usable explains itself`() {
+    fun `a message with nothing usable explains itself without opening a form`() {
         withMessage(attachments = listOf(nonAudio()), content = "lol")
 
         command.handle(event, userDto, 5)
 
-        verify(exactly = 0) { introHelper.handleAttachment(any(), any(), any(), any(), any(), any()) }
-        verify(exactly = 0) { introHelper.handleUrl(any(), any(), any(), any(), any(), any()) }
-        assertTrue(replies.single().contains("no MP3 attachment or link"))
+        // The refusal goes out via event.reply, a JDA default interface method
+        // that mockk can't intercept on these mocks, so the assertion is on the
+        // observable contract: no form, and nothing parked to save later.
+        verify(exactly = 0) { event.replyModal(any()) }
+        assertNull(pending[1L])
     }
 
     @Test
-    fun `at the slot limit the user is asked what to replace`() {
-        val embeds = mutableListOf<MessageEmbed>()
-        val embedSend = mockk<WebhookMessageCreateAction<Message>>(relaxed = true)
-        every { hook.sendMessageEmbeds(capture(embeds)) } returns embedSend
-        every { embedSend.addContent(any()) } returns embedSend
-        // Keep the builder fluent: JDA's covariant addComponents bridge
-        // ClassCastExceptions if a relaxed child answers it.
-        every { embedSend.addComponents(any<ActionRow>()) } returns embedSend
-        every { embedSend.setEphemeral(true) } returns embedSend
+    fun `the form title names the source that was picked`() {
+        withMessage(attachments = listOf(mp3("banger.mp3")))
+        val modal = slot<JdaModal>()
+        every { event.replyModal(capture(modal)) } returns mockk(relaxed = true)
 
-        val full = UserDto(discordId = 1L, guildId = 7L).apply {
-            musicDtos = (1..3).map { MusicDto(this, it, "existing$it", 90, byteArrayOf(1)) }.toMutableList()
-        }
-        val file = mp3()
-        withMessage(attachments = listOf(file))
+        command.handle(event, userDto, 5)
 
-        command.handle(event, full, 5)
+        assertTrue(modal.captured.title.contains("banger.mp3"), modal.captured.title)
+    }
 
-        // Nothing saved yet — the pick is parked for SetIntroMenu to resolve.
-        verify(exactly = 0) { introHelper.handleAttachment(any(), any(), any(), any(), any(), any()) }
-        assertEquals(file, pending[1L]?.attachment)
-        assertEquals(80, pending[1L]?.volume)
-        assertNull(pending[1L]?.url)
-        assertEquals(3, embeds.single().fields.size)
+    @Test
+    fun `the form offers volume and both clip bounds`() {
+        withMessage(attachments = listOf(mp3()))
+        val modal = slot<JdaModal>()
+        every { event.replyModal(capture(modal)) } returns mockk(relaxed = true)
+
+        command.handle(event, userDto, 5)
+
+        val fieldIds = modal.captured.components
+            .mapNotNull { (it as? Label)?.child as? TextInput }
+            .map { it.customId }
+        assertEquals(
+            listOf(
+                SetIntroFromMessageModal.FIELD_VOLUME,
+                SetIntroFromMessageModal.FIELD_START,
+                SetIntroFromMessageModal.FIELD_END,
+            ),
+            fieldIds,
+        )
+    }
+
+    @Test
+    fun `the command does not defer, so the form can open at all`() {
+        // A modal has to be an interaction's first response; deferring first
+        // makes replyModal impossible.
+        assertFalse(command.defersReply)
     }
 
     @Test

--- a/discord-bot/src/test/kotlin/bot/toby/managers/DefaultMessageContextManagerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/managers/DefaultMessageContextManagerTest.kt
@@ -36,6 +36,7 @@ class DefaultMessageContextManagerTest {
         command = mockk(relaxed = true) {
             every { name } returns "Set as my intro"
             every { ephemeral } returns true
+            every { defersReply } returns true
         }
         manager = DefaultMessageContextManager(configService, userDtoHelper, listOf(command))
 
@@ -71,6 +72,19 @@ class DefaultMessageContextManagerTest {
         manager.handle(event)
 
         verify { event.deferReply(true) }
+        verify { command.handle(event, userDto, 12) }
+    }
+
+    @Test
+    fun `a command that opens a modal is dispatched without being acked first`() {
+        // A modal has to be an interaction's first response, so deferring on
+        // its behalf would make replyModal impossible — which is what stopped
+        // "Set as my intro" from being able to ask for clip bounds.
+        every { command.defersReply } returns false
+
+        manager.handle(event)
+
+        verify(exactly = 0) { event.deferReply(any()) }
         verify { command.handle(event, userDto, 12) }
     }
 

--- a/discord-bot/src/test/kotlin/bot/toby/modal/modals/SetIntroFromMessageModalTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/modal/modals/SetIntroFromMessageModalTest.kt
@@ -1,0 +1,281 @@
+package bot.toby.modal.modals
+
+import bot.toby.helpers.IntroHelper
+import bot.toby.helpers.PendingIntro
+import core.modal.ModalContext
+import database.dto.music.MusicDto
+import database.dto.user.UserDto
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.verify
+import net.dv8tion.jda.api.components.label.Label
+import net.dv8tion.jda.api.components.textinput.TextInput
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.entities.User
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
+import net.dv8tion.jda.api.interactions.InteractionHook
+import net.dv8tion.jda.api.interactions.modals.ModalMapping
+import net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.net.URI
+
+/**
+ * The clip form behind **Apps → Set as my intro**.
+ *
+ * Before it existed the context menu saved straight from the message, which
+ * made it the one entry point that couldn't trim — and, because the length
+ * rule lives with the clip rules, the one that never checked how long the
+ * source was. A ten-minute video became a ten-minute intro, reported as saved.
+ */
+class SetIntroFromMessageModalTest {
+
+    private val discordId = 1L
+    private val guildId = 7L
+
+    private lateinit var introHelper: IntroHelper
+    private lateinit var modal: SetIntroFromMessageModal
+    private lateinit var event: ModalInteractionEvent
+    private lateinit var ctx: ModalContext
+    private lateinit var hook: InteractionHook
+    private val replies = mutableListOf<String>()
+    private val pending = mutableMapOf<Long, PendingIntro?>()
+    private lateinit var userDto: UserDto
+
+    @BeforeEach
+    fun setUp() {
+        introHelper = mockk(relaxed = true)
+        modal = SetIntroFromMessageModal(introHelper)
+        userDto = UserDto(discordId = discordId, guildId = guildId)
+
+        hook = mockk(relaxed = true)
+        val guild = mockk<Guild>(relaxed = true) {
+            every { idLong } returns guildId
+            every { id } returns guildId.toString()
+        }
+        val member = mockk<Member>(relaxed = true) { every { effectiveName } returns "Joiner" }
+        event = mockk(relaxed = true) {
+            every { this@mockk.hook } returns this@SetIntroFromMessageModalTest.hook
+            every { user } returns mockk<User>(relaxed = true) {
+                every { idLong } returns discordId
+                every { effectiveName } returns "Joiner"
+            }
+        }
+        ctx = mockk(relaxed = true) {
+            every { this@mockk.event } returns this@SetIntroFromMessageModalTest.event
+            every { this@mockk.guild } returns guild
+            every { this@mockk.member } returns member
+        }
+
+        replies.clear()
+        pending.clear()
+        val send = mockk<WebhookMessageCreateAction<Message>>(relaxed = true)
+        every { hook.sendMessage(capture(replies)) } returns send
+        every { send.setEphemeral(true) } returns send
+
+        every { introHelper.pendingIntros } returns pending
+        every { introHelper.findUserById(discordId, guildId) } returns userDto
+        // Pass the clip gate unless a test says otherwise.
+        every { introHelper.validateClipAgainstSource(any(), any(), any(), any()) } answers {
+            lastArg<(String?) -> Unit>().invoke(null)
+        }
+    }
+
+    @AfterEach
+    fun tearDown() = unmockkAll()
+
+    private fun field(value: String?): ModalMapping? =
+        value?.let { mockk(relaxed = true) { every { asString } returns it } }
+
+    private fun submit(volume: String? = null, start: String? = null, end: String? = null) {
+        every { event.getValue(SetIntroFromMessageModal.FIELD_VOLUME) } returns field(volume)
+        every { event.getValue(SetIntroFromMessageModal.FIELD_START) } returns field(start)
+        every { event.getValue(SetIntroFromMessageModal.FIELD_END) } returns field(end)
+        modal.handle(ctx, 5)
+    }
+
+    private fun parkUrl(url: String = "https://www.youtube.com/watch?v=abc", volume: Int = 80) {
+        pending[discordId] = PendingIntro(attachment = null, url = url, volume = volume)
+    }
+
+    private fun parkFile(volume: Int = 80): Message.Attachment {
+        val attachment = mockk<Message.Attachment>(relaxed = true)
+        pending[discordId] = PendingIntro(attachment = attachment, url = null, volume = volume)
+        return attachment
+    }
+
+    // --- the happy path -----------------------------------------------------
+
+    @Test
+    fun `submitting the form untouched saves at the guild default volume`() {
+        parkUrl(volume = 80)
+
+        submit()
+
+        val uri = slot<URI>()
+        verify { introHelper.handleUrl(event, userDto, "Joiner", 5, capture(uri), 80, null, null, null) }
+        assertEquals("https://www.youtube.com/watch?v=abc", uri.captured.toString())
+    }
+
+    @Test
+    fun `a clip typed into the form reaches the save`() {
+        parkUrl()
+
+        submit(volume = "45", start = "0:03", end = "0:12")
+
+        verify { introHelper.handleUrl(event, userDto, "Joiner", 5, any(), 45, null, 3_000, 12_000) }
+    }
+
+    @Test
+    fun `an attachment is saved through the attachment path`() {
+        val attachment = parkFile()
+
+        submit(volume = "60", start = "0:01", end = "0:06")
+
+        verify { introHelper.handleAttachment(event, userDto, "Joiner", 5, attachment, 60, null, 1_000, 6_000) }
+    }
+
+    // --- validation ---------------------------------------------------------
+
+    @Test
+    fun `the source is put through the same length gate as slash setintro`() {
+        // This is the bug the form exists to close: the context menu never ran
+        // this check, so any length of video went straight in.
+        parkUrl("https://www.youtube.com/watch?v=long")
+
+        submit()
+
+        verify { introHelper.validateClipAgainstSource("https://www.youtube.com/watch?v=long", null, null, any()) }
+    }
+
+    @Test
+    fun `a source that fails the length gate is refused, not saved`() {
+        parkUrl()
+        every { introHelper.validateClipAgainstSource(any(), any(), any(), any()) } answers {
+            lastArg<(String?) -> Unit>().invoke("Video is too long (600s). Max allowed is 15s")
+        }
+
+        submit()
+
+        verify(exactly = 0) { introHelper.handleUrl(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+        assertTrue(replies.single().contains("too long"), replies.single())
+    }
+
+    @Test
+    fun `the clip the user typed is what gets validated`() {
+        // A long video is fine once trimmed — which is the whole reason the
+        // clip fields are on this form rather than being a later /editintro.
+        parkUrl()
+
+        submit(start = "1:00", end = "1:10")
+
+        verify { introHelper.validateClipAgainstSource(any(), 60_000, 70_000, any()) }
+    }
+
+    @Test
+    fun `an unparseable timestamp is reported without saving`() {
+        parkUrl()
+
+        submit(start = "banana")
+
+        verify(exactly = 0) { introHelper.handleUrl(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+        assertTrue(replies.single().contains("Clip start"), replies.single())
+    }
+
+    @Test
+    fun `a volume outside the range is reported without saving`() {
+        parkUrl()
+
+        submit(volume = "500")
+
+        verify(exactly = 0) { introHelper.handleUrl(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+        assertTrue(replies.single().contains("between 0 and 100"), replies.single())
+    }
+
+    @Test
+    fun `a non-numeric volume is reported without saving`() {
+        parkUrl()
+
+        submit(volume = "loud")
+
+        verify(exactly = 0) { introHelper.handleUrl(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    // --- state --------------------------------------------------------------
+
+    @Test
+    fun `a form with no source behind it says so rather than failing silently`() {
+        submit()
+
+        verify(exactly = 0) { introHelper.handleUrl(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+        assertTrue(replies.single().contains("lost track"), replies.single())
+    }
+
+    @Test
+    fun `at the slot limit the user is asked what to replace, clip and all`() {
+        parkUrl()
+        userDto.musicDtos = (1..3).map { MusicDto(userDto, it, "existing$it", 90, byteArrayOf(1)) }.toMutableList()
+        val embedSend = mockk<WebhookMessageCreateAction<Message>>(relaxed = true)
+        every { hook.sendMessageEmbeds(any<net.dv8tion.jda.api.entities.MessageEmbed>()) } returns embedSend
+        every { embedSend.addContent(any()) } returns embedSend
+        every { embedSend.addComponents(any<net.dv8tion.jda.api.components.actionrow.ActionRow>()) } returns embedSend
+        every { embedSend.setEphemeral(true) } returns embedSend
+
+        submit(volume = "33", start = "0:02", end = "0:09")
+
+        // Nothing saved yet — but the choice carries the clip forward, so the
+        // replace menu finishes what the form started.
+        verify(exactly = 0) { introHelper.handleUrl(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+        assertEquals(33, pending[discordId]?.volume)
+        assertEquals(2_000, pending[discordId]?.startMs)
+        assertEquals(9_000, pending[discordId]?.endMs)
+    }
+
+    // --- form shape ---------------------------------------------------------
+
+    @Test
+    fun `the form pre-fills the volume so submitting unchanged is a no-op`() {
+        val built = SetIntroFromMessageModal.buildFor("banger.mp3", 72)
+
+        val volumeField = built.components
+            .mapNotNull { (it as? Label)?.child as? TextInput }
+            .single { it.customId == SetIntroFromMessageModal.FIELD_VOLUME }
+        assertEquals("72", volumeField.value)
+    }
+
+    @Test
+    fun `the clip fields start empty, matching the old one-click behaviour`() {
+        val built = SetIntroFromMessageModal.buildFor("banger.mp3", 72)
+        val fields = built.components
+            .mapNotNull { (it as? Label)?.child as? TextInput }
+            .associateBy { it.customId }
+
+        assertEquals(null, fields[SetIntroFromMessageModal.FIELD_START]?.value)
+        assertEquals(null, fields[SetIntroFromMessageModal.FIELD_END]?.value)
+    }
+
+    @Test
+    fun `a long source name is trimmed to fit Discord's title cap`() {
+        val title = SetIntroFromMessageModal.title("x".repeat(200))
+
+        assertTrue(title.length <= 45, "title was ${title.length} chars: $title")
+        assertTrue(title.endsWith("…"), title)
+    }
+
+    @Test
+    fun `a blank source name still produces a usable title`() {
+        assertEquals("Set as my intro", SetIntroFromMessageModal.title("   "))
+    }
+
+    @Test
+    fun `the form fits Discord's five-component modal cap`() {
+        assertTrue(SetIntroFromMessageModal.buildFor("a.mp3", 50).components.size <= 5)
+    }
+}

--- a/web/src/main/kotlin/web/service/IntroWebService.kt
+++ b/web/src/main/kotlin/web/service/IntroWebService.kt
@@ -343,9 +343,9 @@ class IntroWebService(
         IntroClip.validate(startMs, endMs, sourceDurationMs)
 
     // Shared with the slash-command path via IntroSlots — see there for why
-    // walking the range beats `size + 1`.
+    // occupancy is read from the ids rather than the index column.
     private fun nextFreeIndex(existingIntros: List<MusicDto>): Int? =
-        IntroSlots.nextFreeIndex(existingIntros.map { it.index })
+        IntroSlots.nextFreeSlot(existingIntros.map { it.id })
 
     private fun requireOwnedIntro(discordId: Long, guildId: Long, introId: String): String? =
         if (introId.startsWith("${guildId}_${discordId}_")) null
@@ -418,8 +418,22 @@ class IntroWebService(
     }
 
     /**
-     * Reassign the `index` field across the caller's intros to match the supplied id ordering.
-     * The rest of the bot selects randomly between intros so order is purely organisational.
+     * Reorder the caller's intros to match the supplied id ordering.
+     *
+     * This moves the intros *between* slots rather than renumbering the slots.
+     * It has to: a row's id is `guildId_discordId_slot`, so the slot is part of
+     * the primary key and can't be reassigned without deleting and reinserting.
+     *
+     * The old implementation rewrote the `index` column and left the ids alone,
+     * which quietly broke the invariant the rest of the bot relies on. A user
+     * who dragged a row could end up holding ids `[_1, _3]` with indexes
+     * `[2, 1]`; the next intro they added was allocated slot 3 — free by index,
+     * occupied by id — and `createNewMusicFile` merged it straight over the
+     * intro already living there. They were told it saved. The other one was
+     * gone.
+     *
+     * So the slots stay exactly where they are and the contents move. Which
+     * is what the drag actually means to the person doing it.
      */
     fun reorderIntros(discordId: Long, guildId: Long, orderedIds: List<String>): String? {
         val expectedPrefix = "${guildId}_${discordId}_"
@@ -429,19 +443,26 @@ class IntroWebService(
         val currentIds = user.musicDtos.map { it.id }.toSet()
         if (orderedIds.toSet() != currentIds) return "Reorder list does not match your intros."
 
-        // Two-phase rename: stash as negative temp indexes first to avoid unique-key collisions,
-        // then assign the final 1..N indexes.
-        orderedIds.forEachIndexed { idx, id ->
-            musicFileService.getMusicFileById(id)?.let { dto ->
-                dto.index = -(idx + 1)
-                musicFileService.updateMusicFile(dto)
-            }
+        // Snapshot every intro's content before writing anything: the rows are
+        // about to be overwritten with each other's contents, so reading them
+        // lazily would copy already-copied data.
+        val contentById = orderedIds.associateWith { id ->
+            musicFileService.getMusicFileById(id)?.contentSnapshot()
         }
-        orderedIds.forEachIndexed { idx, id ->
-            musicFileService.getMusicFileById(id)?.let { dto ->
-                dto.index = idx + 1
-                musicFileService.updateMusicFile(dto)
-            }
+        if (contentById.values.any { it == null }) return "One or more intros could not be read."
+
+        // The slots in play, low to high — the same set before and after, which
+        // is what keeps sparse layouts (say [1, 3] after a delete) intact.
+        val slots = user.musicDtos.mapNotNull { it.id }.sortedBy { IntroSlots.slotFromId(it) ?: Int.MAX_VALUE }
+
+        slots.zip(orderedIds).forEach { (slotId, wantedId) ->
+            if (slotId == wantedId) return@forEach
+            val row = musicFileService.getMusicFileById(slotId) ?: return "One or more intros could not be read."
+            row.copyContentFrom(contentById.getValue(wantedId)!!)
+            // Put `index` back in step with the id while we're here: rows that
+            // predate this fix may still carry a drifted value.
+            IntroSlots.slotFromId(slotId)?.let { row.index = it }
+            musicFileService.updateMusicFile(row)
         }
         return null
     }

--- a/web/src/test/kotlin/web/service/IntroWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/IntroWebServiceTest.kt
@@ -456,17 +456,77 @@ class IntroWebServiceTest {
     }
 
     @Test
-    fun `reorderIntros reassigns indexes via a two-phase rename`() {
-        val a = intro(1); val b = intro(2)
+    fun `reorderIntros moves the contents between slots, not the slots`() {
+        // Slots are identity: the id is `guildId_discordId_slot` and is the
+        // primary key, so a reorder can't renumber them. It used to rewrite
+        // the `index` column and leave the ids alone, which put the two out of
+        // step — and the next intro the user added was then allocated a slot
+        // that was free by index and occupied by id, overwriting whatever was
+        // already there.
+        val a = intro(1, fileName = "A"); val b = intro(2, fileName = "B")
         every { userService.getUserById(discordId, guildId) } returns user(a, b)
         every { musicFileService.getMusicFileById(a.id!!) } returns a
         every { musicFileService.getMusicFileById(b.id!!) } returns b
 
         // Reverse the order: b first, then a.
         val result = service.reorderIntros(discordId, guildId, listOf(b.id!!, a.id!!))
+
         assertNull(result)
-        assertEquals(1, b.index)
-        assertEquals(2, a.index)
+        // Ids and indexes are untouched and still agree with each other...
+        assertEquals("${guildId}_${discordId}_1", a.id)
+        assertEquals(1, a.index)
+        assertEquals("${guildId}_${discordId}_2", b.id)
+        assertEquals(2, b.index)
+        // ...and the tracks have swapped places, which is what the drag meant.
+        assertEquals("B", a.fileName)
+        assertEquals("A", b.fileName)
+    }
+
+    @Test
+    fun `reorderIntros leaves a sparse layout sparse`() {
+        // Slots [1, 3] after a delete stay [1, 3]; renumbering them to [1, 2]
+        // would move a row onto an id that is not its own.
+        val a = intro(1, fileName = "A"); val c = intro(3, fileName = "C")
+        every { userService.getUserById(discordId, guildId) } returns user(a, c)
+        every { musicFileService.getMusicFileById(a.id!!) } returns a
+        every { musicFileService.getMusicFileById(c.id!!) } returns c
+
+        assertNull(service.reorderIntros(discordId, guildId, listOf(c.id!!, a.id!!)))
+
+        assertEquals(1, a.index)
+        assertEquals(3, c.index)
+        assertEquals("C", a.fileName)
+        assertEquals("A", c.fileName)
+    }
+
+    @Test
+    fun `reorderIntros carries an intro's playback history with it`() {
+        // Health and play counts describe the track, not the slot; leaving
+        // them behind would blame the wrong intro for the wrong failures.
+        val a = intro(1, fileName = "A").apply { playCount = 7; failureCount = 2 }
+        val b = intro(2, fileName = "B").apply { playCount = 1; failureCount = 0 }
+        every { userService.getUserById(discordId, guildId) } returns user(a, b)
+        every { musicFileService.getMusicFileById(a.id!!) } returns a
+        every { musicFileService.getMusicFileById(b.id!!) } returns b
+
+        assertNull(service.reorderIntros(discordId, guildId, listOf(b.id!!, a.id!!)))
+
+        assertEquals(1, a.playCount)
+        assertEquals(0, a.failureCount)
+        assertEquals(7, b.playCount)
+        assertEquals(2, b.failureCount)
+    }
+
+    @Test
+    fun `reorderIntros to the same order writes nothing`() {
+        val a = intro(1); val b = intro(2)
+        every { userService.getUserById(discordId, guildId) } returns user(a, b)
+        every { musicFileService.getMusicFileById(a.id!!) } returns a
+        every { musicFileService.getMusicFileById(b.id!!) } returns b
+
+        assertNull(service.reorderIntros(discordId, guildId, listOf(a.id!!, b.id!!)))
+
+        verify(exactly = 0) { musicFileService.updateMusicFile(any()) }
     }
 
     // --- preview helpers (offline) --------------------------------------


### PR DESCRIPTION
Both reported problems, plus the feature that closes the second one.

## 1. The overwrite — `1ae5e75`

> it said it succeeded but seems like it overwrote my second intro and set itself into slot 3

Reproduced by reading, not guessing. An intro's primary key is `guildId_discordId_slot`, so the slot **is** the row's identity. Three places disagreed about which slot was free:

1. **`IntroWebService.reorderIntros`** rewrote the `index` column and left the ids alone — it had to, the id is the PK and can't be reassigned. So one drag on the web page leaves you holding ids `[_1, _3]` carrying indexes `[2, 1]`.
2. **Allocation** then read `index`, saw 3 as free, handed it out.
3. **`createNewMusicFile`** looked the id up, found the row already at `_3`, and fell through to `updateMusicFile` — merging the new track straight over it.

That's the report exactly: success at slot 3, and the intro that lived there gone. The #734 fix stopped `size + 1` picking an occupied slot but still trusted `index`, so it never covered this.

Fixed at all three points, because any one alone leaves it reachable from another direction:

- **Allocation reads the ids** (`IntroSlots.nextFreeSlot`), since the id is what collides. Occupancy then can't exceed the row count, so this also can't tell someone with two intros they're full.
- **`createNewMusicFile` refuses a taken id** and logs it, rather than silently converting a create into an overwrite. Worst case becomes "couldn't save".
- **`reorderIntros` moves intros between fixed slots** instead of renumbering them, so id and slot can't drift apart again. Playback history travels with the track, not the slot.

Also stopped `persistMusicUrl` reassigning `id` on the replace path — with index and id out of step that rewrote the PK, so `merge` inserted a second row and orphaned the original.

**Your data:** this stops it recurring but can't bring back the overwritten audio — that row was merged over. Any rows whose `index` already drifted stay readable and heal on the next reorder or replace.

## 2. No length validation — `996fa10`

> it's also not validating the length of the video

Correct, and worse than just the context menu being inconsistent: `validateClipAgainstSource` is called by `SetIntroCommand` and `EditIntroModal` and **nothing else**. The context menu called neither, so any length of video went in and was reported as saved.

## 3. The clip form — `996fa10`

Yes, a context-menu interaction can open a modal: `MessageContextInteraction` → `ContextInteraction` → `CommandInteraction` → `IModalCallback`. The only blocker was `DefaultMessageContextManager` deferring unconditionally — a modal has to be an interaction's *first* response. So `MessageContextCommand` gains the `defersReply` opt-out slash commands already had; every other context command keeps deferring.

Right-click now opens a form for volume and clip bounds, and validates and saves from there — the same duration gate `/setintro` runs, which is what fixes #2. A long video is still fine once trimmed, which is the point of putting the clip fields there rather than making it a follow-up `/editintro`.

Pre-filled with the guild default volume and no clip, so submitting untouched does what the old one-click flow did, minus the missing validation. At the slot limit it still hands over to the replace menu, which now inherits the volume and clip just typed.

The source is carried in `IntroHelper.pendingIntros`, not the modal custom id — a Discord attachment URL is far longer than the 100 characters an id allows.

## Testing

`:common`, `:core-api`, `:database`, `:web`, `:discord-bot` green; Jest 797/797. New coverage for id-based allocation (including the exact `[_1, _3]`/`[2, 1]` shape from the report), the persistence refusal leaving the existing row untouched, reorder swapping contents and carrying history while keeping sparse layouts sparse, and the form — validation gate, clip pass-through, slot-limit hand-off, and that it doesn't defer.

`:application:test` needs Docker and can't run here; it fails identically on unmodified `main`. CI is the arbiter.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzSiANtbGDsaSbCRDkqQWc)_