### PR TITLE
Stop a blocked source being reported as everyone's broken link

### DIFF
--- a/common/src/main/kotlin/common/media/SourceOutage.kt
+++ b/common/src/main/kotlin/common/media/SourceOutage.kt
@@ -1,0 +1,122 @@
+package common.media
+
+/**
+ * Telling "this track is bad" apart from "the host is refusing us".
+ *
+ * Every failure path in the bot treats a load failure as a fact about the
+ * *track*: `/play` reports "Nothing found for the link", and a failed intro
+ * has its failure count bumped until its owner is told it's broken and that
+ * replacing the link will fix it. All of that is true when a video has been
+ * deleted, and all of it is a lie when YouTube has rate-limited or IP-blocked
+ * the bot — which is exactly when it fires for *everybody at once*.
+ *
+ * A single failure can't be classified with any confidence: a blocked lookup
+ * often comes back as "no matches", indistinguishable from a dead link. What
+ * gives it away is correlation. Several *different* sources failing inside a
+ * couple of minutes is not several dead links.
+ */
+object SourceOutage {
+
+    /**
+     * Distinct sources that must fail inside [WINDOW_MS] before the host, not
+     * the tracks, is treated as the problem.
+     *
+     * Three rather than two: two unrelated dead links in the same couple of
+     * minutes is a thing that happens on a busy server, and the cost of a
+     * false positive is a real broken intro going unreported for a while.
+     */
+    const val OUTAGE_AFTER_DISTINCT_FAILURES = 3
+
+    /** How long failures stay relevant to each other. */
+    const val WINDOW_MS = 120_000L
+
+    /** How long an outage stays declared without further evidence. */
+    const val OUTAGE_HOLD_MS = 300_000L
+
+    /**
+     * Phrases that identify a refusal outright, without waiting for
+     * corroboration.
+     *
+     * Deliberately narrow. "Sign in to confirm you're not a bot" is YouTube
+     * refusing *us*; "Sign in to confirm your age" is the track being gated
+     * and genuinely unplayable — near-identical strings meaning opposite
+     * things, so nothing here matches on "sign in" alone.
+     */
+    private val BLOCK_MARKERS = listOf(
+        "not a bot",
+        "too many requests",
+        "http error 429",
+        "status code 429",
+        "rate limit",
+        "rate-limited",
+        "temporarily blocked",
+        "blocked from making requests",
+    )
+
+    /** True when [reason] names the host refusing us rather than a bad track. */
+    fun looksLikeBlock(reason: String?): Boolean {
+        // Curly apostrophes are common in these messages, so compare against a
+        // straightened copy rather than listing both forms of every marker.
+        val text = reason?.lowercase()?.replace('’', '\'') ?: return false
+        return BLOCK_MARKERS.any { text.contains(it) }
+    }
+}
+
+/**
+ * Watches load failures for the shape of a host-side outage.
+ *
+ * Thread-safe: failures arrive on lavaplayer's load threads, and the answer is
+ * read from those and from the Discord dispatch threads.
+ *
+ * @param clock injectable so the windows can be tested without waiting them out.
+ */
+class SourceOutageTracker(
+    private val threshold: Int = SourceOutage.OUTAGE_AFTER_DISTINCT_FAILURES,
+    private val windowMs: Long = SourceOutage.WINDOW_MS,
+    private val holdMs: Long = SourceOutage.OUTAGE_HOLD_MS,
+    private val clock: () -> Long = System::currentTimeMillis,
+) {
+
+    private val lock = Any()
+    private val recentFailures = LinkedHashMap<String, Long>()
+    private var declaredAt: Long? = null
+
+    /**
+     * @param sourceKey what failed. Keyed by source so the *same* dead link
+     *        failing on repeat can never look like an outage on its own.
+     * @param definite true when the failure named a block outright, which
+     *        needs no corroboration.
+     * @return true when this failure is the one that declared the outage, so
+     *         the caller can log the onset once rather than on every failure.
+     */
+    fun recordFailure(sourceKey: String, definite: Boolean = false): Boolean = synchronized(lock) {
+        val now = clock()
+        val alreadyDeclared = isOutageAt(now)
+
+        recentFailures.entries.removeIf { now - it.value > windowMs }
+        recentFailures[sourceKey] = now
+
+        if (definite || recentFailures.size >= threshold) {
+            declaredAt = now
+            return !alreadyDeclared
+        }
+        false
+    }
+
+    /**
+     * A load succeeded, so we are demonstrably not blocked.
+     *
+     * This is what ends an outage: waiting out [holdMs] would keep reporting
+     * one long after playback started working, and the first success is proof
+     * in a way that elapsed time never is.
+     */
+    fun recordSuccess() = synchronized(lock) {
+        recentFailures.clear()
+        declaredAt = null
+    }
+
+    /** Whether the host currently looks like it is refusing us. */
+    fun isOutage(): Boolean = synchronized(lock) { isOutageAt(clock()) }
+
+    private fun isOutageAt(now: Long): Boolean = declaredAt?.let { now - it <= holdMs } ?: false
+}

--- a/common/src/test/kotlin/common/media/SourceOutageTest.kt
+++ b/common/src/test/kotlin/common/media/SourceOutageTest.kt
@@ -1,0 +1,188 @@
+package common.media
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SourceOutageTest {
+
+    // --- reading a failure message ------------------------------------------
+
+    @Test
+    fun `the bot check is recognised as a refusal`() {
+        assertTrue(SourceOutage.looksLikeBlock("Sign in to confirm you're not a bot"))
+    }
+
+    @Test
+    fun `a curly apostrophe in the bot check still matches`() {
+        // These messages come through with typographic punctuation more often
+        // than not, and a marker list that only knew about `'` would miss them.
+        assertTrue(SourceOutage.looksLikeBlock("Sign in to confirm you’re not a bot"))
+    }
+
+    @Test
+    fun `the age gate is not a refusal, despite reading almost the same`() {
+        // "Sign in to confirm your age" is the track being gated and genuinely
+        // unplayable. Conflating the two would pause intro health for a real
+        // broken link, which is the failure mode this whole thing exists to
+        // avoid in the other direction.
+        assertFalse(SourceOutage.looksLikeBlock("Sign in to confirm your age"))
+        assertFalse(SourceOutage.looksLikeBlock("Please sign in"))
+    }
+
+    @Test
+    fun `rate limiting is recognised in its usual forms`() {
+        assertTrue(SourceOutage.looksLikeBlock("HTTP error 429: Too Many Requests"))
+        assertTrue(SourceOutage.looksLikeBlock("Received status code 429"))
+        assertTrue(SourceOutage.looksLikeBlock("You are being rate limited"))
+        assertTrue(SourceOutage.looksLikeBlock("This IP has been temporarily blocked"))
+    }
+
+    @Test
+    fun `an ordinary dead link is not a refusal`() {
+        assertFalse(SourceOutage.looksLikeBlock("This video is not available in your country"))
+        assertFalse(SourceOutage.looksLikeBlock("This video is unavailable"))
+        assertFalse(SourceOutage.looksLikeBlock("The uploader has not made this video available"))
+        assertFalse(SourceOutage.looksLikeBlock(null))
+        assertFalse(SourceOutage.looksLikeBlock(""))
+    }
+
+    // --- correlating failures ------------------------------------------------
+
+    private class Clock(var now: Long = 0) : () -> Long {
+        override fun invoke(): Long = now
+    }
+
+    private fun tracker(clock: Clock) = SourceOutageTracker(clock = clock)
+
+    @Test
+    fun `one dead link is not an outage`() {
+        val t = tracker(Clock())
+
+        t.recordFailure("https://youtu.be/a")
+
+        assertFalse(t.isOutage())
+    }
+
+    @Test
+    fun `the same link failing repeatedly is never an outage on its own`() {
+        // This is why failures are keyed by source: a single dead intro
+        // retried on every join would otherwise declare an outage and
+        // suppress its own reporting forever.
+        val t = tracker(Clock())
+
+        repeat(10) { t.recordFailure("https://youtu.be/dead") }
+
+        assertFalse(t.isOutage())
+    }
+
+    @Test
+    fun `several different sources failing together is an outage`() {
+        val t = tracker(Clock())
+
+        t.recordFailure("https://youtu.be/a")
+        t.recordFailure("https://youtu.be/b")
+        assertFalse(t.isOutage())
+        t.recordFailure("https://youtu.be/c")
+
+        assertTrue(t.isOutage())
+    }
+
+    @Test
+    fun `failures spread out over time do not correlate`() {
+        val clock = Clock()
+        val t = tracker(clock)
+
+        t.recordFailure("https://youtu.be/a")
+        clock.now += SourceOutage.WINDOW_MS + 1
+        t.recordFailure("https://youtu.be/b")
+        clock.now += SourceOutage.WINDOW_MS + 1
+        t.recordFailure("https://youtu.be/c")
+
+        assertFalse(t.isOutage())
+    }
+
+    @Test
+    fun `a message that names a block declares an outage immediately`() {
+        // No point waiting for corroboration when the host has said so.
+        val t = tracker(Clock())
+
+        t.recordFailure("https://youtu.be/a", definite = true)
+
+        assertTrue(t.isOutage())
+    }
+
+    @Test
+    fun `the onset is reported once, not on every subsequent failure`() {
+        val t = tracker(Clock())
+
+        assertFalse(t.recordFailure("https://youtu.be/a"))
+        assertFalse(t.recordFailure("https://youtu.be/b"))
+        assertTrue(t.recordFailure("https://youtu.be/c"), "the third distinct failure declares it")
+        assertFalse(t.recordFailure("https://youtu.be/d"), "already declared — don't log it again")
+    }
+
+    @Test
+    fun `a successful load ends the outage at once`() {
+        // Proof beats elapsed time: waiting the hold out would keep blaming
+        // the host long after playback started working.
+        val t = tracker(Clock())
+        t.recordFailure("https://youtu.be/a", definite = true)
+        assertTrue(t.isOutage())
+
+        t.recordSuccess()
+
+        assertFalse(t.isOutage())
+    }
+
+    @Test
+    fun `a success also clears the failures counted so far`() {
+        val t = tracker(Clock())
+        t.recordFailure("https://youtu.be/a")
+        t.recordFailure("https://youtu.be/b")
+
+        t.recordSuccess()
+        t.recordFailure("https://youtu.be/c")
+
+        assertFalse(t.isOutage(), "the pre-success failures should not still be counting")
+    }
+
+    @Test
+    fun `an outage lapses on its own if nothing more is heard`() {
+        val clock = Clock()
+        val t = tracker(clock)
+        t.recordFailure("https://youtu.be/a", definite = true)
+
+        clock.now += SourceOutage.OUTAGE_HOLD_MS + 1
+
+        assertFalse(t.isOutage())
+    }
+
+    @Test
+    fun `continued failures keep the outage alive`() {
+        val clock = Clock()
+        val t = tracker(clock)
+        t.recordFailure("https://youtu.be/a", definite = true)
+
+        clock.now += SourceOutage.OUTAGE_HOLD_MS - 1
+        t.recordFailure("https://youtu.be/b", definite = true)
+        clock.now += SourceOutage.OUTAGE_HOLD_MS - 1
+
+        assertTrue(t.isOutage())
+    }
+
+    @Test
+    fun `it is safe to record from several threads at once`() {
+        // Failures arrive on lavaplayer's load threads while the answer is
+        // read from Discord's dispatch threads.
+        val t = SourceOutageTracker(threshold = 50, clock = Clock())
+        val threads = (0 until 8).map { thread ->
+            Thread { repeat(50) { i -> t.recordFailure("https://youtu.be/$thread-$i") } }
+        }
+
+        threads.forEach { it.start() }
+        threads.forEach { it.join() }
+
+        assertTrue(t.isOutage())
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/lavaplayer/PlayerManager.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/lavaplayer/PlayerManager.kt
@@ -22,6 +22,8 @@ import com.sedmelluq.discord.lavaplayer.tools.FriendlyException
 import com.sedmelluq.discord.lavaplayer.track.AudioPlaylist
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack
 import common.intro.IntroHealth
+import common.media.SourceOutage
+import common.media.SourceOutageTracker
 import common.logging.DiscordLogger
 import core.command.Command.Companion.replyAndDelete
 import dev.lavalink.youtube.YoutubeAudioSourceManager
@@ -65,6 +67,8 @@ class PlayerManager(
     private val retryExecutor: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor { r ->
         Thread(r, "track-load-retry").apply { isDaemon = true }
     },
+    // Injectable so tests can drive its windows without waiting them out.
+    private val outageTracker: SourceOutageTracker = SourceOutageTracker(),
 ) {
     private val musicManagers: MutableMap<Long, GuildMusicManager> = HashMap()
     var isCurrentlyStoppable: Boolean = true
@@ -269,6 +273,10 @@ class PlayerManager(
             private val requesterId: Long? = event?.member?.idLong
 
             override fun trackLoaded(track: AudioTrack) {
+                // Proof we aren't blocked, and the only thing that ends an
+                // outage — elapsed time would keep reporting one long after
+                // playback started working again.
+                outageTracker.recordSuccess()
                 scheduler.event = event
                 scheduler.deleteDelay = deleteDelay
                 if (isIntro) {
@@ -287,13 +295,22 @@ class PlayerManager(
             }
 
             override fun noMatches() {
-                event?.hook?.replyAndDelete("Nothing found for the link '$trackUrl'", deleteDelay)
+                // A blocked lookup usually comes back as "no matches" rather
+                // than an error, which is why a rate-limited bot spent the
+                // outage telling people their perfectly good links didn't
+                // exist.
+                val outage = noteFailure(trackUrl, definite = false)
+                if (outage) {
+                    event?.hook?.replyAndDelete(OUTAGE_MESSAGE, deleteDelay)
+                } else {
+                    event?.hook?.replyAndDelete("Nothing found for the link '$trackUrl'", deleteDelay)
+                }
                 // On the intro path `event` is always null, so before this the
                 // branch was a no-op and a deleted or private video simply
                 // produced silence forever.
                 introId?.let {
                     logger.warn { "Intro $it resolved nothing for url=$trackUrl" }
-                    SchedulerEvents.publish(IntroLoadFailedEvent(it, "Nothing found at this link"))
+                    reportIntroFailure(it, "Nothing found at this link", outage)
                 }
             }
 
@@ -330,14 +347,60 @@ class PlayerManager(
                     "Track load failed for url=$trackUrl severity=${exception.severity} after $attempt attempt(s)\n" +
                             exception.stackTraceToString()
                 }
-                event?.hook?.replyAndDelete("Could not play: ${exception.message}", deleteDelay)
+                // A message that names a block is enough on its own; anything
+                // else only counts towards the correlation.
+                val outage = noteFailure(trackUrl, definite = SourceOutage.looksLikeBlock(exception.message))
+                if (outage) {
+                    event?.hook?.replyAndDelete(OUTAGE_MESSAGE, deleteDelay)
+                } else {
+                    event?.hook?.replyAndDelete("Could not play: ${exception.message}", deleteDelay)
+                }
                 // Retries are exhausted by this point, so this is a real
                 // failure of the source rather than a blip worth hiding.
                 introId?.let {
-                    SchedulerEvents.publish(IntroLoadFailedEvent(it, IntroHealth.normaliseReason(exception.message)))
+                    reportIntroFailure(it, IntroHealth.normaliseReason(exception.message), outage)
                 }
             }
         }
+    }
+
+    /**
+     * Records a failed load and answers whether the host — rather than the
+     * track — now looks like the problem. Logs the onset once, with the bit an
+     * operator can act on.
+     */
+    private fun noteFailure(trackUrl: String, definite: Boolean): Boolean {
+        val justDeclared = outageTracker.recordFailure(trackUrl, definite)
+        if (justDeclared) {
+            logger.error {
+                "Audio source appears to be refusing us: ${SourceOutage.OUTAGE_AFTER_DISTINCT_FAILURES}+ distinct " +
+                    "sources failed inside ${SourceOutage.WINDOW_MS / 1000}s (latest: $trackUrl). " +
+                    "Intro health is paused until a load succeeds so nobody is told their working intro is broken. " +
+                    "If this persists, check $GOOGLE_REFRESH_TOKEN — anonymous YouTube requests are far more likely " +
+                    "to be IP-blocked."
+            }
+        }
+        return outageTracker.isOutage()
+    }
+
+    /**
+     * An intro failed to load. During an outage this deliberately publishes
+     * nothing.
+     *
+     * The failure counter exists to find intros whose *source* has died, and
+     * it drives a DM telling the owner to go and replace the link. Letting a
+     * rate-limit episode feed it would mark every intro on every server broken
+     * within two joins, DM everybody advice that doesn't apply, and have
+     * [common.intro.IntroSelection] start skipping tracks that were never
+     * anything but fine. Losing a couple of genuine failures to a false
+     * negative is the cheaper mistake by a wide margin.
+     */
+    private fun reportIntroFailure(introId: String, reason: String, outage: Boolean) {
+        if (outage) {
+            logger.warn { "Not counting intro $introId's failure against its health: the source is refusing us." }
+            return
+        }
+        SchedulerEvents.publish(IntroLoadFailedEvent(introId, reason))
     }
 
     /**
@@ -365,6 +428,15 @@ class PlayerManager(
     }
 
     companion object {
+        /**
+         * Shown instead of "nothing found" / "could not play" while the source
+         * is refusing us, because both of those blame the listener's link for
+         * something that has nothing to do with it. No mention of tokens or
+         * IPs: that's the operator's problem and it's in the log.
+         */
+        const val OUTAGE_MESSAGE = "Can't reach the music source right now — it's refusing requests from TobyBot, " +
+            "which isn't a problem with your link. This usually clears on its own; try again in a few minutes."
+
         /** Total load attempts before giving up (1 initial + retries). */
         const val MAX_LOAD_ATTEMPTS = 3
 

--- a/discord-bot/src/test/kotlin/bot/toby/lavaplayer/PlayerManagerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/lavaplayer/PlayerManagerTest.kt
@@ -48,8 +48,17 @@ class PlayerManagerTest {
         event = mockk(relaxed = true)
     }
 
+    /**
+     * A transient failure that doesn't *name* a block — these tests are about
+     * the retry ladder, and a message matching [common.media.SourceOutage]'s
+     * markers would declare an outage on the first failure and change what
+     * the branches below do.
+     */
     private fun transientFailure() =
-        FriendlyException("rate limited", FriendlyException.Severity.SUSPICIOUS, RuntimeException("x"))
+        FriendlyException("Something broke while looking up the track", FriendlyException.Severity.SUSPICIOUS, RuntimeException("x"))
+
+    private fun blockFailure() =
+        FriendlyException("Sign in to confirm you're not a bot", FriendlyException.Severity.SUSPICIOUS, RuntimeException("x"))
 
     @Test
     fun `transient load failures are retried up to the attempt cap`() {
@@ -209,5 +218,137 @@ class PlayerManagerTest {
 
         pm.loadAndPlayIntro(guild, null, "url", 5, 0L, 50, null, "1_2_1")
         handlers.last().noMatches()
+    }
+
+    // --- when the source is refusing us, not the track --------------------------
+    //
+    // A rate-limited or IP-blocked bot fails *every* load. Counting those
+    // against intro health marks every intro on every server broken within two
+    // joins and DMs each owner advice to replace a link that is perfectly
+    // fine — and a blocked lookup usually returns "no matches", so `/play`
+    // spends the outage telling people their working links don't exist.
+
+    private fun failIntro(introId: String, url: String, exception: FriendlyException? = null) {
+        pm.loadAndPlayIntro(guild, null, url, 5, 0L, 50, null, introId)
+        if (exception == null) handlers.last().noMatches() else handlers.last().loadFailed(exception)
+    }
+
+    /** Drives a block failure through the retry ladder to its terminal branch. */
+    private fun failIntroWithBlock(introId: String, url: String) {
+        pm.loadAndPlayIntro(guild, null, url, 5, 0L, 50, null, introId)
+        repeat(PlayerManager.MAX_LOAD_ATTEMPTS) { handlers.last().loadFailed(blockFailure()) }
+    }
+
+    @Test
+    fun `a failure that names a block is not counted against the intro`() {
+        val published = captureEvents()
+
+        failIntroWithBlock("1_2_1", "url-a")
+
+        assertTrue(
+            published.filterIsInstance<IntroLoadFailedEvent>().isEmpty(),
+            "a blocked load says nothing about whether this intro works",
+        )
+    }
+
+    @Test
+    fun `a block is still retried before it is believed`() {
+        // The retry ladder runs first either way: a 429 that clears on the
+        // second attempt should never have been called an outage at all.
+        val published = captureEvents()
+
+        pm.loadAndPlayIntro(guild, null, "url-a", 5, 0L, 50, null, "1_2_1")
+        handlers.last().loadFailed(blockFailure())
+        handlers.last().trackLoaded(realTrack())
+
+        assertTrue(published.filterIsInstance<IntroLoadFailedEvent>().isEmpty())
+        assertEquals(1, published.filterIsInstance<IntroPlayedEvent>().size)
+    }
+
+    @Test
+    fun `once several sources fail together, intro failures stop being counted`() {
+        val published = captureEvents()
+
+        // The first two look like ordinary dead links and are reported as such.
+        failIntro("1_2_1", "url-a")
+        failIntro("1_2_2", "url-b")
+        assertEquals(2, published.filterIsInstance<IntroLoadFailedEvent>().size)
+
+        // The third makes it a pattern, and everything after it is the
+        // outage's fault rather than the intro's.
+        failIntro("1_2_3", "url-c")
+        failIntro("1_3_1", "url-d")
+
+        assertEquals(2, published.filterIsInstance<IntroLoadFailedEvent>().size)
+    }
+
+    @Test
+    fun `one genuinely dead link is still reported`() {
+        // The expensive false negative: an outage that swallowed real failures
+        // would leave broken intros silently broken forever, which is the
+        // problem intro health exists to solve.
+        val published = captureEvents()
+
+        failIntro(
+            "1_2_1", "url-a",
+            FriendlyException("This video is unavailable", FriendlyException.Severity.COMMON, RuntimeException("x")),
+        )
+
+        assertEquals(1, published.filterIsInstance<IntroLoadFailedEvent>().size)
+    }
+
+    @Test
+    fun `the same dead intro failing on repeat never suppresses its own reporting`() {
+        // Keyed by source, so a single bad link retried on every voice join
+        // can't pass itself off as an outage.
+        val published = captureEvents()
+
+        repeat(5) { failIntro("1_2_1", "url-a") }
+
+        assertEquals(5, published.filterIsInstance<IntroLoadFailedEvent>().size)
+    }
+
+    @Test
+    fun `a successful load puts intro reporting straight back`() {
+        val published = captureEvents()
+        // The third distinct failure is the one that reveals the pattern, so
+        // it counts as the outage's too — only the first two are reported.
+        repeat(3) { i -> failIntro("1_2_$i", "url-$i") }
+        failIntro("1_3_1", "url-suppressed")
+        assertEquals(2, published.filterIsInstance<IntroLoadFailedEvent>().size)
+
+        pm.loadAndPlayIntro(guild, null, "url-works", 5, 0L, 50, null, "1_4_1")
+        handlers.last().trackLoaded(realTrack())
+
+        failIntro("1_5_1", "url-really-dead")
+        assertEquals(3, published.filterIsInstance<IntroLoadFailedEvent>().size)
+    }
+
+    @Test
+    fun `during an outage a listener is told it isn't their link`() {
+        // "Nothing found for the link" is a lie in this state, and the one the
+        // bot told everybody all evening.
+        pm.loadAndPlay(guild, event, "url-a", true, 5, 0L, 50, null)
+        repeat(PlayerManager.MAX_LOAD_ATTEMPTS) { handlers.last().loadFailed(blockFailure()) }
+
+        val messages = mutableListOf<String>()
+        every { event.hook.sendMessage(capture(messages)) } returns mockk(relaxed = true)
+
+        pm.loadAndPlay(guild, event, "url-b", true, 5, 0L, 50, null)
+        handlers.last().noMatches()
+
+        assertTrue(messages.any { it == PlayerManager.OUTAGE_MESSAGE }, messages.toString())
+        assertTrue(messages.none { it.contains("Nothing found") }, messages.toString())
+    }
+
+    @Test
+    fun `an ordinary dead link still names the link`() {
+        val messages = mutableListOf<String>()
+        every { event.hook.sendMessage(capture(messages)) } returns mockk(relaxed = true)
+
+        pm.loadAndPlay(guild, event, "url-a", true, 5, 0L, 50, null)
+        handlers.last().noMatches()
+
+        assertTrue(messages.any { it.contains("Nothing found for the link 'url-a'") }, messages.toString())
     }
 }


### PR DESCRIPTION
When the host refuses us — rate limit, IP block, the "confirm you're not a bot" wall — **every** load fails at once. Both failure paths were built on the assumption that a failed load is a fact about the *track*, and during an outage that assumption is wrong in two expensive ways.

## What was happening

**`/play` blamed the listener's link.** A blocked YouTube lookup usually comes back as *no matches* rather than an error, so the bot spent the outage replying "Nothing found for the link 'https://…'" for videos the user was looking at while reading the message.

**Intro health treated it as everyone's intro being broken.** Every failed intro load bumps that row's consecutive-failure counter, and crossing two DMs the owner:

> **Your intro isn't playing** — … This usually means the video was deleted, made private, age-gated or blocked in the bot's region. Replacing the link fixes it.

During a block that fires for every intro on every server, within two joins, with advice that doesn't apply to any of them. `/listintros` then shows `BROKEN` across the board and `IntroSelection` starts skipping tracks that were never anything but fine. One throttling episode could poison a guild's health data wholesale. The retry ladder from earlier work softened this — its own comment says *"otherwise every rate-limited night would mark healthy intros broken"* — but retries only cover a blip, not a sustained block.

## How it's detected

No single failure can be classified with confidence: a blocked lookup is indistinguishable from a dead link. What gives it away is **correlation** — several *different* sources failing inside a couple of minutes is not several dead links.

`SourceOutageTracker` watches for that (3 distinct sources / 2 minutes), and a message that names a refusal outright short-circuits the wait. Failures are keyed by source, so one dead link retried on every voice join can never pass itself off as an outage and suppress its own reporting.

The narrow bit worth calling out: **"sign in to confirm you're not a bot"** is the host refusing us; **"sign in to confirm your age"** is a genuinely unplayable track. Near-identical strings meaning opposite things, so nothing matches on `"sign in"` alone. Both cases are tested.

## What changes while an outage is up

- Intro health is **paused** — no failure counts, no DMs, no `BROKEN` markers.
- Listeners are told it's the source, not their link.
- The onset is logged once at error level with the operator-actionable detail (including the `GOOGLE_REFRESH_TOKEN` hint — anonymous YouTube requests are far more likely to be IP-blocked). That stays out of the user-facing message, which is nobody's problem but the operator's.

A **successful load ends it immediately** — proof, rather than waiting out a timer that would keep blaming the host after playback recovered.

The whole thing is deliberately biased toward *under*-reporting outages. Missing one costs a few minutes of misleading messages; a false one leaves a genuinely broken intro unreported, which is the problem intro health exists to solve.

## Testing

`./gradlew build -x :application:test` passes. `:application:test` needs Docker/Testcontainers and can't run in this sandbox; it is untouched by this change.

New `SourceOutageTest` (16). `PlayerManagerTest` extended to 19, covering both sides of the trade: a block-marked failure and a correlated run are suppressed, while one genuinely dead link and the same dead link on repeat are still reported.

Two of those caught things while being written. The existing `transientFailure()` fixture used the message `"rate limited"`, which the new detector correctly matches — so it had to become a genuinely non-block transient message, which is a better fixture for testing the retry ladder anyway. And a block-marked failure turns out to still go through the full retry ladder before it counts, which is the right behaviour (a 429 that clears on the second attempt was never an outage) and now has a test saying so.

Coverage measured like-for-like — instructions 79.992 → 80.035, lines 82.194 → 82.244. The Kover floors fail identically without `:application:test`, as established on #740.

## Not included

I could not verify the block from here: this sandbox has a different IP from the dyno and no access to production logs. This change is about making the condition legible when it happens, which is right regardless of whether it's happening right now.

Surfacing an active outage in `/introstats` would be a natural follow-on — the log covers operators, but an admin-visible signal would be better. Left out to keep this focused.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzSiANtbGDsaSbCRDkqQWc)_