### PR TITLE
Show an active source outage in the intro report

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/music/intro/IntroStatsCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/music/intro/IntroStatsCommand.kt
@@ -64,15 +64,15 @@ class IntroStatsCommand @Autowired constructor(
         }
 
         val stats = musicFileService.getGuildIntroStats(guild.idLong, IntroHealth.UNHEALTHY_AFTER_FAILURES)
-        event.hook.sendMessageEmbeds(statsEmbed(guild, stats))
+        event.hook.sendMessageEmbeds(statsEmbed(guild, stats, instance.isSourceRefusingRequests()))
             .addComponents(ActionRow.of(IntroPresenter.webDashboardButton(guild.idLong)))
             .setEphemeral(true)
             .queue()
     }
 
-    private fun statsEmbed(guild: Guild, stats: GuildIntroStats) = embed(
+    private fun statsEmbed(guild: Guild, stats: GuildIntroStats, sourceRefusing: Boolean) = embed(
         title = "Intro report — ${guild.name}",
-        color = INTRO_COLOR,
+        color = if (sourceRefusing) OUTAGE_COLOR else INTRO_COLOR,
         description = if (stats.introCount == 0L) {
             "Nobody on this server has set an intro yet."
         } else {
@@ -80,6 +80,16 @@ class IntroStatsCommand @Autowired constructor(
                 "${stats.userCount} member${plural(stats.userCount)}."
         },
     ) {
+        // First, because it changes how everything under it should be read.
+        if (sourceRefusing) {
+            field(
+                name = "⚠️ The audio source is refusing us",
+                value = "Nothing is playing anywhere at the moment — this is TobyBot being rate-limited or " +
+                    "blocked, not a problem with anyone's intro. It usually clears on its own.\n\n" +
+                    "Intro health is **paused** while it lasts, so nobody is being told their intro is " +
+                    "broken and the counts below all predate it.",
+            )
+        }
         field(name = "Plays", value = "**${stats.totalPlays}** since play counts were added", inline = true)
         field(name = "Stored audio", value = "**${formatBytes(stats.storedBytes)}**", inline = true)
         field(
@@ -89,13 +99,16 @@ class IntroStatsCommand @Autowired constructor(
         )
         field(
             name = "Not playing",
-            value = if (stats.brokenCount == 0L) {
-                "**0** — every intro is loading fine"
-            } else {
+            value = when {
+                stats.brokenCount == 0L -> "**0** — every intro is loading fine"
+                // The usual advice is actively wrong mid-outage: their links
+                // are fine, and no DM went out to explain the silence.
+                sourceRefusing -> "**${stats.brokenCount}** were failing before the outage started. " +
+                    "Worth re-checking once the source is back."
                 // Owners are DM'd when theirs breaks, but that DM can be
                 // missed or muted, so the count is repeated where an admin
                 // will see it.
-                "**${stats.brokenCount}** failing to load. Owners have been " +
+                else -> "**${stats.brokenCount}** failing to load. Owners have been " +
                     "DM'd; they can replace the link with `/setintro`."
             },
         )
@@ -136,5 +149,8 @@ class IntroStatsCommand @Autowired constructor(
 
     companion object {
         private val INTRO_COLOR: Color = Color(88, 101, 242) // Discord blurple
+
+        /** Amber, so an outage is visible before a word of it is read. */
+        private val OUTAGE_COLOR: Color = Color(250, 166, 26)
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/lavaplayer/PlayerManager.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/lavaplayer/PlayerManager.kt
@@ -365,6 +365,16 @@ class PlayerManager(
     }
 
     /**
+     * Whether the audio source currently looks like it is refusing us.
+     *
+     * Bot-wide rather than per-guild: it describes YouTube's opinion of this
+     * IP, not anything about a server. Read by `/introstats` so an admin
+     * looking at a pile of "not playing" intros can tell a real problem from
+     * an episode that will clear on its own.
+     */
+    fun isSourceRefusingRequests(): Boolean = outageTracker.isOutage()
+
+    /**
      * Records a failed load and answers whether the host — rather than the
      * track — now looks like the problem. Logs the onset once, with the bit an
      * operator can act on.

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/music/intro/IntroStatsCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/music/intro/IntroStatsCommandTest.kt
@@ -17,6 +17,7 @@ import io.mockk.verify
 import net.dv8tion.jda.api.entities.MessageEmbed
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -40,6 +41,7 @@ class IntroStatsCommandTest : MusicCommandTest {
         every { requestingUserDto.superUser } returns true
         every { configService.getConfigByName(any(), any()) } returns null
         every { musicFileService.getGuildIntroStats(any(), any()) } returns GuildIntroStats()
+        every { MusicCommandTest.playerManager.isSourceRefusingRequests() } returns false
     }
 
     @AfterEach
@@ -49,7 +51,7 @@ class IntroStatsCommandTest : MusicCommandTest {
     }
 
     private fun runAndCaptureEmbed(): MessageEmbed {
-        command.handle(ctx, requestingUserDto, 5)
+        command.handleMusicCommand(ctx, MusicCommandTest.playerManager, requestingUserDto, 5)
         val embeds = mutableListOf<MessageEmbed>()
         verify { event.hook.sendMessageEmbeds(capture(embeds)) }
         return embeds.single()
@@ -63,7 +65,7 @@ class IntroStatsCommandTest : MusicCommandTest {
         // rather than a personal one.
         every { requestingUserDto.superUser } returns false
 
-        command.handle(ctx, requestingUserDto, 5)
+        command.handleMusicCommand(ctx, MusicCommandTest.playerManager, requestingUserDto, 5)
 
         verify(exactly = 0) { musicFileService.getGuildIntroStats(any(), any()) }
     }
@@ -72,7 +74,7 @@ class IntroStatsCommandTest : MusicCommandTest {
     fun `broken intros are counted using the shared threshold`() {
         // Drifting from IntroSelection's definition would have the report
         // disagree with which intros actually get skipped.
-        command.handle(ctx, requestingUserDto, 5)
+        command.handleMusicCommand(ctx, MusicCommandTest.playerManager, requestingUserDto, 5)
 
         verify { musicFileService.getGuildIntroStats(any(), IntroHealth.UNHEALTHY_AFTER_FAILURES) }
     }
@@ -163,4 +165,82 @@ class IntroStatsCommandTest : MusicCommandTest {
         assertEquals("1.5 MB", command.formatBytes(1024 * 1024 * 3 / 2))
         assertEquals("2.00 GB", command.formatBytes(2L * 1024 * 1024 * 1024))
     }
+
+    // --- when the source is refusing us -------------------------------------
+    //
+    // The report is the one place an admin looks when several intros stop
+    // playing. During a rate limit or IP block that is every intro at once,
+    // and the usual reading — "these links are broken, tell their owners" —
+    // is wrong in every particular.
+
+    private fun duringOutage() {
+        every { MusicCommandTest.playerManager.isSourceRefusingRequests() } returns true
+    }
+
+    @Test
+    fun `an active outage is called out before anything else`() {
+        duringOutage()
+
+        val embed = runAndCaptureEmbed()
+
+        val first = embed.fields.first()
+        assertTrue(first.name!!.contains("refusing us"), first.name!!)
+        assertTrue(first.value!!.contains("not a problem with anyone's intro"), first.value!!)
+    }
+
+    @Test
+    fun `the outage says intro health is paused and the counts predate it`() {
+        // Otherwise an admin reads a broken count that stopped moving and
+        // concludes the problem is smaller than it is.
+        duringOutage()
+
+        val embed = runAndCaptureEmbed()
+
+        val warning = embed.fields.first().value!!
+        assertTrue(warning.contains("paused"), warning)
+        assertTrue(warning.contains("predate"), warning)
+    }
+
+    @Test
+    fun `mid-outage the broken count drops the advice to replace links`() {
+        // Their links are fine, and no DM went out to explain the silence, so
+        // both halves of the usual sentence are untrue.
+        duringOutage()
+        every { musicFileService.getGuildIntroStats(any(), any()) } returns
+            GuildIntroStats(introCount = 4, userCount = 2, brokenCount = 3)
+
+        val embed = runAndCaptureEmbed()
+
+        val notPlaying = embed.fields.single { it.name == "Not playing" }.value!!
+        assertTrue(notPlaying.contains("before the outage started"), notPlaying)
+        assertTrue(!notPlaying.contains("DM'd"), notPlaying)
+        assertTrue(!notPlaying.contains("/setintro"), notPlaying)
+    }
+
+    @Test
+    fun `an outage is visible from the colour before a word is read`() {
+        // Two runs in one capture: comparing the reports against each other
+        // beats pinning the exact swatches, which are presentation detail.
+        command.handleMusicCommand(ctx, MusicCommandTest.playerManager, requestingUserDto, 5)
+        duringOutage()
+        command.handleMusicCommand(ctx, MusicCommandTest.playerManager, requestingUserDto, 5)
+
+        val embeds = mutableListOf<MessageEmbed>()
+        verify { event.hook.sendMessageEmbeds(capture(embeds)) }
+        assertEquals(2, embeds.size)
+        assertNotEquals(embeds[0].colorRaw, embeds[1].colorRaw)
+    }
+
+    @Test
+    fun `with the source healthy nothing about an outage is mentioned`() {
+        every { musicFileService.getGuildIntroStats(any(), any()) } returns
+            GuildIntroStats(introCount = 4, userCount = 2, brokenCount = 3)
+
+        val embed = runAndCaptureEmbed()
+
+        assertTrue(embed.fields.none { it.name!!.contains("refusing") }, embed.fields.map { it.name }.toString())
+        val notPlaying = embed.fields.single { it.name == "Not playing" }.value!!
+        assertTrue(notPlaying.contains("DM'd"), notPlaying)
+    }
+
 }


### PR DESCRIPTION
The follow-on flagged in #741. `/introstats` is the one place an admin looks when several intros stop playing — and during a rate limit or IP block that's every intro at once, which is exactly when the report was least trustworthy.

## What it said before

A broken count that had quietly stopped moving (because #741 pauses intro health during an outage), sitting next to:

> **N** failing to load. Owners have been DM'd; they can replace the link with `/setintro`.

Both halves untrue. No DM went out, and their links are fine.

## What it says now

When the source is refusing us, the report leads with it — amber rather than blurple, so it registers before a word is read:

> **⚠️ The audio source is refusing us**
> Nothing is playing anywhere at the moment — this is TobyBot being rate-limited or blocked, not a problem with anyone's intro. It usually clears on its own.
>
> Intro health is **paused** while it lasts, so nobody is being told their intro is broken and the counts below all predate it.

And the "not playing" line drops the replace-the-link advice for the duration, saying instead that those were failing *before* the outage started and are worth re-checking once it's over.

Nothing changes when the source is healthy.

## Under it

`PlayerManager.isSourceRefusingRequests()` exposes what the tracker from #741 already knew. Bot-wide rather than per-guild, because it describes YouTube's opinion of this IP rather than anything about a server — the wording says "TobyBot", not "this server", for that reason.

## One thing worth noting

These tests were calling `handle`, which reaches for the real `PlayerManager.instance` singleton. Harmless while nothing in the method touched it; now that it reads the outage state, it would build a live player and its HTTP clients on every test run. They go through `handleMusicCommand` with the mock instead, matching the other music command tests.

## Testing

`./gradlew build -x :application:test` passes. `IntroStatsCommandTest` 15, five of them new: the warning leading the report, the paused/predates wording, the broken count dropping its advice mid-outage, the colour changing, and nothing being mentioned when the source is fine.

Coverage 80.041 → 80.040 instructions, 82.250 → 82.248 lines — a rounding wobble from added branches, not a regression in what's covered. Kover floors fail identically without the Docker-dependent `:application:test`, as on #740–#743.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzSiANtbGDsaSbCRDkqQWc)_