### PR TITLE
Fix the filter factory throwing on every track it was handed

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/lavaplayer/IntroFilterFactory.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/lavaplayer/IntroFilterFactory.kt
@@ -17,6 +17,12 @@ import common.logging.DiscordLogger
  */
 interface IntroTrackContext {
 
+    /**
+     * The track the player is on, for when the pipeline doesn't say which one
+     * it is building for — which, in lavaplayer 2.2.6, is always.
+     */
+    fun currentTrack(): AudioTrack?
+
     /** The stored intro row [track] is playing, or null when it isn't an intro. */
     fun introIdFor(track: AudioTrack): String?
 
@@ -51,16 +57,43 @@ class IntroFilterFactory(
 
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
 
+    /**
+     * @param track which track the chain is for — **always null** in
+     *        lavaplayer 2.2.6. `AudioProcessingContext` carries no track at
+     *        all, and `UserProvidedAudioFilters` (its only call site) passes a
+     *        literal null. Declaring this non-null, as the first version of
+     *        this class did, put a Kotlin intrinsic null-check in the method
+     *        prologue that threw on every single track — and because the
+     *        pipeline is built whenever a filter factory is set, that was
+     *        every track the bot played, surfacing as "Something went wrong
+     *        when decoding the track".
+     */
     override fun buildChain(
-        track: AudioTrack,
+        track: AudioTrack?,
+        format: AudioDataFormat,
+        output: UniversalPcmAudioFilter,
+    ): List<AudioFilter> = runCatching {
+        // Nothing this class does is worth interrupting playback for. It sits
+        // on the decode path, so anything it throws surfaces as a track that
+        // won't play — which is exactly how it failed the first time.
+        chainFor(track, format, output)
+    }.getOrElse {
+        logger.error("Failed to build the intro filter chain; continuing without it: ${it.message}")
+        emptyList()
+    }
+
+    private fun chainFor(
+        track: AudioTrack?,
         format: AudioDataFormat,
         output: UniversalPcmAudioFilter,
     ): List<AudioFilter> {
-        val introId = runCatching { context.introIdFor(track) }.getOrNull()
-        if (introId != null) return introChain(track, format, output, introId)
-        if (runCatching { context.isResumingTrack(track) }.getOrDefault(false)) {
-            return resumeChain(format, output)
-        }
+        // The pipeline is constructed for whatever the executor is running, so
+        // the player's current track is the one being built for.
+        val subject = track ?: context.currentTrack() ?: return emptyList()
+
+        val introId = context.introIdFor(subject)
+        if (introId != null) return introChain(subject, format, output, introId)
+        if (context.isResumingTrack(subject)) return resumeChain(format, output)
         return emptyList()
     }
 
@@ -71,6 +104,10 @@ class IntroFilterFactory(
         output: UniversalPcmAudioFilter,
         introId: String,
     ): List<AudioFilter> {
+        // Guarded separately from the outer catch: without a length there is
+        // no end to fade *out* towards, but the fade in and the measurement
+        // are both still worth having, so this degrades rather than dropping
+        // the whole chain.
         val playbackMs = runCatching { context.introPlaybackMsFor(track) }.getOrNull()
         val fade = IntroFadeFilter(
             downstream = output,

--- a/discord-bot/src/main/kotlin/bot/toby/lavaplayer/TrackScheduler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/lavaplayer/TrackScheduler.kt
@@ -62,7 +62,7 @@ class TrackScheduler(val player: AudioPlayer, val guildId: Long, var deleteDelay
     internal fun isIntroTrack(track: AudioTrack): Boolean = introTracks.contains(track)
 
     /** The track this guild is playing right now, or null when it is idle. */
-    internal fun currentTrack(): AudioTrack? = player.playingTrack
+    override fun currentTrack(): AudioTrack? = player.playingTrack
 
     /** The intro row id behind [track], or null when it isn't an intro. */
     override fun introIdFor(track: AudioTrack): String? = introTrackIds[track]

--- a/discord-bot/src/test/kotlin/bot/toby/lavaplayer/GuildMusicManagerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/lavaplayer/GuildMusicManagerTest.kt
@@ -73,13 +73,18 @@ class GuildMusicManagerTest {
             AudioTrackInfo("Intro", "Author", 12_000L, "identifier", false, "http://example.com")
         every { intro.duration } returns 12_000L
         guildMusicManager.scheduler.queueIntro(intro, 0L, null, 60, requesterId = null, introId = "1_2_1")
+        // The player is on the intro, which is how the factory identifies it —
+        // lavaplayer passes null for the track.
+        every { guildMusicManager.audioPlayer.playingTrack } returns intro
 
         assertTrue(
-            factory.captured.buildChain(intro, format, output).isNotEmpty(),
+            factory.captured.buildChain(null, format, output).isNotEmpty(),
             "the factory should see this scheduler's intro bookkeeping",
         )
+
+        every { guildMusicManager.audioPlayer.playingTrack } returns mockk<AudioTrack>(relaxed = true)
         assertTrue(
-            factory.captured.buildChain(mockk(relaxed = true), format, output).isEmpty(),
+            factory.captured.buildChain(null, format, output).isEmpty(),
             "an unrelated track should still get an empty chain",
         )
     }

--- a/discord-bot/src/test/kotlin/bot/toby/lavaplayer/IntroFilterFactoryLavaplayerContractTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/lavaplayer/IntroFilterFactoryLavaplayerContractTest.kt
@@ -1,0 +1,155 @@
+package bot.toby.lavaplayer
+
+import com.sedmelluq.discord.lavaplayer.filter.PcmFilterFactory
+import com.sedmelluq.discord.lavaplayer.filter.UniversalPcmAudioFilter
+import com.sedmelluq.discord.lavaplayer.filter.UserProvidedAudioFilters
+import com.sedmelluq.discord.lavaplayer.format.Pcm16AudioDataFormat
+import com.sedmelluq.discord.lavaplayer.player.AudioConfiguration
+import com.sedmelluq.discord.lavaplayer.player.AudioPlayerOptions
+import com.sedmelluq.discord.lavaplayer.track.AudioTrack
+import com.sedmelluq.discord.lavaplayer.track.playback.AudioProcessingContext
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * The factory as **lavaplayer** calls it, rather than as we imagined it.
+ *
+ * Every other test of this class invokes `buildChain` directly, which is a
+ * call that never happens in production — and getting its arguments wrong is
+ * precisely how a `NullPointerException` on every track the bot played got
+ * through a green suite, including a test written specifically to prove the
+ * wiring was real.
+ *
+ * So these drive the library's own construction path instead:
+ * `UserProvidedAudioFilters` is what actually asks for the chain, and it is
+ * built here for real. Nothing in this file asserts anything about our
+ * behaviour that the other tests don't already cover; what it pins down is the
+ * *contract* — what lavaplayer hands over, and that we survive it.
+ */
+class IntroFilterFactoryLavaplayerContractTest {
+
+    private val format = Pcm16AudioDataFormat(2, 48_000, 960, true)
+
+    /** The context lavaplayer reads the factory and output format out of. */
+    private fun contextWith(factory: PcmFilterFactory): AudioProcessingContext {
+        val options = AudioPlayerOptions()
+        options.filterFactory.set(factory)
+        // A real configuration: the context constructor reads its hot-swap
+        // flag. The frame buffer is untouched while the chain is built.
+        return AudioProcessingContext(AudioConfiguration(), null, options, format)
+    }
+
+    /** Builds the chain the way the library does, and returns nothing useful. */
+    private fun buildThroughLavaplayer(factory: PcmFilterFactory) {
+        UserProvidedAudioFilters(contextWith(factory), mockk<UniversalPcmAudioFilter>(relaxed = true))
+    }
+
+    private class RecordingContext(private val introId: String?) : IntroTrackContext {
+        val playing: AudioTrack = mockk(relaxed = true)
+        var askedForCurrentTrack = false
+
+        override fun currentTrack(): AudioTrack {
+            askedForCurrentTrack = true
+            return playing
+        }
+
+        override fun introIdFor(track: AudioTrack): String? = introId
+        override fun introPlaybackMsFor(track: AudioTrack): Long = 9_000
+        override fun isResumingTrack(track: AudioTrack): Boolean = false
+    }
+
+    @Test
+    fun `lavaplayer asks for the chain without saying which track it is for`() {
+        // The fact the whole outage turned on. If a future lavaplayer starts
+        // passing a real track, this is where we find out — and the fallback
+        // in the factory quietly stops being load-bearing.
+        var called = false
+        var handedTrack: AudioTrack? = mockk(relaxed = true)
+
+        buildThroughLavaplayer { track, _, _ ->
+            called = true
+            handedTrack = track
+            emptyList()
+        }
+
+        assertTrue(called, "lavaplayer should have asked the factory for a chain")
+        assertNull(handedTrack, "lavaplayer passes null for the track; the factory must cope with that")
+    }
+
+    @Test
+    fun `the real factory survives being constructed by lavaplayer`() {
+        // The regression itself: a non-null Kotlin parameter made this throw
+        // in the method prologue, failing pipeline construction — and so
+        // playback — for every track.
+        buildThroughLavaplayer(IntroFilterFactory(RecordingContext("1_2_1")) { _, _ -> })
+    }
+
+    @Test
+    fun `it falls back to the playing track, so the chain is really installed`() {
+        // Surviving the call isn't enough — an implementation that returned
+        // an empty chain for everything would also "survive", and silently do
+        // nothing for ever.
+        val context = RecordingContext("1_2_1")
+
+        buildThroughLavaplayer(IntroFilterFactory(context) { _, _ -> })
+
+        assertTrue(context.askedForCurrentTrack, "the factory should resolve the track from the player")
+    }
+
+    @Test
+    fun `ordinary playback still builds through cleanly with no intro filters`() {
+        val context = RecordingContext(introId = null)
+
+        buildThroughLavaplayer(IntroFilterFactory(context) { _, _ -> })
+
+        assertTrue(context.askedForCurrentTrack)
+    }
+
+    @Test
+    fun `an idle player builds through cleanly too`() {
+        val idle = object : IntroTrackContext {
+            override fun currentTrack(): AudioTrack? = null
+            override fun introIdFor(track: AudioTrack): String? = null
+            override fun introPlaybackMsFor(track: AudioTrack): Long? = null
+            override fun isResumingTrack(track: AudioTrack): Boolean = false
+        }
+
+        buildThroughLavaplayer(IntroFilterFactory(idle) { _, _ -> })
+    }
+
+    @Test
+    fun `a factory that throws internally does not take pipeline construction with it`() {
+        // It sits on the decode path: whatever goes wrong in here, the track
+        // still has to play.
+        val exploding = object : IntroTrackContext {
+            override fun currentTrack(): AudioTrack = error("scheduler is gone")
+            override fun introIdFor(track: AudioTrack): String = error("scheduler is gone")
+            override fun introPlaybackMsFor(track: AudioTrack): Long = error("scheduler is gone")
+            override fun isResumingTrack(track: AudioTrack): Boolean = error("scheduler is gone")
+        }
+
+        buildThroughLavaplayer(IntroFilterFactory(exploding) { _, _ -> })
+    }
+
+    @Test
+    fun `a real guild player's factory builds through lavaplayer without throwing`() {
+        // End to end from the wiring GuildMusicManager actually installs,
+        // rather than a factory assembled by this test.
+        val playerManager = mockk<com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager>(relaxed = true)
+        val captured = slot<PcmFilterFactory>()
+        val player = mockk<com.sedmelluq.discord.lavaplayer.player.AudioPlayer>(relaxed = true)
+        every { playerManager.createPlayer() } returns player
+        every { player.setFilterFactory(capture(captured)) } answers { }
+        every { player.playingTrack } returns null
+
+        GuildMusicManager(playerManager, 1L)
+
+        assertFalse(captured.isNull, "GuildMusicManager should have installed a filter factory")
+        buildThroughLavaplayer(captured.captured)
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/lavaplayer/IntroFilterFactoryTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/lavaplayer/IntroFilterFactoryTest.kt
@@ -14,14 +14,19 @@ class IntroFilterFactoryTest {
     private val format = Pcm16AudioDataFormat(2, 48_000, 960, true)
     private val output: UniversalPcmAudioFilter = mockk(relaxed = true)
 
+    private val playing: AudioTrack = mockk(relaxed = true)
+
     /** Stand-in for [TrackScheduler]'s view of what a track is. */
-    private class FakeContext(
+    private inner class FakeContext(
         val introId: String? = null,
         val playbackMs: Long? = null,
         val resuming: Boolean = false,
         val introIdThrows: Boolean = false,
         val playbackThrows: Boolean = false,
+        val current: AudioTrack? = playing,
     ) : IntroTrackContext {
+        override fun currentTrack(): AudioTrack? = current
+
         override fun introIdFor(track: AudioTrack): String? =
             if (introIdThrows) throw IllegalStateException("scheduler state gone") else introId
 
@@ -31,8 +36,16 @@ class IntroFilterFactoryTest {
         override fun isResumingTrack(track: AudioTrack): Boolean = resuming
     }
 
+    /**
+     * Built the way lavaplayer actually builds it: with a **null** track.
+     *
+     * `AudioProcessingContext` carries no track, and `UserProvidedAudioFilters`
+     * — the only call site in 2.2.6 — passes a literal null. Every test here
+     * used to hand over a real track, which is why a non-null Kotlin parameter
+     * that threw on every single track in production passed the whole suite.
+     */
     private fun chainFor(context: IntroTrackContext, onMeasured: (String, Double) -> Unit = { _, _ -> }) =
-        IntroFilterFactory(context, onMeasured).buildChain(mockk<AudioTrack>(relaxed = true), format, output)
+        IntroFilterFactory(context, onMeasured).buildChain(null, format, output)
 
     @Test
     fun `regular music playback gets no filter at all`() {
@@ -100,8 +113,48 @@ class IntroFilterFactoryTest {
     }
 
     @Test
+    fun `a null track is resolved from the player rather than thrown on`() {
+        // The regression that broke every track the bot played: lavaplayer
+        // always passes null here, and a non-null Kotlin parameter turns that
+        // into a NullPointerException in the method prologue — before any of
+        // this class's own code, so none of its defensiveness applied. It
+        // surfaced as "Something went wrong when decoding the track".
+        val chain = IntroFilterFactory(FakeContext(introId = "1_2_1", playbackMs = 9_000)) { _, _ -> }
+            .buildChain(null, format, output)
+
+        assertEquals(2, chain.size)
+    }
+
+    @Test
+    fun `an idle player with a null track yields no filters instead of failing`() {
+        assertTrue(chainFor(FakeContext(current = null)).isEmpty())
+    }
+
+    @Test
+    fun `an explicit track is still honoured if lavaplayer ever supplies one`() {
+        val chain = IntroFilterFactory(FakeContext(introId = "1_2_1", playbackMs = 9_000)) { _, _ -> }
+            .buildChain(mockk<AudioTrack>(relaxed = true), format, output)
+
+        assertEquals(2, chain.size)
+    }
+
+    @Test
     fun `a failure resolving the intro id degrades to no filter`() {
         assertTrue(chainFor(FakeContext(introIdThrows = true)).isEmpty())
+    }
+
+    @Test
+    fun `nothing this class does can take playback down with it`() {
+        // It runs on the decode path, so a throw here is a track that won't
+        // play. Whatever goes wrong, the answer is no filters and a log line.
+        val exploding = object : IntroTrackContext {
+            override fun currentTrack(): AudioTrack = error("boom")
+            override fun introIdFor(track: AudioTrack) = error("boom")
+            override fun introPlaybackMsFor(track: AudioTrack) = error("boom")
+            override fun isResumingTrack(track: AudioTrack) = error("boom")
+        }
+
+        assertTrue(IntroFilterFactory(exploding) { _, _ -> }.buildChain(null, format, output).isEmpty())
     }
 
     @Test


### PR DESCRIPTION
**This is a live playback outage and it is mine.** Found in a production log:

```
Client [TVHTML5] failed: Something went wrong when decoding the track.
Caused by:
	at bot.toby.lavaplayer.IntroFilterFactory.buildChain(IntroFilterFactory.kt)
	at ...UserProvidedAudioFilters.buildFragment(UserProvidedAudioFilters.java:41)
	at ...AudioPipelineFactory.create(AudioPipelineFactory.java:41)
	at ...AacPacketRouter.processInput(AacPacketRouter.java:46)
```

## What was wrong

`IntroFilterFactory.buildChain` declared its `track` parameter **non-null**. Lavaplayer 2.2.6 always passes null:

- `AudioProcessingContext` has no track field at all — verified against the class.
- `UserProvidedAudioFilters.buildFragment` is the **only** `buildChain` call site in the library, and it passes a literal `aconst_null`.

So Kotlin's `checkNotNullParameter` intrinsic threw a `NullPointerException` in the method prologue — before any of this class's own code, and therefore outside every one of its careful `runCatching` blocks. That's also why the stack frame has no line number.

Blast radius: `AudioPipelineFactory.isProcessingRequired` returns true whenever a filter factory is set, and we always set one. So the pipeline is built for **every** track, and every track threw. It surfaced as "Something went wrong when decoding the track" — including on the one YouTube client that was still getting through the current block, which made a partial outage look like a total one.

## The fix

The track is resolved from the player instead. The pipeline is constructed for whatever the executor is running, which is `player.playingTrack`, so `IntroTrackContext` gains `currentTrack()` and `TrackScheduler` already had it.

The factory is now **total**. It sits on the decode path, where anything it throws is a track that won't play, and nothing it does is worth that. Whatever goes wrong it returns no filters and logs. The playback-length lookup keeps its own inner guard so a failure there degrades to a fade-in rather than dropping the whole chain — an existing test caught me removing that, correctly.

## Why the test suite didn't catch it

Two reasons, and both are worth stating plainly:

1. **Every test called `buildChain` with a real track** — a call that never happens in production. That includes the test I added yesterday *specifically to prove the wiring was real*. It asserted the factory was connected to the right scheduler, which was true, while the method it called could not survive being invoked by lavaplayer.
2. **The defensiveness was all inside a method that threw on entry.** Wrapping the body in `runCatching` says nothing about the prologue.

Tests now call it the way lavaplayer does — with `null` — plus one that drives a context whose every method throws, and one that keeps working if lavaplayer ever does supply a track.

## Scope

Introduced with the loudness meter and inherited by the fade work, so it has been live since that deploy. This does not touch the outage detection from #741, which is unrelated and stands.

`./gradlew build -x :application:test` passes. Coverage 80.035 → 80.036 instructions, 82.244 → 82.247 lines; the Kover floors fail identically without the Docker-dependent `:application:test`, as on #740 and #741.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzSiANtbGDsaSbCRDkqQWc)_