### PR TITLE
Play the intro you picked, not one of theirs at random

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/music/PlayIntroButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/music/PlayIntroButton.kt
@@ -2,21 +2,33 @@ package bot.toby.button.buttons.music
 
 import bot.toby.helpers.IntroHelper
 import bot.toby.helpers.MusicPlayerHelper
+import bot.toby.intro.IntroOwnership
 import bot.toby.intro.IntroPresenter
+import common.intro.IntroClip
 import core.button.Button
 import core.button.ButtonContext
+import database.dto.music.MusicDto
 import database.dto.user.UserDto
 import net.dv8tion.jda.api.components.buttons.Button as JdaButton
+import net.dv8tion.jda.api.components.buttons.ButtonStyle
 import net.dv8tion.jda.api.entities.Guild
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 /**
- * Plays a member's intro on demand, from the **View intros** context menu.
+ * Plays one named intro, from the **View intros** context menu.
  *
- * The target's id rides in the component id (`playintro:1234`) because the
- * button outlives the interaction that built it, and the message it sits on is
- * ephemeral — there is nothing else left to read the target off.
+ * There is a button per intro rather than a single "play theirs". The menu
+ * lists somebody's intros by name; offering one button that then played a
+ * *random* one of them was a small betrayal of the list right above it — with
+ * three slots you had a one-in-three chance of hearing the one you were
+ * looking at. The rotation is the right behaviour when the caller means "their
+ * intro" (a voice join, `/play intro`) and the wrong behaviour when they have
+ * pointed at one.
+ *
+ * The intro's id rides in the component id, since the id is
+ * `guildId_discordId_slot` and so already says everything needed — and the
+ * message it sits on is ephemeral, so there is nothing else left to read.
  *
  * Same permission story as `/play intro user:`: previewing is strictly less
  * intrusive than the surprise version everyone already gets on join. It does
@@ -41,23 +53,28 @@ class PlayIntroButton @Autowired constructor(
         }
 
         val guild = ctx.guild
-        val targetId = event.componentId.substringAfter(':').toLongOrNull()
-            ?: return reply(ctx, "That button has lost track of whose intro it was for — try the menu again.")
+        val introId = event.componentId.substringAfter(':').takeIf { it.isNotBlank() }
+        // The id arrives from the client, so being offered it earlier proves
+        // nothing about the one that came back.
+        if (!IntroOwnership.inGuild(introId, guild.idLong)) {
+            return reply(ctx, "That button has lost track of which intro it was for — open the menu again.")
+        }
+
+        val intro = introId?.let { introHelper.findIntroById(it) }
+            ?: return reply(ctx, "That intro has gone — it may have been deleted since you opened this.")
 
         invalidVoiceState(ctx, guild)?.let { return reply(ctx, it) }
 
-        val targetDto = introHelper.findUserById(targetId, guild.idLong)
-        val targetName = guild.getMemberById(targetId)?.effectiveName ?: "They"
-        if (targetDto.musicDtos.none { it.enabled }) {
-            return reply(ctx, "$targetName has nothing playable set right now.")
-        }
+        val name = IntroPresenter.displayName(intro)
 
-        val played = MusicPlayerHelper.playUserIntro(
-            targetDto, guild, deleteDelay = deleteDelay, member = guild.getMemberById(targetId),
-        ) ?: return reply(ctx, "Couldn't load $targetName's intro just now — it may have stopped working.")
+        MusicPlayerHelper.playIntro(intro, guild, deleteDelay = deleteDelay, member = ctx.member)
+            ?: return reply(ctx, "Couldn't load **$name** just now — it may have stopped working.")
 
-        logger.info { "Played $targetId's intro '${played.id}' on request from ${event.user.idLong}" }
-        reply(ctx, "Playing **${IntroPresenter.displayName(played)}** — $targetName's intro.")
+        logger.info { "Played intro '${intro.id}' on request from ${event.user.idLong}" }
+        // No owner name: resolving one means a member-cache lookup that
+        // returns null for anyone not cached, and the reply is ephemeral and
+        // attached to the menu they just opened, so whose it is isn't in doubt.
+        reply(ctx, "Playing **${describe(intro)}** — intro #${intro.index ?: '?'}.")
     }
 
     /**
@@ -83,9 +100,30 @@ class PlayIntroButton @Autowired constructor(
     companion object {
         const val BUTTON_NAME = "playintro"
 
-        fun button(targetDiscordId: Long, isSelf: Boolean): JdaButton = JdaButton.primary(
-            "$BUTTON_NAME:$targetDiscordId",
-            if (isSelf) "▶ Play mine" else "▶ Play theirs",
+        /** Keeps three buttons and a link from crowding one action row. */
+        private const val LABEL_LIMIT = 24
+
+        /**
+         * A play button for one intro.
+         *
+         * Intros that sit out the rotation — switched off, or repeatedly
+         * failing to load — are styled quietly rather than hidden. Hearing one
+         * on purpose is exactly how you'd answer "why doesn't this play?", and
+         * the embed above already says which is which.
+         */
+        fun button(intro: MusicDto): JdaButton = JdaButton.of(
+            if (intro.enabled && !IntroPresenter.isBroken(intro)) ButtonStyle.PRIMARY else ButtonStyle.SECONDARY,
+            "$BUTTON_NAME:${intro.id.orEmpty()}",
+            "▶ ${label(intro)}",
         )
+
+        private fun label(intro: MusicDto): String {
+            val name = IntroPresenter.displayName(intro)
+            return if (name.length <= LABEL_LIMIT) name else name.take(LABEL_LIMIT - 1).trimEnd() + "…"
+        }
+
+        /** Describes what a button will play, for the confirmation message. */
+        internal fun describe(intro: MusicDto): String =
+            "${IntroPresenter.displayName(intro)} (${IntroClip.describe(intro.startMs, intro.endMs)})"
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/music/intro/ViewIntrosContextCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/music/intro/ViewIntrosContextCommand.kt
@@ -56,8 +56,12 @@ class ViewIntrosContextCommand @Autowired constructor(
 
         val rows = buildList {
             val buttons = buildList {
-                // Nothing enabled means nothing would play, so don't offer to.
-                if (intros.any { it.enabled }) add(PlayIntroButton.button(target.idLong, isSelf))
+                // One button per intro rather than a single "play theirs": the
+                // embed right above names them, and picking from a list only
+                // to hear a different one is a strange thing to do to someone.
+                // The slot cap keeps this to three, so they fit beside the
+                // link in one row without ever needing a second menu.
+                IntroPresenter.sorted(intros).forEach { add(PlayIntroButton.button(it)) }
                 add(IntroPresenter.webDashboardButton(guild.idLong))
             }
             add(ActionRow.of(buttons))

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/MusicPlayerHelper.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/MusicPlayerHelper.kt
@@ -61,9 +61,34 @@ object MusicPlayerHelper {
             logger.warn { "User does not have a musicDto. Cannot play intro." }
             return null
         }
+        return playIntro(selected, guild, event, deleteDelay, startPosition, member, normaliseVolume)
+    }
+
+    /**
+     * Play one *named* intro, skipping the rotation entirely.
+     *
+     * Everything below the pick in [playUserIntro], so the two can't drift on
+     * volume normalisation or clip handling. The rotation is right when the
+     * caller means "their intro" — a voice join, or `/play intro` — and wrong
+     * when they have pointed at one: the **View intros** menu shows a member's
+     * intros by name, and picking one out of a list only to hear a different
+     * one is a strange thing to do to somebody.
+     */
+    fun playIntro(
+        selected: MusicDto,
+        guild: Guild,
+        event: SlashCommandInteractionEvent? = null,
+        deleteDelay: Int,
+        startPosition: Long = 0,
+        member: Member? = null,
+        normaliseVolume: Boolean = true,
+    ): MusicDto? {
+        logger.setGuildAndMemberContext(guild, member)
+        val instance = PlayerManager.instance
+        val currentVolume = instance.getMusicManager(guild).audioPlayer.volume
 
         return runCatching {
-            logger.info { "User has a musicDto. Preparing to play intro." }
+            logger.info { "Preparing to play intro '${selected.id}'." }
             val nominalVolume = selected.introVolume ?: currentVolume
             val playbackVolume = if (normaliseVolume) {
                 IntroLoudness.normalisedVolume(nominalVolume, selected.measuredRms)

--- a/discord-bot/src/main/kotlin/bot/toby/intro/IntroOwnership.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/intro/IntroOwnership.kt
@@ -15,4 +15,16 @@ object IntroOwnership {
 
     fun ownedBy(introId: String?, guildId: Long, discordId: Long): Boolean =
         introId != null && introId.startsWith("${guildId}_${discordId}_")
+
+    /**
+     * Whether [introId] belongs to this server at all — the weaker check, for
+     * actions anyone may take on anyone's intro.
+     *
+     * The **View intros** menu lets any member play any member's intro, so
+     * there is no owner to compare against. What still has to hold is that a
+     * component id sent from a client can't reach across into another guild's
+     * rows.
+     */
+    fun inGuild(introId: String?, guildId: Long): Boolean =
+        introId != null && introId.startsWith("${guildId}_")
 }

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/music/PlayIntroButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/music/PlayIntroButtonTest.kt
@@ -10,6 +10,7 @@ import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import io.mockk.verify
+import net.dv8tion.jda.api.components.buttons.ButtonStyle
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.GuildVoiceState
 import net.dv8tion.jda.api.entities.Member
@@ -29,7 +30,7 @@ import org.junit.jupiter.api.Test
 class PlayIntroButtonTest {
 
     private val guildId = 7L
-    private val targetId = 99L
+    private val ownerId = 99L
 
     private lateinit var introHelper: IntroHelper
     private lateinit var button: PlayIntroButton
@@ -42,7 +43,8 @@ class PlayIntroButtonTest {
 
     private val replies = mutableListOf<String>()
     private val caller = UserDto(discordId = 1L, guildId = guildId).apply { musicPermission = true }
-    private val targetDto = UserDto(discordId = targetId, guildId = guildId)
+    private val owner = UserDto(discordId = ownerId, guildId = guildId)
+    private lateinit var second: MusicDto
 
     @BeforeEach
     fun setUp() {
@@ -50,22 +52,29 @@ class PlayIntroButtonTest {
         introHelper = mockk(relaxed = true)
         button = PlayIntroButton(introHelper)
 
+        owner.musicDtos = mutableListOf(
+            MusicDto(owner, 1, "first", 80, byteArrayOf(1)),
+            MusicDto(owner, 2, "second", 80, byteArrayOf(2)),
+            MusicDto(owner, 3, "third", 80, byteArrayOf(3)),
+        )
+        second = owner.musicDtos[1]
+
         channel = mockk(relaxed = true)
         callerVoiceState = mockk(relaxed = true) { every { this@mockk.channel } returns this@PlayIntroButtonTest.channel }
         selfVoiceState = mockk(relaxed = true) { every { this@mockk.channel } returns this@PlayIntroButtonTest.channel }
-        val targetMember = mockk<Member>(relaxed = true) { every { effectiveName } returns "Them" }
+        val ownerMember = mockk<Member>(relaxed = true) { every { effectiveName } returns "Them" }
 
         guild = mockk(relaxed = true) {
             every { idLong } returns guildId
             every { selfMember } returns mockk<SelfMember>(relaxed = true) {
                 every { voiceState } returns selfVoiceState
             }
-            every { getMemberById(targetId) } returns targetMember
+            every { getMemberById(ownerId) } returns ownerMember
         }
         val hook = mockk<InteractionHook>(relaxed = true)
         val send = mockk<WebhookMessageCreateAction<Message>>(relaxed = true)
         event = mockk(relaxed = true) {
-            every { componentId } returns "playintro:$targetId"
+            every { componentId } returns "playintro:7_99_2"
             every { this@mockk.hook } returns hook
             every { user } returns mockk<User>(relaxed = true) { every { idLong } returns 1L }
         }
@@ -79,43 +88,77 @@ class PlayIntroButtonTest {
         every { hook.sendMessage(capture(replies)) } returns send
         every { send.setEphemeral(any()) } returns send
 
-        targetDto.musicDtos = mutableListOf(MusicDto(targetDto, 1, "banger", 80, byteArrayOf(1)))
-        every { introHelper.findUserById(targetId, guildId) } returns targetDto
-        every { MusicPlayerHelper.playUserIntro(any(), any(), any(), any(), any(), any(), any()) } returns
-            targetDto.musicDtos.first()
+        every { introHelper.findIntroById("7_99_2") } returns second
+        every { MusicPlayerHelper.playIntro(any(), any(), any(), any(), any(), any(), any()) } returns second
     }
 
     @AfterEach
     fun tearDown() = unmockkAll()
 
     @Test
-    fun `it plays the intro of whoever the button was built for`() {
+    fun `it plays the intro the button names, not one of them at random`() {
+        // The point of the change: the menu lists a member's intros by name,
+        // so picking one and hearing a different one is a strange thing to do
+        // to somebody. Three slots meant a one-in-three chance of the right
+        // one before this.
         button.handle(ctx, caller, 5)
 
-        verify { MusicPlayerHelper.playUserIntro(targetDto, guild, any(), 5, any(), any(), any()) }
-        assertTrue(replies.single().contains("banger"), replies.single())
+        verify { MusicPlayerHelper.playIntro(second, guild, any(), 5, any(), any(), any()) }
+        assertTrue(replies.single().contains("second"), replies.single())
     }
 
     @Test
-    fun `the target comes from the component id, not the message`() {
-        // The message is ephemeral and outlives nothing, so the id is the only
-        // place the target can be carried.
-        every { event.componentId } returns "playintro:12345"
-        every { introHelper.findUserById(12345L, guildId) } returns targetDto
-
+    fun `the confirmation names the intro, its clip and its slot`() {
+        // Deliberately no owner name: that needs a member-cache lookup which
+        // returns null for anyone not cached, and the reply is ephemeral and
+        // attached to the menu they just opened.
         button.handle(ctx, caller, 5)
 
-        verify { introHelper.findUserById(12345L, guildId) }
+        assertTrue(replies.single().contains("second"), replies.single())
+        assertTrue(replies.single().contains("#2"), replies.single())
     }
 
     @Test
-    fun `a component id with no usable target is reported rather than throwing`() {
-        every { event.componentId } returns "playintro:not-a-number"
+    fun `the intro comes from the component id, since the message is ephemeral`() {
+        every { event.componentId } returns "playintro:7_99_3"
+        every { introHelper.findIntroById("7_99_3") } returns owner.musicDtos[2]
 
         button.handle(ctx, caller, 5)
 
-        verify(exactly = 0) { MusicPlayerHelper.playUserIntro(any(), any(), any(), any(), any(), any(), any()) }
+        verify { introHelper.findIntroById("7_99_3") }
+    }
+
+    @Test
+    fun `an id from another guild is refused rather than played`() {
+        // The id arrives from the client, so having been offered it earlier
+        // proves nothing about the one that came back.
+        every { event.componentId } returns "playintro:12345_99_1"
+
+        button.handle(ctx, caller, 5)
+
+        verify(exactly = 0) { MusicPlayerHelper.playIntro(any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 0) { introHelper.findIntroById(any()) }
         assertTrue(replies.single().contains("lost track"), replies.single())
+    }
+
+    @Test
+    fun `a component id with no intro on it is reported rather than throwing`() {
+        every { event.componentId } returns "playintro:"
+
+        button.handle(ctx, caller, 5)
+
+        verify(exactly = 0) { MusicPlayerHelper.playIntro(any(), any(), any(), any(), any(), any(), any()) }
+        assertTrue(replies.single().contains("lost track"), replies.single())
+    }
+
+    @Test
+    fun `an intro deleted since the menu opened is reported, not played`() {
+        every { introHelper.findIntroById("7_99_2") } returns null
+
+        button.handle(ctx, caller, 5)
+
+        verify(exactly = 0) { MusicPlayerHelper.playIntro(any(), any(), any(), any(), any(), any(), any()) }
+        assertTrue(replies.single().contains("has gone"), replies.single())
     }
 
     @Test
@@ -126,7 +169,7 @@ class PlayIntroButtonTest {
 
         button.handle(ctx, noMusic, 5)
 
-        verify(exactly = 0) { MusicPlayerHelper.playUserIntro(any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 0) { MusicPlayerHelper.playIntro(any(), any(), any(), any(), any(), any(), any()) }
         assertTrue(replies.single().contains("permission"), replies.single())
     }
 
@@ -136,7 +179,7 @@ class PlayIntroButtonTest {
 
         button.handle(ctx, caller, 5)
 
-        verify(exactly = 0) { MusicPlayerHelper.playUserIntro(any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 0) { MusicPlayerHelper.playIntro(any(), any(), any(), any(), any(), any(), any()) }
         assertTrue(replies.single().contains("I need to be in a voice channel"), replies.single())
     }
 
@@ -146,7 +189,7 @@ class PlayIntroButtonTest {
 
         button.handle(ctx, caller, 5)
 
-        verify(exactly = 0) { MusicPlayerHelper.playUserIntro(any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 0) { MusicPlayerHelper.playIntro(any(), any(), any(), any(), any(), any(), any()) }
         assertTrue(replies.single().contains("You need to be in a voice channel"), replies.single())
     }
 
@@ -156,35 +199,48 @@ class PlayIntroButtonTest {
 
         button.handle(ctx, caller, 5)
 
-        verify(exactly = 0) { MusicPlayerHelper.playUserIntro(any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 0) { MusicPlayerHelper.playIntro(any(), any(), any(), any(), any(), any(), any()) }
         assertTrue(replies.single().contains("same voice channel"), replies.single())
     }
 
     @Test
-    fun `a target with nothing playable is reported instead of played`() {
-        targetDto.musicDtos = mutableListOf(
-            MusicDto(targetDto, 1, "off", 80, byteArrayOf(1)).apply { enabled = false }
-        )
-
-        button.handle(ctx, caller, 5)
-
-        verify(exactly = 0) { MusicPlayerHelper.playUserIntro(any(), any(), any(), any(), any(), any(), any()) }
-        assertTrue(replies.single().contains("nothing playable"), replies.single())
-    }
-
-    @Test
     fun `an intro that fails to load says so rather than replying with a success`() {
-        every { MusicPlayerHelper.playUserIntro(any(), any(), any(), any(), any(), any(), any()) } returns null
+        every { MusicPlayerHelper.playIntro(any(), any(), any(), any(), any(), any(), any()) } returns null
 
         button.handle(ctx, caller, 5)
 
         assertTrue(replies.single().contains("Couldn't load"), replies.single())
     }
 
+    // --- how the buttons are built -------------------------------------------
+
     @Test
-    fun `the button label says whose intro it is`() {
-        assertEquals("playintro:$targetId", PlayIntroButton.button(targetId, isSelf = false).customId)
-        assertTrue(PlayIntroButton.button(targetId, isSelf = false).label.contains("theirs"))
-        assertTrue(PlayIntroButton.button(1L, isSelf = true).label.contains("mine"))
+    fun `each button carries its own intro's id and name`() {
+        val built = PlayIntroButton.button(second)
+
+        assertEquals("playintro:7_99_2", built.customId)
+        assertTrue(built.label.contains("second"), built.label)
+    }
+
+    @Test
+    fun `an intro that sits out the rotation is styled quietly rather than hidden`() {
+        // Hearing a switched-off intro on purpose is exactly how you answer
+        // "why doesn't this one play?", and the embed already labels it.
+        val off = MusicDto(owner, 1, "muted", 80, byteArrayOf(1)).apply { enabled = false }
+        val broken = MusicDto(owner, 2, "dead", 80, byteArrayOf(1)).apply { failureCount = 5 }
+
+        assertEquals(ButtonStyle.SECONDARY, PlayIntroButton.button(off).style)
+        assertEquals(ButtonStyle.SECONDARY, PlayIntroButton.button(broken).style)
+        assertEquals(ButtonStyle.PRIMARY, PlayIntroButton.button(second).style)
+    }
+
+    @Test
+    fun `a long track title is trimmed so three buttons still fit a row`() {
+        val longName = MusicDto(owner, 1, "x".repeat(200), 80, byteArrayOf(1))
+
+        val label = PlayIntroButton.button(longName).label
+
+        assertTrue(label.length <= 30, "label was ${label.length} chars: $label")
+        assertTrue(label.endsWith("…"), label)
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/music/intro/ViewIntrosContextCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/music/intro/ViewIntrosContextCommandTest.kt
@@ -12,6 +12,7 @@ import io.mockk.unmockkAll
 import io.mockk.verify
 import net.dv8tion.jda.api.components.actionrow.ActionRow
 import net.dv8tion.jda.api.components.buttons.Button
+import net.dv8tion.jda.api.components.buttons.ButtonStyle
 import net.dv8tion.jda.api.components.selections.StringSelectMenu
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Member
@@ -124,15 +125,45 @@ class ViewIntrosContextCommandTest {
     }
 
     @Test
-    fun `the play button carries the target's id, since the message is ephemeral`() {
-        // Nothing else survives to say whose intro the button was for.
+    fun `there is one play button per intro, each naming its own`() {
+        // A single "play theirs" that then picked at random was a small
+        // betrayal of the list right above it — with three slots you had a
+        // one-in-three chance of hearing the one you were looking at.
+        every { introHelper.findUserById(targetId, guildId) } returns theirIntros(3)
+
+        command.handle(event, caller, 5)
+
+        val play = components().filterIsInstance<Button>()
+            .filter { it.customId?.startsWith("playintro") == true }
+        assertEquals(3, play.size)
+        assertEquals(
+            listOf("playintro:7_99_1", "playintro:7_99_2", "playintro:7_99_3"),
+            play.map { it.customId },
+        )
+        assertTrue(play.all { it.label.contains("track") }, play.map { it.label }.toString())
+    }
+
+    @Test
+    fun `the buttons carry intro ids, since the message is ephemeral`() {
+        // The id is guildId_discordId_slot, so it says everything the handler
+        // needs — nothing else survives the interaction.
         every { introHelper.findUserById(targetId, guildId) } returns theirIntros(1)
 
         command.handle(event, caller, 5)
 
         val play = components().filterIsInstance<Button>()
             .single { it.customId?.startsWith("playintro") == true }
-        assertEquals("playintro:$targetId", play.customId)
+        assertEquals("playintro:7_99_1", play.customId)
+    }
+
+    @Test
+    fun `the play buttons and the web link still fit one action row`() {
+        // Three slots plus the link is four, inside Discord's five.
+        every { introHelper.findUserById(targetId, guildId) } returns theirIntros(3)
+
+        command.handle(event, caller, 5)
+
+        assertTrue(rows.flatten().first().components.size <= 5)
     }
 
     @Test
@@ -181,13 +212,18 @@ class ViewIntrosContextCommandTest {
     }
 
     @Test
-    fun `a member whose intros are all switched off is not offered a play button`() {
-        // Nothing would come out, so offering to play it is a lie.
+    fun `an intro that sits out the rotation can still be played on purpose`() {
+        // Switched off means "skip me on join", not "never playable" — and
+        // hearing one is exactly how you answer "why doesn't this play?".
+        // The embed above already marks it, so the button is offered quietly
+        // rather than withheld.
         every { introHelper.findUserById(targetId, guildId) } returns theirIntros(2, enabled = false)
 
         command.handle(event, caller, 5)
 
-        assertTrue(components().filterIsInstance<Button>().none { it.customId?.startsWith("playintro") == true })
+        val play = components().filterIsInstance<Button>().filter { it.customId?.startsWith("playintro") == true }
+        assertEquals(2, play.size)
+        assertTrue(play.all { it.style == ButtonStyle.SECONDARY }, play.map { it.style }.toString())
         // Copying a switched-off intro is still fine — it comes across enabled.
         assertTrue(components().filterIsInstance<StringSelectMenu>().isNotEmpty())
     }


### PR DESCRIPTION
The **View intros** menu lists a member's intros by name, then offered a single **▶ Play theirs** button which went through the ordinary rotation. With three slots that's a one-in-three chance of hearing the one you were looking at — and it was inconsistent with the copy menu directly below it, which has always made you choose.

## What changes

One button per intro, labelled with its name:

```
[▶ banger]  [▶ quiet one]  [▶ the good one]  [Manage on the web]
[ Copy one to my intros ▼ ]
```

The slot cap is three, so they fit beside the web link inside a single action row — no second dropdown, and picking stays **one** click rather than the two a select menu costs.

Intros that sit out the rotation get a button too, styled secondary rather than withheld. Switched off means "skip me on join", not "never playable", and hearing one is exactly how you'd answer *"why doesn't this one play?"*. The embed above already marks them `OFF` / `BROKEN`.

`/play intro` and voice joins are untouched — the rotation is right when the caller means "their intro" and wrong only when they've pointed at one.

## Under it

`MusicPlayerHelper.playIntro` is the pick-free half of `playUserIntro`, extracted so the two can't drift on volume normalisation or clip handling.

The component id now carries the **intro** id rather than the owner's, which is strictly more information — ids are `guildId_discordId_slot`. Since it arrives from the client, `IntroOwnership.inGuild` checks it can't reach into another guild's rows; that's the weaker sibling of the existing `ownedBy`, for an action any member may take on any member's intro.

## One thing worth flagging

I dropped the owner's name from the confirmation message. It needed `Guild.getMemberById`, which reads the member cache and returns null for anyone not currently in it — so the message would have degraded to "someone's intro" in production often enough to matter.

It's also a **default interface method**, which mockk cannot intercept. The stub in the test I wrote yesterday was therefore doing nothing, and the assertion passed only because it never checked the name. That surfaced when this change made the test actually look. The reply is ephemeral and attached to the menu you just opened, so whose intro it is was never in doubt — it now names the intro, its clip and its slot.

## Testing

`./gradlew build -x :application:test` passes. `PlayIntroButtonTest` 14, `ViewIntrosContextCommandTest` 15, including: one button per intro with the right ids, a cross-guild id refused without a lookup, an id for a deleted intro reported rather than played, disabled intros offered quietly, long titles trimmed so three still fit a row, and the row staying within Discord's five-component cap.

Coverage 80.036 → 80.041 instructions, 82.247 → 82.250 lines. Kover floors fail identically without the Docker-dependent `:application:test`, as on #740–#742.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzSiANtbGDsaSbCRDkqQWc)_