### PR TITLE
Tidy up the intro save path: pending-intro cache, API timeouts, honest failure message

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/music/intro/SetIntroCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/music/intro/SetIntroCommand.kt
@@ -170,12 +170,16 @@ class SetIntroCommand @Autowired constructor(
     ): Boolean {
         val introList = requestingUserDto.musicDtos
         if (introList.size >= LIMIT) {
-            introHelper.pendingIntros[requestingUserDto.discordId] = PendingIntro(
-                attachment = attachmentOption?.asAttachment,
-                url = linkOption,
-                volume = introVolume,
-                startMs = clip.startMs,
-                endMs = clip.endMs,
+            introHelper.parkPendingIntro(
+                requestingUserDto.guildId,
+                requestingUserDto.discordId,
+                PendingIntro(
+                    attachment = attachmentOption?.asAttachment,
+                    url = linkOption,
+                    volume = introVolume,
+                    startMs = clip.startMs,
+                    endMs = clip.endMs,
+                ),
             )
             sendReplacePrompt(hook, member, introList)
             return true

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/music/intro/SetIntroFromMessageCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/music/intro/SetIntroFromMessageCommand.kt
@@ -56,10 +56,14 @@ class SetIntroFromMessageCommand @Autowired constructor(
 
         // Stashed for the modal to pick up: an attachment URL is far too long
         // for a modal custom id, and the id travels through the client anyway.
-        introHelper.pendingIntros[requestingUserDto.discordId] = PendingIntro(
-            attachment = (source as? Source.File)?.attachment,
-            url = (source as? Source.Link)?.url,
-            volume = volume,
+        introHelper.parkPendingIntro(
+            requestingUserDto.guildId,
+            requestingUserDto.discordId,
+            PendingIntro(
+                attachment = (source as? Source.File)?.attachment,
+                url = (source as? Source.Link)?.url,
+                volume = volume,
+            ),
         )
 
         event.replyModal(

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/HttpHelper.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/HttpHelper.kt
@@ -2,6 +2,7 @@ package bot.toby.helpers
 
 import io.ktor.client.*
 import io.ktor.client.call.*
+import io.ktor.client.plugins.timeout
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
@@ -16,6 +17,10 @@ class HttpHelper(
     private val client: HttpClient,
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val youtubeApiKey: String? = System.getenv("YOUTUBE_API_KEY"),
+    // Injectable so tests can exercise the timeout without spending the real
+    // budget on every run.
+    private val youtubeRequestTimeoutMs: Long = YOUTUBE_REQUEST_TIMEOUT_MS,
+    private val youtubeConnectTimeoutMs: Long = YOUTUBE_CONNECT_TIMEOUT_MS,
 ) {
 
     suspend fun fetchFromGet(url: String?): String = withContext(dispatcher) {
@@ -37,22 +42,47 @@ class HttpHelper(
         }
     }
 
+    /**
+     * How long the source is, for the intro length rule.
+     *
+     * Bounded, because a caller waits on it: setting an intro blocks on this
+     * lookup, and the shared client installs `HttpTimeout` without configuring
+     * one, leaving each call site to opt in. This one never did — so a
+     * googleapis request that *hung* rather than failed left the user's
+     * deferred reply unanswered until Discord gave up on the interaction, with
+     * nothing saved and nothing said. A timeout turns that into an ordinary
+     * "duration unknown", which the clip rules already know how to handle.
+     */
     suspend fun getYouTubeVideoDuration(youtubeUrl: String): Duration? = withContext(dispatcher) {
         val videoId = extractVideoIdFromUrl(youtubeUrl) ?: return@withContext null
         val apiUrl = "https://www.googleapis.com/youtube/v3/videos?id=$videoId&part=contentDetails&key=$youtubeApiKey"
-        val response: HttpResponse = client.get(apiUrl)
+        val response: HttpResponse = client.get(apiUrl) { youtubeTimeouts() }
         val videoResponse: YouTubeVideoResponse = response.body()
 
         val durationIso = videoResponse.items?.firstOrNull()?.contentDetails?.duration ?: return@withContext null
         return@withContext parseIso8601Duration(durationIso) // Return Duration
     }
 
+    /** The video's title, used to name an intro. Bounded for the same reason. */
     suspend fun getYouTubeVideoTitle(youtubeUrl: String): String? = withContext(dispatcher) {
         val videoId = extractVideoIdFromUrl(youtubeUrl) ?: return@withContext null
         val apiUrl = "https://www.googleapis.com/youtube/v3/videos?id=$videoId&part=snippet&key=$youtubeApiKey"
-        val response: HttpResponse = client.get(apiUrl)
+        val response: HttpResponse = client.get(apiUrl) { youtubeTimeouts() }
         val videoResponse: YouTubeVideoSnippetResponse = response.body()
         videoResponse.items?.firstOrNull()?.snippet?.title
+    }
+
+    /**
+     * Timeouts for the YouTube Data API calls that an interaction waits on.
+     *
+     * `requestTimeoutMillis` is the one that matters — it bounds the whole
+     * call, including a server that accepts the connection and then stops
+     * talking, which is exactly the hang a connect timeout alone would miss.
+     */
+    private fun HttpRequestBuilder.youtubeTimeouts() = timeout {
+        requestTimeoutMillis = youtubeRequestTimeoutMs
+        connectTimeoutMillis = youtubeConnectTimeoutMs
+        socketTimeoutMillis = youtubeRequestTimeoutMs
     }
 
     // Function to parse ISO 8601 duration and return a Kotlin `Duration`
@@ -99,4 +129,14 @@ class HttpHelper(
     @Serializable
     data class Snippet(val title: String?)
 
+    companion object {
+        /**
+         * Whole-call budget for a YouTube Data API lookup. Comfortably longer
+         * than a healthy response and comfortably shorter than Discord's
+         * 15-minute interaction window, so a slow API costs the user a clear
+         * "we couldn't check the length" rather than a dead form.
+         */
+        const val YOUTUBE_REQUEST_TIMEOUT_MS = 10_000L
+        const val YOUTUBE_CONNECT_TIMEOUT_MS = 5_000L
+    }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/IntroHelper.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/IntroHelper.kt
@@ -4,6 +4,8 @@ import bot.toby.intro.IntroMediaLoader
 import bot.toby.intro.IntroNotificationService
 import bot.toby.intro.IntroOwnership
 import bot.toby.intro.IntroValidationService
+import com.github.benmanes.caffeine.cache.Caffeine
+import com.github.benmanes.caffeine.cache.Ticker
 import common.intro.IntroClip
 import common.intro.IntroSlots
 import common.logging.DiscordLogger
@@ -30,6 +32,7 @@ import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback
 import org.jetbrains.annotations.VisibleForTesting
 import org.springframework.stereotype.Service
 import java.io.InputStream
+import java.util.concurrent.TimeUnit
 import java.net.URI
 
 @Service
@@ -46,18 +49,56 @@ class IntroHelper(
     private val mediaLoader: IntroMediaLoader = IntroMediaLoader(),
     private val notificationService: IntroNotificationService =
         IntroNotificationService(notificationPrefService),
+    // Injectable so the pending-intro expiry is testable without waiting a
+    // quarter of an hour. Production uses the system clock.
+    pendingTicker: Ticker = Ticker.systemTicker(),
 ) {
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
     private val supervisorJob = SupervisorJob()
     private val coroutineScope = CoroutineScope(supervisorJob + dispatcher)
 
-    // Per-user pending intro cache, written by /setintro and read by the
-    // confirmation menu. Distinct from the DM prompt flow, which lives in
-    // IntroNotificationService.
-    //
-    // Was a Triple; became a named type once clip bounds joined the payload,
-    // since `pending.startMs` beats `pending.fourth` for readability.
-    val pendingIntros = mutableMapOf<Long, PendingIntro?>()
+    /**
+     * Intros accepted from a user but not yet saved, because something still
+     * has to come back from them — which slot to replace, or the volume and
+     * clip form the message context menu opens.
+     *
+     * This was a bare `mutableMapOf`, which was wrong twice over. It's written
+     * from JDA's dispatch threads and from the coroutine the modal listener
+     * launches, and a `LinkedHashMap` under concurrent writes can corrupt into
+     * a lookup that never returns. And only the replace menu's success path
+     * ever removed an entry, so every abandoned flow leaked one — each pinning
+     * a [Message.Attachment] — with nothing to ever clear it. Closing a modal
+     * without submitting is an entirely ordinary thing to do, so the context
+     * menu made that leak easy to hit.
+     *
+     * Caffeine gives both: thread safety, and entries that expire on their own.
+     * The rest of this package already stores short-lived state this way
+     * ([bot.toby.intro.IntroUndoStore], [bot.toby.intro.IntroPlaybackTracker]).
+     *
+     * Keyed by guild *and* user, so a form opened in one server can't be
+     * answered with a pick made in another.
+     */
+    private val pendingIntros = Caffeine.newBuilder()
+        .expireAfterWrite(PENDING_INTRO_TTL_MINUTES, TimeUnit.MINUTES)
+        .maximumSize(1_000)
+        .ticker(pendingTicker)
+        .build<String, PendingIntro>()
+
+    private fun pendingKey(guildId: Long, discordId: Long) = "$guildId:$discordId"
+
+    /** Hold [pending] until the user tells us where it goes. */
+    fun parkPendingIntro(guildId: Long, discordId: Long, pending: PendingIntro) {
+        pendingIntros.put(pendingKey(guildId, discordId), pending)
+    }
+
+    /** The intro this user is part-way through setting, if it hasn't expired. */
+    fun pendingIntro(guildId: Long, discordId: Long): PendingIntro? =
+        pendingIntros.getIfPresent(pendingKey(guildId, discordId))
+
+    /** Drop a pending intro once it has been saved, or abandoned deliberately. */
+    fun clearPendingIntro(guildId: Long, discordId: Long) {
+        pendingIntros.invalidate(pendingKey(guildId, discordId))
+    }
 
     fun calculateIntroVolume(event: SlashCommandInteractionEvent): Int =
         resolveIntroVolume(event.guild?.id, event.getOption(VOLUME)?.asInt)
@@ -246,7 +287,7 @@ class IntroHelper(
         if (selectedMusicDto == null) {
             musicFileService.createNewMusicFile(musicDto)
                 ?.let { sendSuccessMessage(event, userName, filename, introVolume, index, deleteDelay, startMs, endMs) }
-                ?: rejectIntroForDuplication(event, userName, filename, deleteDelay, musicDto)
+                ?: rejectIntroSave(event, userName, filename, deleteDelay, musicDto)
         } else {
             musicFileService.updateMusicFile(musicDto)
                 ?.let {
@@ -254,7 +295,7 @@ class IntroHelper(
                         event, userName, filename, introVolume, musicDto.index!!, deleteDelay, startMs, endMs
                     )
                 }
-                ?: rejectIntroForDuplication(event, userName, filename, deleteDelay)
+                ?: rejectIntroSave(event, userName, filename, deleteDelay)
         }
     }
 
@@ -294,7 +335,7 @@ class IntroHelper(
             logger.info { "Creating new music file $musicDto" }
             musicFileService.createNewMusicFile(musicDto)
                 ?.let { sendSuccessMessage(event, memberName, filename, introVolume, index, deleteDelay, startMs, endMs) }
-                ?: rejectIntroForDuplication(event, memberName, filename, deleteDelay, musicDto)
+                ?: rejectIntroSave(event, memberName, filename, deleteDelay, musicDto)
         } else {
             logger.info { "Updating music file $musicDto" }
             musicFileService.updateMusicFile(musicDto)
@@ -303,7 +344,7 @@ class IntroHelper(
                         event, memberName, filename, introVolume, musicDto.index!!, deleteDelay, startMs, endMs
                     )
                 }
-                ?: rejectIntroForDuplication(event, memberName, filename, deleteDelay)
+                ?: rejectIntroSave(event, memberName, filename, deleteDelay)
         }
     }
 
@@ -380,7 +421,17 @@ class IntroHelper(
         )
     }
 
-    private fun rejectIntroForDuplication(
+    /**
+     * Explain a save that didn't happen.
+     *
+     * `createNewMusicFile` returns null for two different reasons, and this
+     * used to report both as a duplicate. Since the persistence layer started
+     * refusing an already-occupied slot rather than merging over it, "rejected
+     * as it already exists as one of their intros" could be shown to someone
+     * whose audio was nowhere in their list — leaving them to work out what
+     * happened from a message that wasn't true.
+     */
+    private fun rejectIntroSave(
         event: IReplyCallback,
         memberName: String,
         filename: String,
@@ -388,11 +439,28 @@ class IntroHelper(
         attempted: MusicDto? = null
     ) {
         logger.setGuildAndMemberContext(event.guild, event.member)
+        val duplicate = attempted?.let { musicFileService.isFileAlreadyUploaded(it) }
+        if (duplicate == null) {
+            // Not already uploaded, so the row was refused for the only other
+            // reason the persistence layer refuses one: something is already
+            // in that slot. The allocator is supposed to make this
+            // unreachable, so it's worth a loud log as well as an honest
+            // message.
+            logger.error(
+                "Could not save $memberName's intro '$filename': the target slot " +
+                    "(${attempted?.id ?: "unknown"}) was already taken."
+            )
+            event.hook.replyEphemeralAndDelete(
+                "Couldn't save '$filename' — the slot it was going into is already in use. " +
+                    "Check `/listintros`, then use `/setintro` to pick which intro to replace.",
+                deleteDelay,
+            )
+            return
+        }
         logger.info { "$memberName's intro song '$filename' was rejected for duplication" }
         // Naming the slot turns "that's already there" into something the user
         // can act on — it's the slot they'd pass to /setintro to replace.
-        val existingSlot = attempted?.let { musicFileService.isFileAlreadyUploaded(it)?.index }
-        val where = existingSlot?.let { " in slot #$it" }.orEmpty()
+        val where = duplicate.index?.let { " in slot #$it" }.orEmpty()
         event.hook.replyEphemeralAndDelete(
             "$memberName's intro song '$filename' was rejected as it already exists$where " +
                 "as one of their intros for this server",
@@ -422,6 +490,16 @@ class IntroHelper(
     companion object {
         private const val VOLUME = "volume"
 
+        /**
+         * How long a half-finished intro is held for.
+         *
+         * Matches Discord's 15-minute interaction lifetime: past that the
+         * replace menu or clip form can't be answered anyway, so holding the
+         * payload longer only keeps an attachment reference alive. Both
+         * readers already explain themselves when there's nothing waiting.
+         */
+        const val PENDING_INTRO_TTL_MINUTES = 15L
+
         // Backwards-compat aliases — canonical values live on
         // [IntroValidationService.Companion]. Existing callers (SetIntroCommand,
         // tests) still see the same constants here.
@@ -439,7 +517,7 @@ sealed class InputData {
 /**
  * An intro `/setintro` has accepted but can't save yet, because the user is at
  * their slot limit and still has to choose which existing intro to replace.
- * Held in [IntroHelper.pendingIntros] until [bot.toby.menu.menus.SetIntroMenu]
+ * Held by [IntroHelper.parkPendingIntro] until [bot.toby.menu.menus.SetIntroMenu]
  * resolves the choice.
  */
 data class PendingIntro(

--- a/discord-bot/src/main/kotlin/bot/toby/menu/menus/SetIntroMenu.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/menu/menus/SetIntroMenu.kt
@@ -40,7 +40,7 @@ class SetIntroMenu @Autowired constructor(
                 .queue()
             return
         }
-        val pendingIntro = introHelper.pendingIntros[requestingUserDto.discordId]
+        val pendingIntro = introHelper.pendingIntro(requestingUserDto.guildId, requestingUserDto.discordId)
         if (pendingIntro != null) {
             runCatching {
                 val pendingDtoAttachment = pendingIntro.attachment
@@ -62,7 +62,7 @@ class SetIntroMenu @Autowired constructor(
                 )
             }.onSuccess {
                 logger.info { "Successfully set pending intro, removing from the cache for user '${requestingUserDto.discordId}'" }
-                introHelper.pendingIntros.remove(requestingUserDto.discordId)
+                introHelper.clearPendingIntro(requestingUserDto.guildId, requestingUserDto.discordId)
             }.onFailure {
                 logger.error { "Error handling intro replacement" }
                 event.hook

--- a/discord-bot/src/main/kotlin/bot/toby/modal/modals/SetIntroFromMessageModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/modal/modals/SetIntroFromMessageModal.kt
@@ -25,7 +25,7 @@ import org.springframework.stereotype.Component
  * The form is pre-filled with the guild's default volume and no clip, so
  * submitting it untouched does exactly what the old one-click flow did, minus
  * the missing validation. The source itself is carried in
- * [IntroHelper.pendingIntros] rather than the modal id — a Discord attachment
+ * [IntroHelper.parkPendingIntro] rather than the modal id — a Discord attachment
  * URL is far longer than the 100 characters a custom id allows.
  */
 @Component
@@ -39,7 +39,7 @@ class SetIntroFromMessageModal(
         val event = ctx.event
         logger.setGuildAndMemberContext(ctx.guild, ctx.member)
 
-        val pending = introHelper.pendingIntros[event.user.idLong] ?: return reply(
+        val pending = introHelper.pendingIntro(ctx.guild.idLong, event.user.idLong) ?: return reply(
             ctx,
             "That form lost track of which track it was for — right-click the message and try again.",
         )
@@ -74,16 +74,21 @@ class SetIntroFromMessageModal(
     private fun save(ctx: ModalContext, deleteDelay: Int, pending: bot.toby.helpers.PendingIntro) {
         val event = ctx.event
         val requestingUserDto: UserDto = introHelper.findUserById(event.user.idLong, ctx.guild.idLong)
-        introHelper.pendingIntros[event.user.idLong] = pending
 
-        // At the slot limit the user still has to choose what to replace. The
-        // pending intro now carries their volume and clip, so the menu picks up
+        // At the slot limit the user still has to choose what to replace, so
+        // re-park with the volume and clip they just typed — the menu picks up
         // where this left off.
         val intros = requestingUserDto.musicDtos
         if (intros.size >= IntroSlots.MAX_INTRO_COUNT) {
+            introHelper.parkPendingIntro(ctx.guild.idLong, event.user.idLong, pending)
             sendReplacePrompt(event.hook, ctx.member, intros)
             return
         }
+
+        // Saving now, so there is nothing left to hold: releasing it here means
+        // the entry goes when the flow ends rather than lingering until it
+        // expires, holding an attachment reference for no reason.
+        introHelper.clearPendingIntro(ctx.guild.idLong, event.user.idLong)
 
         val userName = ctx.member?.effectiveName ?: event.user.effectiveName
         pending.attachment?.let {

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/fetch/TestHttpHelperHelper.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/fetch/TestHttpHelperHelper.kt
@@ -3,6 +3,7 @@ package bot.toby.command.commands.fetch
 import bot.toby.helpers.HttpHelper
 import io.ktor.client.*
 import io.ktor.client.engine.mock.*
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
@@ -112,6 +113,10 @@ object TestHttpHelperHelper {
             }
         }
         val client = HttpClient(mockEngine) {
+            // Mirrors AppConfig: the real client installs HttpTimeout so
+            // individual calls can opt into a timeout. Leaving it out here
+            // makes any such call throw before it reaches the engine.
+            install(HttpTimeout)
             install(ContentNegotiation) {
                 json(Json { ignoreUnknownKeys = true })
             }

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/music/intro/SetIntroFromMessageCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/music/intro/SetIntroFromMessageCommandTest.kt
@@ -38,7 +38,7 @@ class SetIntroFromMessageCommandTest {
     private lateinit var hook: InteractionHook
     private lateinit var target: Message
     private val replies = mutableListOf<String>()
-    private val pending = mutableMapOf<Long, PendingIntro?>()
+    private val pending = mutableMapOf<Pair<Long, Long>, PendingIntro>()
 
     private val userDto = UserDto(discordId = 1L, guildId = 7L)
 
@@ -69,7 +69,14 @@ class SetIntroFromMessageCommandTest {
         every { send.setEphemeral(true) } returns send
 
         every { introHelper.defaultIntroVolume(any()) } returns 80
-        every { introHelper.pendingIntros } returns pending
+        // Back the helper's pending-intro API with a local map so the tests
+        // can assert on what was parked without reaching into its cache.
+        every { introHelper.parkPendingIntro(any(), any(), any()) } answers {
+            pending[firstArg<Long>() to secondArg<Long>()] = thirdArg()
+        }
+        every { introHelper.pendingIntro(any(), any()) } answers {
+            pending[firstArg<Long>() to secondArg<Long>()]
+        }
     }
 
     @AfterEach
@@ -102,9 +109,9 @@ class SetIntroFromMessageCommandTest {
         // the duration check that lives with them.
         verify(exactly = 0) { introHelper.handleAttachment(any(), any(), any(), any(), any(), any()) }
         verify { event.replyModal(any()) }
-        assertEquals(file, pending[1L]?.attachment)
-        assertNull(pending[1L]?.url)
-        assertEquals(80, pending[1L]?.volume)
+        assertEquals(file, pending[7L to 1L]?.attachment)
+        assertNull(pending[7L to 1L]?.url)
+        assertEquals(80, pending[7L to 1L]?.volume)
     }
 
     @Test
@@ -114,8 +121,8 @@ class SetIntroFromMessageCommandTest {
         command.handle(event, userDto, 5)
 
         verify { event.replyModal(any()) }
-        assertEquals("https://www.youtube.com/watch?v=abc", pending[1L]?.url)
-        assertNull(pending[1L]?.attachment)
+        assertEquals("https://www.youtube.com/watch?v=abc", pending[7L to 1L]?.url)
+        assertNull(pending[7L to 1L]?.attachment)
     }
 
     @Test
@@ -125,8 +132,8 @@ class SetIntroFromMessageCommandTest {
 
         command.handle(event, userDto, 5)
 
-        assertEquals(file, pending[1L]?.attachment)
-        assertNull(pending[1L]?.url)
+        assertEquals(file, pending[7L to 1L]?.attachment)
+        assertNull(pending[7L to 1L]?.url)
     }
 
     @Test
@@ -135,8 +142,8 @@ class SetIntroFromMessageCommandTest {
 
         command.handle(event, userDto, 5)
 
-        assertEquals("https://youtu.be/abc", pending[1L]?.url)
-        assertNull(pending[1L]?.attachment)
+        assertEquals("https://youtu.be/abc", pending[7L to 1L]?.url)
+        assertNull(pending[7L to 1L]?.attachment)
     }
 
     @Test
@@ -149,7 +156,7 @@ class SetIntroFromMessageCommandTest {
         // that mockk can't intercept on these mocks, so the assertion is on the
         // observable contract: no form, and nothing parked to save later.
         verify(exactly = 0) { event.replyModal(any()) }
-        assertNull(pending[1L])
+        assertNull(pending[7L to 1L])
     }
 
     @Test

--- a/discord-bot/src/test/kotlin/bot/toby/helpers/HttpHelperTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/helpers/HttpHelperTest.kt
@@ -20,9 +20,20 @@ import bot.toby.command.commands.fetch.TestHttpHelperHelper.YOUTUBE_SNIPPET_NULL
 import bot.toby.command.commands.fetch.TestHttpHelperHelper.YOUTUBE_VIDEO_URL
 import bot.toby.command.commands.fetch.TestHttpHelperHelper.createMockHttpClient
 import bot.toby.command.commands.fetch.TestHttpHelperHelper.createYouTubeMockHttpClient
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.HttpRequestTimeoutException
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
@@ -227,5 +238,56 @@ internal class HttpHelperTest {
         val httpClient = createYouTubeMockHttpClient()
         val result = httpClient.getYouTubeVideoTitle("https://www.youtube.com/shorts/dQw4w9WgXcQ")
         assertEquals("Never Gonna Give You Up", result)
+    }
+
+    // --- timeouts -----------------------------------------------------------
+    //
+    // Setting an intro blocks on these lookups. The shared client installs
+    // HttpTimeout without configuring one, leaving each call site to opt in,
+    // and these never did — so a googleapis request that *hung* rather than
+    // failed left the user's deferred reply unanswered until Discord gave up,
+    // with nothing saved and nothing said.
+
+    /** A client whose engine never answers, standing in for a hung API. */
+    private fun hangingClient(): HttpHelper {
+        val engine = MockEngine {
+            delay(Long.MAX_VALUE)
+            respond("")
+        }
+        return HttpHelper(
+            HttpClient(engine) {
+                install(HttpTimeout)
+                install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+            },
+            youtubeApiKey = "test-key",
+            // Real budget is seconds; the behaviour under test is "it gives up
+            // at all", so don't spend them on every CI run.
+            youtubeRequestTimeoutMs = 100L,
+            youtubeConnectTimeoutMs = 100L,
+        )
+    }
+
+    @Test
+    fun `a hanging duration lookup gives up instead of waiting forever`() = runBlocking {
+        assertThrows(HttpRequestTimeoutException::class.java) {
+            runBlocking { hangingClient().getYouTubeVideoDuration(YOUTUBE_VIDEO_URL) }
+        }
+        Unit
+    }
+
+    @Test
+    fun `a hanging title lookup gives up instead of waiting forever`() = runBlocking {
+        assertThrows(HttpRequestTimeoutException::class.java) {
+            runBlocking { hangingClient().getYouTubeVideoTitle(YOUTUBE_VIDEO_URL) }
+        }
+        Unit
+    }
+
+    @Test
+    fun `the budget leaves room for a healthy response and stays well inside Discord's window`() {
+        // Long enough not to trip on a slow-but-working API; short enough that
+        // the user gets an answer rather than a dead interaction.
+        assertTrue(HttpHelper.YOUTUBE_REQUEST_TIMEOUT_MS in 2_000..30_000)
+        assertTrue(HttpHelper.YOUTUBE_CONNECT_TIMEOUT_MS <= HttpHelper.YOUTUBE_REQUEST_TIMEOUT_MS)
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/helpers/IntroHelperTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/helpers/IntroHelperTest.kt
@@ -20,10 +20,12 @@ import net.dv8tion.jda.api.interactions.commands.OptionMapping
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.util.concurrent.TimeUnit
 import org.junit.jupiter.api.extension.ExtendWith
 import java.io.InputStream
 import java.net.URI
@@ -276,6 +278,67 @@ class IntroHelperTest {
         verify {
             musicFileService.updateMusicFile(musicDto)
         }
+    }
+
+    // --- explaining a save that didn't happen -------------------------------
+    //
+    // createNewMusicFile returns null for two different reasons, and both used
+    // to be reported as a duplicate. Since the persistence layer started
+    // refusing an already-occupied slot rather than merging over it, someone
+    // whose audio was nowhere in their list could be told it "already exists
+    // as one of their intros".
+
+    private fun captureRejection(): MutableList<String> {
+        val messages = mutableListOf<String>()
+        every { hook.sendMessage(capture(messages)) } returns mockk(relaxed = true)
+        return messages
+    }
+
+    @Test
+    fun `audio the user already uploaded is reported as a duplicate, with its slot`() {
+        val inputStream = mockk<InputStream>()
+        every { FileUtils.readInputStreamToByteArray(inputStream) } returns ByteArray(10)
+        every { musicFileService.createNewMusicFile(any()) } returns null
+        every { musicFileService.isFileAlreadyUploaded(any()) } returns
+            MusicDto(database.dto.user.UserDto(1234L, 1L), 2, "already-here", 90, ByteArray(10))
+        val messages = captureRejection()
+
+        introHelper.persistMusicFile(event, userDto, "TestUser", 10, "filename.mp3", 70, inputStream, null)
+
+        val message = messages.single()
+        assertTrue(message.contains("already exists"), message)
+        assertTrue(message.contains("slot #2"), message)
+    }
+
+    @Test
+    fun `a refused slot is not reported as a duplicate that does not exist`() {
+        val inputStream = mockk<InputStream>()
+        every { FileUtils.readInputStreamToByteArray(inputStream) } returns ByteArray(10)
+        every { musicFileService.createNewMusicFile(any()) } returns null
+        // Nothing matching was ever uploaded — the save was refused because
+        // the target slot was occupied.
+        every { musicFileService.isFileAlreadyUploaded(any()) } returns null
+        val messages = captureRejection()
+
+        introHelper.persistMusicFile(event, userDto, "TestUser", 10, "filename.mp3", 70, inputStream, null)
+
+        val message = messages.single()
+        assertFalse(message.contains("already exists"), "must not claim a duplicate that isn't there: $message")
+        assertTrue(message.contains("slot it was going into is already in use"), message)
+        assertTrue(message.contains("/setintro"), "tell them how to fix it: $message")
+    }
+
+    @Test
+    fun `the same distinction applies when the source was a link`() {
+        every { musicFileService.createNewMusicFile(any()) } returns null
+        every { musicFileService.isFileAlreadyUploaded(any()) } returns null
+        val messages = captureRejection()
+
+        introHelper.persistMusicUrl(
+            event, userDto, 10, "a title", "https://youtu.be/abc", "TestUser", 70, null,
+        )
+
+        assertTrue(messages.single().contains("already in use"), messages.single())
     }
 
     // --- slot allocation ---------------------------------------------------
@@ -573,5 +636,134 @@ class IntroHelperTest {
 
     // saveUserMusicDto — displayName sets fileName
 
+    // --- pending intros -----------------------------------------------------
+    //
+    // Half-finished intros used to live in a bare mutableMapOf: written from
+    // JDA's dispatch threads and from the modal listener's coroutine, and only
+    // ever removed by the replace menu's success path, so every abandoned flow
+    // leaked an entry holding a Message.Attachment.
 
+    @Test
+    fun `a parked intro comes back to the same user in the same guild`() {
+        val pending = PendingIntro(attachment = null, url = "https://youtu.be/a", volume = 60)
+
+        introHelper.parkPendingIntro(7L, 1L, pending)
+
+        assertEquals(pending, introHelper.pendingIntro(7L, 1L))
+    }
+
+    @Test
+    fun `nothing is waiting for a user who has not started one`() {
+        assertNull(introHelper.pendingIntro(7L, 1L))
+    }
+
+    @Test
+    fun `a form opened in one server cannot be answered in another`() {
+        // Keyed on guild as well as user: the payload decides what gets saved,
+        // so picking it up in the wrong server would write the wrong intro.
+        introHelper.parkPendingIntro(7L, 1L, PendingIntro(null, "https://youtu.be/a", 60))
+
+        assertNull(introHelper.pendingIntro(8L, 1L))
+    }
+
+    @Test
+    fun `two users in the same guild do not share a pending intro`() {
+        introHelper.parkPendingIntro(7L, 1L, PendingIntro(null, "https://youtu.be/mine", 60))
+        introHelper.parkPendingIntro(7L, 2L, PendingIntro(null, "https://youtu.be/theirs", 60))
+
+        assertEquals("https://youtu.be/mine", introHelper.pendingIntro(7L, 1L)?.url)
+        assertEquals("https://youtu.be/theirs", introHelper.pendingIntro(7L, 2L)?.url)
+    }
+
+    @Test
+    fun `starting a second intro replaces the first rather than stacking`() {
+        introHelper.parkPendingIntro(7L, 1L, PendingIntro(null, "https://youtu.be/first", 60))
+        introHelper.parkPendingIntro(7L, 1L, PendingIntro(null, "https://youtu.be/second", 60))
+
+        assertEquals("https://youtu.be/second", introHelper.pendingIntro(7L, 1L)?.url)
+    }
+
+    @Test
+    fun `clearing releases the payload so an attachment is not held on to`() {
+        introHelper.parkPendingIntro(7L, 1L, PendingIntro(mockk(relaxed = true), null, 60))
+
+        introHelper.clearPendingIntro(7L, 1L)
+
+        assertNull(introHelper.pendingIntro(7L, 1L))
+    }
+
+    @Test
+    fun `clearing one user's pending intro leaves everyone else's alone`() {
+        introHelper.parkPendingIntro(7L, 1L, PendingIntro(null, "https://youtu.be/a", 60))
+        introHelper.parkPendingIntro(7L, 2L, PendingIntro(null, "https://youtu.be/b", 60))
+
+        introHelper.clearPendingIntro(7L, 1L)
+
+        assertNull(introHelper.pendingIntro(7L, 1L))
+        assertNotNull(introHelper.pendingIntro(7L, 2L))
+    }
+
+    @Test
+    fun `clearing something that was never parked is not an error`() {
+        introHelper.clearPendingIntro(7L, 1L)
+    }
+
+    @Test
+    fun `concurrent parks from different threads neither lose entries nor corrupt the store`() {
+        // The old LinkedHashMap could be left in a state where a lookup never
+        // returns; JDA dispatches interactions on a pool and the modal
+        // listener adds a coroutine on top. Kept comfortably under the cache's
+        // 1,000-entry bound so eviction can't be mistaken for a lost write.
+        val threads = 8
+        val perThread = 100
+        val barrier = java.util.concurrent.CyclicBarrier(threads)
+        val pool = java.util.concurrent.Executors.newFixedThreadPool(threads)
+        try {
+            (0 until threads).map { t ->
+                pool.submit {
+                    barrier.await()
+                    repeat(perThread) { i ->
+                        val user = (t * perThread + i).toLong()
+                        introHelper.parkPendingIntro(7L, user, PendingIntro(null, "https://youtu.be/$user", 50))
+                    }
+                }
+            }.forEach { it.get(30, java.util.concurrent.TimeUnit.SECONDS) }
+        } finally {
+            pool.shutdownNow()
+        }
+
+        val readBack = (0 until threads * perThread).map { introHelper.pendingIntro(7L, it.toLong())?.url }
+        assertEquals(
+            (0 until threads * perThread).map { "https://youtu.be/$it" },
+            readBack,
+            "every concurrent write should be readable afterwards",
+        )
+    }
+
+    @Test
+    fun `an abandoned intro is released on its own rather than held forever`() {
+        // The leak this replaced: only the replace menu's success path ever
+        // removed an entry, so closing a form without submitting left a
+        // PendingIntro — and its Message.Attachment — alive for the life of
+        // the process.
+        val clock = java.util.concurrent.atomic.AtomicLong(0)
+        val helper = IntroHelper(
+            userDtoHelper, musicFileService, configService, httpHelper,
+            pendingTicker = com.github.benmanes.caffeine.cache.Ticker { clock.get() },
+        )
+        helper.parkPendingIntro(7L, 1L, PendingIntro(mockk(relaxed = true), null, 60))
+
+        clock.addAndGet(TimeUnit.MINUTES.toNanos(IntroHelper.PENDING_INTRO_TTL_MINUTES - 1))
+        assertNotNull(helper.pendingIntro(7L, 1L), "should still be waiting inside the window")
+
+        clock.addAndGet(TimeUnit.MINUTES.toNanos(2))
+        assertNull(helper.pendingIntro(7L, 1L), "should have been released once the window passed")
+    }
+
+    @Test
+    fun `the hold is bounded by Discord's interaction lifetime`() {
+        // Past 15 minutes the menu or form can't be answered anyway, so
+        // holding the payload longer only pins an attachment.
+        assertEquals(15L, IntroHelper.PENDING_INTRO_TTL_MINUTES)
+    }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/menu/menus/SetIntroMenuTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/menu/menus/SetIntroMenuTest.kt
@@ -77,7 +77,7 @@ internal class SetIntroMenuTest : MenuTest {
 
         every { userDtoHelper.calculateUserDto(1234L, 1L, true) } returns userDto
         val musicDtoToReplace = userDto.musicDtos.first { it.id == "2" } // Match the selectedMusicDtoId
-        every { introHelper.pendingIntros[1234L] } returns PendingIntro(mockk(), "url", 50)
+        every { introHelper.pendingIntro(userDto.guildId, 1234L) } returns PendingIntro(mockk(), "url", 50)
 
         // Act
         setIntroMenu.handle(menuContext, 10)
@@ -149,7 +149,7 @@ internal class SetIntroMenuTest : MenuTest {
         })
 
         every { userDtoHelper.calculateUserDto(1234L, 1L, true) } returns userDto
-        every { introHelper.pendingIntros[1234L] } returns null
+        every { introHelper.pendingIntro(any(), any()) } returns null
 
         // Act
         setIntroMenu.handle(menuContext, 10)

--- a/discord-bot/src/test/kotlin/bot/toby/modal/modals/SetIntroFromMessageModalTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/modal/modals/SetIntroFromMessageModalTest.kt
@@ -46,7 +46,7 @@ class SetIntroFromMessageModalTest {
     private lateinit var ctx: ModalContext
     private lateinit var hook: InteractionHook
     private val replies = mutableListOf<String>()
-    private val pending = mutableMapOf<Long, PendingIntro?>()
+    private val pending = mutableMapOf<Pair<Long, Long>, PendingIntro>()
     private lateinit var userDto: UserDto
 
     @BeforeEach
@@ -80,7 +80,15 @@ class SetIntroFromMessageModalTest {
         every { hook.sendMessage(capture(replies)) } returns send
         every { send.setEphemeral(true) } returns send
 
-        every { introHelper.pendingIntros } returns pending
+        every { introHelper.parkPendingIntro(any(), any(), any()) } answers {
+            pending[firstArg<Long>() to secondArg<Long>()] = thirdArg()
+        }
+        every { introHelper.pendingIntro(any(), any()) } answers {
+            pending[firstArg<Long>() to secondArg<Long>()]
+        }
+        every { introHelper.clearPendingIntro(any(), any()) } answers {
+            pending.remove(firstArg<Long>() to secondArg<Long>())
+        }
         every { introHelper.findUserById(discordId, guildId) } returns userDto
         // Pass the clip gate unless a test says otherwise.
         every { introHelper.validateClipAgainstSource(any(), any(), any(), any()) } answers {
@@ -102,12 +110,12 @@ class SetIntroFromMessageModalTest {
     }
 
     private fun parkUrl(url: String = "https://www.youtube.com/watch?v=abc", volume: Int = 80) {
-        pending[discordId] = PendingIntro(attachment = null, url = url, volume = volume)
+        pending[guildId to discordId] = PendingIntro(attachment = null, url = url, volume = volume)
     }
 
     private fun parkFile(volume: Int = 80): Message.Attachment {
         val attachment = mockk<Message.Attachment>(relaxed = true)
-        pending[discordId] = PendingIntro(attachment = attachment, url = null, volume = volume)
+        pending[guildId to discordId] = PendingIntro(attachment = attachment, url = null, volume = volume)
         return attachment
     }
 
@@ -233,9 +241,9 @@ class SetIntroFromMessageModalTest {
         // Nothing saved yet — but the choice carries the clip forward, so the
         // replace menu finishes what the form started.
         verify(exactly = 0) { introHelper.handleUrl(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
-        assertEquals(33, pending[discordId]?.volume)
-        assertEquals(2_000, pending[discordId]?.startMs)
-        assertEquals(9_000, pending[discordId]?.endMs)
+        assertEquals(33, pending[guildId to discordId]?.volume)
+        assertEquals(2_000, pending[guildId to discordId]?.startMs)
+        assertEquals(9_000, pending[guildId to discordId]?.endMs)
     }
 
     // --- form shape ---------------------------------------------------------


### PR DESCRIPTION
The three things from the last review, one commit each.

## 1. Half-finished intros piled up in a shared `HashMap` — `1b2d1f1`

An intro that had been accepted but not yet saved — waiting on which slot to replace, or on the new clip form — was parked in a public `mutableMapOf` on `IntroHelper`. Wrong three ways:

- **Never cleaned up.** The only removal was the replace menu's *success* path, so every abandoned flow left an entry holding a `Message.Attachment`, with nothing anywhere that would drop it. The context menu made this trivial to hit: closing a modal without submitting is now the normal way to change your mind.
- **Not thread-safe.** Writes come from JDA's dispatch threads *and* the coroutine the modal listener launches. A concurrently-mutated `LinkedHashMap` can be left where a lookup never returns — a spinning core, not a clean failure.
- **Keyed on user alone**, so a form opened in one server could in principle be answered with a pick made in another.

Now a Caffeine cache keyed on `(guild, user)` — how the rest of the package already holds short-lived state (`IntroUndoStore`, `IntroPlaybackTracker`, `IntroNotificationService`). 15-minute expiry, matching Discord's interaction lifetime: past that neither the menu nor the form can be answered anyway, and both readers already explain themselves when nothing's waiting.

The map is no longer public — `parkPendingIntro` / `pendingIntro` / `clearPendingIntro` — and the modal releases its entry on save rather than leaving it to expire. The ticker is injectable so expiry is genuinely covered rather than asserted by reading the constant back.

## 2. The lookups an intro save waits on had no timeout — `267d65e`

`AppConfig` installs `HttpTimeout` but sets no global timeout, leaving each call site to opt in. Both YouTube Data API calls never did — and both are on the path a user waits on (duration for the length rule, title to name the intro).

An API that **hung** rather than failed had nothing to stop it. `runCatching` doesn't catch a hang, so the callback never fired, the deferred ephemeral was never answered, and the user got an interaction that eventually failed with nothing saved and no explanation. The exposure grew when the context menu started routing through the same duration gate.

Both now carry request, connect and socket timeouts. A timeout surfaces as the "duration unknown" the clip rules already handle — the same trade `sourceDurationMs` already makes deliberately for a failed lookup, and far better than a dead form.

The budget is injectable so the tests prove the give-up behaviour without spending 10 real seconds twice per CI run (they'd have cost 20s; they cost 0.24s).

`TestHttpHelperHelper`'s mock client gains `install(HttpTimeout)` to match how the real one is built.

## 3. "Already exists" was shown for saves that weren't duplicates — `48c8425`

`createNewMusicFile` returns null for two reasons and the caller reported both as *"rejected as it already exists as one of their intros"*. True when the only null was a duplicate hash; since the persistence layer started refusing an occupied slot instead of merging over it, that message could be shown to someone whose audio appears nowhere in their list.

The two are now told apart by asking the question the message depends on — is this audio already uploaded? If yes, the existing message stands, still naming the slot. If no, it says the slot is in use and points at `/listintros` and `/setintro`. The slot case also logs at **error**, since the allocator is supposed to make it unreachable.

## Testing

`:common`, `:core-api`, `:database`, `:web`, `:discord-bot` green.

New coverage: pending intros round-trip, don't cross guilds or users, replace rather than stack, clear on demand, survive 800 concurrent writes from 8 threads with every write readable afterwards, and **expire once the interaction window passes** (via the injected ticker). Both hanging lookups give up. Both branches of the failure message, for the file and link paths, including that the slot case never claims a duplicate that isn't there.

`:application:test` needs Docker and can't run here; it fails identically on unmodified `main`.

Kover, like-for-like clean reruns with `:application:test` excluded: instructions 79.688% → **79.861%**, lines 81.936% → **82.090%**, branches passing.

## One judgement call

I sized the concurrency test at 800 writes rather than 1,600 — the cache is bounded at 1,000, and my first attempt failed because Caffeine had (correctly) evicted the key I was spot-checking. I also dropped an assertion on the size bound itself: Caffeine evicts asynchronously, so it held 1,328 immediately after 1,500 writes, and asserting otherwise tests the library's maintenance timing rather than our code.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzSiANtbGDsaSbCRDkqQWc)_